### PR TITLE
feat(ui-website): split components by tier on homepage + docs sidenav

### DIFF
--- a/packages/ui/packages/website/app/_lib/tier.ts
+++ b/packages/ui/packages/website/app/_lib/tier.ts
@@ -1,0 +1,62 @@
+/**
+ * Tier classification for `@webjskit/ui` registry items.
+ *
+ * The kit's core mental model: visual primitives are Tier-1 class-helper
+ * functions applied to native HTML elements; stateful primitives that
+ * need focus management, keyboard nav, or open/close state are Tier-2
+ * custom elements. Documented in `packages/ui/AGENTS.md`.
+ *
+ * Kept in a non-server module so it can be imported from any context
+ * (page, layout, client component, build script) without going through
+ * the `*.server.ts` RPC-stub rewrite.
+ */
+
+import type { RegistryItem } from './registry.server.ts';
+
+/**
+ * The 12 Tier-2 components — stateful custom elements (`<ui-X>` tags)
+ * that manage focus, keyboard nav, open/close state, etc. Everything
+ * else with `type === 'registry:ui'` is Tier 1.
+ *
+ * When adding a new component to the registry, add its name here if its
+ * source defines `class X extends WebComponent` + `.register('ui-...')`.
+ */
+export const TIER_2_NAMES: ReadonlySet<string> = new Set([
+  'dialog',
+  'alert-dialog',
+  'popover',
+  'tooltip',
+  'hover-card',
+  'tabs',
+  'accordion',
+  'collapsible',
+  'dropdown-menu',
+  'sonner',
+  'progress',
+  'toggle-group',
+]);
+
+/** 'tier-1' | 'tier-2' classification for a `registry:ui` item. */
+export type Tier = 'tier-1' | 'tier-2';
+
+/**
+ * Classify a `registry:ui` item. Caller should ensure the item is of
+ * `type === 'registry:ui'` — themes / lib items don't have a tier.
+ */
+export function tierOf(item: Pick<RegistryItem, 'name'>): Tier {
+  return TIER_2_NAMES.has(item.name) ? 'tier-2' : 'tier-1';
+}
+
+/**
+ * Split `registry:ui` items by tier, preserving the input order within
+ * each tier. Non-`registry:ui` items (themes, libs) are skipped.
+ */
+export function splitByTier(items: RegistryItem[]): { tier1: RegistryItem[]; tier2: RegistryItem[] } {
+  const tier1: RegistryItem[] = [];
+  const tier2: RegistryItem[] = [];
+  for (const it of items) {
+    if (it.type !== 'registry:ui') continue;
+    (tierOf(it) === 'tier-2' ? tier2 : tier1).push(it);
+  }
+  return { tier1, tier2 };
+}

--- a/packages/ui/packages/website/app/docs/layout.ts
+++ b/packages/ui/packages/website/app/docs/layout.ts
@@ -1,5 +1,6 @@
 import { html, css } from '@webjskit/core';
 import { loadRegistryIndex } from '../_lib/registry.server.ts';
+import { splitByTier } from '../_lib/tier.ts';
 
 // Subtle, hover-revealed scrollbar for the sidenav.
 //
@@ -49,6 +50,7 @@ const SIDENAV_STYLES = css`
 export default async function DocsLayout({ children }: { children: unknown }) {
   const all = await loadRegistryIndex();
   const components = all.filter((i) => i.type === 'registry:ui');
+  const { tier1, tier2 } = splitByTier(components);
 
   // Shared link styling: padded, rounded, with a clearly visible hover
   // surface. `-mx-2` lets the rounded hover background extend slightly
@@ -98,9 +100,21 @@ export default async function DocsLayout({ children }: { children: unknown }) {
           <a href="/docs" class=${linkClass}>Introduction</a>
           <a href="/" class=${linkClass}>All components</a>
         </nav>
-        <div class="font-semibold mb-2 text-fg">Components <span class="font-normal text-xs text-fg-subtle">(${components.length})</span></div>
+        <div class="flex items-baseline justify-between mb-2">
+          <div class="font-semibold text-fg">Tier 1 <span class="font-normal text-xs text-fg-subtle">Class helpers</span></div>
+          <span class="text-xs text-fg-subtle">${tier1.length}</span>
+        </div>
+        <nav class="flex flex-col gap-0.5 mb-6">
+          ${tier1.map(
+            (c) => html`<a href="/docs/components/${c.name}" class=${linkClass}>${c.name}</a>`,
+          )}
+        </nav>
+        <div class="flex items-baseline justify-between mb-2">
+          <div class="font-semibold text-fg">Tier 2 <span class="font-normal text-xs text-fg-subtle">Custom elements</span></div>
+          <span class="text-xs text-fg-subtle">${tier2.length}</span>
+        </div>
         <nav class="flex flex-col gap-0.5">
-          ${components.map(
+          ${tier2.map(
             (c) => html`<a href="/docs/components/${c.name}" class=${linkClass}>${c.name}</a>`,
           )}
         </nav>

--- a/packages/ui/packages/website/app/page.ts
+++ b/packages/ui/packages/website/app/page.ts
@@ -1,9 +1,11 @@
 import { html } from '@webjskit/core';
 import { loadRegistryIndex } from './_lib/registry.server.ts';
+import { splitByTier } from './_lib/tier.ts';
 
 export default async function Home() {
   const items = await loadRegistryIndex();
   const ui = items.filter((i) => i.type === 'registry:ui');
+  const { tier1, tier2 } = splitByTier(ui);
 
   return html`
     <!-- Hero -->
