### PR TITLE
fix(docker): pin Node 26 so module.stripTypeScriptTypes runs natively

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,23 @@
-# Single image for the whole monorepo - website, docs, blog. Each
-# Railway service runs the same image with a different start command.
-# Locally: `docker compose up --build` runs all three via compose.yaml.
+# Single image for the whole monorepo. Each Railway service runs the
+# same image with a different start command. Locally:
+# `docker compose up --build` runs all three via compose.yaml.
 #
-# No build step for JS - webjs serves .ts directly, Node 22+ strips types.
-# Tailwind CSS IS built at image time (CLI, no browser runtime). The blog
-# runs `prisma generate` at build and `prisma migrate deploy` at start.
-FROM node:22-alpine
+# No build step for JS. webjs serves .ts directly via Node's built-in
+# `module.stripTypeScriptTypes` (position-preserving whitespace
+# replacement, no sourcemap shipped to the browser).
+#
+# **Node 24+ is REQUIRED** for that path. On Node 22, the runtime falls
+# back to esbuild for every .ts file. esbuild's class-declaration
+# transformation has been observed to break webjs's SSR walker for
+# multi-class component files: Tier-2 components (dialog, tooltip,
+# dropdown-menu, etc.) all rendered with the wrong shell because the
+# first class's render() was being invoked for every sub-tag. Pinning
+# Node 24 here pairs with the AGENTS.md "Node 24+ required" invariant.
+#
+# Tailwind CSS IS built at image time (CLI, no browser runtime). The
+# blog runs `prisma generate` at build and `prisma migrate deploy` at
+# start.
+FROM node:24-alpine
 
 # openssl is required by Prisma's query engine at runtime.
 RUN apk add --no-cache openssl ca-certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 # Tailwind CSS IS built at image time (CLI, no browser runtime). The
 # blog runs `prisma generate` at build and `prisma migrate deploy` at
 # start.
-FROM node:24-alpine
+FROM node:26-alpine
 
 # openssl is required by Prisma's query engine at runtime.
 RUN apk add --no-cache openssl ca-certificates


### PR DESCRIPTION
## Summary

Root-cause fix for the Tier-2 component preview being broken on ui.webjs.dev after the Tier-2 refactor merged.

(Replaces the closed-by-rename predecessor PR.)

## Symptom

On ui.webjs.dev/docs/components/dialog (and every other Tier-2 component page), the SSR HTML rendered every sub-tag of a Tier-2 component with the OUTER parent's shell:

- `<ui-dialog>` → `<div data-slot="dialog">` (correct)
- `<ui-dialog-trigger>` → `<div data-slot="dialog">` (WRONG, should be `data-slot="dialog-trigger"`)
- `<ui-dialog-content>` → `<div data-slot="dialog">` (WRONG)
- `<ui-dialog-close>` → `<div data-slot="dialog">` (WRONG)

Slot projection never ran (the slots stayed bare `<slot></slot>`), so authored children landed as dangling siblings inside the parent custom element. Client-side hydration then wiped them out, leaving an empty preview.

## Diagnosis

Local reproduction:
- Node 26 + `npm start` (production mode): **correct output** (each sub-tag renders its own shell).
- Node 22 (Dockerfile): **broken**.

The only difference is the Node version. Node 22 doesn't have `module.stripTypeScriptTypes` available, so webjs's `dev.js` falls back to esbuild for every `.ts` file. esbuild's class-declaration transformation breaks webjs's SSR walker for multi-class component files. The deployed `dialog.ts` from production confirms it: classes hoisted, exports moved, sourceMappingURL appended.

The Tier-2 refactor merged components per-file with multiple classes per `.ts` file. On Node 22's esbuild fallback path the SSR walker's class lookup ends up returning the first class for all sub-tags.

## Fix

Pin `FROM node:26-alpine` so the native `module.stripTypeScriptTypes` path is used and the `.ts` files reach the runtime structurally unchanged. Matches the local-dev Node version (26.1.0) for SSR-output parity. `node:26-alpine` is published on Docker Hub.

## Verification

- [x] Local Node 26 production mode renders correctly (root-cause confirmation)
- [ ] Post-merge Railway redeploy serves correct SSR HTML on ui.webjs.dev