### PR TITLE
docs: retire "less is more" philosophy framing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,8 +206,6 @@ import { html, css, WebComponent, render, renderToString } from '@webjskit/core'
 
 ### Directives, from `import { … } from '@webjskit/core/directives'`
 
-**"Less is more":** only directives that solve problems with no native alternative.
-
 | Directive | Purpose | Example |
 |---|---|---|
 | `repeat(items, keyFn, templateFn)` | Keyed reconciliation | `${repeat(items, i => i.id, i => html\`…\`)}` |
@@ -296,7 +294,7 @@ class StudentCard extends WebComponent {
 | `hasChanged` | strict `!==` | Custom change detection |
 | `converter` | type-based | Custom attribute ↔ property serialization |
 
-### Lifecycle (less-is-more)
+### Lifecycle
 
 | Hook | When | Use for |
 |---|---|---|

--- a/docs/app/docs/directives/page.ts
+++ b/docs/app/docs/directives/page.ts
@@ -5,7 +5,7 @@ export const metadata = { title: 'Directives | webjs' };
 export default function Directives() {
   return html`
     <h1>Directives</h1>
-    <p>webjs follows a <strong>"less is more"</strong> philosophy. Only three directives are built in, and each solves a problem that has <em>no native alternative</em>. Everything else uses native JavaScript and HTML patterns.</p>
+    <p>webjs currently ships three built-in directives, each solving a problem with <em>no native alternative</em>. Everything else uses native JavaScript and HTML patterns.</p>
 
     <pre>import { repeat } from '@webjskit/core';            // keyed lists
 import { unsafeHTML, live } from '@webjskit/core/directives'; // raw HTML, input sync</pre>
@@ -91,13 +91,5 @@ html\`
   &lt;div style=\${\`display:\${tab === 'b' ? 'block' : 'none'}\`}&gt;Tab B content&lt;/div&gt;
 \`;</pre>
 
-    <h2>Why "less is more"</h2>
-    <p>webjs is an AI-first framework. AI agents don't need syntax sugar, since they generate verbose code as easily as terse code. Fewer directives means:</p>
-    <ul>
-      <li><strong>Fewer concepts</strong> for agents to choose between (less chance of wrong choice)</li>
-      <li><strong>Smaller API surface</strong> to maintain and test</li>
-      <li><strong>More portable knowledge</strong>: native patterns work in any framework</li>
-      <li><strong>Fewer edge cases</strong> in the renderer</li>
-    </ul>
   `;
 }

--- a/docs/app/docs/lifecycle/page.ts
+++ b/docs/app/docs/lifecycle/page.ts
@@ -5,7 +5,7 @@ export const metadata = { title: 'Lifecycle Hooks | webjs' };
 export default function Lifecycle() {
   return html`
     <h1>Lifecycle Hooks</h1>
-    <p>webjs follows a <strong>"less is more"</strong> philosophy for lifecycle hooks. Only hooks with no native workaround are included. AI agents don't need abstractions for things that a few lines of code can handle.</p>
+    <p>webjs ships the lifecycle hooks listed below. The set is being expanded to full lit parity (see the ongoing API parity initiative).</p>
 
     <h2>The Update Cycle</h2>
     <p>When <code>setState()</code> or a property change triggers a re-render:</p>

--- a/packages/core/src/component.js
+++ b/packages/core/src/component.js
@@ -110,9 +110,11 @@ function defaultHasChanged(a, b) {
  *  3. controllers' `afterRender()`
  *  4. `firstUpdated()`: once, after the very first render
  *
- * "Less is more": only hooks with no native workaround are included.
  * Use `render()` for derived state. Use `firstUpdated()` for one-time
  * DOM setup. Use `this.shadowRoot.querySelector()` for element refs.
+ * Additional lit-aligned hooks (shouldUpdate, willUpdate, updated,
+ * updateComplete, changedProperties) are being added per the lit-API
+ * parity initiative.
  *
  * Usage:
  * ```js

--- a/packages/core/src/directives.js
+++ b/packages/core/src/directives.js
@@ -1,28 +1,14 @@
 /**
  * Built-in directives for the webjs `html` tagged template system.
  *
- * webjs follows a "less is more" philosophy: only directives that solve
- * problems with NO native alternative are included. AI agents don't need
- * syntax sugar: they can write ternaries, string concatenation, and
- * lifecycle hooks just fine.
+ * Currently exported from this file:
+ * - `unsafeHTML(str)`. Render trusted raw HTML. Never use with user input.
+ * - `live(value)`. Force `.value` to sync with the live DOM property.
  *
- * **What's here:**
- * - `unsafeHTML(str)`: render trusted raw HTML (no alternative in templates)
+ * `repeat()` is in `./repeat.js` for keyed list reconciliation.
  *
- * **What's NOT here (and why):**
- * - classMap → use `class=${'btn ' + (active ? 'active' : '')}`
- * - styleMap → use `style=${'color:' + color}`
- * - ifDefined → use `attr=${val ?? null}` (null removes the attribute)
- * - when/choose → use ternary `${cond ? a : b}` or if/else before the template
- * - guard → memoize in `willUpdate()` lifecycle hook
- * - ref → use `this.query('#el')` in `firstUpdated()` or `updated()`
- * - cache → use CSS `display:none` to preserve DOM instead of removing
- * - until → use the `Task` controller for component-scoped async data
- * - live → set `.value` via property binding `.value=${val}` and handle
- *   input events with `@input=${e => this.setState({val: e.target.value})}`
- *
- * `repeat()` is in its own file (`./repeat.js`): it's essential for keyed
- * list reconciliation and has no native alternative.
+ * More directives (full lit-html parity) are being added as part of the
+ * lit-API parity initiative. See the project memo for the locked scope.
  *
  * @module directives
  */


### PR DESCRIPTION
## Summary

- Removes the "less is more" prose from AGENTS.md (line 209, 299), `docs/app/docs/directives/page.ts`, `docs/app/docs/lifecycle/page.ts`, and source comments in `packages/core/src/component.js` and `packages/core/src/directives.js`.
- Prepares the docs for the locked lit-API parity initiative (full lifecycle + full directive set).
- Facts stay accurate to current state. Phase PRs will expand descriptions as features land.

## Test plan

- [x] `webjs test` passes (940/940)
- [x] Manual grep confirms no remaining "less is more" / "less-is-more" matches