### PR TITLE
release: bump core/server/cli versions, honest engines fields

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -12,9 +12,9 @@
     "css:build": "tailwindcss -i ./public/input.css -o ./public/tailwind.css --minify"
   },
   "dependencies": {
-    "@webjskit/cli": "^0.5.2",
-    "@webjskit/core": "^0.4.1",
-    "@webjskit/server": "^0.5.2"
+    "@webjskit/cli": "^0.6.0",
+    "@webjskit/core": "^0.5.0",
+    "@webjskit/server": "^0.6.0"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/examples/blog/package.json
+++ b/examples/blog/package.json
@@ -16,9 +16,9 @@
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",
-    "@webjskit/cli": "^0.5.2",
-    "@webjskit/core": "^0.4.1",
-    "@webjskit/server": "^0.5.2"
+    "@webjskit/cli": "^0.6.0",
+    "@webjskit/core": "^0.5.0",
+    "@webjskit/server": "^0.6.0"
   },
   "devDependencies": {
     "prisma": "^5.22.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,9 +34,9 @@
       "name": "@webjskit/docs",
       "version": "0.1.0",
       "dependencies": {
-        "@webjskit/cli": "^0.5.2",
-        "@webjskit/core": "^0.4.1",
-        "@webjskit/server": "^0.5.2"
+        "@webjskit/cli": "^0.6.0",
+        "@webjskit/core": "^0.5.0",
+        "@webjskit/server": "^0.6.0"
       },
       "engines": {
         "node": ">=24.0.0"
@@ -47,9 +47,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@prisma/client": "^5.22.0",
-        "@webjskit/cli": "^0.5.2",
-        "@webjskit/core": "^0.4.1",
-        "@webjskit/server": "^0.5.2"
+        "@webjskit/cli": "^0.6.0",
+        "@webjskit/core": "^0.5.0",
+        "@webjskit/server": "^0.6.0"
       },
       "devDependencies": {
         "@webjskit/ts-plugin": "^0.4.0",
@@ -6662,10 +6662,10 @@
     },
     "packages/cli": {
       "name": "@webjskit/cli",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
-        "@webjskit/server": "0.5.2",
+        "@webjskit/server": "^0.6.0",
         "@webjskit/ui": "0.1.0"
       },
       "bin": {
@@ -6677,18 +6677,15 @@
     },
     "packages/core": {
       "name": "@webjskit/core",
-      "version": "0.4.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=24.0.0"
-      }
+      "version": "0.5.0",
+      "license": "MIT"
     },
     "packages/server": {
       "name": "@webjskit/server",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
-        "@webjskit/core": "0.4.1",
+        "@webjskit/core": "^0.5.0",
         "chokidar": "^3.6.0",
         "esbuild": "^0.28.0",
         "ws": "^8.20.0"
@@ -6703,9 +6700,6 @@
       "license": "MIT",
       "dependencies": {
         "ts-lit-plugin": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=24.0.0"
       },
       "peerDependencies": {
         "typescript": ">=5.0.0"
@@ -6723,9 +6717,37 @@
       },
       "bin": {
         "webjsui": "bin/webjsui.js"
+      }
+    },
+    "packages/ui/node_modules/@webjskit/cli": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@webjskit/cli/-/cli-0.5.2.tgz",
+      "integrity": "sha512-j98SA7Qe9P2E4YpGYBso24ndUU886ngfdYxV+oZn7N/h5cjBqTcDov53+wXbHoEJECGd1SX1Q8HrmCxsFJFXUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@webjskit/server": "0.5.2",
+        "@webjskit/ui": "0.1.0"
       },
