### PR TITLE
feat(scaffold): OpenCode commit-nudge plugin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,11 +121,12 @@ bypass/autonomous mode).
    different concerns, you already waited too long. Push after each
    commit so the remote stays in sync. Scaffolded apps ship hook
    coverage for Claude Code (`PostToolUse`), Gemini CLI
-   (`AfterTool`), and Cursor 1.7+ (`afterFileEdit`), all firing at
-   threshold 4. Other agents (Windsurf, Copilot, OpenCode,
-   Antigravity) fall back to the text rules in this file and
-   `.cursorrules` / `.windsurfrules` / `copilot-instructions.md`.
-   The framework repo itself uses the Claude Code hook only.
+   (`AfterTool`), Cursor 1.7+ (`afterFileEdit`), and OpenCode
+   (`tool.execute.after` TS plugin), all firing at threshold 4.
+   Other agents (Windsurf, Copilot, Antigravity) fall back to the
+   text rules in this file and `.cursorrules` / `.windsurfrules` /
+   `copilot-instructions.md`. The framework repo itself uses the
+   Claude Code hook only.
 3. **Meaningful commit messages.** Describe what changed and why. Imperative
    mood, under 72 chars on the first line. Body explains the reason,
    not the diff (the diff is right there).

--- a/packages/cli/lib/create.js
+++ b/packages/cli/lib/create.js
@@ -275,6 +275,8 @@ export async function scaffoldApp(name, cwd, opts = {}) {
     // Cursor config + hooks
     '.cursor/hooks.json',
     '.cursor/hooks/nudge-uncommitted.sh',
+    // OpenCode plugins (loaded as TS by Bun at runtime)
+    '.opencode/plugins/nudge-uncommitted.ts',
     // Cross-agent config files
     '.cursorrules',
     '.windsurfrules',

--- a/packages/cli/templates/.opencode/plugins/nudge-uncommitted.ts
+++ b/packages/cli/templates/.opencode/plugins/nudge-uncommitted.ts
@@ -1,0 +1,62 @@
+/**
+ * OpenCode commit-frequency nudge plugin.
+ *
+ * Counterpart of the Claude Code, Gemini CLI, and Cursor hooks in
+ * `.claude/hooks/`, `.gemini/hooks/`, and `.cursor/hooks/`. After
+ * each edit/write tool call, counts uncommitted changes in the
+ * working tree. When the count crosses a threshold (default 4,
+ * override with the WEBJS_COMMIT_NUDGE_THRESHOLD env var), appends
+ * a reminder to the tool result so the agent sees it on the next
+ * turn.
+ *
+ * Soft nudge by design. Does NOT block the edit. The goal is to
+ * keep the agent honest about the "commit per logical unit" rule,
+ * not to interrupt valid work.
+ *
+ * Skipped on main/master (different guard rules cover that) and
+ * outside a git work tree.
+ *
+ * Auto-discovered by OpenCode at startup. No opencode.json entry
+ * needed. Lives in .opencode/plugins/ at the project root.
+ *
+ * Docs: https://opencode.ai/docs/plugins/
+ */
+import type { Plugin } from "@opencode-ai/plugin";
+
+export const NudgeUncommitted: Plugin = async ({ $ }) => {
+  const THRESHOLD = Number(process.env.WEBJS_COMMIT_NUDGE_THRESHOLD ?? 4);
+
+  return {
+    "tool.execute.after": async (input, output) => {
+      if (input.tool !== "edit" && input.tool !== "write") return;
+
+      let branch = "";
+      try {
+        branch = (await $`git symbolic-ref --short HEAD`.text()).trim();
+      } catch {
+        return; // not in a git work tree
+      }
+      if (branch === "main" || branch === "master") return;
+
+      let changed = 0;
+      try {
+        const out = (await $`git status --porcelain`.text()).trim();
+        changed = out === "" ? 0 : out.split("\n").length;
+      } catch {
+        return;
+      }
+      if (changed < THRESHOLD) return;
+
+      const reason =
+        `[webjs] You have ${changed} uncommitted changes on '${branch}'. ` +
+        `The webjs convention is small, focused commits per logical unit ` +
+        `(one feature, one fix, one rename, one doc rewrite). Before ` +
+        `continuing with more edits, group the current changes into a ` +
+        `meaningful commit. See AGENTS.md "Git workflow" for the rule ` +
+        `and the rationale. To raise the threshold for this hook in ` +
+        `long-running tasks, set WEBJS_COMMIT_NUDGE_THRESHOLD.`;
+
+      output.output = output.output ? `${output.output}\n\n${reason}` : reason;
+    },
+  };
+};

--- a/packages/cli/templates/AGENTS.md
+++ b/packages/cli/templates/AGENTS.md
@@ -686,9 +686,9 @@ composition, so a nested shell ends up dropped by the HTML parser.
    | Claude Code | `.claude/hooks/nudge-uncommitted.sh` (`PostToolUse`) | `.claude/settings.json` |
    | Gemini CLI | `.gemini/hooks/nudge-uncommitted.sh` (`AfterTool`) | `.gemini/settings.json` |
    | Cursor 1.7+ | `.cursor/hooks/nudge-uncommitted.sh` (`afterFileEdit`) | `.cursor/hooks.json` |
+   | OpenCode | `.opencode/plugins/nudge-uncommitted.ts` (`tool.execute.after`) | `.opencode/plugins/` |
    | Windsurf | text rule only (post-write hooks cannot inject context) | `.windsurfrules` |
    | GitHub Copilot | text rule only (no hooks API) | `.github/copilot-instructions.md` |
-   | OpenCode | text rule only for now (TS plugin support planned) | `AGENTS.md` |
    | Google Antigravity | text rule only (no hooks API) | `AGENTS.md` |
 
    Tool-agnostic fallback: `.hooks/pre-commit` runs `webjs test` + `webjs check`


### PR DESCRIPTION
## Summary

Closes the last gap in cross-agent commit-frequency enforcement. OpenCode users now get the same nudge that Claude Code, Gemini CLI, and Cursor users got in PR #13.

## Mechanism

OpenCode doesn't use shell-script hooks. It uses TS plugin modules loaded by Bun at runtime, registered automatically when dropped into `.opencode/plugins/`. The plugin exports an async function that returns a `Hooks` object whose handlers fire on lifecycle events.

The plugin in this PR:

1. Hooks `tool.execute.after`
2. Filters to `input.tool === "edit" || input.tool === "write"`
3. Runs `git status --porcelain` via the injected Bun shell (`$`)
4. If uncommitted file count crosses `WEBJS_COMMIT_NUDGE_THRESHOLD` (default 4), appends a reminder to `output.output` so the agent sees it on the next turn

Same threshold and same message text as the Claude / Gemini / Cursor hooks. Skipped on `main`/`master` and outside a git work tree.

## Updated enforcement matrix

| Agent | Mechanism |
|---|---|
| Claude Code | `.claude/hooks/nudge-uncommitted.sh` (`PostToolUse`) |
| Gemini CLI | `.gemini/hooks/nudge-uncommitted.sh` (`AfterTool`) |
| Cursor 1.7+ | `.cursor/hooks/nudge-uncommitted.sh` (`afterFileEdit`) |
| **OpenCode (new)** | **`.opencode/plugins/nudge-uncommitted.ts` (`tool.execute.after`)** |
| Windsurf | text rule only (post-write hooks can't inject context) |
| GitHub Copilot | text rule only (no hooks API) |
| Google Antigravity | text rule only (no hooks API) |

Plus the tool-agnostic `.hooks/pre-commit` that runs `webjs test` + `webjs check` for everyone.

## Commits

Two. First adds the plugin file plus the `create.js` copy-list entry. Second updates the enforcement matrix in framework `AGENTS.md` and scaffold `templates/AGENTS.md`.

## Test plan

- [x] Framework `npm test` passes on every commit (pre-commit gate)
- [x] Plugin signature matches `@opencode-ai/plugin` types per https://opencode.ai/docs/plugins/
- [ ] End-to-end test by running OpenCode against a scaffolded webjs app with 4+ uncommitted files would require an OpenCode install. Not done in this PR. The plugin logic mirrors the Claude / Gemini / Cursor hooks which are all known-good.

## References

- OpenCode plugins docs: https://opencode.ai/docs/plugins/
- Companion shell hooks shipped in PR #13