### PR TITLE
fix(ui-website): align @webjskit/* deps to workspace versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,25 @@
         "node": ">=24.0.0"
       }
     },
+    "examples/blog/node_modules/@webjskit/ui": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@webjskit/ui/-/ui-0.1.0.tgz",
+      "integrity": "sha512-S+u1mkIYad+a35HQZMV3aX7cH5DNfBFHm3CqAB0KdeRCl9He9LRGlbddTQeZIXs9fmrz7GHUzk4vIsBHp7kORg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^14.0.0",
+        "kleur": "^4.1.5",
+        "prompts": "^2.4.2",
+        "zod": "^3.24.1"
+      },
+      "bin": {
+        "webjsui": "bin/webjsui.js"
+      },
+      "engines": {
+        "node": ">=24.0.0"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
       "dev": true,
@@ -2881,17 +2900,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/anymatch": {
-      "version": "3.1.3",
-      "license": "ISC",
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/array-back": {
       "version": "3.1.0",
       "dev": true,
@@ -3038,16 +3046,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/binary-extensions": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "dev": true,
@@ -3156,28 +3154,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk-template?sponsor=1"
-      }
-    },
-    "node_modules/chokidar": {
-      "version": "3.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
       }
     },
     "node_modules/chrome-launcher": {
@@ -3995,6 +3971,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -4351,16 +4328,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-core-module": {
@@ -5273,13 +5240,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
       "dev": true,
@@ -5721,16 +5681,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/readdirp": {
-      "version": "3.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
       }
     },
     "node_modules/require-directory": {
@@ -6675,6 +6625,24 @@
         "node": ">=24.0.0"
       }
     },
+    "packages/cli/node_modules/@webjskit/ui": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@webjskit/ui/-/ui-0.1.0.tgz",
+      "integrity": "sha512-S+u1mkIYad+a35HQZMV3aX7cH5DNfBFHm3CqAB0KdeRCl9He9LRGlbddTQeZIXs9fmrz7GHUzk4vIsBHp7kORg==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^14.0.0",
+        "kleur": "^4.1.5",
+        "prompts": "^2.4.2",
+        "zod": "^3.24.1"
+      },
+      "bin": {
+        "webjsui": "bin/webjsui.js"
+      },
+      "engines": {
+        "node": ">=24.0.0"
+      }
+    },
     "packages/core": {
       "name": "@webjskit/core",
       "version": "0.5.0",
@@ -6707,7 +6675,7 @@
     },
     "packages/ui": {
       "name": "@webjskit/ui",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.0",
@@ -6719,37 +6687,6 @@
         "webjsui": "bin/webjsui.js"
       }
     },
-    "packages/ui/node_modules/@webjskit/cli": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@webjskit/cli/-/cli-0.5.2.tgz",
-      "integrity": "sha512-j98SA7Qe9P2E4YpGYBso24ndUU886ngfdYxV+oZn7N/h5cjBqTcDov53+wXbHoEJECGd1SX1Q8HrmCxsFJFXUQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@webjskit/server": "0.5.2",
-        "@webjskit/ui": "0.1.0"
-      },
-      "bin": {
-        "webjs": "bin/webjs.js"
-      }
-    },
-    "packages/ui/node_modules/@webjskit/core": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@webjskit/core/-/core-0.4.1.tgz",
-      "integrity": "sha512-N9nf1i+AiPXAH9XbHCW8HfnaVK1D/BqIXot/KyrhUePoleLiKPYtoLzeSQFGtOcwObHvMA75zgtShxldLAbaXA==",
-      "license": "MIT"
-    },
-    "packages/ui/node_modules/@webjskit/server": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@webjskit/server/-/server-0.5.2.tgz",
-      "integrity": "sha512-nuFV5YRqKBlmo6TcuSIfCNOCDzxxIdB/93g0P8Y8fOkUKu9FrJitMyJKIXt8HChWkQFip4p5BzZrW8FRNyq29w==",
-      "license": "MIT",
-      "dependencies": {
-        "@webjskit/core": "0.4.1",
-        "chokidar": "^3.6.0",
-        "esbuild": "^0.28.0",
-        "ws": "^8.20.0"
-      }
-    },
     "packages/ui/packages/registry": {
       "name": "@webjskit/ui-registry",
       "version": "0.1.0"
@@ -6758,9 +6695,9 @@
       "name": "@webjskit/ui-website",
       "version": "0.1.0",
       "dependencies": {
-        "@webjskit/cli": "^0.5.2",
-        "@webjskit/core": "^0.4.1",
-        "@webjskit/server": "^0.5.2",
+        "@webjskit/cli": "^0.6.0",
+        "@webjskit/core": "^0.5.0",
+        "@webjskit/server": "^0.6.0",
         "@webjskit/ui-registry": "*"
       },
       "devDependencies": {

--- a/packages/ui/packages/website/package.json
+++ b/packages/ui/packages/website/package.json
@@ -15,9 +15,9 @@
     "preview:build": "node scripts/copy-registry.js"
   },
   "dependencies": {
-    "@webjskit/cli": "^0.5.2",
-    "@webjskit/core": "^0.4.1",
-    "@webjskit/server": "^0.5.2",
+    "@webjskit/cli": "^0.6.0",
+    "@webjskit/core": "^0.5.0",
+    "@webjskit/server": "^0.6.0",
     "@webjskit/ui-registry": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
## Root cause

`packages/ui/packages/website/package.json` pinned old framework versions:

```
"@webjskit/cli": "^0.5.2",
"@webjskit/core": "^0.4.1",
"@webjskit/server": "^0.5.2",
```

The workspaces are at `0.6.0`, `0.5.0`, `0.6.0`. Caret on a 0.x version is patch-only (`^0.5.2` means `>=0.5.2 <0.6.0`), so the workspace did not satisfy the range. npm installed published tarballs from the registry into `packages/ui/node_modules/@webjskit/*` and skipped the workspace symlink.

Production therefore ran the published `@webjskit/server@0.5.2`, whose TypeScript serving path is esbuild-only. esbuild's multi-class declaration transform has a known bug where every `<ui-dialog-*>` sub-tag rendered with UiDialog's shell (`data-slot="dialog" data-state="closed"`) instead of its own. The local fix (Node 24+ native `module.stripTypeScriptTypes` first, esbuild fallback only on `ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX`) shipped in `@webjskit/server@0.6.0` but the website never picked it up.

## What changed

Bumped the three ranges to the current workspace versions so npm links the local workspace instead of pulling stale tarballs. `package-lock.json` regenerated to drop `packages/ui/node_modules/@webjskit/{cli,core,server}`.

## Verification

Local `npm start` in the website now serves `/components/ui/dialog.ts` at 13780 bytes with no `sourceMappingURL` (native strip-types output, position-preserving whitespace replacement) instead of the previous 31748 bytes of esbuild output. SSR for `<ui-dialog>` now renders each sub-element with its own shell.

## Test plan

- [x] `npm install` resolves `@webjskit/server` to the workspace, not the registry tarball
- [x] Website's `npm start` serves `dialog.ts` via strip-types (no sourceMappingURL)
- [x] SSR of `/docs/components/dialog` shows `data-slot="dialog-trigger"`, `dialog-native`, `dialog-close` (each sub-element renders its own shell)
- [ ] Deploy and re-test https://ui.webjs.dev/docs/components/dialog