-      "engines": {
-        "node": ">=24.0.0"
+      "bin": {
+        "webjs": "bin/webjs.js"
+      }
+    },
+    "packages/ui/node_modules/@webjskit/core": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@webjskit/core/-/core-0.4.1.tgz",
+      "integrity": "sha512-N9nf1i+AiPXAH9XbHCW8HfnaVK1D/BqIXot/KyrhUePoleLiKPYtoLzeSQFGtOcwObHvMA75zgtShxldLAbaXA==",
+      "license": "MIT"
+    },
+    "packages/ui/node_modules/@webjskit/server": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@webjskit/server/-/server-0.5.2.tgz",
+      "integrity": "sha512-nuFV5YRqKBlmo6TcuSIfCNOCDzxxIdB/93g0P8Y8fOkUKu9FrJitMyJKIXt8HChWkQFip4p5BzZrW8FRNyq29w==",
+      "license": "MIT",
+      "dependencies": {
+        "@webjskit/core": "0.4.1",
+        "chokidar": "^3.6.0",
+        "esbuild": "^0.28.0",
+        "ws": "^8.20.0"
       }
     },
     "packages/ui/packages/registry": {
@@ -6750,9 +6772,9 @@
       "name": "@webjskit/website",
       "version": "0.1.0",
       "dependencies": {
-        "@webjskit/cli": "^0.5.2",
-        "@webjskit/core": "^0.4.1",
-        "@webjskit/server": "^0.5.2"
+        "@webjskit/cli": "^0.6.0",
+        "@webjskit/core": "^0.5.0",
+        "@webjskit/server": "^0.6.0"
       },
       "engines": {
         "node": ">=24.0.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjskit/cli",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {
@@ -13,7 +13,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@webjskit/server": "0.5.2",
+    "@webjskit/server": "^0.6.0",
     "@webjskit/ui": "0.1.0"
   },
   "publishConfig": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjskit/core",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",
@@ -35,9 +35,6 @@
   "homepage": "https://github.com/vivek7405/webjs#readme",
   "bugs": "https://github.com/vivek7405/webjs/issues",
   "license": "MIT",
-  "engines": {
-    "node": ">=24.0.0"
-  },
   "keywords": [
     "webjs",
     "web-components",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjskit/server",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",
@@ -14,7 +14,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@webjskit/core": "0.4.1",
+    "@webjskit/core": "^0.5.0",
     "chokidar": "^3.6.0",
     "esbuild": "^0.28.0",
     "ws": "^8.20.0"

--- a/packages/ts-plugin/package.json
+++ b/packages/ts-plugin/package.json
@@ -32,8 +32,5 @@
     "language-service",
     "tsserver-plugin",
     "web-components"
-  ],
-  "engines": {
-    "node": ">=24.0.0"
-  }
+  ]
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -44,8 +44,5 @@
     "tailwind",
     "components",
     "webjs"
-  ],
-  "engines": {
-    "node": ">=24.0.0"
-  }
+  ]
 }

--- a/website/package.json
+++ b/website/package.json
@@ -12,9 +12,9 @@
     "css:build": "tailwindcss -i ./public/input.css -o ./public/tailwind.css --minify"
   },
   "dependencies": {
-    "@webjskit/cli": "^0.5.2",
-    "@webjskit/core": "^0.4.1",
-    "@webjskit/server": "^0.5.2"
+    "@webjskit/cli": "^0.6.0",
+    "@webjskit/core": "^0.5.0",
+    "@webjskit/server": "^0.6.0"
   },
   "engines": {
     "node": ">=24.0.0"


### PR DESCRIPTION
## Summary

Release prep for the slot work (PR #8) and the strip-types refactor (PR #9 + #10). Bumps the three packages that actually changed, ships the `ui` package at its current version (first publish), leaves `ts-plugin` alone, and corrects the engines fields so only the packages that genuinely require Node 24 declare it.

## Version bumps

| Package | Bump | Reason |
|---|---|---|
| `@webjskit/core` | `0.4.1 -> 0.5.0` | Light-DOM `<slot>` API. Strictly additive (minor, pre-1.0 semver). |
| `@webjskit/server` | `0.5.2 -> 0.6.0` | Breaking. Removed esbuild-loader.js, requires Node 24+, behavior change for non-erasable TS. |
| `@webjskit/cli` | `0.5.2 -> 0.6.0` | Breaking. Requires Node 24+. New scaffold tsconfig includes `erasableSyntaxOnly: true`. |
| `@webjskit/ui` | stays `0.1.0` | First publish at current version. |
| `@webjskit/ts-plugin` | (no change) | Zero code changes since 0.4.0; engines reverted. |

## Engines fields, corrected

- **Kept** `engines: ">=24.0.0"` on `@webjskit/server` and `@webjskit/cli`. These packages actually call `module.stripTypeScriptTypes` and ship the `erasableSyntaxOnly` tooling.
- **Removed** `engines` from `@webjskit/core`, `@webjskit/ui`, `@webjskit/ts-plugin`. The slot runtime in core works on any Node + any browser; the ui CLI doesn't require Node 24; the tsserver plugin runs inside the editor's tsserver and doesn't care about Node version.

## Inter-package dep range updates

- `@webjskit/server` -> `@webjskit/core: ^0.5.0` (was `0.4.1`)
- `@webjskit/cli` -> `@webjskit/server: ^0.6.0` (was `0.5.2`)

## First-party app deps

`examples/blog`, `docs/`, `website/` all bumped their `@webjskit/*` ranges to the new `^x.y.0` to match.

## Test plan

- [x] Unit tests: 895/895 pass after lockfile refresh.
- [x] All inter-package ranges resolve (verified via `npm install`).
- [x] No source changes; only package metadata + lockfile.

## Publish order after merge

This PR does NOT run `npm publish` (needs your npm auth). After merging, the publish order is:

1. `@webjskit/core@0.5.0`
2. `@webjskit/server@0.6.0`
3. `@webjskit/ui@0.1.0`
4. `@webjskit/cli@0.6.0`