### PR TITLE
feat(ui): Tier-2 components -> WebComponent + render() + <slot>

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjskit/ui",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "description": "An AI-first component library - class-helper functions for visuals, custom elements only where state matters. Source-copied into your repo, you own it. Works with any Tailwind v4 project.",
   "bin": {

--- a/packages/ui/packages/registry/components/alert-dialog.ts
+++ b/packages/ui/packages/registry/components/alert-dialog.ts
@@ -144,6 +144,10 @@ export class UiAlertDialog extends WebComponent {
   show(): void { this.open = true; }
   hide(): void { this.open = false; }
 
+  // Back-compat getter: tests + consumer code that read `el.isOpen`
+  // keep working alongside the reactive `open` prop.
+  get isOpen(): boolean { return this.open; }
+
   render() {
     this.setAttribute('data-state', this.open ? 'open' : 'closed');
     queueMicrotask(() => this._afterRender());

--- a/packages/ui/packages/registry/components/alert-dialog.ts
+++ b/packages/ui/packages/registry/components/alert-dialog.ts
@@ -5,14 +5,10 @@
  *
  * APG pattern: https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/
  *
- * The custom element wraps <ui-alert-dialog-content> inside a native
- * <dialog> on connection and calls showModal() to open. Native Escape
- * behavior is cancelled via the dialog's `cancel` event, the user
- * MUST choose Cancel or Action. No click-to-close on the backdrop
- * (matches shadcn).
- *
- * The previous version's hand-rolled focus management is gone, the
- * native <dialog>'s focus trap and focus-restore behavior cover it.
+ * Composition follows the same named-slot pattern as dialog.ts:
+ * the rendered template emits a <dialog> with a named slot inside,
+ * and the user's authored <ui-alert-dialog-content> is routed there
+ * by setting slot="alert-dialog-content" on it during connection.
  *
  * shadcn parity:
  *   AlertDialog, AlertDialogTrigger, AlertDialogContent (size: default | sm),
@@ -38,7 +34,8 @@
  *
  * Design tokens used: --background, --border, --muted-foreground.
  */
-import { cn, Base, defineElement } from '../lib/utils.ts';
+import { WebComponent, html } from '@webjskit/core';
+import { cn } from '../lib/utils.ts';
 import { buttonClass, type ButtonVariant, type ButtonSize } from './button.ts';
 
 export const alertDialogContentClass = (): string =>
@@ -54,23 +51,11 @@ export const alertDialogTitleClass = (): string => 'text-lg font-semibold';
 
 export const alertDialogDescriptionClass = (): string => 'text-sm text-muted-foreground';
 
-// Pre-hydration paint fallback. Hides the content panel until JS marks
-// the host as `[open]` (Tailwind cannot author classes on the user's
-// <ui-alert-dialog> at SSR time, so this stays as a selector-based
-// injection). Everything specific to the native <dialog> wrapper goes
-// through Tailwind classes on the element, see NATIVE_DIALOG_CLASS below.
 const STYLES = `
 ui-alert-dialog:not([open]) ui-alert-dialog-content { display: none !important; }
 ui-alert-dialog-content { display: grid; }
 `;
 
-// Tailwind class string applied to the programmatic <dialog> wrapper.
-// `border-0 bg-transparent p-0 m-0 w-0 h-0 max-w-none max-h-none
-// overflow-visible text-inherit` clears the UA defaults so the <dialog>
-// is an invisible top-layer host; the visible panel is rendered by
-// <ui-alert-dialog-content> with alertDialogContentClass.
-// `backdrop:bg-black/50` paints the overlay via the Tailwind 4
-// `backdrop:` variant.
 const NATIVE_DIALOG_CLASS = 'border-0 bg-transparent p-0 m-0 w-0 h-0 max-w-none max-h-none overflow-visible text-inherit backdrop:bg-black/50';
 
 function installStyles(): void {
@@ -113,125 +98,148 @@ function unlockScroll(): void {
 // <ui-alert-dialog>
 // --------------------------------------------------------------------------
 
-export class UiAlertDialog extends Base {
-  static get observedAttributes(): string[] {
-    return ['open'];
-  }
-
-  private _native: HTMLDialogElement | null = null;
-
-  // Cancel the native Escape-to-close. The browser fires a `cancel` event
-  // when the user presses Escape on an open dialog; preventDefault stops
-  // the subsequent close. No click-to-close on the backdrop either (intentional
-  // omission, alert dialogs require an explicit Cancel/Action choice).
-  private _onNativeCancel = (e: Event): void => e.preventDefault();
-  private _onNativeClose = (): void => {
-    if (this.isOpen) this.removeAttribute('open');
+export class UiAlertDialog extends WebComponent {
+  static properties = {
+    open: { type: Boolean, reflect: true },
   };
+  declare open: boolean;
+
+  _native: HTMLDialogElement | null = null;
+  _lastOpen: boolean = false;
+
+  constructor() {
+    super();
+    this.open = false;
+  }
 
   connectedCallback(): void {
     installStyles();
+    const content = this.querySelector<HTMLElement>(':scope > ui-alert-dialog-content');
+    if (content && !content.hasAttribute('slot')) {
+      content.setAttribute('slot', 'alert-dialog-content');
+    }
+    this.querySelector<HTMLElement>(':scope > ui-alert-dialog-overlay')?.remove();
+    super.connectedCallback?.();
+  }
+
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'alert-dialog');
-    this._wrap();
-    this._reflect();
-    if (this.isOpen) this._setup();
+    this._native = this.querySelector<HTMLDialogElement>('dialog[data-slot="alert-dialog-native"]');
+    if (this._native) {
+      this._native.addEventListener('cancel', this._onNativeCancel);
+      this._native.addEventListener('close', this._onNativeClose);
+    }
+    if (this.open) this._setup();
   }
 
   disconnectedCallback(): void {
-    if (this.isOpen) this._teardown();
+    if (this.open) this._teardown();
     if (this._native) {
       this._native.removeEventListener('cancel', this._onNativeCancel);
       this._native.removeEventListener('close', this._onNativeClose);
     }
+    super.disconnectedCallback?.();
   }
 
-  attributeChangedCallback(name: string, oldVal: string | null, newVal: string | null): void {
-    if (name === 'open' && oldVal !== newVal) {
-      this._reflect();
-      if (newVal !== null) this._setup();
+  show(): void { this.open = true; }
+  hide(): void { this.open = false; }
+
+  render() {
+    this.setAttribute('data-state', this.open ? 'open' : 'closed');
+    queueMicrotask(() => this._afterRender());
+    return html`
+      <slot></slot>
+      <dialog data-slot="alert-dialog-native" class=${NATIVE_DIALOG_CLASS}>
+        <slot name="alert-dialog-content"></slot>
+      </dialog>
+    `;
+  }
+
+  _afterRender(): void {
+    const content = this.querySelector<HTMLElement>('ui-alert-dialog-content');
+    if (content) {
+      content.setAttribute('data-state', this.open ? 'open' : 'closed');
+      content.setAttribute('role', 'alertdialog');
+      content.setAttribute('aria-modal', 'true');
+    }
+    if (this._lastOpen !== this.open) {
+      this._lastOpen = this.open;
+      if (this.open) this._setup();
       else this._teardown();
     }
   }
 
-  show(): void {
-    this.setAttribute('open', '');
-  }
-
-  hide(): void {
-    this.removeAttribute('open');
-  }
-
-  private get isOpen(): boolean {
-    return this.hasAttribute('open');
-  }
-
-  private _wrap(): void {
-    const content = this.querySelector<HTMLElement>(':scope > ui-alert-dialog-content');
-    if (!content) return;
-    if (content.parentElement?.tagName === 'DIALOG') {
-      this._native = content.parentElement as HTMLDialogElement;
-    } else {
-      const dlg = document.createElement('dialog');
-      dlg.setAttribute('data-slot', 'alert-dialog-native');
-      dlg.className = NATIVE_DIALOG_CLASS;
-      content.replaceWith(dlg);
-      dlg.appendChild(content);
-      this._native = dlg;
-    }
-    // The legacy <ui-alert-dialog-overlay> is no longer needed; ::backdrop covers it.
-    this.querySelector<HTMLElement>(':scope > ui-alert-dialog-overlay')?.remove();
-    this._native.addEventListener('cancel', this._onNativeCancel);
-    this._native.addEventListener('close', this._onNativeClose);
-    // No click-to-close on backdrop. Alert dialogs require explicit choice.
-  }
-
-  private _reflect(): void {
-    const open = this.isOpen;
-    this.setAttribute('data-state', open ? 'open' : 'closed');
-    const content = this.querySelector<HTMLElement>('ui-alert-dialog-content');
-    if (content) {
-      content.setAttribute('data-state', open ? 'open' : 'closed');
-      content.setAttribute('role', 'alertdialog');
-      content.setAttribute('aria-modal', 'true');
-    }
-  }
-
-  private _setup(): void {
+  _setup(): void {
     if (!this._native) return;
     lockScroll();
     if (!this._native.open) this._native.showModal();
   }
 
-  private _teardown(): void {
+  _teardown(): void {
     unlockScroll();
     if (this._native?.open) this._native.close();
   }
-}
-defineElement('ui-alert-dialog', UiAlertDialog);
 
-export class UiAlertDialogTrigger extends Base {
-  connectedCallback(): void {
+  // Cancel the native Escape-to-close. The browser fires a `cancel` event
+  // when the user presses Escape on an open dialog; preventDefault stops
+  // the subsequent close. No click-to-close on the backdrop either (intentional
+  // omission, alert dialogs require an explicit Cancel/Action choice).
+  _onNativeCancel = (e: Event): void => e.preventDefault();
+  _onNativeClose = (): void => {
+    if (this.open) this.open = false;
+  };
+}
+UiAlertDialog.register('ui-alert-dialog');
+
+export class UiAlertDialogTrigger extends WebComponent {
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'alert-dialog-trigger');
     this.addEventListener('click', this._onClick);
   }
+
   disconnectedCallback(): void {
     this.removeEventListener('click', this._onClick);
+    super.disconnectedCallback?.();
   }
-  private _onClick = (): void => (this.closest('ui-alert-dialog') as UiAlertDialog | null)?.show();
-}
-defineElement('ui-alert-dialog-trigger', UiAlertDialogTrigger);
 
-export class UiAlertDialogContent extends Base {
+  render() {
+    return html`<slot></slot>`;
+  }
+
+  _onClick = (): void => (this.closest('ui-alert-dialog') as UiAlertDialog | null)?.show();
+}
+UiAlertDialogTrigger.register('ui-alert-dialog-trigger');
+
+export class UiAlertDialogContent extends WebComponent {
+  static properties = {
+    size: { type: String, reflect: true },
+  };
+  declare size: 'default' | 'sm';
+
+  _userClass: string = '';
+
+  constructor() {
+    super();
+    this.size = 'default';
+  }
+
   connectedCallback(): void {
+    this._userClass = this.getAttribute('class') ?? '';
+    super.connectedCallback?.();
+  }
+
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'alert-dialog-content');
-    if (!this.hasAttribute('size')) this.setAttribute('size', 'default');
-    this.setAttribute('data-size', this.getAttribute('size') ?? 'default');
     this.setAttribute('tabindex', '-1');
-    const userClass = this.getAttribute('class') ?? '';
-    this.className = cn(alertDialogContentClass(), userClass);
+  }
+
+  render() {
+    this.setAttribute('data-size', this.size);
+    this.className = cn(alertDialogContentClass(), this._userClass);
+    return html`<slot></slot>`;
   }
 }
-defineElement('ui-alert-dialog-content', UiAlertDialogContent);
+UiAlertDialogContent.register('ui-alert-dialog-content');
 
 // shadcn's <AlertDialogAction> and <AlertDialogCancel> ARE button-styled
 // elements with forwarded `variant` and `size` props from the Button
@@ -245,11 +253,10 @@ defineElement('ui-alert-dialog-content', UiAlertDialogContent);
 // wrap-a-button pattern), we don't restyle the host. Their button keeps
 // its own buttonClass call and the host stays a transparent wrapper.
 
-function applyAlertDialogButton(host: HTMLElement, defaultVariant: ButtonVariant): void {
+function applyAlertDialogButton(host: HTMLElement, defaultVariant: ButtonVariant, userClass: string): void {
   if (host.querySelector(':scope > button')) return;
   const variant = (host.getAttribute('variant') ?? defaultVariant) as ButtonVariant;
   const size = (host.getAttribute('size') ?? 'default') as ButtonSize;
-  const userClass = host.getAttribute('class') ?? '';
   host.className = cn(buttonClass({ variant, size }), userClass);
   host.setAttribute('role', 'button');
   if (!host.hasAttribute('tabindex')) host.setAttribute('tabindex', '0');
@@ -262,32 +269,60 @@ function alertDialogButtonKeydown(this: HTMLElement, e: KeyboardEvent): void {
   }
 }
 
-export class UiAlertDialogCancel extends Base {
-  connectedCallback(): void {
-    this.setAttribute('data-slot', 'alert-dialog-cancel');
-    applyAlertDialogButton(this, 'outline');
-    this.addEventListener('click', this._onClick);
-    this.addEventListener('keydown', alertDialogButtonKeydown as EventListener);
-  }
-  disconnectedCallback(): void {
-    this.removeEventListener('click', this._onClick);
-    this.removeEventListener('keydown', alertDialogButtonKeydown as EventListener);
-  }
-  private _onClick = (): void => (this.closest('ui-alert-dialog') as UiAlertDialog | null)?.hide();
-}
-defineElement('ui-alert-dialog-cancel', UiAlertDialogCancel);
+export class UiAlertDialogCancel extends WebComponent {
+  _userClass: string = '';
 
-export class UiAlertDialogAction extends Base {
   connectedCallback(): void {
-    this.setAttribute('data-slot', 'alert-dialog-action');
-    applyAlertDialogButton(this, 'default');
+    this._userClass = this.getAttribute('class') ?? '';
+    super.connectedCallback?.();
+  }
+
+  firstUpdated(): void {
+    this.setAttribute('data-slot', 'alert-dialog-cancel');
     this.addEventListener('click', this._onClick);
     this.addEventListener('keydown', alertDialogButtonKeydown as EventListener);
   }
+
   disconnectedCallback(): void {
     this.removeEventListener('click', this._onClick);
     this.removeEventListener('keydown', alertDialogButtonKeydown as EventListener);
+    super.disconnectedCallback?.();
   }
-  private _onClick = (): void => (this.closest('ui-alert-dialog') as UiAlertDialog | null)?.hide();
+
+  render() {
+    applyAlertDialogButton(this, 'outline', this._userClass);
+    return html`<slot></slot>`;
+  }
+
+  _onClick = (): void => (this.closest('ui-alert-dialog') as UiAlertDialog | null)?.hide();
 }
-defineElement('ui-alert-dialog-action', UiAlertDialogAction);
+UiAlertDialogCancel.register('ui-alert-dialog-cancel');
+
+export class UiAlertDialogAction extends WebComponent {
+  _userClass: string = '';
+
+  connectedCallback(): void {
+    this._userClass = this.getAttribute('class') ?? '';
+    super.connectedCallback?.();
+  }
+
+  firstUpdated(): void {
+    this.setAttribute('data-slot', 'alert-dialog-action');
+    this.addEventListener('click', this._onClick);
+    this.addEventListener('keydown', alertDialogButtonKeydown as EventListener);
+  }
+
+  disconnectedCallback(): void {
+    this.removeEventListener('click', this._onClick);
+    this.removeEventListener('keydown', alertDialogButtonKeydown as EventListener);
+    super.disconnectedCallback?.();
+  }
+
+  render() {
+    applyAlertDialogButton(this, 'default', this._userClass);
+    return html`<slot></slot>`;
+  }
+
+  _onClick = (): void => (this.closest('ui-alert-dialog') as UiAlertDialog | null)?.hide();
+}
+UiAlertDialogAction.register('ui-alert-dialog-action');

--- a/packages/ui/packages/registry/components/dialog.ts
+++ b/packages/ui/packages/registry/components/dialog.ts
@@ -199,6 +199,11 @@ export class UiDialog extends WebComponent {
   hide(): void { this.open = false; }
   toggle(): void { this.open = !this.open; }
 
+  // Back-compat getter: the previous API exposed `isOpen` while the
+  // new reactive prop is `open`. Tests + consumer code that read
+  // `dialog.isOpen` keep working.
+  get isOpen(): boolean { return this.open; }
+
   render() {
     this.setAttribute('data-state', this.open ? 'open' : 'closed');
     queueMicrotask(() => this._afterRender());

--- a/packages/ui/packages/registry/components/dialog.ts
+++ b/packages/ui/packages/registry/components/dialog.ts
@@ -10,15 +10,13 @@
  *   - Escape-to-close via the cancel event
  *   - Background made inert (clicks pass through to nothing)
  *
- * On connection the component reparents <ui-dialog-content> inside a
- * programmatically-created <dialog> so we can call showModal() on it.
- * The <dialog> is transparent and zero-sized; the visible panel is
- * <ui-dialog-content> with its `position: fixed; top: 50%; left: 50%`
- * classes, which is what gets the shadow and rounded border.
- *
- * The previous version's focus trap, Tab cycling, Escape listener,
- * `<ui-dialog-overlay>` element, and document-level keydown handler are
- * all gone, the platform owns them now.
+ * Component composition uses named slots: the rendered template emits
+ * a programmatic <dialog> with `<slot name="dialog-content">` inside.
+ * The user authors `<ui-dialog-content>` as a normal child; the
+ * component sets `slot="dialog-content"` on it during connection so
+ * the slot machinery routes it inside the <dialog> automatically.
+ * Triggers and other children stay in the default slot, outside the
+ * <dialog>.
  *
  * shadcn parity:
  *   <Dialog>            → <ui-dialog open>
@@ -61,7 +59,8 @@
  * Design tokens used: --background, --border, --muted-foreground.
  */
 
-import { cn, Base, defineElement } from '../lib/utils.ts';
+import { WebComponent, html } from '@webjskit/core';
+import { cn } from '../lib/utils.ts';
 import { buttonClass } from './button.ts';
 
 // --------------------------------------------------------------------------
@@ -91,10 +90,7 @@ export const dialogContentClass = (): string =>
 // need explicit values, which Tailwind cannot supply on tags the user
 // authors. Once upgraded, the native <dialog> wrapper takes over:
 // closed `<dialog>` is UA `display: none`, opened via showModal() is
-// `display: block` in the top layer. Everything specific to the native
-// <dialog> wrapper (background, border, padding reset; ::backdrop) is
-// applied via Tailwind classes on the dynamically-created element, see
-// NATIVE_DIALOG_CLASS below.
+// `display: block` in the top layer.
 // --------------------------------------------------------------------------
 
 const STYLES = `
@@ -103,15 +99,11 @@ ui-dialog[open] { display: contents; }
 ui-dialog-content { display: grid; }
 `;
 
-// Tailwind class string applied to the programmatic <dialog> element
-// in _wrap(). Replaces the prior ui-dialog dialog[...] CSS rule one
-// utility at a time:
-//   - border-0 bg-transparent p-0 m-0 w-0 h-0 max-w-none max-h-none
-//     overflow-visible text-inherit  clears the UA defaults so the
-//     <dialog> itself becomes an invisible top-layer host; the visible
-//     box is rendered by <ui-dialog-content> with dialogContentClass.
-//   - backdrop:bg-black/50  styles the `::backdrop` pseudo-element via
-//     the Tailwind 4 `backdrop:` variant.
+// Tailwind class string applied to the rendered <dialog> element.
+// Clears the UA defaults so the <dialog> itself becomes an invisible
+// top-layer host. The visible box is rendered by <ui-dialog-content>
+// with dialogContentClass. backdrop: variant styles the ::backdrop
+// pseudo-element.
 const NATIVE_DIALOG_CLASS = 'border-0 bg-transparent p-0 m-0 w-0 h-0 max-w-none max-h-none overflow-visible text-inherit backdrop:bg-black/50';
 
 function installStyles(): void {
@@ -156,127 +148,130 @@ function unlockScroll(): void {
 // <ui-dialog>
 // --------------------------------------------------------------------------
 
-export class UiDialog extends Base {
-  static get observedAttributes(): string[] {
-    return ['open'];
-  }
+export class UiDialog extends WebComponent {
+  static properties = {
+    open: { type: Boolean, reflect: true },
+  };
+  declare open: boolean;
 
-  private _native: HTMLDialogElement | null = null;
-  private _onNativeClose = (): void => {
-    if (this.isOpen) this.removeAttribute('open');
-  };
-  private _onNativeClick = (e: MouseEvent): void => {
-    if (e.target === this._native) this.hide();
-  };
+  _native: HTMLDialogElement | null = null;
+  _lastOpen: boolean = false;
+
+  constructor() {
+    super();
+    this.open = false;
+  }
 
   connectedCallback(): void {
     installStyles();
+    // Route the authored <ui-dialog-content> child into the named slot
+    // inside the rendered <dialog>. This happens BEFORE the framework's
+    // slot machinery captures children, so projection is automatic.
+    const content = this.querySelector<HTMLElement>(':scope > ui-dialog-content');
+    if (content && !content.hasAttribute('slot')) {
+      content.setAttribute('slot', 'dialog-content');
+    }
+    // Remove the legacy overlay; native ::backdrop handles it.
+    this.querySelector<HTMLElement>(':scope > ui-dialog-overlay')?.remove();
+    super.connectedCallback?.();
+  }
+
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'dialog');
-    this._wrap();
-    this._reflect();
-    if (this.isOpen) this._setup();
+    this._native = this.querySelector<HTMLDialogElement>('dialog[data-slot="dialog-native"]');
+    if (this._native) {
+      this._native.addEventListener('close', this._onNativeClose);
+      this._native.addEventListener('click', this._onNativeClick as EventListener);
+    }
+    if (this.open) this._setup();
   }
 
   disconnectedCallback(): void {
-    if (this.isOpen) this._teardown();
+    if (this.open) this._teardown();
     if (this._native) {
       this._native.removeEventListener('close', this._onNativeClose);
       this._native.removeEventListener('click', this._onNativeClick as EventListener);
     }
+    super.disconnectedCallback?.();
   }
 
-  attributeChangedCallback(name: string, oldVal: string | null, newVal: string | null): void {
-    if (name === 'open' && oldVal !== newVal) {
-      this._reflect();
-      if (newVal !== null) this._setup();
+  show(): void { this.open = true; }
+  hide(): void { this.open = false; }
+  toggle(): void { this.open = !this.open; }
+
+  render() {
+    this.setAttribute('data-state', this.open ? 'open' : 'closed');
+    queueMicrotask(() => this._afterRender());
+    return html`
+      <slot></slot>
+      <dialog data-slot="dialog-native" class=${NATIVE_DIALOG_CLASS}>
+        <slot name="dialog-content"></slot>
+      </dialog>
+    `;
+  }
+
+  _afterRender(): void {
+    const content = this.querySelector<HTMLElement>('ui-dialog-content');
+    if (content) {
+      content.setAttribute('data-state', this.open ? 'open' : 'closed');
+      content.setAttribute('role', 'dialog');
+      content.setAttribute('aria-modal', 'true');
+    }
+    if (this._lastOpen !== this.open) {
+      this._lastOpen = this.open;
+      if (this.open) this._setup();
       else this._teardown();
       this.dispatchEvent(
-        new CustomEvent('ui-open-change', { detail: { open: this.isOpen }, bubbles: true }),
+        new CustomEvent('ui-open-change', { detail: { open: this.open }, bubbles: true }),
       );
     }
   }
 
-  get isOpen(): boolean {
-    return this.hasAttribute('open');
-  }
-
-  set isOpen(v: boolean) {
-    if (v) this.setAttribute('open', '');
-    else this.removeAttribute('open');
-  }
-
-  show(): void {
-    this.isOpen = true;
-  }
-
-  hide(): void {
-    this.isOpen = false;
-  }
-
-  toggle(): void {
-    this.isOpen = !this.isOpen;
-  }
-
-  private _wrap(): void {
-    const content = this.querySelector<HTMLElement>(':scope > ui-dialog-content');
-    if (!content) return;
-    // Already wrapped (HMR re-attach or repeated connectedCallback).
-    if (content.parentElement?.tagName === 'DIALOG') {
-      this._native = content.parentElement as HTMLDialogElement;
-    } else {
-      const dlg = document.createElement('dialog');
-      dlg.setAttribute('data-slot', 'dialog-native');
-      dlg.className = NATIVE_DIALOG_CLASS;
-      content.replaceWith(dlg);
-      dlg.appendChild(content);
-      this._native = dlg;
-    }
-    // The legacy <ui-dialog-overlay> is no longer needed; ::backdrop covers it.
-    this.querySelector<HTMLElement>(':scope > ui-dialog-overlay')?.remove();
-    this._native.addEventListener('close', this._onNativeClose);
-    this._native.addEventListener('click', this._onNativeClick as EventListener);
-  }
-
-  private _reflect(): void {
-    this.setAttribute('data-state', this.isOpen ? 'open' : 'closed');
-    const content = this.querySelector<HTMLElement>('ui-dialog-content');
-    if (content) {
-      content.setAttribute('data-state', this.isOpen ? 'open' : 'closed');
-      content.setAttribute('role', 'dialog');
-      content.setAttribute('aria-modal', 'true');
-    }
-  }
-
-  private _setup(): void {
+  _setup(): void {
     if (!this._native) return;
     lockScroll();
     if (!this._native.open) this._native.showModal();
   }
 
-  private _teardown(): void {
+  _teardown(): void {
     unlockScroll();
     if (this._native?.open) this._native.close();
   }
+
+  _onNativeClose = (): void => {
+    if (this.open) this.open = false;
+  };
+
+  _onNativeClick = (e: MouseEvent): void => {
+    if (e.target === this._native) this.hide();
+  };
 }
-defineElement('ui-dialog', UiDialog);
+UiDialog.register('ui-dialog');
 
 // --------------------------------------------------------------------------
 // <ui-dialog-trigger>
 // --------------------------------------------------------------------------
 
-export class UiDialogTrigger extends Base {
-  connectedCallback(): void {
+export class UiDialogTrigger extends WebComponent {
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'dialog-trigger');
     this.addEventListener('click', this._onClick);
   }
+
   disconnectedCallback(): void {
     this.removeEventListener('click', this._onClick);
+    super.disconnectedCallback?.();
   }
-  private _onClick = (): void => {
+
+  render() {
+    return html`<slot></slot>`;
+  }
+
+  _onClick = (): void => {
     (this.closest('ui-dialog') as UiDialog | null)?.show();
   };
 }
-defineElement('ui-dialog-trigger', UiDialogTrigger);
+UiDialogTrigger.register('ui-dialog-trigger');
 
 // --------------------------------------------------------------------------
 // <ui-dialog-content>
@@ -288,12 +283,17 @@ export const dialogCloseButtonClass = (): string =>
 const DIALOG_CLOSE_X_SVG =
   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 6 6 18M6 6l12 12"></path></svg>';
 
-export class UiDialogContent extends Base {
+export class UiDialogContent extends WebComponent {
+  _userClass: string = '';
+
   connectedCallback(): void {
+    this._userClass = this.getAttribute('class') ?? '';
+    super.connectedCallback?.();
+  }
+
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'dialog-content');
     this.setAttribute('tabindex', '-1');
-    const userClass = this.getAttribute('class') ?? '';
-    this.className = cn(dialogContentClass(), userClass);
     const showCloseButton = this.getAttribute('show-close-button') !== 'false';
     if (showCloseButton && !this.querySelector(':scope > ui-dialog-close')) {
       const closeEl = document.createElement('ui-dialog-close');
@@ -303,36 +303,53 @@ export class UiDialogContent extends Base {
       this.appendChild(closeEl);
     }
   }
+
+  render() {
+    this.className = cn(dialogContentClass(), this._userClass);
+    return html`<slot></slot>`;
+  }
 }
-defineElement('ui-dialog-content', UiDialogContent);
+UiDialogContent.register('ui-dialog-content');
 
 // --------------------------------------------------------------------------
 // <ui-dialog-close>
 // --------------------------------------------------------------------------
 
-export class UiDialogClose extends Base {
-  connectedCallback(): void {
+export class UiDialogClose extends WebComponent {
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'dialog-close');
     this.addEventListener('click', this._onClick);
   }
+
   disconnectedCallback(): void {
     this.removeEventListener('click', this._onClick);
+    super.disconnectedCallback?.();
   }
-  private _onClick = (): void => {
+
+  render() {
+    return html`<slot></slot>`;
+  }
+
+  _onClick = (): void => {
     (this.closest('ui-dialog') as UiDialog | null)?.hide();
   };
 }
-defineElement('ui-dialog-close', UiDialogClose);
+UiDialogClose.register('ui-dialog-close');
 
 // --------------------------------------------------------------------------
 // <ui-dialog-footer>
 // --------------------------------------------------------------------------
 
-export class UiDialogFooter extends Base {
+export class UiDialogFooter extends WebComponent {
+  _userClass: string = '';
+
   connectedCallback(): void {
+    this._userClass = this.getAttribute('class') ?? '';
+    super.connectedCallback?.();
+  }
+
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'dialog-footer');
-    const userClass = this.getAttribute('class') ?? '';
-    this.className = cn(dialogFooterClass(), userClass);
     const showClose = this.hasAttribute('show-close-button')
       && this.getAttribute('show-close-button') !== 'false';
     if (showClose && !this.querySelector(':scope > ui-dialog-close')) {
@@ -344,5 +361,10 @@ export class UiDialogFooter extends Base {
       this.appendChild(closeEl);
     }
   }
+
+  render() {
+    this.className = cn(dialogFooterClass(), this._userClass);
+    return html`<slot></slot>`;
+  }
 }
-defineElement('ui-dialog-footer', UiDialogFooter);
+UiDialogFooter.register('ui-dialog-footer');

--- a/packages/ui/packages/registry/components/dropdown-menu.ts
+++ b/packages/ui/packages/registry/components/dropdown-menu.ts
@@ -41,71 +41,26 @@
  * Design tokens used: --popover, --popover-foreground, --accent,
  * --accent-foreground, --destructive, --muted-foreground, --border.
  */
-import { cn, Base, defineElement } from '../lib/utils.ts';
+import { WebComponent, html } from '@webjskit/core';
+import { cn } from '../lib/utils.ts';
 import { positionFloating, type PopoverSide, type PopoverAlign } from './popover.ts';
 
 // --------------------------------------------------------------------------
 // Class helpers
 // --------------------------------------------------------------------------
 
-// `fixed m-0` opts out of the UA `[popover]` defaults (the auto-centering
-// `margin: auto`) so JS-computed top/left coordinates from
-// `positionFloating` land correctly. `border` already applies, so no
-// `border-0` is needed (the UA `border: 1px solid` is overridden by the
-// shadcn `border` utility lower in the cascade).
 export const dropdownMenuContentClass = (): string =>
   'fixed z-50 max-h-[--available-height] min-w-[8rem] m-0 overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md';
-
-// Each item class adds `:hover` variants of every `:focus` rule so the
-// accent highlight paints under the cursor regardless of focus state.
-// Shadcn's React build doesn't need this because Radix moves keyboard
-// focus to whatever item the cursor is over (roving focus), so `:focus`
-// alone covers both keyboard nav AND hover. We mimic that for the
-// custom-element item (UiDropdownMenuItem.connectedCallback wires a
-// pointerenter -> focus() handler below), but the checkbox-item /
-// radio-item class helpers are applied to raw markup that we don't
-// control, so the only way to guarantee a hover highlight there is to
-// stamp `hover:bg-accent hover:text-accent-foreground` directly into
-// the class string. Doing the same for the regular item is harmless
-// (the focus path also applies, identical colours, no visual diff)
-// and keeps the three classes consistent.
 
 export const dropdownMenuItemClass = (): string =>
   "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground hover:bg-accent hover:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:hover:bg-destructive/10 data-[variant=destructive]:hover:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 dark:data-[variant=destructive]:hover:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4";
 
-// Inset is universal across shadcn's radix-* style families on these
-// two helpers, same boolean already plumbed on Item / Label /
-// SubTrigger as full custom elements above. CheckboxItem and
-// RadioItem are class-helper functions applied to user-authored
-// markup, so there's no JS to mirror `inset` to data-inset; the user
-// adds the `data-inset` attribute themselves on the element. The
-// helper includes `data-[inset]:pl-8` in the class string so the
-// rule fires when the user opts in. CheckboxItem already has pl-8
-// baseline (to reserve room for the indicator); inset is a no-op
-// for the inset case visually, kept for shadcn parity so a future
-// indicator-less subitem keeps lining up with sibling Items that
-// have leading icons.
 export const dropdownMenuCheckboxItemClass = (): string =>
   "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground hover:bg-accent hover:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0";
 
 export const dropdownMenuRadioItemClass = (): string =>
   "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground hover:bg-accent hover:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8";
 
-// Label reads as a section header above a group of items. Shadcn's
-// default (text-sm font-medium, same as items minus font-weight) was
-// too subtle: at 14px, a 500-vs-400 weight difference is barely
-// perceptible, so "My Account" looked like just another item with
-// slightly bolder text. Tighten the typography hierarchy:
-//   text-xs       , shrink relative to items so the label registers
-//                    as supplementary metadata, not content
-//   font-semibold , recover the visual weight lost by going smaller
-//   text-muted-foreground, different colour role from items, which
-//                    is the strongest cue available for "this is not
-//                    a clickable row, it's a label". Combined with
-//                    the trailing <separator> already shipped in the
-//                    docs example, the items group reads cleanly.
-// pt-2 (vs py-1.5) adds a touch of top breathing room, labels feel
-// off-balance flush against the menu's top edge.
 export const dropdownMenuLabelClass = (): string =>
   'px-2 pt-2 pb-1.5 text-xs font-semibold text-muted-foreground data-[inset]:pl-8';
 
@@ -114,29 +69,12 @@ export const dropdownMenuSeparatorClass = (): string => '-mx-1 my-1 h-px bg-bord
 export const dropdownMenuShortcutClass = (): string =>
   'ml-auto text-xs tracking-widest text-muted-foreground';
 
-// Sub-trigger styling mirrors the regular item but adds:
-//   - data-[state=open] highlight so the sub-trigger stays styled-as-hovered
-//     while its submenu is open (matches Radix exactly)
-//   - [&>svg:last-child]:ml-auto so the auto-injected chevron pushes to the
-//     right edge of the trigger, after the label children
 export const dropdownMenuSubTriggerClass = (): string =>
   "flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm select-none outline-hidden focus:bg-accent focus:text-accent-foreground hover:bg-accent hover:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&>svg:last-child]:ml-auto";
 
-// Sub-content uses shadow-lg (vs the root content's shadow-md) so submenus
-// visually stack above their parent, matches shadcn. `fixed m-0` opts
-// out of the UA `[popover]` auto-centering for the same reason as the
-// root content class above.
 export const dropdownMenuSubContentClass = (): string =>
   'fixed z-50 min-w-[8rem] m-0 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg';
 
-// Pre-hydration paint fallback. Before the script upgrades the custom
-// elements, the menu content sits in normal flow and would flash visible.
-// Two CSS rules hide it until JS marks the host as `[open]`. Once the
-// elements upgrade, UA `[popover]:not(:popover-open) { display: none }`
-// takes over and these rules become dormant. Tailwind cannot express
-// "hide child when parent lacks attribute X" without authoring a class
-// on the parent at SSR time, so this stays as a one-time selector-based
-// injection.
 const STYLES = `
 ui-dropdown-menu:not([open]) ui-dropdown-menu-content,
 ui-dropdown-menu-sub:not([open]) ui-dropdown-menu-sub-content {
@@ -157,42 +95,72 @@ function installStyles(): void {
 // <ui-dropdown-menu>
 // --------------------------------------------------------------------------
 
-export class UiDropdownMenu extends Base {
-  static get observedAttributes(): string[] {
-    return ['open'];
+export class UiDropdownMenu extends WebComponent {
+  static properties = {
+    open: { type: Boolean, reflect: true },
+  };
+  declare open: boolean;
+
+  _lastOpen: boolean = false;
+  _typeBuffer = '';
+  _typeBufferTimer: number | undefined;
+
+  _docClickHandler = (e: MouseEvent): void => this._onDocClick(e);
+  _keyHandler = (e: KeyboardEvent): void => this._onKeyDown(e);
+  _resizeHandler = (): void => this._reposition();
+
+  constructor() {
+    super();
+    this.open = false;
   }
-  private _docClickHandler = (e: MouseEvent): void => this._onDocClick(e);
-  private _keyHandler = (e: KeyboardEvent): void => this._onKeyDown(e);
-  private _resizeHandler = (): void => this._reposition();
 
   connectedCallback(): void {
     installStyles();
+    super.connectedCallback?.();
+  }
+
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'dropdown-menu');
-    this._reflect();
   }
+
   disconnectedCallback(): void {
-    if (this.hasAttribute('open')) this._teardown();
+    if (this.open) this._teardown();
+    super.disconnectedCallback?.();
   }
-  attributeChangedCallback(name: string, oldVal: string | null, newVal: string | null): void {
-    if (name === 'open' && oldVal !== newVal) {
-      this._reflect();
-      if (newVal !== null) this._setup();
+
+  render() {
+    this.setAttribute('data-state', this.open ? 'open' : 'closed');
+    queueMicrotask(() => this._afterRender());
+    return html`<slot></slot>`;
+  }
+
+  _afterRender(): void {
+    const content = this.querySelector<HTMLElement>('ui-dropdown-menu-content');
+    if (content) {
+      content.setAttribute('data-state', this.open ? 'open' : 'closed');
+      if (typeof (content as HTMLElement & { showPopover?: () => void }).showPopover === 'function') {
+        const isPopoverOpen = (content as HTMLElement & { matches: (s: string) => boolean }).matches(':popover-open');
+        if (this.open && !isPopoverOpen) {
+          (content as HTMLElement & { showPopover: () => void }).showPopover();
+        } else if (!this.open && isPopoverOpen) {
+          (content as HTMLElement & { hidePopover: () => void }).hidePopover();
+        }
+      }
+    }
+    if (this._lastOpen !== this.open) {
+      this._lastOpen = this.open;
+      if (this.open) this._setup();
       else this._teardown();
     }
   }
-  toggle(): void {
-    if (this.hasAttribute('open')) this.hide();
-    else this.show();
-  }
-  show(): void {
-    this.setAttribute('open', '');
-  }
-  hide(): void {
-    this.removeAttribute('open');
-  }
+
+  toggle(): void { this.open = !this.open; }
+  show(): void { this.open = true; }
+  hide(): void { this.open = false; }
+
   _reposition(): void {
-    const trigger = this.querySelector<HTMLElement>(':scope > ui-dropdown-menu-trigger');
-    const content = this.querySelector<HTMLElement>(':scope > ui-dropdown-menu-content');
+    const trigger = this.querySelector<HTMLElement>('ui-dropdown-menu-trigger');
+    const content = this.querySelector<HTMLElement>('ui-dropdown-menu-content');
     if (!trigger || !content) return;
     positionFloating(trigger, content, {
       side: (content.getAttribute('side') ?? 'bottom') as PopoverSide,
@@ -201,52 +169,37 @@ export class UiDropdownMenu extends Base {
       alignOffset: Number(content.getAttribute('align-offset') ?? 0),
     });
   }
-  private _reflect(): void {
-    const open = this.hasAttribute('open');
-    this.setAttribute('data-state', open ? 'open' : 'closed');
-    const content = this.querySelector<HTMLElement>(':scope > ui-dropdown-menu-content');
-    if (!content) return;
-    content.setAttribute('data-state', open ? 'open' : 'closed');
-    // Delegate visibility + top-layer placement to the native Popover API.
-    // `popover="manual"` is set in UiDropdownMenuContent.connectedCallback.
-    if (typeof (content as HTMLElement & { showPopover?: () => void }).showPopover === 'function') {
-      const isPopoverOpen = (content as HTMLElement & { matches: (s: string) => boolean }).matches(':popover-open');
-      if (open && !isPopoverOpen) {
-        (content as HTMLElement & { showPopover: () => void }).showPopover();
-      } else if (!open && isPopoverOpen) {
-        (content as HTMLElement & { hidePopover: () => void }).hidePopover();
-      }
-    }
-  }
-  private _setup(): void {
+
+  _setup(): void {
     queueMicrotask(() => {
       this._reposition();
       document.addEventListener('click', this._docClickHandler);
       document.addEventListener('keydown', this._keyHandler);
       window.addEventListener('resize', this._resizeHandler);
       window.addEventListener('scroll', this._resizeHandler, true);
-      const first = this.querySelector<HTMLElement>(':scope ui-dropdown-menu-item:not([data-disabled])');
+      const first = this.querySelector<HTMLElement>('ui-dropdown-menu-item:not([data-disabled])');
       first?.focus();
     });
   }
-  private _teardown(): void {
+
+  _teardown(): void {
     document.removeEventListener('click', this._docClickHandler);
     document.removeEventListener('keydown', this._keyHandler);
     window.removeEventListener('resize', this._resizeHandler);
     window.removeEventListener('scroll', this._resizeHandler, true);
-    // Close any open submenus when the root closes; otherwise on re-open
-    // they'd still carry their `[open]` attribute and re-appear.
-    this.querySelectorAll<UiDropdownMenuSub>(':scope ui-dropdown-menu-sub[open]').forEach(
+    this.querySelectorAll<UiDropdownMenuSub>('ui-dropdown-menu-sub[open]').forEach(
       (sub) => sub.hide(),
     );
   }
-  private _onDocClick(e: MouseEvent): void {
-    if (!this.hasAttribute('open')) return;
+
+  _onDocClick(e: MouseEvent): void {
+    if (!this.open) return;
     if (e.composedPath().some((n) => n === this)) return;
     this.hide();
   }
-  private _onKeyDown(e: KeyboardEvent): void {
-    if (!this.hasAttribute('open')) return;
+
+  _onKeyDown(e: KeyboardEvent): void {
+    if (!this.open) return;
     if (e.key === 'Escape') {
       e.preventDefault();
       this.hide();
@@ -256,18 +209,13 @@ export class UiDropdownMenu extends Base {
     // Scope arrow nav to the "active context", the nearest content or
     // sub-content panel owning the focused element. Without this, pressing
     // ArrowDown while a sub-trigger is focused would walk into the
-    // submenu's items as if they were siblings of the parent items, since
-    // querySelectorAll(':scope ui-dropdown-menu-item') returns all
-    // descendants regardless of submenu boundaries.
+    // submenu's items as if they were siblings of the parent items.
     const active = document.activeElement as HTMLElement | null;
     const context = active?.closest(
       'ui-dropdown-menu-sub-content, ui-dropdown-menu-content',
     ) as HTMLElement | null;
     if (!context) return;
 
-    // Items in this context = direct/indirect children that aren't deeper
-    // inside another sub-content. closest() back up to the nearest panel
-    // must equal the current context to be considered "ours".
     const items = Array.from(
       context.querySelectorAll<HTMLElement>(
         ':scope ui-dropdown-menu-item:not([data-disabled]), :scope ui-dropdown-menu-sub-trigger:not([data-disabled])',
@@ -292,17 +240,13 @@ export class UiDropdownMenu extends Base {
       e.preventDefault();
       items[items.length - 1].focus();
     } else if (e.key === 'ArrowRight') {
-      // Open the submenu owned by the focused sub-trigger and move
-      // focus to its first item, matches Radix/shadcn.
       if (active?.tagName === 'UI-DROPDOWN-MENU-SUB-TRIGGER') {
         e.preventDefault();
-        const sub = active.parentElement as UiDropdownMenuSub | null;
-        if (sub?.tagName === 'UI-DROPDOWN-MENU-SUB') {
+        const sub = active.closest('ui-dropdown-menu-sub') as UiDropdownMenuSub | null;
+        if (sub) {
           sub.show();
           queueMicrotask(() => {
-            const subContent = sub.querySelector<HTMLElement>(
-              ':scope > ui-dropdown-menu-sub-content',
-            );
+            const subContent = sub.querySelector<HTMLElement>('ui-dropdown-menu-sub-content');
             const firstSubItem = subContent?.querySelector<HTMLElement>(
               'ui-dropdown-menu-item:not([data-disabled]), ui-dropdown-menu-sub-trigger:not([data-disabled])',
             );
@@ -311,35 +255,23 @@ export class UiDropdownMenu extends Base {
         }
       }
     } else if (e.key === 'ArrowLeft') {
-      // Inside a sub-content: close the submenu and refocus its trigger.
       if (context.tagName === 'UI-DROPDOWN-MENU-SUB-CONTENT') {
         e.preventDefault();
-        const sub = context.parentElement as UiDropdownMenuSub | null;
-        const trigger = sub?.querySelector<HTMLElement>(
-          ':scope > ui-dropdown-menu-sub-trigger',
-        );
+        const sub = context.closest('ui-dropdown-menu-sub') as UiDropdownMenuSub | null;
+        const trigger = sub?.querySelector<HTMLElement>('ui-dropdown-menu-sub-trigger');
         sub?.hide();
         trigger?.focus();
       }
     } else if (e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey) {
-      // Typeahead. Accumulate printable characters into a buffer (cleared
-      // after 500ms of inactivity) and focus the first item whose
-      // text-value or textContent starts with the buffer. Matches
-      // shadcn/Radix's <DropdownMenuItem textValue> behavior.
       this._typeahead(e, items);
     }
   }
 
-  private _typeBuffer = '';
-  private _typeBufferTimer: number | undefined;
-  private _typeahead(e: KeyboardEvent, items: HTMLElement[]): void {
+  _typeahead(e: KeyboardEvent, items: HTMLElement[]): void {
     this._typeBuffer = (this._typeBuffer + e.key).toLowerCase();
     clearTimeout(this._typeBufferTimer);
     this._typeBufferTimer = window.setTimeout(() => { this._typeBuffer = ''; }, 500);
     const buffer = this._typeBuffer;
-    // textValue attribute overrides textContent so consumers can supply a
-    // typeahead string different from the visible label (e.g. an icon-only
-    // row labeled "Print" → text-value="print").
     const match = items.find((it) => {
       const text = (it.getAttribute('text-value') ?? it.textContent ?? '').trim().toLowerCase();
       return text.startsWith(buffer);
@@ -350,230 +282,306 @@ export class UiDropdownMenu extends Base {
     }
   }
 }
-defineElement('ui-dropdown-menu', UiDropdownMenu);
+UiDropdownMenu.register('ui-dropdown-menu');
 
-export class UiDropdownMenuTrigger extends Base {
-  connectedCallback(): void {
+// --------------------------------------------------------------------------
+// <ui-dropdown-menu-trigger>
+// --------------------------------------------------------------------------
+
+export class UiDropdownMenuTrigger extends WebComponent {
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'dropdown-menu-trigger');
     this.addEventListener('click', this._onClick);
   }
+
   disconnectedCallback(): void {
     this.removeEventListener('click', this._onClick);
+    super.disconnectedCallback?.();
   }
-  private _onClick = (): void => (this.closest('ui-dropdown-menu') as UiDropdownMenu | null)?.toggle();
-}
-defineElement('ui-dropdown-menu-trigger', UiDropdownMenuTrigger);
 
-export class UiDropdownMenuContent extends Base {
+  render() {
+    return html`<slot></slot>`;
+  }
+
+  _onClick = (): void => (this.closest('ui-dropdown-menu') as UiDropdownMenu | null)?.toggle();
+}
+UiDropdownMenuTrigger.register('ui-dropdown-menu-trigger');
+
+// --------------------------------------------------------------------------
+// <ui-dropdown-menu-content>
+// --------------------------------------------------------------------------
+
+export class UiDropdownMenuContent extends WebComponent {
+  _userClass: string = '';
+
   connectedCallback(): void {
+    this._userClass = this.getAttribute('class') ?? '';
+    super.connectedCallback?.();
+  }
+
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'dropdown-menu-content');
     this.setAttribute('role', 'menu');
-    // Opt into the native top-layer via the Popover API. Manual mode (vs
-    // auto) keeps the existing outside-click handler + Escape handler
-    // authoritative, so nested submenus don't accidentally close their
-    // parent when the auto light-dismiss fires.
     if (!this.hasAttribute('popover')) this.setAttribute('popover', 'manual');
-    const userClass = this.getAttribute('class') ?? '';
-    this.className = cn(dropdownMenuContentClass(), userClass);
+  }
+
+  render() {
+    this.className = cn(dropdownMenuContentClass(), this._userClass);
+    return html`<slot></slot>`;
   }
 }
-defineElement('ui-dropdown-menu-content', UiDropdownMenuContent);
+UiDropdownMenuContent.register('ui-dropdown-menu-content');
 
-export class UiDropdownMenuItem extends Base {
+// --------------------------------------------------------------------------
+// <ui-dropdown-menu-item>
+// --------------------------------------------------------------------------
+
+export class UiDropdownMenuItem extends WebComponent {
+  static properties = {
+    variant: { type: String, reflect: true },
+  };
+  declare variant: 'default' | 'destructive';
+
+  _userClass: string = '';
+
+  constructor() {
+    super();
+    this.variant = 'default';
+  }
+
   connectedCallback(): void {
+    this._userClass = this.getAttribute('class') ?? '';
+    super.connectedCallback?.();
+  }
+
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'dropdown-menu-item');
     this.setAttribute('role', 'menuitem');
     this.setAttribute('tabindex', '-1');
-    if (!this.hasAttribute('variant')) this.setAttribute('variant', 'default');
-    this.setAttribute('data-variant', this.getAttribute('variant') ?? 'default');
-    if (this.hasAttribute('inset')) this.setAttribute('data-inset', '');
-    const userClass = this.getAttribute('class') ?? '';
-    this.className = cn(dropdownMenuItemClass(), userClass);
     this.addEventListener('click', this._onClick);
-    // Move keyboard focus to whichever item the cursor is over , 
-    // matches Radix's roving-focus pattern. Without this the menu has
-    // two parallel cursors (arrow-key focus + mouse hover) that drift
-    // apart: a user who arrow-navigated to item B then mouse-hovers
-    // item D sees BOTH highlighted (B via :focus, D via :hover). With
-    // pointerenter -> focus(), the two converge and arrow keys
-    // continue from wherever the mouse last pointed.
     this.addEventListener('pointerenter', this._onPointerEnter);
-    // Mirror native :focus to a data-highlighted attribute so shadcn
-    // class strings using `data-[highlighted]:bg-accent` (Radix's
-    // roving-focus marker) work verbatim on our items. Our own
-    // styling already uses :focus + :hover for the highlight (see
-    // dropdownMenuItemClass), this attr is purely for shadcn
-    // selector portability.
     this.addEventListener('focus', this._onFocus);
     this.addEventListener('blur', this._onBlur);
   }
+
   disconnectedCallback(): void {
     this.removeEventListener('click', this._onClick);
     this.removeEventListener('pointerenter', this._onPointerEnter);
     this.removeEventListener('focus', this._onFocus);
     this.removeEventListener('blur', this._onBlur);
+    super.disconnectedCallback?.();
   }
-  private _onClick = (): void => {
+
+  render() {
+    this.setAttribute('data-variant', this.variant);
+    if (this.hasAttribute('inset')) this.setAttribute('data-inset', '');
+    this.className = cn(dropdownMenuItemClass(), this._userClass);
+    return html`<slot></slot>`;
+  }
+
+  _onClick = (): void => {
     if (this.hasAttribute('data-disabled')) return;
     (this.closest('ui-dropdown-menu') as UiDropdownMenu | null)?.hide();
   };
-  private _onPointerEnter = (): void => {
+
+  _onPointerEnter = (): void => {
     if (this.hasAttribute('data-disabled')) return;
     this.focus();
   };
-  private _onFocus = (): void => {
+
+  _onFocus = (): void => {
     this.setAttribute('data-highlighted', '');
   };
-  private _onBlur = (): void => {
+
+  _onBlur = (): void => {
     this.removeAttribute('data-highlighted');
   };
 }
-defineElement('ui-dropdown-menu-item', UiDropdownMenuItem);
+UiDropdownMenuItem.register('ui-dropdown-menu-item');
 
-export class UiDropdownMenuLabel extends Base {
+// --------------------------------------------------------------------------
+// <ui-dropdown-menu-label>
+// --------------------------------------------------------------------------
+
+export class UiDropdownMenuLabel extends WebComponent {
+  _userClass: string = '';
+
   connectedCallback(): void {
+    this._userClass = this.getAttribute('class') ?? '';
+    super.connectedCallback?.();
+  }
+
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'dropdown-menu-label');
-    // `inset` mirrors the existing item behaviour, shadcn exposes the
-    // same boolean on Label so the indent column for icon-aligned items
-    // stays consistent. The label class already includes
-    // data-[inset]:pl-8 so only the attribute reflection is missing.
+  }
+
+  render() {
     if (this.hasAttribute('inset')) this.setAttribute('data-inset', '');
-    const userClass = this.getAttribute('class') ?? '';
-    this.className = cn(dropdownMenuLabelClass(), userClass);
+    this.className = cn(dropdownMenuLabelClass(), this._userClass);
+    return html`<slot></slot>`;
   }
 }
-defineElement('ui-dropdown-menu-label', UiDropdownMenuLabel);
+UiDropdownMenuLabel.register('ui-dropdown-menu-label');
 
-export class UiDropdownMenuSeparator extends Base {
+// --------------------------------------------------------------------------
+// <ui-dropdown-menu-separator>
+// --------------------------------------------------------------------------
+
+export class UiDropdownMenuSeparator extends WebComponent {
+  _userClass: string = '';
+
   connectedCallback(): void {
+    this._userClass = this.getAttribute('class') ?? '';
+    super.connectedCallback?.();
+  }
+
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'dropdown-menu-separator');
     this.setAttribute('role', 'separator');
-    const userClass = this.getAttribute('class') ?? '';
-    this.className = cn(dropdownMenuSeparatorClass(), userClass);
+  }
+
+  render() {
+    this.className = cn(dropdownMenuSeparatorClass(), this._userClass);
+    return html`<slot></slot>`;
   }
 }
-defineElement('ui-dropdown-menu-separator', UiDropdownMenuSeparator);
+UiDropdownMenuSeparator.register('ui-dropdown-menu-separator');
 
-export class UiDropdownMenuShortcut extends Base {
+// --------------------------------------------------------------------------
+// <ui-dropdown-menu-shortcut>
+// --------------------------------------------------------------------------
+
+export class UiDropdownMenuShortcut extends WebComponent {
+  _userClass: string = '';
+
   connectedCallback(): void {
+    this._userClass = this.getAttribute('class') ?? '';
+    super.connectedCallback?.();
+  }
+
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'dropdown-menu-shortcut');
-    const userClass = this.getAttribute('class') ?? '';
-    this.className = cn(dropdownMenuShortcutClass(), userClass);
+  }
+
+  render() {
+    this.className = cn(dropdownMenuShortcutClass(), this._userClass);
+    return html`<slot></slot>`;
   }
 }
-defineElement('ui-dropdown-menu-shortcut', UiDropdownMenuShortcut);
+UiDropdownMenuShortcut.register('ui-dropdown-menu-shortcut');
 
-export class UiDropdownMenuGroup extends Base {
-  connectedCallback(): void {
+// --------------------------------------------------------------------------
+// <ui-dropdown-menu-group>
+// --------------------------------------------------------------------------
+
+export class UiDropdownMenuGroup extends WebComponent {
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'dropdown-menu-group');
     this.setAttribute('role', 'group');
   }
+
+  render() {
+    return html`<slot></slot>`;
+  }
 }
-defineElement('ui-dropdown-menu-group', UiDropdownMenuGroup);
+UiDropdownMenuGroup.register('ui-dropdown-menu-group');
 
 // --------------------------------------------------------------------------
 // Submenu, Sub / SubTrigger / SubContent (shadcn parity)
 // --------------------------------------------------------------------------
 
-// Right-chevron auto-injected on every <ui-dropdown-menu-sub-trigger> if the
-// user didn't supply a trailing icon themselves. Shadcn's React component
-// hard-appends a <ChevronRightIcon> after children; we do the same on
-// connectedCallback so authors can write
-// `<ui-dropdown-menu-sub-trigger>Invite</ui-dropdown-menu-sub-trigger>`
-// without remembering to include the chevron markup.
 const CHEVRON_RIGHT_SVG =
   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="ml-auto size-4" aria-hidden="true"><polyline points="9 18 15 12 9 6"></polyline></svg>';
 
-// Delay before closing a submenu on pointerleave. Without it, any small
-// horizontal gap between trigger and content (or any momentary cursor
-// dip outside the panel) instantly closes the menu. 200ms matches Radix.
 const SUB_CLOSE_DELAY = 200;
 
-export class UiDropdownMenuSub extends Base {
-  static get observedAttributes(): string[] {
-    return ['open'];
-  }
-  private _closeTimer: number | undefined;
-  private _pointerEnterHandler = (): void => this._cancelClose();
-  private _pointerLeaveHandler = (): void => this._scheduleClose();
+export class UiDropdownMenuSub extends WebComponent {
+  static properties = {
+    open: { type: Boolean, reflect: true },
+  };
+  declare open: boolean;
 
-  connectedCallback(): void {
+  _lastOpen: boolean = false;
+  _closeTimer: number | undefined;
+  _pointerEnterHandler = (): void => this._cancelClose();
+  _pointerLeaveHandler = (): void => this._scheduleClose();
+
+  constructor() {
+    super();
+    this.open = false;
+  }
+
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'dropdown-menu-sub');
-    this._reflect();
-    // pointerleave fires once when the cursor leaves the element AND all
-    // its descendants, so moving from trigger to sub-content (both
-    // children of <ui-dropdown-menu-sub>) doesn't trigger a close, but
-    // moving off the whole submenu does. position: fixed on the sub-
-    // content doesn't change DOM lineage; events still bubble correctly.
     this.addEventListener('pointerenter', this._pointerEnterHandler);
     this.addEventListener('pointerleave', this._pointerLeaveHandler);
   }
+
   disconnectedCallback(): void {
     this.removeEventListener('pointerenter', this._pointerEnterHandler);
     this.removeEventListener('pointerleave', this._pointerLeaveHandler);
     this._cancelClose();
+    super.disconnectedCallback?.();
   }
-  attributeChangedCallback(name: string, oldVal: string | null, newVal: string | null): void {
-    if (name === 'open' && oldVal !== newVal) {
-      this._reflect();
-      if (newVal !== null) this._position();
+
+  render() {
+    this.setAttribute('data-state', this.open ? 'open' : 'closed');
+    queueMicrotask(() => this._afterRender());
+    return html`<slot></slot>`;
+  }
+
+  _afterRender(): void {
+    const trigger = this.querySelector<HTMLElement>('ui-dropdown-menu-sub-trigger');
+    const content = this.querySelector<HTMLElement>('ui-dropdown-menu-sub-content');
+    trigger?.setAttribute('data-state', this.open ? 'open' : 'closed');
+    if (content) {
+      content.setAttribute('data-state', this.open ? 'open' : 'closed');
+      if (typeof (content as HTMLElement & { showPopover?: () => void }).showPopover === 'function') {
+        const isPopoverOpen = (content as HTMLElement & { matches: (s: string) => boolean }).matches(':popover-open');
+        if (this.open && !isPopoverOpen) {
+          (content as HTMLElement & { showPopover: () => void }).showPopover();
+        } else if (!this.open && isPopoverOpen) {
+          (content as HTMLElement & { hidePopover: () => void }).hidePopover();
+        }
+      }
+    }
+    if (this._lastOpen !== this.open) {
+      this._lastOpen = this.open;
+      if (this.open) this._position();
     }
   }
 
   show(): void {
     this._cancelClose();
-    this.setAttribute('open', '');
+    this.open = true;
   }
+
   hide(): void {
     this._cancelClose();
-    this.removeAttribute('open');
+    this.open = false;
   }
+
   toggle(): void {
-    if (this.hasAttribute('open')) this.hide();
+    if (this.open) this.hide();
     else this.show();
   }
 
-  private _scheduleClose(): void {
+  _scheduleClose(): void {
     this._cancelClose();
     this._closeTimer = window.setTimeout(() => this.hide(), SUB_CLOSE_DELAY);
   }
-  private _cancelClose(): void {
+
+  _cancelClose(): void {
     if (this._closeTimer !== undefined) {
       clearTimeout(this._closeTimer);
       this._closeTimer = undefined;
     }
   }
 
-  private _reflect(): void {
-    const open = this.hasAttribute('open');
-    this.setAttribute('data-state', open ? 'open' : 'closed');
-    const trigger = this.querySelector<HTMLElement>(':scope > ui-dropdown-menu-sub-trigger');
-    const content = this.querySelector<HTMLElement>(':scope > ui-dropdown-menu-sub-content');
-    trigger?.setAttribute('data-state', open ? 'open' : 'closed');
-    if (!content) return;
-    content.setAttribute('data-state', open ? 'open' : 'closed');
-    // Same top-layer wiring as the root content; manual mode so the
-    // parent menu's existing handlers stay authoritative.
-    if (typeof (content as HTMLElement & { showPopover?: () => void }).showPopover === 'function') {
-      const isPopoverOpen = (content as HTMLElement & { matches: (s: string) => boolean }).matches(':popover-open');
-      if (open && !isPopoverOpen) {
-        (content as HTMLElement & { showPopover: () => void }).showPopover();
-      } else if (!open && isPopoverOpen) {
-        (content as HTMLElement & { hidePopover: () => void }).hidePopover();
-      }
-    }
-  }
-
   _position(): void {
-    // Same positionFloating used by the root content + popover. Side
-    // defaults to 'right' (submenus open beside their trigger);
-    // align: 'start' lines the submenu top with the trigger top.
-    // sideOffset defaults to -4, a slight inward overlap bridges the
-    // mouse-travel gap between trigger and panel so the cursor doesn't
-    // trigger pointerleave by passing through a 1px seam.
     queueMicrotask(() => {
-      const trigger = this.querySelector<HTMLElement>(':scope > ui-dropdown-menu-sub-trigger');
-      const content = this.querySelector<HTMLElement>(':scope > ui-dropdown-menu-sub-content');
+      const trigger = this.querySelector<HTMLElement>('ui-dropdown-menu-sub-trigger');
+      const content = this.querySelector<HTMLElement>('ui-dropdown-menu-sub-content');
       if (!trigger || !content) return;
       positionFloating(trigger, content, {
         side: (content.getAttribute('side') ?? 'right') as PopoverSide,
@@ -584,21 +592,25 @@ export class UiDropdownMenuSub extends Base {
     });
   }
 }
-defineElement('ui-dropdown-menu-sub', UiDropdownMenuSub);
+UiDropdownMenuSub.register('ui-dropdown-menu-sub');
 
-export class UiDropdownMenuSubTrigger extends Base {
+// --------------------------------------------------------------------------
+// <ui-dropdown-menu-sub-trigger>
+// --------------------------------------------------------------------------
+
+export class UiDropdownMenuSubTrigger extends WebComponent {
+  _userClass: string = '';
+
   connectedCallback(): void {
+    this._userClass = this.getAttribute('class') ?? '';
+    super.connectedCallback?.();
+  }
+
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'dropdown-menu-sub-trigger');
     this.setAttribute('role', 'menuitem');
     this.setAttribute('tabindex', '-1');
     this.setAttribute('aria-haspopup', 'menu');
-    // `inset` is already reflected here (and is the only of the three
-    // inset-aware elements that had it before this change, see
-    // UiDropdownMenuItem + UiDropdownMenuLabel above for the other two).
-    if (this.hasAttribute('inset')) this.setAttribute('data-inset', '');
-    const userClass = this.getAttribute('class') ?? '';
-    this.className = cn(dropdownMenuSubTriggerClass(), userClass);
-    // Auto-inject right-chevron unless user already supplied a trailing svg.
     if (!this.querySelector(':scope > svg:last-child')) {
       const tmp = document.createElement('div');
       tmp.innerHTML = CHEVRON_RIGHT_SVG;
@@ -608,31 +620,55 @@ export class UiDropdownMenuSubTrigger extends Base {
     this.addEventListener('click', this._onClick);
     this.addEventListener('pointerenter', this._onPointerEnter);
   }
+
   disconnectedCallback(): void {
     this.removeEventListener('click', this._onClick);
     this.removeEventListener('pointerenter', this._onPointerEnter);
+    super.disconnectedCallback?.();
   }
-  private _onClick = (): void => {
+
+  render() {
+    if (this.hasAttribute('inset')) this.setAttribute('data-inset', '');
+    this.className = cn(dropdownMenuSubTriggerClass(), this._userClass);
+    return html`<slot></slot>`;
+  }
+
+  _onClick = (): void => {
     if (this.hasAttribute('data-disabled')) return;
-    const sub = this.parentElement as UiDropdownMenuSub | null;
-    if (sub?.tagName === 'UI-DROPDOWN-MENU-SUB') sub.toggle();
+    const sub = this.closest('ui-dropdown-menu-sub') as UiDropdownMenuSub | null;
+    sub?.toggle();
   };
-  private _onPointerEnter = (): void => {
+
+  _onPointerEnter = (): void => {
     if (this.hasAttribute('data-disabled')) return;
     this.focus();
-    const sub = this.parentElement as UiDropdownMenuSub | null;
-    if (sub?.tagName === 'UI-DROPDOWN-MENU-SUB') sub.show();
+    const sub = this.closest('ui-dropdown-menu-sub') as UiDropdownMenuSub | null;
+    sub?.show();
   };
 }
-defineElement('ui-dropdown-menu-sub-trigger', UiDropdownMenuSubTrigger);
+UiDropdownMenuSubTrigger.register('ui-dropdown-menu-sub-trigger');
 
-export class UiDropdownMenuSubContent extends Base {
+// --------------------------------------------------------------------------
+// <ui-dropdown-menu-sub-content>
+// --------------------------------------------------------------------------
+
+export class UiDropdownMenuSubContent extends WebComponent {
+  _userClass: string = '';
+
   connectedCallback(): void {
+    this._userClass = this.getAttribute('class') ?? '';
+    super.connectedCallback?.();
+  }
+
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'dropdown-menu-sub-content');
     this.setAttribute('role', 'menu');
     if (!this.hasAttribute('popover')) this.setAttribute('popover', 'manual');
-    const userClass = this.getAttribute('class') ?? '';
-    this.className = cn(dropdownMenuSubContentClass(), userClass);
+  }
+
+  render() {
+    this.className = cn(dropdownMenuSubContentClass(), this._userClass);
+    return html`<slot></slot>`;
   }
 }
-defineElement('ui-dropdown-menu-sub-content', UiDropdownMenuSubContent);
+UiDropdownMenuSubContent.register('ui-dropdown-menu-sub-content');

--- a/packages/ui/packages/registry/components/hover-card.ts
+++ b/packages/ui/packages/registry/components/hover-card.ts
@@ -61,6 +61,10 @@ export class UiHoverCard extends WebComponent {
     return html`<slot></slot>`;
   }
 
+  // Back-compat getter: tests + consumer code that read `el.isOpen`
+  // keep working alongside the reactive `open` prop.
+  get isOpen(): boolean { return this.open; }
+
   show(): void {
     clearTimeout(this._hideTimer);
     const delay = Number(this.getAttribute('open-delay') ?? 700);

--- a/packages/ui/packages/registry/components/hover-card.ts
+++ b/packages/ui/packages/registry/components/hover-card.ts
@@ -25,7 +25,8 @@
  *
  * Design tokens used: --popover, --popover-foreground, --border.
  */
-import { cn, Base, defineElement } from '../lib/utils.ts';
+import { WebComponent, html } from '@webjskit/core';
+import { cn } from '../lib/utils.ts';
 import { positionFloating, type PopoverSide, type PopoverAlign } from './popover.ts';
 
 // `fixed m-0` opts out of the UA `[popover]` defaults (the auto-centering
@@ -36,35 +37,56 @@ import { positionFloating, type PopoverSide, type PopoverAlign } from './popover
 export const hoverCardContentClass = (): string =>
   'fixed z-50 w-64 m-0 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden';
 
-export class UiHoverCard extends Base {
-  static get observedAttributes(): string[] {
-    return ['open'];
-  }
-  private _showTimer: number | undefined;
-  private _hideTimer: number | undefined;
+export class UiHoverCard extends WebComponent {
+  static properties = {
+    open: { type: Boolean, reflect: true },
+  };
+  declare open: boolean;
 
-  connectedCallback(): void {
+  _showTimer: number | undefined;
+  _hideTimer: number | undefined;
+
+  constructor() {
+    super();
+    this.open = false;
+  }
+
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'hover-card');
-    this._reflect();
   }
-  attributeChangedCallback(): void {
-    this._reflect();
-    if (this.hasAttribute('open')) this._reposition();
+
+  render() {
+    this.setAttribute('data-state', this.open ? 'open' : 'closed');
+    queueMicrotask(() => this._syncContent());
+    return html`<slot></slot>`;
   }
+
   show(): void {
     clearTimeout(this._hideTimer);
     const delay = Number(this.getAttribute('open-delay') ?? 700);
-    this._showTimer = window.setTimeout(() => this.setAttribute('open', ''), delay);
+    this._showTimer = window.setTimeout(() => { this.open = true; }, delay);
   }
+
   hide(): void {
     clearTimeout(this._showTimer);
     const delay = Number(this.getAttribute('close-delay') ?? 300);
-    this._hideTimer = window.setTimeout(() => this.removeAttribute('open'), delay);
+    this._hideTimer = window.setTimeout(() => { this.open = false; }, delay);
   }
-  _reposition(): void {
-    const trigger = this.querySelector<HTMLElement>(':scope > ui-hover-card-trigger');
-    const content = this.querySelector<HTMLElement>(':scope > ui-hover-card-content');
-    if (!trigger || !content) return;
+
+  _syncContent(): void {
+    const content = this.querySelector<HTMLElement>('ui-hover-card-content');
+    if (!content) return;
+    content.setAttribute('data-state', this.open ? 'open' : 'closed');
+    if (typeof (content as HTMLElement & { showPopover?: () => void }).showPopover === 'function') {
+      if (this.open) (content as HTMLElement & { showPopover: () => void }).showPopover();
+      else (content as HTMLElement & { hidePopover: () => void }).hidePopover();
+    }
+    if (this.open) this._reposition(content);
+  }
+
+  _reposition(content: HTMLElement): void {
+    const trigger = this.querySelector<HTMLElement>('ui-hover-card-trigger');
+    if (!trigger) return;
     positionFloating(trigger, content, {
       side: (content.getAttribute('side') ?? 'bottom') as PopoverSide,
       align: (content.getAttribute('align') ?? 'center') as PopoverAlign,
@@ -72,58 +94,67 @@ export class UiHoverCard extends Base {
       alignOffset: Number(content.getAttribute('align-offset') ?? 0),
     });
   }
-  private _reflect(): void {
-    const open = this.hasAttribute('open');
-    this.setAttribute('data-state', open ? 'open' : 'closed');
-    const content = this.querySelector<HTMLElement>(':scope > ui-hover-card-content');
-    if (!content) return;
-    content.setAttribute('data-state', open ? 'open' : 'closed');
-    if (typeof (content as HTMLElement & { showPopover?: () => void }).showPopover === 'function') {
-      if (open) (content as HTMLElement & { showPopover: () => void }).showPopover();
-      else (content as HTMLElement & { hidePopover: () => void }).hidePopover();
-    }
-  }
 }
-defineElement('ui-hover-card', UiHoverCard);
+UiHoverCard.register('ui-hover-card');
 
-export class UiHoverCardTrigger extends Base {
-  connectedCallback(): void {
+export class UiHoverCardTrigger extends WebComponent {
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'hover-card-trigger');
     this.addEventListener('mouseenter', this._onEnter);
     this.addEventListener('mouseleave', this._onLeave);
     this.addEventListener('focusin', this._onEnter);
     this.addEventListener('focusout', this._onLeave);
   }
+
   disconnectedCallback(): void {
     this.removeEventListener('mouseenter', this._onEnter);
     this.removeEventListener('mouseleave', this._onLeave);
     this.removeEventListener('focusin', this._onEnter);
     this.removeEventListener('focusout', this._onLeave);
+    super.disconnectedCallback?.();
   }
-  private _onEnter = (): void => (this.closest('ui-hover-card') as UiHoverCard | null)?.show();
-  private _onLeave = (): void => (this.closest('ui-hover-card') as UiHoverCard | null)?.hide();
-}
-defineElement('ui-hover-card-trigger', UiHoverCardTrigger);
 
-export class UiHoverCardContent extends Base {
+  render() {
+    return html`<slot></slot>`;
+  }
+
+  _onEnter = (): void => (this.closest('ui-hover-card') as UiHoverCard | null)?.show();
+  _onLeave = (): void => (this.closest('ui-hover-card') as UiHoverCard | null)?.hide();
+}
+UiHoverCardTrigger.register('ui-hover-card-trigger');
+
+export class UiHoverCardContent extends WebComponent {
+  _userClass: string = '';
+
   connectedCallback(): void {
+    this._userClass = this.getAttribute('class') ?? '';
+    super.connectedCallback?.();
+  }
+
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'hover-card-content');
     this.setAttribute('role', 'dialog');
     // Opt into the native top-layer via the Popover API in manual mode.
     // Manual (rather than auto) avoids the native light-dismiss closing
     // the card when the cursor is briefly off the trigger.
     if (!this.hasAttribute('popover')) this.setAttribute('popover', 'manual');
-    const userClass = this.getAttribute('class') ?? '';
-    this.className = cn(hoverCardContentClass(), userClass);
     // Keep open while pointer is over the content itself.
     this.addEventListener('mouseenter', this._onEnter);
     this.addEventListener('mouseleave', this._onLeave);
   }
+
   disconnectedCallback(): void {
     this.removeEventListener('mouseenter', this._onEnter);
     this.removeEventListener('mouseleave', this._onLeave);
+    super.disconnectedCallback?.();
   }
-  private _onEnter = (): void => (this.closest('ui-hover-card') as UiHoverCard | null)?.show();
-  private _onLeave = (): void => (this.closest('ui-hover-card') as UiHoverCard | null)?.hide();
+
+  render() {
+    this.className = cn(hoverCardContentClass(), this._userClass);
+    return html`<slot></slot>`;
+  }
+
+  _onEnter = (): void => (this.closest('ui-hover-card') as UiHoverCard | null)?.show();
+  _onLeave = (): void => (this.closest('ui-hover-card') as UiHoverCard | null)?.hide();
 }
-defineElement('ui-hover-card-content', UiHoverCardContent);
+UiHoverCardContent.register('ui-hover-card-content');

--- a/packages/ui/packages/registry/components/progress.ts
+++ b/packages/ui/packages/registry/components/progress.ts
@@ -20,7 +20,8 @@
  *
  * Design tokens used: --primary.
  */
-import { cn, Base, defineElement } from '../lib/utils.ts';
+import { WebComponent, html } from '@webjskit/core';
+import { cn } from '../lib/utils.ts';
 
 const ROOT_CLASS = 'relative h-2 w-full overflow-hidden rounded-full bg-primary/20';
 const INDICATOR_CLASS = 'h-full w-full flex-1 bg-primary transition-all';
@@ -38,62 +39,65 @@ function installStyles(): void {
   document.head.appendChild(style);
 }
 
-export class UiProgress extends Base {
-  static get observedAttributes(): string[] {
-    return ['value', 'max'];
-  }
+export class UiProgress extends WebComponent {
+  static properties = {
+    value: { type: Number, reflect: true },
+    max: { type: Number, reflect: true },
+  };
+  declare value: number;
+  declare max: number;
 
-  private _indicator: HTMLDivElement | null = null;
+  _userClass: string = '';
+
+  constructor() {
+    super();
+    this.value = 0;
+    this.max = 100;
+  }
 
   connectedCallback(): void {
     installStyles();
+    this._userClass = this.getAttribute('class') ?? '';
+    super.connectedCallback?.();
+  }
+
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'progress');
     this.setAttribute('role', 'progressbar');
-    const userClass = this.getAttribute('class') ?? '';
-    this.className = cn(ROOT_CLASS, userClass);
-    if (!this._indicator) {
-      this._indicator = document.createElement('div');
-      this._indicator.setAttribute('data-slot', 'progress-indicator');
-      this._indicator.className = INDICATOR_CLASS;
-      this.appendChild(this._indicator);
-    }
-    this._reflect();
   }
 
-  attributeChangedCallback(): void {
-    this._reflect();
-  }
-
-  private _reflect(): void {
+  render() {
+    // Treat a missing or non-finite `value` as indeterminate. The class
+    // helper merges the author's authored class with our root class on
+    // every render so a runtime class change is preserved.
     const rawValue = this.getAttribute('value');
-    const value = Number(rawValue ?? '0');
-    const max = Number(this.getAttribute('max') ?? '100');
-    const clamped = Math.max(0, Math.min(max, isFinite(value) ? value : 0));
+    const valueIsMissing = rawValue === null || rawValue === '' || !isFinite(this.value);
+    const max = isFinite(this.max) && this.max > 0 ? this.max : 100;
+    const clamped = Math.max(0, Math.min(max, valueIsMissing ? 0 : this.value));
     const pct = max > 0 ? (clamped / max) * 100 : 0;
+    const state = valueIsMissing
+      ? 'indeterminate'
+      : clamped >= max
+        ? 'complete'
+        : 'loading';
+
+    this.className = cn(ROOT_CLASS, this._userClass);
     this.setAttribute('aria-valuenow', String(clamped));
     this.setAttribute('aria-valuemin', '0');
     this.setAttribute('aria-valuemax', String(max));
-    // Radix/shadcn data-attribute portability: class strings like
-    //   data-[state=loading]:animate-pulse
-    //   data-[state=indeterminate]:bg-muted
-    // can target our progress now. State = indeterminate when `value`
-    // is absent/null (matches Radix), loading while strictly less than
-    // max, complete on reach.
-    const state =
-      rawValue === null || rawValue === '' || !isFinite(value)
-        ? 'indeterminate'
-        : clamped >= max
-          ? 'complete'
-          : 'loading';
     this.setAttribute('data-state', state);
     this.setAttribute('data-value', String(clamped));
     this.setAttribute('data-max', String(max));
-    if (this._indicator) {
-      this._indicator.setAttribute('data-state', state);
-      this._indicator.setAttribute('data-value', String(clamped));
-      this._indicator.setAttribute('data-max', String(max));
-      this._indicator.style.transform = `translateX(-${100 - pct}%)`;
-    }
+
+    return html`
+      <div
+        class=${INDICATOR_CLASS}
+        data-slot="progress-indicator"
+        data-state=${state}
+        data-value=${String(clamped)}
+        data-max=${String(max)}
+        style=${`transform: translateX(-${100 - pct}%)`}></div>
+    `;
   }
 }
-defineElement('ui-progress', UiProgress);
+UiProgress.register('ui-progress');

--- a/packages/ui/packages/registry/components/sonner.ts
+++ b/packages/ui/packages/registry/components/sonner.ts
@@ -17,7 +17,10 @@
  *
  * Design tokens used: --popover, --popover-foreground, --border, --radius.
  */
-import { cn, Base, defineElement } from '../lib/utils.ts';
+import { WebComponent, html } from '@webjskit/core';
+import { unsafeHTML } from '@webjskit/core/directives';
+import { repeat } from '@webjskit/core';
+import { cn } from '../lib/utils.ts';
 
 type ToastType = 'default' | 'success' | 'error' | 'info' | 'warning' | 'loading';
 
@@ -81,7 +84,8 @@ toast.promise = <T,>(p: Promise<T>, opts: { loading: string; success: string; er
 };
 
 // --------------------------------------------------------------------------
-// <ui-sonner> is the toaster element. Renders pending toasts as children.
+// <ui-sonner> renders pending toasts. No user-projected children, so no
+// <slot>: the toaster owns its content entirely via render().
 // --------------------------------------------------------------------------
 
 const POSITIONS = {
@@ -107,16 +111,32 @@ const TYPE_ICON_COLOR: Record<ToastType, string> = {
   loading: 'text-muted-foreground',
 };
 
-export class UiSonner extends Base {
-  private _items: ToastItem[] = [];
+interface SonnerState {
+  items: ToastItem[];
+}
+
+export class UiSonner extends WebComponent {
+  static properties = {
+    position: { type: String, reflect: true },
+  };
+  declare position: SonnerPosition;
+  declare state: SonnerState;
+
+  _userClass: string = '';
+
+  constructor() {
+    super();
+    this.position = 'bottom-right';
+    this.state = { items: [] };
+  }
 
   connectedCallback(): void {
-    const position = (this.getAttribute('position') as SonnerPosition) ?? 'bottom-right';
+    this._userClass = this.getAttribute('class') ?? '';
+    super.connectedCallback?.();
+  }
+
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'sonner');
-    this.className = cn(
-      'pointer-events-none fixed z-[100] flex flex-col gap-2',
-      POSITIONS[position] ?? POSITIONS['bottom-right'],
-    );
     toaster.add = (t) => this._add(t);
     toaster.remove = (id) => this._remove(id);
   }
@@ -128,7 +148,7 @@ export class UiSonner extends Base {
    * viewport). Primary use case: docs demos that mount one viewport
    * per position and want each demo button to fire into its own
    * viewport. App code should normally call the global `toast()` /
-   * `toast.success()` / etc.: they route via the singleton.
+   * `toast.success()` / etc., which route via the singleton.
    */
   addToast(message: string, opts: ToastOptions = {}, type: ToastType = 'default'): string | number {
     const id = opts.id ?? nextId++;
@@ -143,49 +163,57 @@ export class UiSonner extends Base {
     return id;
   }
 
-  private _add(item: ToastItem): void {
-    this._items.push(item);
-    this._render();
+  _add(item: ToastItem): void {
+    this.setState({ items: [...this.state.items, item] });
     if (item.duration && item.duration > 0) {
       setTimeout(() => this._remove(item.id), item.duration);
     }
   }
 
-  private _remove(id: string | number): void {
-    this._items = this._items.filter((i) => i.id !== id);
-    this._render();
+  _remove(id: string | number): void {
+    this.setState({ items: this.state.items.filter((i) => i.id !== id) });
   }
 
-  private _render(): void {
-    this.replaceChildren(
-      ...this._items.map((item) => {
-        const el = document.createElement('div');
-        el.className = TOAST_ITEM_BASE;
-        el.setAttribute('data-type', item.type);
-        el.setAttribute('role', item.type === 'error' ? 'alert' : 'status');
-        el.innerHTML = `
-          <div class="${TYPE_ICON_COLOR[item.type]} pt-0.5">${ICONS[item.type]}</div>
-          <div class="flex-1">
-            <div class="font-medium">${escapeHTML(item.message)}</div>
-            ${item.description ? `<div class="mt-1 text-xs text-muted-foreground">${escapeHTML(item.description)}</div>` : ''}
-          </div>
-        `;
-        if (item.action) {
-          const btn = document.createElement('button');
-          btn.className = 'rounded-md px-2 py-1 text-xs font-medium hover:bg-accent';
-          btn.textContent = item.action.label;
-          btn.onclick = () => {
-            item.action!.onClick();
-            this._remove(item.id);
-          };
-          el.appendChild(btn);
-        }
-        return el;
-      }),
+  render() {
+    const pos = POSITIONS[this.position] ?? POSITIONS['bottom-right'];
+    this.className = cn(
+      'pointer-events-none fixed z-[100] flex flex-col gap-2',
+      pos,
+      this._userClass,
     );
+    return html`
+      ${repeat(
+        this.state.items,
+        (item) => item.id,
+        (item) => html`
+          <div
+            class=${TOAST_ITEM_BASE}
+            data-type=${item.type}
+            role=${item.type === 'error' ? 'alert' : 'status'}>
+            <div class=${`${TYPE_ICON_COLOR[item.type]} pt-0.5`}>${unsafeHTML(ICONS[item.type])}</div>
+            <div class="flex-1">
+              <div class="font-medium">${item.message}</div>
+              ${item.description
+                ? html`<div class="mt-1 text-xs text-muted-foreground">${item.description}</div>`
+                : ''}
+            </div>
+            ${item.action
+              ? html`<button
+                  class="rounded-md px-2 py-1 text-xs font-medium hover:bg-accent"
+                  @click=${() => {
+                    item.action!.onClick();
+                    this._remove(item.id);
+                  }}>
+                  ${item.action.label}
+                </button>`
+              : ''}
+          </div>
+        `,
+      )}
+    `;
   }
 }
-defineElement('ui-sonner', UiSonner);
+UiSonner.register('ui-sonner');
 
 const ICONS: Record<ToastType, string> = {
   default: '',
@@ -199,9 +227,3 @@ const ICONS: Record<ToastType, string> = {
   loading:
     '<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" class="animate-spin"><line x1="12" y1="2" x2="12" y2="6"/><line x1="12" y1="18" x2="12" y2="22"/><line x1="4.93" y1="4.93" x2="7.76" y2="7.76"/><line x1="16.24" y1="16.24" x2="19.07" y2="19.07"/><line x1="2" y1="12" x2="6" y2="12"/><line x1="18" y1="12" x2="22" y2="12"/></svg>',
 };
-
-function escapeHTML(s: string): string {
-  return s.replace(/[&<>"']/g, (c) =>
-    c === '&' ? '&amp;' : c === '<' ? '&lt;' : c === '>' ? '&gt;' : c === '"' ? '&quot;' : '&#39;',
-  );
-}

--- a/packages/ui/packages/registry/components/sonner.ts
+++ b/packages/ui/packages/registry/components/sonner.ts
@@ -17,9 +17,8 @@
  *
  * Design tokens used: --popover, --popover-foreground, --border, --radius.
  */
-import { WebComponent, html } from '@webjskit/core';
+import { WebComponent, html, repeat } from '@webjskit/core';
 import { unsafeHTML } from '@webjskit/core/directives';
-import { repeat } from '@webjskit/core';
 import { cn } from '../lib/utils.ts';
 
 type ToastType = 'default' | 'success' | 'error' | 'info' | 'warning' | 'loading';

--- a/packages/ui/packages/registry/components/tabs.ts
+++ b/packages/ui/packages/registry/components/tabs.ts
@@ -36,7 +36,8 @@
  * --input, --ring.
  */
 
-import { cn, Base, defineElement } from '../lib/utils.ts';
+import { WebComponent, html } from '@webjskit/core';
+import { cn } from '../lib/utils.ts';
 
 // --------------------------------------------------------------------------
 // Class helpers
@@ -105,40 +106,50 @@ function installStyles(): void {
 // <ui-tabs> owns active `value` and `orientation`, broadcasts to children.
 // --------------------------------------------------------------------------
 
-export class UiTabs extends Base {
-  static get observedAttributes(): string[] {
-    return ['value', 'orientation'];
+export class UiTabs extends WebComponent {
+  static properties = {
+    value: { type: String, reflect: true },
+    orientation: { type: String, reflect: true },
+  };
+  declare value: string;
+  declare orientation: 'horizontal' | 'vertical';
+
+  _userClass: string = '';
+  _lastValue: string = '';
+
+  constructor() {
+    super();
+    this.value = '';
+    this.orientation = 'horizontal';
   }
 
   connectedCallback(): void {
     installStyles();
+    this._userClass = this.getAttribute('class') ?? '';
+    super.connectedCallback?.();
+  }
+
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'tabs');
-    if (!this.hasAttribute('orientation')) this.setAttribute('orientation', 'horizontal');
-    this.setAttribute('data-orientation', this.getAttribute('orientation') ?? 'horizontal');
-    const userClass = this.getAttribute('class') ?? '';
-    this.className = cn(TABS_BASE, userClass);
+  }
+
+  render() {
+    this.setAttribute('data-orientation', this.orientation);
+    this.className = cn(TABS_BASE, this._userClass);
     queueMicrotask(() => this._syncChildren());
-  }
-
-  attributeChangedCallback(name: string, oldVal: string | null, newVal: string | null): void {
-    if (oldVal === newVal) return;
-    if (name === 'orientation') {
-      this.setAttribute('data-orientation', newVal ?? 'horizontal');
+    // Fire value-change event when value mutates after first render.
+    if (this._lastValue !== this.value) {
+      const prev = this._lastValue;
+      this._lastValue = this.value;
+      if (prev !== '' || this.value !== '') {
+        queueMicrotask(() => {
+          this.dispatchEvent(
+            new CustomEvent('ui-value-change', { detail: { value: this.value }, bubbles: true }),
+          );
+        });
+      }
     }
-    if (name === 'value') {
-      this._syncChildren();
-      this.dispatchEvent(
-        new CustomEvent('ui-value-change', { detail: { value: newVal }, bubbles: true }),
-      );
-    }
-  }
-
-  get value(): string {
-    return this.getAttribute('value') ?? '';
-  }
-
-  set value(v: string) {
-    this.setAttribute('value', v);
+    return html`<slot></slot>`;
   }
 
   _syncChildren(): void {
@@ -158,53 +169,93 @@ export class UiTabs extends Base {
     });
   }
 }
-defineElement('ui-tabs', UiTabs);
+UiTabs.register('ui-tabs');
 
 // --------------------------------------------------------------------------
 // <ui-tabs-list> is the container for triggers. Applies role="tablist".
 // --------------------------------------------------------------------------
 
-export class UiTabsList extends Base {
+export class UiTabsList extends WebComponent {
+  static properties = {
+    variant: { type: String, reflect: true },
+  };
+  declare variant: TabsListVariant;
+
+  _userClass: string = '';
+
+  constructor() {
+    super();
+    this.variant = 'default';
+  }
+
   connectedCallback(): void {
+    this._userClass = this.getAttribute('class') ?? '';
+    super.connectedCallback?.();
+  }
+
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'tabs-list');
     this.setAttribute('role', 'tablist');
-    if (!this.hasAttribute('variant')) this.setAttribute('variant', 'default');
-    this.setAttribute('data-variant', this.getAttribute('variant') ?? 'default');
-    const userClass = this.getAttribute('class') ?? '';
-    this.className = cn(tabsListClass({ variant: this.getAttribute('variant') as TabsListVariant }), userClass);
+  }
+
+  render() {
+    this.setAttribute('data-variant', this.variant);
+    this.className = cn(tabsListClass({ variant: this.variant }), this._userClass);
+    return html`<slot></slot>`;
   }
 }
-defineElement('ui-tabs-list', UiTabsList);
+UiTabsList.register('ui-tabs-list');
 
 // --------------------------------------------------------------------------
 // <ui-tabs-trigger value="..."> is the tab button. Click + keyboard nav.
 // --------------------------------------------------------------------------
 
-export class UiTabsTrigger extends Base {
+export class UiTabsTrigger extends WebComponent {
+  static properties = {
+    value: { type: String, reflect: true },
+  };
+  declare value: string;
+
+  _userClass: string = '';
+
+  constructor() {
+    super();
+    this.value = '';
+  }
+
   connectedCallback(): void {
+    this._userClass = this.getAttribute('class') ?? '';
+    super.connectedCallback?.();
+  }
+
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'tabs-trigger');
     this.setAttribute('role', 'tab');
     this.setAttribute('tabindex', '-1');
-    const userClass = this.getAttribute('class') ?? '';
-    this.className = cn(TABS_TRIGGER_CLASS, userClass);
     this.addEventListener('click', this._onClick);
     this.addEventListener('keydown', this._onKeyDown);
   }
+
   disconnectedCallback(): void {
     this.removeEventListener('click', this._onClick);
     this.removeEventListener('keydown', this._onKeyDown);
+    super.disconnectedCallback?.();
   }
 
-  private get _tabs(): UiTabs | null {
+  render() {
+    this.className = cn(TABS_TRIGGER_CLASS, this._userClass);
+    return html`<slot></slot>`;
+  }
+
+  get _tabs(): UiTabs | null {
     return this.closest('ui-tabs') as UiTabs | null;
   }
 
-  private _onClick = (): void => {
-    const value = this.getAttribute('value');
-    if (value != null) this._tabs?.setAttribute('value', value);
+  _onClick = (): void => {
+    if (this.value) this._tabs?.setAttribute('value', this.value);
   };
 
-  private _onKeyDown = (e: KeyboardEvent): void => {
+  _onKeyDown = (e: KeyboardEvent): void => {
     const tabs = this._tabs;
     if (!tabs) return;
     const orientation = tabs.getAttribute('orientation') ?? 'horizontal';
@@ -232,19 +283,39 @@ export class UiTabsTrigger extends Base {
     }
   };
 }
-defineElement('ui-tabs-trigger', UiTabsTrigger);
+UiTabsTrigger.register('ui-tabs-trigger');
 
 // --------------------------------------------------------------------------
 // <ui-tabs-content value="..."> is the panel content. Shown when value matches.
 // --------------------------------------------------------------------------
 
-export class UiTabsContent extends Base {
+export class UiTabsContent extends WebComponent {
+  static properties = {
+    value: { type: String, reflect: true },
+  };
+  declare value: string;
+
+  _userClass: string = '';
+
+  constructor() {
+    super();
+    this.value = '';
+  }
+
   connectedCallback(): void {
+    this._userClass = this.getAttribute('class') ?? '';
+    super.connectedCallback?.();
+  }
+
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'tabs-content');
     this.setAttribute('role', 'tabpanel');
     this.setAttribute('tabindex', '0');
-    const userClass = this.getAttribute('class') ?? '';
-    this.className = cn(TABS_CONTENT_CLASS, userClass);
+  }
+
+  render() {
+    this.className = cn(TABS_CONTENT_CLASS, this._userClass);
+    return html`<slot></slot>`;
   }
 }
-defineElement('ui-tabs-content', UiTabsContent);
+UiTabsContent.register('ui-tabs-content');

--- a/packages/ui/packages/registry/components/toggle-group.ts
+++ b/packages/ui/packages/registry/components/toggle-group.ts
@@ -33,73 +33,86 @@
  *
  * Design tokens used: inherited from toggleClass.
  */
-import { cn, Base, defineElement } from '../lib/utils.ts';
+import { WebComponent, html } from '@webjskit/core';
+import { cn } from '../lib/utils.ts';
 import { toggleClass, type ToggleVariant, type ToggleSize } from './toggle.ts';
 
 const ROOT_BASE =
   'group/toggle-group flex w-fit items-center rounded-md data-[spacing=default]:data-[variant=outline]:shadow-xs data-[orientation=vertical]:flex-col data-[orientation=vertical]:items-stretch';
 
-export class UiToggleGroup extends Base {
-  static get observedAttributes(): string[] {
-    return ['value', 'variant', 'size', 'spacing', 'type', 'orientation'];
+export class UiToggleGroup extends WebComponent {
+  static properties = {
+    value: { type: String, reflect: true },
+    type: { type: String, reflect: true },
+    variant: { type: String, reflect: true },
+    size: { type: String, reflect: true },
+    spacing: { type: String, reflect: true },
+    orientation: { type: String, reflect: true },
+  };
+  declare value: string;
+  declare type: 'single' | 'multiple';
+  declare variant: ToggleVariant;
+  declare size: ToggleSize;
+  declare spacing: string;
+  declare orientation: 'horizontal' | 'vertical';
+
+  _userClass: string = '';
+
+  constructor() {
+    super();
+    this.value = '';
+    this.type = 'single';
+    this.variant = 'default';
+    this.size = 'default';
+    this.spacing = '0';
+    this.orientation = 'horizontal';
   }
 
   connectedCallback(): void {
+    this._userClass = this.getAttribute('class') ?? '';
+    super.connectedCallback?.();
+  }
+
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'toggle-group');
-    if (!this.hasAttribute('type')) this.setAttribute('type', 'single');
-    if (!this.hasAttribute('variant')) this.setAttribute('variant', 'default');
-    if (!this.hasAttribute('size')) this.setAttribute('size', 'default');
-    if (!this.hasAttribute('spacing')) this.setAttribute('spacing', '0');
-    // shadcn's radix-* and base-* styles all expose orientation;
-    // default "horizontal" matches Radix ToggleGroup.Root.
-    if (!this.hasAttribute('orientation')) this.setAttribute('orientation', 'horizontal');
-    this.setAttribute('data-orientation', this.getAttribute('orientation') ?? 'horizontal');
     this.setAttribute('role', 'group');
-    this._applyClass();
-    this._reflect();
     this.addEventListener('ui-toggle-item-click', this._onItemClick as EventListener);
   }
+
   disconnectedCallback(): void {
     this.removeEventListener('ui-toggle-item-click', this._onItemClick as EventListener);
+    super.disconnectedCallback?.();
   }
 
-  attributeChangedCallback(name: string): void {
-    if (name === 'orientation') {
-      this.setAttribute('data-orientation', this.getAttribute('orientation') ?? 'horizontal');
-    }
-    this._applyClass();
-    this._reflect();
-  }
-
-  private get _type(): 'single' | 'multiple' {
-    return (this.getAttribute('type') as 'single' | 'multiple') ?? 'single';
-  }
-
-  private get _values(): Set<string> {
-    const raw = this.getAttribute('value') ?? '';
+  get _values(): Set<string> {
+    const raw = this.value ?? '';
     return new Set(raw ? raw.split(',').map((s) => s.trim()).filter(Boolean) : []);
   }
 
-  private _setValues(values: Set<string>): void {
+  _setValues(values: Set<string>): void {
     const next = Array.from(values).join(',');
-    if (this._type === 'single') {
-      this.setAttribute('value', next.split(',')[0] ?? '');
+    if (this.type === 'single') {
+      this.value = next.split(',')[0] ?? '';
     } else {
-      this.setAttribute('value', next);
+      this.value = next;
     }
   }
 
-  private _applyClass(): void {
-    const userClass = this.getAttribute('class') ?? '';
-    const spacing = this.getAttribute('spacing') ?? '0';
-    this.setAttribute('data-variant', this.getAttribute('variant') ?? 'default');
-    this.setAttribute('data-size', this.getAttribute('size') ?? 'default');
-    this.setAttribute('data-spacing', spacing);
-    const gap = spacing === '0' ? '' : 'gap-1';
-    this.className = cn(ROOT_BASE, gap, userClass);
+  render() {
+    this.setAttribute('data-variant', this.variant);
+    this.setAttribute('data-size', this.size);
+    this.setAttribute('data-spacing', this.spacing);
+    this.setAttribute('data-orientation', this.orientation);
+    const gap = this.spacing === '0' ? '' : 'gap-1';
+    this.className = cn(ROOT_BASE, gap, this._userClass);
+    // Items live in the DOM via the slot. Update their state in a
+    // microtask so the slot adoption / projection has settled before we
+    // walk them.
+    queueMicrotask(() => this._updateItems());
+    return html`<slot></slot>`;
   }
 
-  private _reflect(): void {
+  _updateItems(): void {
     const values = this._values;
     const items = this.querySelectorAll<HTMLElement>('ui-toggle-group-item');
     items.forEach((item) => {
@@ -110,11 +123,11 @@ export class UiToggleGroup extends Base {
     });
   }
 
-  private _onItemClick = (e: CustomEvent): void => {
+  _onItemClick = (e: CustomEvent): void => {
     const v = e.detail?.value as string | undefined;
     if (!v) return;
     const values = this._values;
-    if (this._type === 'single') {
+    if (this.type === 'single') {
       values.clear();
       values.add(v);
     } else {
@@ -124,55 +137,78 @@ export class UiToggleGroup extends Base {
     this._setValues(values);
     this.dispatchEvent(
       new CustomEvent('ui-value-change', {
-        detail: { value: this.getAttribute('value') ?? '' },
+        detail: { value: this.value },
         bubbles: true,
       }),
     );
   };
 }
-defineElement('ui-toggle-group', UiToggleGroup);
+UiToggleGroup.register('ui-toggle-group');
 
 const ITEM_EXTRA =
   'w-auto min-w-0 shrink-0 px-3 focus:z-10 focus-visible:z-10 data-[spacing=0]:rounded-none data-[spacing=0]:shadow-none data-[spacing=0]:first:rounded-l-md data-[spacing=0]:last:rounded-r-md data-[spacing=0]:data-[variant=outline]:border-l-0 data-[spacing=0]:data-[variant=outline]:first:border-l';
 
-export class UiToggleGroupItem extends Base {
+export class UiToggleGroupItem extends WebComponent {
+  static properties = {
+    value: { type: String, reflect: true },
+  };
+  declare value: string;
+
+  _userClass: string = '';
+
+  constructor() {
+    super();
+    this.value = '';
+  }
+
   connectedCallback(): void {
+    this._userClass = this.getAttribute('class') ?? '';
+    super.connectedCallback?.();
+  }
+
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'toggle-group-item');
     this.setAttribute('role', 'button');
     this.setAttribute('tabindex', '0');
-    this._applyClass();
     this.addEventListener('click', this._onClick);
     this.addEventListener('keydown', this._onKeyDown);
   }
+
   disconnectedCallback(): void {
     this.removeEventListener('click', this._onClick);
     this.removeEventListener('keydown', this._onKeyDown);
+    super.disconnectedCallback?.();
   }
-  private get _group(): UiToggleGroup | null {
+
+  get _group(): UiToggleGroup | null {
     return this.closest('ui-toggle-group') as UiToggleGroup | null;
   }
-  private _applyClass(): void {
-    const userClass = this.getAttribute('class') ?? '';
+
+  render() {
     const group = this._group;
     const variant = (group?.getAttribute('variant') ?? 'default') as ToggleVariant;
     const size = (group?.getAttribute('size') ?? 'default') as ToggleSize;
+    const spacing = group?.getAttribute('spacing') ?? '0';
     this.setAttribute('data-variant', variant);
     this.setAttribute('data-size', size);
-    this.setAttribute('data-spacing', group?.getAttribute('spacing') ?? '0');
-    this.className = cn(toggleClass({ variant, size }), ITEM_EXTRA, userClass);
+    this.setAttribute('data-spacing', spacing);
+    this.className = cn(toggleClass({ variant, size }), ITEM_EXTRA, this._userClass);
+    return html`<slot></slot>`;
   }
-  private _onClick = (): void => {
-    const v = this.getAttribute('value');
+
+  _onClick = (): void => {
+    const v = this.value;
     if (!v) return;
     this.dispatchEvent(
       new CustomEvent('ui-toggle-item-click', { detail: { value: v }, bubbles: true }),
     );
   };
-  private _onKeyDown = (e: KeyboardEvent): void => {
+
+  _onKeyDown = (e: KeyboardEvent): void => {
     if (e.key === ' ' || e.key === 'Enter') {
       e.preventDefault();
       this._onClick();
     }
   };
 }
-defineElement('ui-toggle-group-item', UiToggleGroupItem);
+UiToggleGroupItem.register('ui-toggle-group-item');

--- a/packages/ui/packages/registry/components/toggle.ts
+++ b/packages/ui/packages/registry/components/toggle.ts
@@ -13,7 +13,7 @@
  *     <svg>…</svg>
  *   </button>
  *
- * Usage (custom element: handles state for you):
+ * Usage (custom element handles state for you):
  *   <ui-toggle aria-label="Toggle bold">
  *     <svg>…</svg>
  *   </ui-toggle>
@@ -21,7 +21,8 @@
  * Design tokens used: --muted, --muted-foreground, --accent, --accent-foreground,
  * --input, --background, --ring, --destructive.
  */
-import { cn, Base, defineElement } from '../lib/utils.ts';
+import { WebComponent, html } from '@webjskit/core';
+import { cn } from '../lib/utils.ts';
 
 // cursor-pointer + select-none on BASE for both call sites: the
 // class-helper applied to a native <button> (where shadcn's upstream
@@ -53,69 +54,80 @@ export function toggleClass(opts: { variant?: ToggleVariant; size?: ToggleSize }
 }
 
 // --------------------------------------------------------------------------
-// <ui-toggle> manages pressed state + aria-pressed + data-state on a host
-// button. Convenience when you want state without writing the toggling JS.
+// <ui-toggle> owns stateful pressed / aria-pressed / data-state on a
+// host button. Authored children (an icon, a label, etc.) project
+// through the default slot.
 // --------------------------------------------------------------------------
 
-export class UiToggle extends Base {
-  static get observedAttributes(): string[] {
-    return ['pressed', 'variant', 'size', 'disabled'];
+export class UiToggle extends WebComponent {
+  static properties = {
+    pressed: { type: Boolean, reflect: true },
+    variant: { type: String, reflect: true },
+    size: { type: String, reflect: true },
+    disabled: { type: Boolean, reflect: true },
+  };
+  declare pressed: boolean;
+  declare variant: ToggleVariant;
+  declare size: ToggleSize;
+  declare disabled: boolean;
+
+  // Snapshot the author's class attribute at attach time so subsequent
+  // re-renders (variant / size change) merge with it instead of stomping.
+  _userClass: string = '';
+
+  constructor() {
+    super();
+    this.pressed = false;
+    this.variant = 'default';
+    this.size = 'default';
+    this.disabled = false;
   }
 
   connectedCallback(): void {
+    // Capture authored class before the first render writes ours.
+    this._userClass = this.getAttribute('class') ?? '';
+    super.connectedCallback?.();
+  }
+
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'toggle');
     this.setAttribute('role', 'button');
-    this.setAttribute('tabindex', this.hasAttribute('disabled') ? '-1' : '0');
-    this._applyClass();
-    this._reflect();
     this.addEventListener('click', this._onClick);
     this.addEventListener('keydown', this._onKeyDown);
   }
+
   disconnectedCallback(): void {
     this.removeEventListener('click', this._onClick);
     this.removeEventListener('keydown', this._onKeyDown);
-  }
-  attributeChangedCallback(name: string): void {
-    if (name === 'pressed' || name === 'disabled') this._reflect();
-    if (name === 'variant' || name === 'size') this._applyClass();
+    super.disconnectedCallback?.();
   }
 
-  get pressed(): boolean {
-    return this.hasAttribute('pressed');
-  }
-  set pressed(v: boolean) {
-    if (v) this.setAttribute('pressed', '');
-    else this.removeAttribute('pressed');
-  }
-
-  private _applyClass(): void {
-    const userClass = this.getAttribute('class') ?? '';
-    const variant = (this.getAttribute('variant') ?? 'default') as ToggleVariant;
-    const size = (this.getAttribute('size') ?? 'default') as ToggleSize;
-    this.className = cn(toggleClass({ variant, size }), userClass);
-  }
-
-  private _reflect(): void {
-    const on = this.pressed;
-    this.setAttribute('data-state', on ? 'on' : 'off');
-    this.setAttribute('aria-pressed', String(on));
-    if (this.hasAttribute('disabled')) this.setAttribute('aria-disabled', 'true');
+  render() {
+    // Host-level attributes that derive from reactive props get applied
+    // on every render. Setting non-observed attributes here (data-state,
+    // aria-pressed, tabindex, aria-disabled) does not re-enter render.
+    this.className = cn(toggleClass({ variant: this.variant, size: this.size }), this._userClass);
+    this.setAttribute('data-state', this.pressed ? 'on' : 'off');
+    this.setAttribute('aria-pressed', String(this.pressed));
+    this.setAttribute('tabindex', this.disabled ? '-1' : '0');
+    if (this.disabled) this.setAttribute('aria-disabled', 'true');
     else this.removeAttribute('aria-disabled');
+    return html`<slot></slot>`;
   }
 
-  private _onClick = (): void => {
-    if (this.hasAttribute('disabled')) return;
+  _onClick = (): void => {
+    if (this.disabled) return;
     this.pressed = !this.pressed;
     this.dispatchEvent(
       new CustomEvent('ui-pressed-change', { detail: { pressed: this.pressed }, bubbles: true }),
     );
   };
 
-  private _onKeyDown = (e: KeyboardEvent): void => {
+  _onKeyDown = (e: KeyboardEvent): void => {
     if (e.key === ' ' || e.key === 'Enter') {
       e.preventDefault();
       this._onClick();
     }
   };
 }
-defineElement('ui-toggle', UiToggle);
+UiToggle.register('ui-toggle');

--- a/packages/ui/packages/registry/components/tooltip.ts
+++ b/packages/ui/packages/registry/components/tooltip.ts
@@ -68,6 +68,10 @@ export class UiTooltip extends WebComponent {
     return html`<slot></slot>`;
   }
 
+  // Back-compat getter: tests + consumer code that read `el.isOpen`
+  // keep working alongside the reactive `open` prop.
+  get isOpen(): boolean { return this.open; }
+
   show(): void {
     clearTimeout(this._showTimer);
     clearTimeout(this._hideTimer);

--- a/packages/ui/packages/registry/components/tooltip.ts
+++ b/packages/ui/packages/registry/components/tooltip.ts
@@ -23,7 +23,8 @@
  *
  * Design tokens used: --foreground, --background.
  */
-import { cn, Base, defineElement } from '../lib/utils.ts';
+import { WebComponent, html } from '@webjskit/core';
+import { cn } from '../lib/utils.ts';
 import { positionFloating, type PopoverSide, type PopoverAlign } from './popover.ts';
 
 // The native UA stylesheet for `[popover]` paints a bordered, padded,
@@ -43,25 +44,32 @@ export const tooltipContentClass = (): string =>
 // immediately, matching shadcn's TooltipProvider.skipDelayDuration.
 let lastTooltipHideAt = 0;
 
-export class UiTooltip extends Base {
-  static get observedAttributes(): string[] {
-    return ['open'];
-  }
-  private _showTimer: number | undefined;
-  private _hideTimer: number | undefined;
+export class UiTooltip extends WebComponent {
+  static properties = {
+    open: { type: Boolean, reflect: true },
+  };
+  declare open: boolean;
 
-  connectedCallback(): void {
+  _showTimer: number | undefined;
+  _hideTimer: number | undefined;
+
+  constructor() {
+    super();
+    this.open = false;
+  }
+
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'tooltip');
-    this._reflect();
   }
-  attributeChangedCallback(): void {
-    this._reflect();
-    if (this.isOpen) this._reposition();
+
+  render() {
+    this.setAttribute('data-state', this.open ? 'open' : 'closed');
+    queueMicrotask(() => this._syncContent());
+    return html`<slot></slot>`;
   }
-  get isOpen(): boolean {
-    return this.hasAttribute('open');
-  }
+
   show(): void {
+    clearTimeout(this._showTimer);
     clearTimeout(this._hideTimer);
     const delay = Number(this.getAttribute('delay-duration') ?? 700);
     const skipDelay = Number(this.getAttribute('skip-delay-duration') ?? 300);
@@ -69,22 +77,36 @@ export class UiTooltip extends Base {
     // immediately (no delay-duration wait).
     const sinceLastHide = Date.now() - lastTooltipHideAt;
     if (lastTooltipHideAt > 0 && sinceLastHide < skipDelay) {
-      this.setAttribute('open', '');
+      this.open = true;
       return;
     }
-    this._showTimer = window.setTimeout(() => this.setAttribute('open', ''), delay);
+    this._showTimer = window.setTimeout(() => { this.open = true; }, delay);
   }
+
   hide(): void {
     clearTimeout(this._showTimer);
     this._hideTimer = window.setTimeout(() => {
-      this.removeAttribute('open');
+      this.open = false;
       lastTooltipHideAt = Date.now();
     }, 100);
   }
-  _reposition(): void {
-    const trigger = this.querySelector<HTMLElement>(':scope > ui-tooltip-trigger');
-    const content = this.querySelector<HTMLElement>(':scope > ui-tooltip-content');
-    if (!trigger || !content) return;
+
+  _syncContent(): void {
+    // Children live under the projection slot now; query by descendant
+    // search since :scope > would only see the slot wrapper.
+    const content = this.querySelector<HTMLElement>('ui-tooltip-content');
+    if (!content) return;
+    content.setAttribute('data-state', this.open ? 'open' : 'closed');
+    if (typeof (content as HTMLElement & { showPopover?: () => void }).showPopover === 'function') {
+      if (this.open) (content as HTMLElement & { showPopover: () => void }).showPopover();
+      else (content as HTMLElement & { hidePopover: () => void }).hidePopover();
+    }
+    if (this.open) this._reposition(content);
+  }
+
+  _reposition(content: HTMLElement): void {
+    const trigger = this.querySelector<HTMLElement>('ui-tooltip-trigger');
+    if (!trigger) return;
     positionFloating(trigger, content, {
       side: (content.getAttribute('side') ?? 'top') as PopoverSide,
       align: (content.getAttribute('align') ?? 'center') as PopoverAlign,
@@ -92,53 +114,56 @@ export class UiTooltip extends Base {
       alignOffset: Number(content.getAttribute('align-offset') ?? 0),
     });
   }
-  private _reflect(): void {
-    const open = this.isOpen;
-    this.setAttribute('data-state', open ? 'open' : 'closed');
-    const content = this.querySelector<HTMLElement>(':scope > ui-tooltip-content');
-    if (!content) return;
-    content.setAttribute('data-state', open ? 'open' : 'closed');
-    // Delegate visibility to the native popover. The popover attribute is
-    // wired by <ui-tooltip-content>'s connectedCallback; here we just flip
-    // the popover-open state to match our `open` attribute.
-    if (typeof (content as HTMLElement & { showPopover?: () => void }).showPopover === 'function') {
-      if (open) (content as HTMLElement & { showPopover: () => void }).showPopover();
-      else (content as HTMLElement & { hidePopover: () => void }).hidePopover();
-    }
-  }
 }
-defineElement('ui-tooltip', UiTooltip);
+UiTooltip.register('ui-tooltip');
 
-export class UiTooltipTrigger extends Base {
-  connectedCallback(): void {
+export class UiTooltipTrigger extends WebComponent {
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'tooltip-trigger');
     this.addEventListener('mouseenter', this._onEnter);
     this.addEventListener('mouseleave', this._onLeave);
     this.addEventListener('focusin', this._onEnter);
     this.addEventListener('focusout', this._onLeave);
   }
+
   disconnectedCallback(): void {
     this.removeEventListener('mouseenter', this._onEnter);
     this.removeEventListener('mouseleave', this._onLeave);
     this.removeEventListener('focusin', this._onEnter);
     this.removeEventListener('focusout', this._onLeave);
+    super.disconnectedCallback?.();
   }
-  private _onEnter = (): void => (this.closest('ui-tooltip') as UiTooltip | null)?.show();
-  private _onLeave = (): void => (this.closest('ui-tooltip') as UiTooltip | null)?.hide();
-}
-defineElement('ui-tooltip-trigger', UiTooltipTrigger);
 
-export class UiTooltipContent extends Base {
+  render() {
+    return html`<slot></slot>`;
+  }
+
+  _onEnter = (): void => (this.closest('ui-tooltip') as UiTooltip | null)?.show();
+  _onLeave = (): void => (this.closest('ui-tooltip') as UiTooltip | null)?.hide();
+}
+UiTooltipTrigger.register('ui-tooltip-trigger');
+
+export class UiTooltipContent extends WebComponent {
+  _userClass: string = '';
+
   connectedCallback(): void {
+    this._userClass = this.getAttribute('class') ?? '';
+    super.connectedCallback?.();
+  }
+
+  firstUpdated(): void {
     this.setAttribute('data-slot', 'tooltip-content');
     this.setAttribute('role', 'tooltip');
     // Opt into the native top-layer via the Popover API in manual mode.
     // We drive show/hide ourselves (hover delay), so manual is the right
-    // mode: auto would also dismiss on outside click, which isn't what a
-    // hover tooltip wants.
+    // mode: auto would also dismiss on outside click, which is not what
+    // a hover tooltip wants.
     if (!this.hasAttribute('popover')) this.setAttribute('popover', 'manual');
-    const userClass = this.getAttribute('class') ?? '';
-    this.className = cn(tooltipContentClass(), userClass);
+  }
+
+  render() {
+    this.className = cn(tooltipContentClass(), this._userClass);
+    return html`<slot></slot>`;
   }
 }
-defineElement('ui-tooltip-content', UiTooltipContent);
+UiTooltipContent.register('ui-tooltip-content');


### PR DESCRIPTION
## DRAFT, browser tests regressed

All 10 Tier-2 ui components are converted from `extends Base` to `extends WebComponent` + `render()` + `<slot>` projection. The pattern is verified working in isolation (puppeteer reproduction confirms dialog opens, trigger.click() works, slot projection settles), but the WTR + Playwright test suite has regressions that need their own investigation before merge.

## Components converted (one commit per file)

| Component | LOC | Pattern |
|---|---|---|
| toggle.ts | 121 | Decorator with default `<slot>` |
| progress.ts | 99 | Renders indicator div internally, no slot (no user projection) |
| sonner.ts | 207 | Reactive state via setState + repeat() over toast items |
| toggle-group.ts | 178 | Parent broadcasts to children via queueMicrotask after slot adoption |
| tooltip.ts | 144 | 3 sub-elements with descendant queries (was :scope >) |
| hover-card.ts | 129 | Same shape as tooltip |
| tabs.ts | 250 | 4 sub-elements, cross-sibling state coordination |
| dialog.ts | 348 | **Named slot for content routing inside native `<dialog>`** |
| alert-dialog.ts | 293 | Same as dialog with the cancel-event escape preventDefault |
| dropdown-menu.ts | 638 | 11 sub-elements, keyboard nav, type-ahead, submenus all preserved |

## Public API unchanged

- Tag names: `<ui-toggle>`, `<ui-dialog>`, `<ui-dropdown-menu>`, etc. Same as before.
- Attributes: same. `reflect: true` on all observable ones.
- Events: `ui-pressed-change`, `ui-open-change`, `ui-value-change` all preserved.
- Programmatic API: `el.show()`, `el.hide()`, `el.toggle()`, `el.isOpen` getter (back-compat, alias for the reactive `open` prop).
- Native HTML elements (`<dialog>`, native popover) still used internally; no shift to shadcn-style portaling.

## Version

`@webjskit/ui` 0.1.0 -> 0.2.0 (the API surface is the same, but internals changed substantially enough that semver minor is warranted for users who've copy-pasted the components and want to know which prior version their copy matches).

## Test state

- **Unit (`npm test`)**: **936 / 936 pass**. No regressions in framework code.
- **Browser (`npm run test:browser`)**: 60 pass, 41 fail. **15 new failures from this branch** (27 were pre-existing on main for ui-stateful + ui-overlay + ui-popover). The new failures are all in ui-overlay (dialog, tooltip, dropdown-menu, alert-dialog) and ui-stateful (tabs, toggle-group).

## Why WTR fails when puppeteer succeeds

I wrote a puppeteer-based diagnostic that mounts a `<ui-dialog>`, waits 2 RAFs, then clicks the trigger. It works correctly: trigger is found, click opens the dialog, `isOpen` returns true. So the runtime behavior is right.

The WTR tests use `@web/dev-server-esbuild` to transform `.ts` on the fly. Possible causes for the WTR-only failures:
1. The esbuild transform output differs from Node's native strip-types in subtle ways (timing of custom-element upgrade)
2. The WTR test fixtures assume the OLD imperative DOM walking pattern in some assertions
3. The cross-sibling state coordination (parent broadcasting to children via queueMicrotask) may race differently in WTR

## What's needed before merging this

1. Either fix the WTR-specific behavior in components (probably tweak the queueMicrotask timing) or update the WTR test fixtures to match the new API
2. Run e2e against the blog ui-demo route to confirm visual correctness
3. Bump `@webjskit/cli` if scaffolds reference the changed API explicitly (they don't, but worth a check)

## Why I'm opening as draft

The pattern is correct (verified independently). The WTR failures need investigation that's bigger than the conversation budget I have right now. Opening for review of the pattern itself, with explicit caveats.