### PR TITLE
docs: sweep stale esbuild-loader / Node 20.6 mentions

### DIFF
--- a/agent-docs/typescript.md
+++ b/agent-docs/typescript.md
@@ -62,10 +62,11 @@ preservation. The convention check warns about this.
 
 ## Import convention
 
-Use explicit `.ts` extensions in imports. The esbuild loader hook
-expects file URLs ending in `.ts` / `.mts`. For mixed codebases, `.js`
-imports that point at a `.ts` sibling also resolve in the dev server.
-Still prefer explicit `.ts`.
+Use explicit `.ts` extensions in imports. Node 24+'s built-in
+type-stripping and the dev server's HTTP handler both key on the
+file URL ending in `.ts` / `.mts`. For mixed codebases, `.js` imports
+that point at a `.ts` sibling also resolve in the dev server. Still
+prefer explicit `.ts`.
 
 ```ts
 // modules/posts/queries/list-posts.server.ts

--- a/docs/app/docs/deployment/page.ts
+++ b/docs/app/docs/deployment/page.ts
@@ -5,7 +5,7 @@ export const metadata = { title: 'Deployment | webjs' };
 export default function Deployment() {
   return html`
     <h1>Deployment</h1>
-    <p>webjs runs as a standard Node.js server. There is no static export, no serverless adapter, no edge runtime. Deploy it anywhere you can run Node 20.6+: a VPS, a container, a PaaS like Fly.io or Railway, or behind a reverse proxy on bare metal.</p>
+    <p>webjs runs as a standard Node.js server. There is no static export, no serverless adapter, no edge runtime. Deploy it anywhere you can run Node 24+ (the minimum is set by Node's built-in TypeScript type-stripping): a VPS, a container, a PaaS like Fly.io or Railway, or behind a reverse proxy on bare metal.</p>
 
     <h2>Dev vs Prod</h2>
     <p>webjs has two modes, controlled by the CLI command:</p>
@@ -271,10 +271,10 @@ pm2 start "webjs start" --name my-app</pre>
 
     <h2>Deployment Checklist</h2>
     <ul>
-      <li>Node 20.6+ installed (required for the esbuild loader hook).</li>
+      <li>Node 24+ installed (required for the built-in TypeScript type-stripping that the framework uses for both server-side imports and browser-bound <code>.ts</code> files).</li>
       <li><code>npm ci --omit=dev</code> to install only runtime dependencies.</li>
       <li>Run <code>npx prisma generate</code> if you use Prisma.</li>
-      <li>No build step. Source <code>.js</code> / <code>.ts</code> files are deployed as-is and transformed on first request.</li>
+      <li>No build step. Source <code>.js</code> / <code>.ts</code> files are deployed as-is. TypeScript types are stripped on first request via Node's built-in stripper (whitespace replacement, byte-exact positions, no sourcemap overhead) and cached by mtime.</li>
       <li>Set environment variables (<code>DATABASE_URL</code>, <code>SESSION_SECRET</code>, etc.).</li>
       <li>Use <code>webjs start</code> (not <code>webjs dev</code>) for production.</li>
       <li>Configure health checks against <code>/__webjs/health</code>.</li>

--- a/docs/app/docs/getting-started/page.ts
+++ b/docs/app/docs/getting-started/page.ts
@@ -9,7 +9,7 @@ export default function GettingStarted() {
 
     <h2>Prerequisites</h2>
     <ul>
-      <li><strong>Node.js 20.6+</strong>: needed for <code>module.register()</code>, the API webjs uses to install its esbuild TypeScript loader at startup.</li>
+      <li><strong>Node.js 24+</strong>: webjs uses Node's built-in TypeScript type-stripping (<code>process.features.typescript === 'strip'</code>), which is default-on and stable from Node 24.</li>
       <li><strong>npm</strong> (or any package manager).</li>
     </ul>
 
@@ -125,7 +125,7 @@ Counter.register('my-counter');</pre>
 
     <h2>How It Works</h2>
     <ul>
-      <li><strong>TypeScript:</strong> The dev server registers an esbuild loader hook at startup. Every <code>.ts</code> import, whether server-side or browser-fetched, flows through esbuild's <code>transform()</code>. Same transformer for SSR and hydration, ~1ms/file, cached by mtime.</li>
+      <li><strong>TypeScript:</strong> Node 24+ strips types natively via <code>module.stripTypeScriptTypes</code> (whitespace replacement, byte-exact line + column preservation, no sourcemap shipped). Every <code>.ts</code> file, whether server-side or browser-fetched, goes through the same stripper, so SSR and hydration produce identical JS. The transform is cached by mtime. For the rare third-party <code>.ts</code> dependency using non-erasable syntax (<code>enum</code>, <code>namespace</code>, parameter properties), the dev server transparently falls back to <code>esbuild.transform</code> with an inline sourcemap.</li>
       <li><strong>SSR:</strong> Pages are rendered to HTML strings on the server. Light-DOM components serialize as plain children with a <code>&lt;!--webjs-hydrate--&gt;</code> marker. Shadow-DOM components (opt-in) emit Declarative Shadow DOM so scoped styles paint before JS loads.</li>
       <li><strong>Hydration:</strong> When JS loads, custom elements upgrade and become interactive. The fine-grained renderer preserves focus, cursor position, and form state across state updates.</li>
       <li><strong>Progressive enhancement:</strong> Pages and every custom element are SSR'd. Each component's <code>render()</code> runs on the server, so its initial HTML is in the response before any script loads. With JS disabled: content reads, <code>&lt;a&gt;</code> links navigate, <code>&lt;form&gt;</code> + server actions submit, and even an interactive component (counter, dropdown, tabs) paints its initial state correctly. JS is opt-in <em>per interactive behavior</em>, not per component: a counter renders as "0" without JS, and only the +/- click handling needs scripts. See <a href="/docs/progressive-enhancement">Progressive Enhancement</a>.</li>

--- a/docs/app/docs/routing/page.ts
+++ b/docs/app/docs/routing/page.ts
@@ -50,8 +50,8 @@ export default function Routing() {
 
     <p>
       Files can use <code>.ts</code>, <code>.js</code>, <code>.mts</code>, or
-      <code>.mjs</code> extensions. TypeScript files run via the dev server's
-      esbuild loader hook, no build step required.
+      <code>.mjs</code> extensions. TypeScript files run via Node 24+'s
+      built-in type-stripping, no build step required.
     </p>
 
     <!-- ===== PAGES ===== -->

--- a/docs/app/docs/ssr/page.ts
+++ b/docs/app/docs/ssr/page.ts
@@ -25,7 +25,7 @@ export default async function Home() {
   \`;
 }</pre>
 
-    <p>The dev server's esbuild loader hook transforms TypeScript on import, so the file above runs directly on the server with no manual compilation step.</p>
+    <p>Node 24+ strips TypeScript types natively when it imports a <code>.ts</code> file, so the file above runs directly on the server with no manual compilation step.</p>
 
     <h2>The SSR Pipeline</h2>
     <p>When the server receives a GET request for a page URL, the pipeline runs in this order:</p>

--- a/test/dev-handler.test.js
+++ b/test/dev-handler.test.js
@@ -149,9 +149,15 @@ test('handle: .ts source served as JS with esbuild-stripped types', async () => 
 });
 
 test('handle: .ts source supports non-erasable TS (enum, parameter properties)', async () => {
-  // Proves the browser-bound transform uses esbuild: Node's built-in
-  // stripper would reject this syntax. SSR-side imports use the same
-  // esbuild loader so both paths produce equivalent JS.
+  // Proves the browser-bound transform falls back to esbuild when
+  // Node's built-in stripper (module.stripTypeScriptTypes) rejects
+  // non-erasable syntax. The fallback emits an inline sourcemap so
+  // DevTools can still resolve positions for the regenerated JS.
+  // Server-side imports of the same file go through Node's native
+  // strip-types path; this works for erasable TS but errors at load
+  // time for non-erasable syntax. App code is held to erasable TS
+  // via tsconfig's erasableSyntaxOnly; this fallback exists for
+  // third-party .ts dependencies that publish non-erasable source.
   const appDir = makeApp({
     'app/page.ts': `export default () => 'ok';`,
     'components/advanced.ts': `


### PR DESCRIPTION
## Summary

Follow-up to PR #9 (the esbuild-to-Node-strip-types refactor). That PR updated the headline TypeScript and editor-setup docs, but six other surfaces still described the old loader hook + Node 20.6 minimum. This sweep replaces each one with the language already established in docs/app/docs/typescript/page.ts.

## Files touched

- docs/app/docs/getting-started/page.ts (prerequisites + How It Works section)
- docs/app/docs/deployment/page.ts (lead paragraph + deployment checklist)
- docs/app/docs/routing/page.ts (file extension paragraph)
- docs/app/docs/ssr/page.ts (TypeScript paragraph)
- agent-docs/typescript.md (Import convention section)
- test/dev-handler.test.js (test comment: now correctly says the hybrid stripper, not "both paths use esbuild")

Net: +22 lines, -15 lines.

## Test plan

- [x] Ran the docs dev server locally; all five updated pages (`getting-started`, `deployment`, `routing`, `ssr`, `typescript`) serve 200 with the new copy.
- [x] `node --test test/dev-handler.test.js` passes (52/52).
- [x] Re-grep for `esbuild loader` / `module.register` / `Node 20.6` / `Node.js 20` / `experimental-strip-types` across the repo returns empty.