### PR TITLE
test(e2e): update stale data-layout assertion to wj:children markers

### DIFF
--- a/test/e2e.test.mjs
+++ b/test/e2e.test.mjs
@@ -109,18 +109,29 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
     assert.ok(title.toLowerCase().includes('blog'), `Expected blog title, got: ${title}`);
   });
 
-  test('layout renders a data-layout wrapper around page content', async () => {
-    // Light-DOM shell: the router uses the data-layout wrapper to detect
-    // same-layout navigations (instead of a custom-element shell).
+  test('layout emits wj:children markers for the client router', async () => {
+    // Per-layout `<!--wj:children:<segment>-->` comment markers wrap
+    // each ${children} interpolation. The client router walks these
+    // markers across old + new DOMs to detect the deepest shared
+    // layout for partial-swap navigation. Replaced the older single
+    // `data-layout` attribute approach on 2026-05-16 (f216f0e).
     await page.goto(baseUrl, { waitUntil: 'domcontentloaded', timeout: 10000 });
     await sleep(1000);
     const markers = await page.evaluate(() => {
-      const wrapper = document.querySelector('[data-layout]');
+      const it = document.createNodeIterator(document, NodeFilter.SHOW_COMMENT);
+      const layoutMarkers = [];
+      let n;
+      while ((n = it.nextNode())) {
+        if (n.data && n.data.startsWith('wj:children:')) {
+          layoutMarkers.push(n.data);
+        }
+      }
       const hasNav = !!document.querySelector('header nav');
       const hasMain = !!document.querySelector('main');
-      return { hasWrapper: !!wrapper, layoutId: wrapper?.getAttribute('data-layout'), hasNav, hasMain };
+      return { layoutMarkers, hasNav, hasMain };
     });
-    assert.ok(markers.hasWrapper, 'data-layout wrapper should be present');
+    assert.ok(markers.layoutMarkers.length > 0,
+      `wj:children comment markers should be present; got ${JSON.stringify(markers.layoutMarkers)}`);
     assert.ok(markers.hasNav, '<header> <nav> should render in the layout');
     assert.ok(markers.hasMain, '<main> should render in the layout');
   });


### PR DESCRIPTION
## Summary

The e2e test `layout renders a data-layout wrapper around page content` was authored on 2026-04-19. The framework switched from a single `[data-layout]` wrapper attribute to per-layout `<!--wj:children:<segment>-->` comment markers on 2026-05-16 (`f216f0e`). The test wasn't updated; nobody noticed because the e2e suite is gated behind `WEBJS_E2E=1` and doesn't run in regular CI.

Surfaced as a 1/48 failure when I ran the gated suite as post-merge verification for #31.

## Fix

Updates the test to walk the comment tree via `NodeIterator(document, SHOW_COMMENT)` and assert presence of at least one `wj:children:` marker. Keeps the same `<header>`/`<main>` structural assertions.

## Test plan

- [x] `WEBJS_E2E=1 node --test --test-name-pattern="wj:children" test/e2e.test.mjs` passes (1/1)
- [ ] Full gated suite re-run after merge will show 48/48