### PR TITLE
feat(check): no-server-imports-in-pages lint rule

### DIFF
--- a/packages/cli/templates/AGENTS.md
+++ b/packages/cli/templates/AGENTS.md
@@ -283,13 +283,34 @@ Scripts:
 - `predev` hook auto-runs `prisma generate` before `npm run dev`
 - `prestart` hook runs `prisma migrate deploy` before `npm start` (idempotent in prod)
 
-Always import the client from `lib/prisma.ts` (never `new PrismaClient()` directly -
-the singleton avoids opening a new connection on every dev-server reload):
+Always import the client from `lib/prisma.ts` (never `new PrismaClient()`
+directly). The singleton avoids opening a new connection on every dev-server
+reload.
 
 ```ts
+// modules/users/queries/list-users.server.ts     ← must be a .server.ts file
+'use server';
 import { prisma } from '../../../lib/prisma.ts';
-const users = await prisma.user.findMany();
+
+export async function listUsers() {
+  return prisma.user.findMany();
+}
 ```
+
+**Where prisma imports can live** (this is enforced by `webjs check`):
+
+| File | Can `import { prisma } from '...lib/prisma.ts'`? |
+|---|---|
+| `**/*.server.{js,ts}` (server actions, queries) | Yes |
+| `app/**/route.ts` (HTTP handlers) | Yes (server-only execution, file never reaches the browser) |
+| `middleware.ts` (root and per-segment) | Yes (server-only) |
+| `app/**/{page,layout,loading,error,not-found}.{js,ts}` | **No.** These files load in the browser to register components, and prisma's transitive imports would crash. The `no-server-imports-in-pages` lint rule catches this. |
+| `components/**/*.ts`, `modules/*/components/**/*.ts` | **No.** Components are isomorphic. The `no-server-imports-in-components` lint rule catches this. |
+
+The pattern for **any** file that loads in the browser (page, layout,
+component): wrap the prisma call in a `.server.{js,ts}` file and import
+the function. The dev server rewrites the import into an RPC stub for the
+browser, so the prisma source never reaches the client.
 
 To switch to Postgres or MySQL: change `provider` in `prisma/schema.prisma`
 and the `DATABASE_URL` in `.env`.