@@ -186,14 +188,57 @@ npx webjsui add button card dialog</code></pre>
       </div>
     </section>
 
-    <!-- Components grid -->
+    <!-- Components grid (split by tier) -->
     <section class="py-16">
-      <div class="flex items-baseline justify-between mb-6">
+      <div class="flex items-baseline justify-between mb-2">
         <h2 class="text-2xl font-semibold">All components</h2>
         <span class="text-sm text-fg-muted">${ui.length} primitives</span>
       </div>
+      <p class="text-sm text-fg-muted mb-8">
+        Grouped by composition tier. Pick Tier 1 by default — Tier 2
+        only when the browser doesn't ship the behavior natively.
+      </p>
+
+      <!-- Tier 1 -->
+      <div class="flex items-baseline justify-between mb-3">
+        <div class="flex items-baseline gap-3">
+          <span class="text-xs font-mono uppercase tracking-widest text-brand">Tier 1</span>
+          <h3 class="text-lg font-semibold">Class‑helper functions</h3>
+        </div>
+        <span class="text-xs text-fg-muted">${tier1.length} components</span>
+      </div>
+      <p class="text-sm text-fg-muted mb-4">
+        Apply <code class="text-xs bg-bg-subtle px-1 py-0.5 rounded">*Class()</code> to a real <code class="text-xs bg-bg-subtle px-1 py-0.5 rounded">&lt;button&gt;</code> / <code class="text-xs bg-bg-subtle px-1 py-0.5 rounded">&lt;input&gt;</code> / <code class="text-xs bg-bg-subtle px-1 py-0.5 rounded">&lt;div&gt;</code>. Native semantics, native a11y, native form submission.
+      </p>
+      <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 mb-12">
+        ${tier1.map(
+    (it) => html`
+            <a
+              href="/docs/components/${it.name}"
+              class="block rounded-lg border border-border bg-bg-elev p-4 transition-colors hover:bg-bg-subtle hover:border-border-strong"
+            >
+              <div class="font-medium text-fg">${it.name}</div>
+              ${it.description
+        ? html`<div class="text-xs text-fg-muted mt-1 line-clamp-2 leading-relaxed">${it.description}</div>`
+        : ''}
+            </a>
+          `,
+  )}
+      </div>
+
+      <!-- Tier 2 -->
+      <div class="flex items-baseline justify-between mb-3">
+        <div class="flex items-baseline gap-3">
+          <span class="text-xs font-mono uppercase tracking-widest text-brand">Tier 2</span>
+          <h3 class="text-lg font-semibold">Stateful custom elements</h3>
+        </div>
+        <span class="text-xs text-fg-muted">${tier2.length} components</span>
+      </div>
+      <p class="text-sm text-fg-muted mb-4">
+        <code class="text-xs bg-bg-subtle px-1 py-0.5 rounded">&lt;ui-X&gt;</code> tags that manage open/close, keyboard nav, focus trap, escape, click‑outside. Import once in your layout.
+      </p>
       <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
-        ${ui.map(
+        ${tier2.map(
     (it) => html`
             <a
               href="/docs/components/${it.name}"


### PR DESCRIPTION
## Summary

Surfaces the kit's Tier 1 / Tier 2 mental model on the two places users browse components:

- **Homepage** *All components* section: two tier-grouped grids (Tier 1 = 20 class helpers, Tier 2 = 12 custom elements) with intro copy and a default-to-Tier-1 hint
- **Docs sidenav**: two grouped sections — *Tier 1 · Class helpers (20)* and *Tier 2 · Custom elements (12)*, each alphabetical within its tier
- New `_lib/tier.ts` helper exports `TIER_2_NAMES`, `tierOf(item)`, and `splitByTier(items)` — single canonical source, kept outside `*.server.ts` so it's importable from any context

Three logical commits on this branch:
- `f2ba5c4` — add tier classifier
- `4845c86` — split homepage grid
- `6becc7f` — split docs sidenav

## Test plan

- [x] Homepage HTTP 200, both tier sections render
- [x] Docs sidenav HTTP 200, shows 32 components grouped (first 5 Tier-1: alert/aspect-ratio/avatar/badge/breadcrumb; last 5 Tier-2: progress/sonner/tabs/toggle-group/tooltip)
- [x] Individual component pages still 200 (`/docs/components/dialog`, `/docs/components/button`)
- [ ] Visual review on staging deploy (no design changes, just regrouping)