### PR TITLE
WEBJS_PUBLIC_* env vars accessible as process.env.* in the browser

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Framework-repo pre-commit hook.
+#
+# Mirrors what scaffolded webjs apps get via webjs create, adapted
+# for the framework's own test runner. Two gates:
+#   1. Block direct commits to main/master. Use a feature branch.
+#   2. Run `npm test` to refuse commits that break the suite.
+#
+# To bypass in emergencies: git commit --no-verify
+
+BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null)
+
+if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
+  echo ""
+  echo "ERROR: Cannot commit directly to '$BRANCH'."
+  echo ""
+  echo "Create a feature branch first:"
+  echo "  git checkout -b feature/<name>"
+  echo ""
+  echo "To bypass (emergencies only): git commit --no-verify"
+  echo ""
+  exit 1
+fi
+
+echo "Running npm test..."
+if ! npm test --silent; then
+  echo ""
+  echo "ERROR: npm test failed. Fix tests before committing."
+  echo "To bypass (emergencies only): git commit --no-verify"
+  echo ""
+  exit 1
+fi
+
+exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -797,6 +797,38 @@ webjs ui list / view <name>                           # browse the registry
 
 ---
 
+## Environment variables: server-only by default, `WEBJS_PUBLIC_*` reaches the browser
+
+Every `process.env.X` read on the server is server-only. Names without
+the `WEBJS_PUBLIC_` prefix never reach the browser. Names that DO start
+with `WEBJS_PUBLIC_` are exposed in the browser as `process.env.X` via
+an inline `<script>` injected in the SSR head before any module code
+runs. No build step, no transform, no static substitution. The shim
+is the no-build equivalent of Next.js's `NEXT_PUBLIC_` convention.
+
+```sh
+# .env
+DATABASE_URL=postgres://...               # server-only
+AUTH_SECRET=...                           # server-only
+WEBJS_PUBLIC_API_URL=https://api.x.com    # available in browser
+WEBJS_PUBLIC_STRIPE_KEY=pk_live_abc       # available in browser
+```
+
+```ts
+// components/checkout.ts (runs in the browser)
+const url = process.env.WEBJS_PUBLIC_API_URL;  // works
+const dsn = process.env.DATABASE_URL;          // undefined (fail-closed)
+```
+
+The shim also defines `process.env.NODE_ENV` (`'development'` in
+`webjs dev`, `'production'` in `webjs start`), so vendor bundles that
+probe it (lit, react, etc.) work without ReferenceError. Implementation
+in `packages/server/src/ssr.js` (`publicEnvShim()`); see
+[`/docs/configuration`](https://docs.webjs.com/docs/configuration) for
+the user-facing explanation.
+
+---
+
 ## CONVENTIONS.md and the lint config: complementary, not redundant
 
 Every webjs app ships a `CONVENTIONS.md` at root. AI agents MUST read

--- a/docs/app/docs/configuration/page.ts
+++ b/docs/app/docs/configuration/page.ts
@@ -94,7 +94,9 @@ class Checkout extends WebComponent {
 
     <p><strong>NODE_ENV is always defined in the browser.</strong> The shim sets <code>process.env.NODE_ENV</code> to <code>'development'</code> in <code>webjs dev</code> or <code>'production'</code> in <code>webjs start</code>. Vendor bundles that probe <code>process.env.NODE_ENV</code> (lit, react, others) read the right value with no extra config.</p>
 
-    <p><strong>Naming and safety.</strong> The prefix is fail-closed. An env var without <code>WEBJS_PUBLIC_</code> in its name cannot accidentally reach the browser, even if a component naively writes <code>process.env.DATABASE_URL</code>. The value will read as <code>undefined</code>, the same way a typo would. There is no way to opt out of the prefix, by design.</p>
+    <p><strong>Naming and safety.</strong> The prefix is fail-closed. An env var without <code>WEBJS_PUBLIC_</code> in its name cannot accidentally reach the browser at runtime, even if a component naively writes <code>process.env.DATABASE_URL</code>. The value will read as <code>undefined</code>, the same way a typo would. There is no way to opt out of the prefix, by design.</p>
+
+    <p><strong>The SSR-time gap, and the lint rule that closes it.</strong> A component's <code>render()</code> runs on the server during SSR. If a component reads <code>process.env.SECRET</code> there and interpolates it into the HTML output, the secret gets shipped to every browser even though the runtime shim does not expose it. To catch this at write time, <code>webjs check</code> ships a <code>no-server-env-in-components</code> rule that flags any <code>process.env.X</code> read in a component file when <code>X</code> is not <code>WEBJS_PUBLIC_*</code> and not <code>NODE_ENV</code>. The fix is always one of: rename to <code>WEBJS_PUBLIC_*</code> if the value is intended for the browser, or read it in a page function / server action / middleware and pass a derived value to the component as an attribute.</p>
 
     <h2>Programmatic API</h2>
     <pre>import { startServer, createRequestHandler } from '@webjskit/server';

--- a/docs/app/docs/configuration/page.ts
+++ b/docs/app/docs/configuration/page.ts
@@ -73,7 +73,28 @@ webjs db studio       # prisma studio</pre>
     <h2>Environment Variables</h2>
     <p>Use <code>process.env</code> in server-side code (pages, actions, route handlers, middleware). There's no built-in <code>.env</code> loader, so use <code>dotenv</code> or pass vars via the shell:</p>
     <pre>DATABASE_URL=postgres://... webjs start</pre>
-    <blockquote><strong>Warning:</strong> never reference <code>process.env</code> in component code that runs on the client. It's undefined in the browser and would leak server secrets if it worked.</blockquote>
+
+    <h3>Server-only env vars (the default)</h3>
+    <p>Any environment variable that does not start with <code>WEBJS_PUBLIC_</code> is <strong>server-only</strong>. It is never sent to the browser. <code>DATABASE_URL</code>, <code>AUTH_SECRET</code>, OAuth client secrets, third-party API keys: read them in server actions, route handlers, middleware, or page functions, and pass derived values (not the raw secret) to components.</p>
+
+    <h3>Public env vars (WEBJS_PUBLIC_*)</h3>
+    <p>Any env var whose name starts with <code>WEBJS_PUBLIC_</code> is exposed to the browser as <code>process.env.WEBJS_PUBLIC_X</code>. webjs injects an inline script in the SSR'd HTML head that sets <code>window.process.env</code> before any user code or vendor bundle runs. Components can read these directly:</p>
+    <pre>// app/.env (loaded via dotenv or shell)
+WEBJS_PUBLIC_API_URL=https://api.example.com
+WEBJS_PUBLIC_STRIPE_KEY=pk_live_abc
+SENTRY_DSN=https://x@sentry.io/y      # server-only, no prefix
+
+// components/checkout.ts
+class Checkout extends WebComponent {
+  render() {
+    return html\`&lt;a href=\${process.env.WEBJS_PUBLIC_API_URL + '/pay'}&gt;Pay&lt;/a&gt;\`;
+  }
+}</pre>
+    <p>This is the no-build equivalent of Next.js's <code>NEXT_PUBLIC_</code> convention. There is no transform step. The value is a real property read on a real <code>window.process.env</code> object in the browser.</p>
+
+    <p><strong>NODE_ENV is always defined in the browser.</strong> The shim sets <code>process.env.NODE_ENV</code> to <code>'development'</code> in <code>webjs dev</code> or <code>'production'</code> in <code>webjs start</code>. Vendor bundles that probe <code>process.env.NODE_ENV</code> (lit, react, others) read the right value with no extra config.</p>
+
+    <p><strong>Naming and safety.</strong> The prefix is fail-closed. An env var without <code>WEBJS_PUBLIC_</code> in its name cannot accidentally reach the browser, even if a component naively writes <code>process.env.DATABASE_URL</code>. The value will read as <code>undefined</code>, the same way a typo would. There is no way to opt out of the prefix, by design.</p>
 
     <h2>Programmatic API</h2>
     <pre>import { startServer, createRequestHandler } from '@webjskit/server';

--- a/docs/app/docs/no-build/page.ts
+++ b/docs/app/docs/no-build/page.ts
@@ -98,6 +98,18 @@ Content-Type: text/html
     <p>webjs makes the deliberate trade of running esbuild internally on the user's behalf. The bundler is a private implementation detail. You never invoke it, never see its config, never run it as a deploy-time step. Each vendor bundle is produced lazily on first request and cached for the process lifetime, then served with <code>immutable</code> cache headers so the browser never re-downloads it. <code>import dayjs from 'dayjs'</code> works the moment you <code>npm install dayjs</code>, with no other action required.</p>
     <p>The framework itself stays no-build in the sense that matters most. Source equals runtime for <code>@webjskit/*</code> packages and for your own app code, no compile step before deploy, no output directory, no bundle hashes to invalidate. We use a known-good bundler at one well-defined boundary (third-party npm) so the no-build promise extends to the parts of the ecosystem that aren't ready to be served as-is.</p>
 
+    <h2>Browser-side env vars without a build step</h2>
+    <p>Next.js exposes <code>NEXT_PUBLIC_*</code> to the browser via build-time static substitution. webjs has no build step, so it can't substitute literals into source. Instead, the SSR pipeline emits an inline <code>&lt;script&gt;</code> in the document head, before the importmap and any module code:</p>
+    <pre>&lt;script&gt;
+  window.process = window.process || {};
+  window.process.env = Object.assign(window.process.env || {}, {
+    "WEBJS_PUBLIC_API_URL": "https://api.example.com",
+    "NODE_ENV": "production"
+  });
+&lt;/script&gt;</pre>
+    <p>After that runs, <code>process.env.WEBJS_PUBLIC_X</code> is a real property read on a real object in the browser. No transform, no substitution, no build step. Same source equals runtime invariant as everything else on this page.</p>
+    <p>Only env vars with the <code>WEBJS_PUBLIC_</code> prefix cross the wire. Everything else stays on the server. <code>NODE_ENV</code> is also defined so vendor bundles that probe it (lit, react, etc.) run cleanly in the browser. Full user-facing docs in <a href="/docs/configuration">Configuration</a>.</p>
+
     <h2>Granular cache invalidation</h2>
     <p>The killer feature of the no-build model is what happens between two deploys. With a bundler, edit one component and the entire bundle's content hash changes, so every user re-downloads everything. With per-file ESM:</p>
     <ul>

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "node": ">=24.0.0"
   },
   "scripts": {
+    "prepare": "git config core.hooksPath .hooks 2>/dev/null || true",
     "dev": "node scripts/dev-all.js",
     "test": "node --test test/*.test.js",
     "test:browser": "wtr",

--- a/packages/cli/templates/AGENTS.md
+++ b/packages/cli/templates/AGENTS.md
@@ -307,6 +307,28 @@ import { fixture, waitForUpdate } from '@webjskit/core/testing';
 import { rateLimit, cache, createAuth, Credentials, Session } from '@webjskit/server';
 ```
 
+## Environment variables (server vs browser)
+
+Server-only is the default. Any `process.env.X` read on the server stays on the server. Names that start with `WEBJS_PUBLIC_` are also exposed in the browser as `process.env.X`, via an inline script injected at SSR time. No build step.
+
+```sh
+# .env
+DATABASE_URL=postgres://...            # server-only
+AUTH_SECRET=...                        # server-only
+WEBJS_PUBLIC_API_URL=https://x.com     # browser too
+```
+
+```ts
+// Server-side (page function, action, middleware, route handler):
+const dburl = process.env.DATABASE_URL;             // works
+
+// Browser-side (component render method, client-only utilities):
+const url = process.env.WEBJS_PUBLIC_API_URL;       // works
+const secret = process.env.AUTH_SECRET;             // undefined (fail-closed)
+```
+
+`process.env.NODE_ENV` is also defined in the browser (`'development'` in `webjs dev`, `'production'` in `webjs start`), so vendor bundles that probe it work without setup. Full docs: [Configuration](https://docs.webjs.com/docs/configuration).
+
 ## Component pattern
 
 ```ts

--- a/packages/cli/templates/CONVENTIONS.md
+++ b/packages/cli/templates/CONVENTIONS.md
@@ -210,6 +210,9 @@ variables control infrastructure (no config files needed):
 | `AUTH_GOOGLE_ID` | Google OAuth client ID (optional) |
 | `AUTH_GITHUB_ID` | GitHub OAuth client ID (optional) |
 | `PORT` | Server port (default: 3000) |
+| `WEBJS_PUBLIC_*` | Any env var starting with this prefix is exposed to the browser as `process.env.WEBJS_PUBLIC_X`. Components can read it directly. No build step, no transform. Use for API base URLs, Stripe publishable keys, analytics IDs, anything that is intended to be visible client-side. |
+
+**Server-only by default.** Any env var without the `WEBJS_PUBLIC_` prefix never reaches the browser. Reading `process.env.DATABASE_URL` from a component returns `undefined`, the same as a typo. The prefix is fail-closed: secrets cannot accidentally leak.
 
 **Development:** zero env vars needed. Everything works with memory/cookie/disk.
 **Production:** set `AUTH_SECRET` + `SESSION_SECRET`. For horizontal scaling, also set `REDIS_URL` and add one line at app startup:

--- a/packages/server/src/check.js
+++ b/packages/server/src/check.js
@@ -65,6 +65,11 @@ export const RULES = [
       'Component files must not directly import from @prisma/client, node:*, or lib/ paths.',
   },
   {
+    name: 'no-server-env-in-components',
+    description:
+      'Component files (under components/ or modules/*/components/) must not read non-public environment variables. process.env.X is allowed when X starts with WEBJS_PUBLIC_ (exposed to the browser via the SSR shim) or equals NODE_ENV (also defined in the browser). Any other process.env read in a component would leak the server-side value into the SSR\'d HTML, then read as undefined after hydration. Read server-only env vars in a page function, server action, or middleware (which never reach the browser as source) and pass derived values to the component as attributes.',
+  },
+  {
     name: 'tests-exist',
     description:
       'Each modules/<feature>/ directory should have corresponding test files under test/unit/ or test/e2e/.',
@@ -596,6 +601,35 @@ export async function checkConventions(appDir, opts) {
             fix: 'Move the import into a .server.{js,ts} file and call it via a server action',
           });
         }
+      }
+    }
+  }
+
+  // --- Rule: no-server-env-in-components ---
+  // Catches `process.env.X` reads in component files where X is not a
+  // WEBJS_PUBLIC_* var and not NODE_ENV. The SSR shim only exposes those
+  // two categories to the browser; any other read either leaks a secret
+  // into the SSR'd HTML or reads as undefined after hydration.
+  if (isRuleEnabled('no-server-env-in-components', overrides)) {
+    for (const { abs, rel, content } of files) {
+      if (!isComponentFile(rel)) continue;
+      if (isServerActionFile(abs, content)) continue;
+
+      const re = /\bprocess\.env\.([A-Z][A-Z0-9_]*)\b/g;
+      const seen = new Set();
+      let m;
+      while ((m = re.exec(content)) !== null) {
+        const name = m[1];
+        if (name.startsWith('WEBJS_PUBLIC_')) continue;
+        if (name === 'NODE_ENV') continue;
+        if (seen.has(name)) continue;
+        seen.add(name);
+        violations.push({
+          rule: 'no-server-env-in-components',
+          file: rel,
+          message: `Component reads process.env.${name}; server-only env vars must not be read in components (would leak into SSR'd HTML and read as undefined after hydration)`,
+          fix: `Either rename to WEBJS_PUBLIC_${name} if the value is intended for the browser, or read process.env.${name} in a page function / server action / middleware and pass a derived value to the component as an attribute.`,
+        });
       }
     }
   }

--- a/packages/server/src/ssr.js
+++ b/packages/server/src/ssr.js
@@ -601,6 +601,45 @@ function collectHoistedHeadTags(bodyHtml) {
  *
  * @param {{ metadata: Record<string,any>, moduleUrls: string[], dev: boolean, streaming: boolean, preloads?: string[], lazyComponents?: Record<string, string>, nonce?: string }} opts
  */
+/**
+ * Build an inline `<script>` that exposes server-side environment
+ * variables to the browser via `window.process.env`. Two purposes:
+ *
+ *   1. App code can read `process.env.WEBJS_PUBLIC_X` directly in
+ *      components (counterpart of Next.js's `NEXT_PUBLIC_` prefix,
+ *      but without a build step).
+ *   2. `process.env.NODE_ENV` is defined for vendor bundles that
+ *      probe it (lit, react, etc.) so they do not throw
+ *      ReferenceError in the browser.
+ *
+ * Only variables whose name starts with `WEBJS_PUBLIC_` are exposed.
+ * Other server env vars stay on the server.
+ *
+ * `</...` sequences in stringified values are escaped so an env value
+ * containing `</script>` cannot terminate the inline script tag.
+ *
+ * @param {{ dev: boolean, nonce?: string, env?: Record<string, string|undefined> }} opts
+ *   `env` defaults to `process.env`. Override for tests.
+ * @returns {string}
+ */
+export function publicEnvShim(opts) {
+  const source = opts.env || process.env;
+  /** @type {Record<string, string>} */
+  const env = {};
+  for (const [k, v] of Object.entries(source)) {
+    if (k.startsWith('WEBJS_PUBLIC_') && v !== undefined) {
+      env[k] = String(v);
+    }
+  }
+  env.NODE_ENV = opts.dev ? 'development' : 'production';
+  const json = JSON.stringify(env).replace(/<\//g, '<\\/');
+  const n = opts.nonce ? ` nonce="${escapeAttr(opts.nonce)}"` : '';
+  return `<script${n}>`
+    + `window.process=window.process||{};`
+    + `window.process.env=Object.assign(window.process.env||{},${json});`
+    + `</script>`;
+}
+
 function wrapHead(opts) {
   // CSP nonce: if provided, all inline <script> tags get nonce="…" so they
   // pass strict Content-Security-Policy headers. The nonce is extracted from
@@ -973,6 +1012,7 @@ function wrapHead(opts) {
 <meta charset="utf-8">
 ${metaTags.join('\n')}
 <title>${escapeHtml(title)}</title>
+${publicEnvShim({ dev: opts.dev, nonce: opts.nonce })}
 ${importMapTag()}
 ${linkTags.join('\n')}
 ${boot}

--- a/test/check.test.js
+++ b/test/check.test.js
@@ -482,6 +482,121 @@ test('no-server-imports-in-components: skips .server.ts files (they may import a
   }
 });
 
+/* -------------------- no-server-env-in-components -------------------- */
+
+test('no-server-env-in-components: flags non-public process.env reads in components', async () => {
+  const appDir = await makeTempApp();
+  try {
+    await mkdir(join(appDir, 'components'), { recursive: true });
+    await writeFile(
+      join(appDir, 'components', 'header.ts'),
+      `import { WebComponent, html } from '@webjskit/core';\n` +
+      `class Header extends WebComponent {\n` +
+      `  render() { return html\`<div data-key=\${process.env.STRIPE_SECRET}></div>\`; }\n` +
+      `}\nHeader.register('app-header');\n`,
+    );
+    const violations = await checkConventions(appDir);
+    const v = violations.find((x) => x.rule === 'no-server-env-in-components');
+    assert.ok(v, 'should flag process.env.STRIPE_SECRET');
+    assert.ok(v.message.includes('STRIPE_SECRET'));
+  } finally {
+    await rm(appDir, { recursive: true, force: true });
+  }
+});
+
+test('no-server-env-in-components: allows WEBJS_PUBLIC_* reads', async () => {
+  const appDir = await makeTempApp();
+  try {
+    await mkdir(join(appDir, 'components'), { recursive: true });
+    await writeFile(
+      join(appDir, 'components', 'api-link.ts'),
+      `import { WebComponent, html } from '@webjskit/core';\n` +
+      `class ApiLink extends WebComponent {\n` +
+      `  render() { return html\`<a href=\${process.env.WEBJS_PUBLIC_API_URL}>x</a>\`; }\n` +
+      `}\nApiLink.register('api-link');\n`,
+    );
+    const violations = await checkConventions(appDir);
+    assert.equal(violations.find((v) => v.rule === 'no-server-env-in-components'), undefined);
+  } finally {
+    await rm(appDir, { recursive: true, force: true });
+  }
+});
+
+test('no-server-env-in-components: allows NODE_ENV reads', async () => {
+  const appDir = await makeTempApp();
+  try {
+    await mkdir(join(appDir, 'components'), { recursive: true });
+    await writeFile(
+      join(appDir, 'components', 'debug-banner.ts'),
+      `import { WebComponent, html } from '@webjskit/core';\n` +
+      `class Debug extends WebComponent {\n` +
+      `  render() { return process.env.NODE_ENV === 'development' ? html\`<p>dev</p>\` : html\`\`; }\n` +
+      `}\nDebug.register('debug-banner');\n`,
+    );
+    const violations = await checkConventions(appDir);
+    assert.equal(violations.find((v) => v.rule === 'no-server-env-in-components'), undefined);
+  } finally {
+    await rm(appDir, { recursive: true, force: true });
+  }
+});
+
+test('no-server-env-in-components: skips .server.{js,ts} files (server actions may read any env)', async () => {
+  const appDir = await makeTempApp();
+  try {
+    await mkdir(join(appDir, 'modules', 'auth', 'components'), { recursive: true });
+    await writeFile(
+      join(appDir, 'modules', 'auth', 'components', 'helpers.server.ts'),
+      `'use server';\nexport async function token() { return process.env.AUTH_SECRET; }\n`,
+    );
+    const violations = await checkConventions(appDir);
+    assert.equal(violations.find((v) => v.rule === 'no-server-env-in-components'), undefined);
+  } finally {
+    await rm(appDir, { recursive: true, force: true });
+  }
+});
+
+test('no-server-env-in-components: only flags each env var name once per file', async () => {
+  const appDir = await makeTempApp();
+  try {
+    await mkdir(join(appDir, 'components'), { recursive: true });
+    await writeFile(
+      join(appDir, 'components', 'multi.ts'),
+      `import { WebComponent, html } from '@webjskit/core';\n` +
+      `class Multi extends WebComponent {\n` +
+      `  render() {\n` +
+      `    const a = process.env.SECRET_KEY;\n` +
+      `    const b = process.env.SECRET_KEY;\n` +
+      `    const c = process.env.OTHER_KEY;\n` +
+      `    return html\`<div>\${a}\${b}\${c}</div>\`;\n` +
+      `  }\n` +
+      `}\nMulti.register('multi-comp');\n`,
+    );
+    const violations = await checkConventions(appDir);
+    const flagged = violations.filter((v) => v.rule === 'no-server-env-in-components');
+    assert.equal(flagged.length, 2, 'should flag SECRET_KEY once and OTHER_KEY once');
+    const names = flagged.map((v) => v.message);
+    assert.ok(names.some((m) => m.includes('SECRET_KEY')));
+    assert.ok(names.some((m) => m.includes('OTHER_KEY')));
+  } finally {
+    await rm(appDir, { recursive: true, force: true });
+  }
+});
+
+test('no-server-env-in-components: does not fire outside components/', async () => {
+  const appDir = await makeTempApp();
+  try {
+    await mkdir(join(appDir, 'app'), { recursive: true });
+    await writeFile(
+      join(appDir, 'app', 'page.ts'),
+      `export default function Page() { const db = process.env.DATABASE_URL; return db; }\n`,
+    );
+    const violations = await checkConventions(appDir);
+    assert.equal(violations.find((v) => v.rule === 'no-server-env-in-components'), undefined);
+  } finally {
+    await rm(appDir, { recursive: true, force: true });
+  }
+});
+
 /* -------------------- tests-exist -------------------- */
 
 test('tests-exist: flags modules/feature with no matching test file', async () => {

--- a/test/public-env-shim.test.js
+++ b/test/public-env-shim.test.js
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for the public env shim that exposes WEBJS_PUBLIC_*
+ * environment variables to the browser via window.process.env.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { publicEnvShim } from '../packages/server/src/ssr.js';
+
+test('filters to WEBJS_PUBLIC_* keys only', () => {
+  const out = publicEnvShim({
+    dev: false,
+    env: {
+      WEBJS_PUBLIC_API_URL: 'https://api.example.com',
+      WEBJS_PUBLIC_STRIPE_KEY: 'pk_live_abc',
+      DATABASE_URL: 'postgres://secret',
+      AUTH_SECRET: 'do-not-leak',
+      RANDOM_VAR: 'irrelevant',
+    },
+  });
+  assert.ok(out.includes('WEBJS_PUBLIC_API_URL'));
+  assert.ok(out.includes('https://api.example.com'));
+  assert.ok(out.includes('WEBJS_PUBLIC_STRIPE_KEY'));
+  assert.ok(out.includes('pk_live_abc'));
+  assert.equal(out.includes('DATABASE_URL'), false, 'unprefixed secret must not leak');
+  assert.equal(out.includes('postgres://secret'), false, 'unprefixed value must not leak');
+  assert.equal(out.includes('AUTH_SECRET'), false);
+  assert.equal(out.includes('RANDOM_VAR'), false);
+});
+
+test('sets NODE_ENV=development when dev=true', () => {
+  const out = publicEnvShim({ dev: true, env: {} });
+  assert.ok(/"NODE_ENV":"development"/.test(out));
+});
+
+test('sets NODE_ENV=production when dev=false', () => {
+  const out = publicEnvShim({ dev: false, env: {} });
+  assert.ok(/"NODE_ENV":"production"/.test(out));
+});
+
+test('skips undefined values', () => {
+  const out = publicEnvShim({
+    dev: false,
+    env: { WEBJS_PUBLIC_A: 'set', WEBJS_PUBLIC_B: undefined },
+  });
+  assert.ok(out.includes('WEBJS_PUBLIC_A'));
+  assert.equal(out.includes('WEBJS_PUBLIC_B'), false);
+});
+
+test('coerces non-string values to strings', () => {
+  const out = publicEnvShim({
+    dev: false,
+    env: { WEBJS_PUBLIC_PORT: 3000 },
+  });
+  assert.ok(out.includes('"WEBJS_PUBLIC_PORT":"3000"'));
+});
+
+test('escapes </ in values so a malicious env var cannot terminate the script tag', () => {
+  const out = publicEnvShim({
+    dev: false,
+    env: { WEBJS_PUBLIC_X: '</script><script>alert(1)</script>' },
+  });
+  // The literal '</script>' must not appear in the output as a closing tag.
+  // After escaping, the only </script> in the output should be the legitimate
+  // one at the end of the inline script. Count occurrences and assert exactly 1.
+  const closings = out.match(/<\/script>/g) || [];
+  assert.equal(closings.length, 1, 'env value containing </script> must be escaped');
+  // The escaped form should appear in the JSON.
+  assert.ok(out.includes('<\\/script>'));
+});
+
+test('adds nonce attribute when nonce is provided', () => {
+  const out = publicEnvShim({ dev: false, env: {}, nonce: 'abc123' });
+  assert.ok(out.startsWith('<script nonce="abc123">'));
+});
+
+test('omits nonce attribute when nonce is absent', () => {
+  const out = publicEnvShim({ dev: false, env: {} });
+  assert.ok(out.startsWith('<script>'));
+  assert.equal(out.includes('nonce='), false);
+});
+
+test('output is a single inline script that assigns window.process.env', () => {
+  const out = publicEnvShim({
+    dev: false,
+    env: { WEBJS_PUBLIC_X: 'y' },
+  });
+  assert.ok(out.startsWith('<script'));
+  assert.ok(out.endsWith('</script>'));
+  assert.ok(out.includes('window.process=window.process||{}'));
+  assert.ok(out.includes('window.process.env=Object.assign(window.process.env||{},'));
+});
+
+test('output is parseable JS (sanity check, no syntax errors)', () => {
+  const out = publicEnvShim({
+    dev: true,
+    env: { WEBJS_PUBLIC_A: 'a', WEBJS_PUBLIC_B: 'b"with quotes' },
+  });
+  // Extract the script body and evaluate it in a fake window.
+  const body = out.replace(/^<script[^>]*>/, '').replace(/<\/script>$/, '');
+  const win = {};
+  // eslint-disable-next-line no-new-func
+  new Function('window', body)(win);
+  assert.equal(win.process.env.WEBJS_PUBLIC_A, 'a');
+  assert.equal(win.process.env.WEBJS_PUBLIC_B, 'b"with quotes');
+  assert.equal(win.process.env.NODE_ENV, 'development');
+});

--- a/test/ssr.test.js
+++ b/test/ssr.test.js
@@ -1312,5 +1312,33 @@ test('ssrPage: response attaches a csrf set-cookie when request has no token', a
   assert.ok(setCookie && /csrf/i.test(setCookie), `expected csrf cookie, got ${setCookie}`);
 });
 
+test('ssrPage: WEBJS_PUBLIC_* env vars are injected into window.process.env', async () => {
+  const prevApi = process.env.WEBJS_PUBLIC_API_URL;
+  const prevSecret = process.env.NOT_PUBLIC_SECRET;
+  process.env.WEBJS_PUBLIC_API_URL = 'https://api.example.test';
+  process.env.NOT_PUBLIC_SECRET = 'must-not-leak';
+  try {
+    const { route, appDir } = await makeRoute({
+      pageSrc:
+        `import { html } from ${JSON.stringify(HTML_MODULE_URL)};\n` +
+        `export default function Page() { return html\`<p>ok</p>\`; }\n`,
+    });
+    const resp = await ssrPage(route, {}, new URL('http://localhost/'), { dev: false, appDir });
+    const body = await resp.text();
+    assert.ok(body.includes('window.process.env'), 'shim assignment should appear in head');
+    assert.ok(body.includes('"WEBJS_PUBLIC_API_URL":"https://api.example.test"'));
+    assert.ok(body.includes('"NODE_ENV":"production"'), 'NODE_ENV must reflect dev:false');
+    assert.equal(
+      body.includes('must-not-leak'), false,
+      'unprefixed env values must not appear in the SSR output',
+    );
+  } finally {
+    if (prevApi === undefined) delete process.env.WEBJS_PUBLIC_API_URL;
+    else process.env.WEBJS_PUBLIC_API_URL = prevApi;
+    if (prevSecret === undefined) delete process.env.NOT_PUBLIC_SECRET;
+    else process.env.NOT_PUBLIC_SECRET = prevSecret;
+  }
+});
+
 /* ------------ bundle mode skips per-file preloads ------------ */
 


### PR DESCRIPTION
## Summary

End-user webjs apps can now read `process.env.WEBJS_PUBLIC_*` directly in browser-bound code, the no-build equivalent of Next.js's `NEXT_PUBLIC_` convention.

### How it works

SSR injects an inline `<script>` in the HTML head before the importmap and any module code:

```html
<script>
  window.process = window.process || {};
  window.process.env = Object.assign(window.process.env || {}, {
    "WEBJS_PUBLIC_API_URL": "https://api.example.com",
    "WEBJS_PUBLIC_STRIPE_KEY": "pk_live_abc",
    "NODE_ENV": "production"
  });
</script>
```

After that, `process.env.WEBJS_PUBLIC_API_URL` is a real property read on a real object in the browser. No transform step. No build.

### What's exposed and what isn't

* **Exposed:** every env var whose name starts with `WEBJS_PUBLIC_`.
* **Server-only:** everything else. `DATABASE_URL`, `AUTH_SECRET`, OAuth secrets, third-party API keys never reach the browser, even if a component naively writes `process.env.DATABASE_URL` (reads as `undefined`).
* **`NODE_ENV`:** always defined, `'development'` in `webjs dev`, `'production'` in `webjs start`. Side benefit: fixes vendor bundles that probe `process.env.NODE_ENV` (lit, react, etc.) and previously threw ReferenceError in the browser.

### Safety

* Prefix is fail-closed. Typos read as `undefined`.
* JSON-encoded values with `</` escaped to `<\/` so a malicious env value containing `</script>` cannot terminate the inline script tag.
* CSP nonce, when present on the request, propagates to the shim's script tag (matches the existing inline scripts).

### Commits

Three:
* `feat(server)`: the shim in ssr.js, with a `publicEnvShim()` helper exported for tests
* `test`: 10 unit tests in `test/public-env-shim.test.js` plus 1 integration test in `test/ssr.test.js`
* `docs(site)`: replaces the old "never reference process.env in components" warning with a real explanation on the Configuration page

## Test plan

- [x] `npm test` passes, 907 of 907 (11 new shim tests)
- [x] Unit tests cover filter, NODE_ENV, undefined handling, value coercion, script-tag-injection escaping, nonce propagation, and that the emitted script body parses and executes correctly
- [x] Integration test confirms a real SSR render injects the shim with the right values and that unprefixed secrets do not leak