--- a/packages/server/src/check.js
+++ b/packages/server/src/check.js
@@ -65,6 +65,11 @@ export const RULES = [
       'Component files must not directly import from @prisma/client, node:*, or lib/ paths.',
   },
   {
+    name: 'no-server-imports-in-pages',
+    description:
+      'Page-like files under app/ (page, layout, loading, error, not-found) load in the browser as ES modules so that transitively imported components can register. They must not directly import @prisma/client, node:*, or lib/ paths because those would also load in the browser and crash. Wrap server-side access in a .server.{js,ts} file and import the function (the framework rewrites that import to an RPC stub on the browser side). Server-only files that never load in the browser, route.ts, middleware.ts, and metadata routes (sitemap.ts, robots.ts, manifest.ts, opengraph-image.ts, twitter-image.ts, apple-icon.ts, icon.ts), are exempt.',
+  },
+  {
     name: 'no-server-env-in-components',
     description:
       'Component files (under components/ or modules/*/components/) must not read non-public environment variables. process.env.X is allowed when X starts with WEBJS_PUBLIC_ (exposed to the browser via the SSR shim) or equals NODE_ENV (also defined in the browser). Any other process.env read in a component would leak the server-side value into the SSR\'d HTML, then read as undefined after hydration. Read server-only env vars in a page function, server action, or middleware (which never reach the browser as source) and pass derived values to the component as attributes.',
@@ -125,6 +130,32 @@ function isServerActionFile(filePath, content) {
 function isComponentFile(relPath) {
   const segments = relPath.split(sep);
   return segments.includes('components');
+}
+
+/**
+ * Check whether a file is a "page-like" module under app/, meaning a
+ * module that loads in the browser as part of the page bundle (so its
+ * top-level imports must be browser-safe). The framework loads these
+ * client-side to let transitively imported components register.
+ *
+ * Includes: page, layout, loading, error, not-found.
+ * Excludes: route (HTTP handler, server-only), middleware (server-only),
+ * metadata routes like sitemap, robots, manifest, icon, opengraph-image,
+ * twitter-image, apple-icon (all server-only).
+ *
+ * @param {string} relPath path relative to appDir
+ * @returns {boolean}
+ */
+function isPageLikeFile(relPath) {
+  const segments = relPath.split(sep);
+  if (segments[0] !== 'app') return false;
+  const filename = segments[segments.length - 1];
+  const base = filename.replace(/\.m?[jt]s$/, '');
+  return base === 'page'
+    || base === 'layout'
+    || base === 'loading'
+    || base === 'error'
+    || base === 'not-found';
 }
 
 /**
@@ -599,6 +630,36 @@ export async function checkConventions(appDir, opts) {
             file: rel,
             message: `Component imports ${label} directly; this will break in the browser`,
             fix: 'Move the import into a .server.{js,ts} file and call it via a server action',
+          });
+        }
+      }
+    }
+  }
+
+  // --- Rule: no-server-imports-in-pages ---
+  // page.ts, layout.ts, loading.ts, error.ts, not-found.ts all load
+  // in the browser as ES modules so that transitively imported
+  // components register. A top-level import of @prisma/client,
+  // node:*, or lib/ would also load in the browser and crash.
+  if (isRuleEnabled('no-server-imports-in-pages', overrides)) {
+    for (const { abs, rel, content } of files) {
+      if (!isPageLikeFile(rel)) continue;
+      if (isServerActionFile(abs, content)) continue;
+
+      const importPatterns = [
+        { re: /import\s+.*from\s+['"]@prisma\/client['"]/gm, label: '@prisma/client' },
+        { re: /import\s+.*from\s+['"]node:[^'"]+['"]/gm, label: 'node:* built-in' },
+        { re: /import\s+.*from\s+['"]\.{0,2}\/lib\/[^'"]*['"]/gm, label: 'lib/' },
+      ];
+
+      for (const { re, label } of importPatterns) {
+        const match = re.exec(content);
+        if (match) {
+          violations.push({
+            rule: 'no-server-imports-in-pages',
+            file: rel,
+            message: `Page-like file imports ${label} directly; this loads in the browser and will crash`,
+            fix: 'Wrap the access in a .server.{js,ts} file and import the function (the framework rewrites that import to an RPC stub on the browser side)',
           });
         }
       }

--- a/test/check.test.js
+++ b/test/check.test.js
@@ -482,6 +482,175 @@ test('no-server-imports-in-components: skips .server.ts files (they may import a
   }
 });
 
+/* -------------------- no-server-imports-in-pages -------------------- */
+
+test('no-server-imports-in-pages: flags @prisma/client in app/page.ts', async () => {
+  const appDir = await makeTempApp();
+  try {
+    await mkdir(join(appDir, 'app'), { recursive: true });
+    await writeFile(
+      join(appDir, 'app', 'page.ts'),
+      `import { prisma } from '@prisma/client';\nexport default function Page() { return null; }\n`,
+    );
+    const violations = await checkConventions(appDir);
+    const v = violations.find((x) => x.rule === 'no-server-imports-in-pages');
+    assert.ok(v, 'page.ts must flag @prisma/client import');
+    assert.match(v.message, /@prisma\/client/);
+  } finally {
+    await rm(appDir, { recursive: true, force: true });
+  }
+});
+
+test('no-server-imports-in-pages: flags node:* in app/layout.ts', async () => {
+  const appDir = await makeTempApp();
+  try {
+    await mkdir(join(appDir, 'app'), { recursive: true });
+    await writeFile(
+      join(appDir, 'app', 'layout.ts'),
+      `import { readFile } from 'node:fs/promises';\nexport default function Layout() {}\n`,
+    );
+    const violations = await checkConventions(appDir);
+    const v = violations.find((x) => x.rule === 'no-server-imports-in-pages');
+    assert.ok(v, 'layout.ts must flag node:* import');
+    assert.match(v.message, /node:/);
+  } finally {
+    await rm(appDir, { recursive: true, force: true });
+  }
+});
+
+test('no-server-imports-in-pages: flags lib/ imports in app/loading.ts and error.ts and not-found.ts', async () => {
+  const appDir = await makeTempApp();
+  try {
+    await mkdir(join(appDir, 'app'), { recursive: true });
+    await mkdir(join(appDir, 'lib'), { recursive: true });
+    await writeFile(join(appDir, 'lib', 'prisma.ts'), `export const prisma = {};\n`);
+    await writeFile(
+      join(appDir, 'app', 'loading.ts'),
+      `import { prisma } from '../lib/prisma.ts';\nexport default function L() {}\n`,
+    );
+    await writeFile(
+      join(appDir, 'app', 'error.ts'),
+      `import { prisma } from '../lib/prisma.ts';\nexport default function E() {}\n`,
+    );
+    await writeFile(
+      join(appDir, 'app', 'not-found.ts'),
+      `import { prisma } from '../lib/prisma.ts';\nexport default function NF() {}\n`,
+    );
+    const violations = await checkConventions(appDir);
+    const flagged = violations.filter((v) => v.rule === 'no-server-imports-in-pages');
+    assert.equal(flagged.length, 3, 'one violation per file');
+    const files = flagged.map((v) => v.file).sort();
+    assert.deepEqual(files, [
+      join('app', 'error.ts'),
+      join('app', 'loading.ts'),
+      join('app', 'not-found.ts'),
+    ]);
+  } finally {
+    await rm(appDir, { recursive: true, force: true });
+  }
+});
+
+test('no-server-imports-in-pages: EXEMPTS route.ts (server-only HTTP handler)', async () => {
+  const appDir = await makeTempApp();
+  try {
+    await mkdir(join(appDir, 'app', 'api', 'users'), { recursive: true });
+    await writeFile(
+      join(appDir, 'app', 'api', 'users', 'route.ts'),
+      `import { prisma } from '@prisma/client';\nexport async function GET() { return prisma.user.findMany(); }\n`,
+    );
+    const violations = await checkConventions(appDir);
+    assert.equal(violations.find((v) => v.rule === 'no-server-imports-in-pages'), undefined);
+  } finally {
+    await rm(appDir, { recursive: true, force: true });
+  }
+});
+
+test('no-server-imports-in-pages: EXEMPTS middleware.ts (server-only)', async () => {
+  const appDir = await makeTempApp();
+  try {
+    await writeFile(
+      join(appDir, 'middleware.ts'),
+      `import { prisma } from '@prisma/client';\nexport default async function mw(req, next) { return next(); }\n`,
+    );
+    // Also test app/middleware.ts location.
+    await mkdir(join(appDir, 'app', 'admin'), { recursive: true });
+    await writeFile(
+      join(appDir, 'app', 'admin', 'middleware.ts'),
+      `import { prisma } from '@prisma/client';\nexport default async function mw(req, next) { return next(); }\n`,
+    );
+    const violations = await checkConventions(appDir);
+    assert.equal(violations.find((v) => v.rule === 'no-server-imports-in-pages'), undefined);
+  } finally {
+    await rm(appDir, { recursive: true, force: true });
+  }
+});
+
+test('no-server-imports-in-pages: EXEMPTS metadata routes (sitemap, robots, etc.)', async () => {
+  const appDir = await makeTempApp();
+  try {
+    await mkdir(join(appDir, 'app'), { recursive: true });
+    for (const name of ['sitemap.ts', 'robots.ts', 'manifest.ts', 'icon.ts', 'opengraph-image.ts', 'twitter-image.ts', 'apple-icon.ts']) {
+      await writeFile(
+        join(appDir, 'app', name),
+        `import { prisma } from '@prisma/client';\nexport default function gen() {}\n`,
+      );
+    }
+    const violations = await checkConventions(appDir);
+    assert.equal(violations.find((v) => v.rule === 'no-server-imports-in-pages'), undefined);
+  } finally {
+    await rm(appDir, { recursive: true, force: true });
+  }
+});
+
+test('no-server-imports-in-pages: EXEMPTS page.server.ts (server-only by convention)', async () => {
+  // A page file with the .server.ts suffix is server-only by file
+  // convention. Browser never loads it, so direct prisma is fine.
+  // (Unusual pattern but the rule shouldn't fire.)
+  const appDir = await makeTempApp();
+  try {
+    await mkdir(join(appDir, 'app'), { recursive: true });
+    await writeFile(
+      join(appDir, 'app', 'page.server.ts'),
+      `'use server';\nimport { prisma } from '@prisma/client';\nexport default function P() {}\n`,
+    );
+    const violations = await checkConventions(appDir);
+    assert.equal(violations.find((v) => v.rule === 'no-server-imports-in-pages'), undefined);
+  } finally {
+    await rm(appDir, { recursive: true, force: true });
+  }
+});
+
+test('no-server-imports-in-pages: page.ts WITHOUT a server import passes cleanly', async () => {
+  const appDir = await makeTempApp();
+  try {
+    await mkdir(join(appDir, 'app'), { recursive: true });
+    await writeFile(
+      join(appDir, 'app', 'page.ts'),
+      `import { html } from '@webjskit/core';\nexport default function Page() { return html\`<p>hello</p>\`; }\n`,
+    );
+    const violations = await checkConventions(appDir);
+    assert.equal(violations.find((v) => v.rule === 'no-server-imports-in-pages'), undefined);
+  } finally {
+    await rm(appDir, { recursive: true, force: true });
+  }
+});
+
+test('no-server-imports-in-pages: nested page in route group still flagged', async () => {
+  const appDir = await makeTempApp();
+  try {
+    await mkdir(join(appDir, 'app', '(marketing)', 'about'), { recursive: true });
+    await writeFile(
+      join(appDir, 'app', '(marketing)', 'about', 'page.ts'),
+      `import { prisma } from '@prisma/client';\nexport default function Page() {}\n`,
+    );
+    const violations = await checkConventions(appDir);
+    const v = violations.find((x) => x.rule === 'no-server-imports-in-pages');
+    assert.ok(v, 'nested page.ts under (route-group) must still flag');
+  } finally {
+    await rm(appDir, { recursive: true, force: true });
+  }
+});
+
 /* -------------------- no-server-env-in-components -------------------- */
 
 test('no-server-env-in-components: flags non-public process.env reads in components', async () => {


### PR DESCRIPTION
## Summary

Closes a long-standing enforcement gap. `AGENTS.md` has long said "Page modules also load on the client. Keep top-level imports browser-safe. Do NOT import `@prisma/client`, `node:fs`, etc. directly. Go through a server action." That rule was documented but never programmatically enforced. A user could naively write `import { prisma } from '../lib/prisma.ts'` at the top of `app/page.ts` and ship a browser-crashing app while `webjs check` passed.

This PR adds `no-server-imports-in-pages`, a near-sibling of the existing `no-server-imports-in-components` rule, scoped to page-like files.

## What counts as "page-like"

Page-like files load in the browser as ES modules so transitively imported components can register. Server-only files do NOT load in the browser and stay exempt.

| File | Rule fires? |
|---|---|
| `app/**/page.{js,ts}` | Yes |
| `app/**/layout.{js,ts}` | Yes |
| `app/**/loading.{js,ts}` | Yes |
| `app/**/error.{js,ts}` | Yes |
| `app/**/not-found.{js,ts}` | Yes |
| `app/**/route.{js,ts}` | No (HTTP handler, server-only) |
| `middleware.{js,ts}` (root or per-segment) | No (server-only) |
| `app/sitemap.{js,ts}`, `robots.{js,ts}`, `manifest.{js,ts}`, `icon.{js,ts}`, `opengraph-image.{js,ts}`, `twitter-image.{js,ts}`, `apple-icon.{js,ts}` | No (metadata routes, server-only) |
| `**/*.server.{js,ts}` or files with `'use server'` directive | No (server-only by file convention) |

## What gets flagged

Same import patterns as `no-server-imports-in-components`:
- `@prisma/client`
- `node:*` built-ins
- `lib/*` paths

## Tests

Nine new tests in `test/check.test.js` (940 baseline plus 9 new, all pass):
- Positive: `@prisma/client` in `page.ts`, `node:*` in `layout.ts`, `lib/` in `loading.ts` + `error.ts` + `not-found.ts`, nested `page.ts` under route groups
- Exempt: `route.ts`, `middleware.ts` (top-level and per-segment), all metadata routes, `page.server.ts`
- Clean: plain `page.ts` with only safe imports passes

## Docs

`packages/cli/templates/AGENTS.md` Database section had a misleading example. The previous example imported prisma without specifying the file location, so a reader could place it in `app/page.ts`. Now the example shows the `.server.ts` wrapper pattern explicitly and includes a table of which file types can import prisma directly.

## Commits (3)

1. `feat(check)`: the rule
2. `test`: 9 cases covering positive flags and every exempt category
3. `docs(scaffold)`: clarify the prisma-import boundary with the new rule cited

## Test plan

- [x] `npm test`, all pass (framework pre-commit ran on every commit on this branch)
- [x] Rule fires for every page-like file in `app/`
- [x] Rule does NOT fire for the exempt categories
- [x] The pre-existing `no-server-imports-in-components` is unchanged (separate rule, narrower scope)