### PR TITLE
docs(scaffold): inline lit muscle-memory gotchas

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -12,9 +12,9 @@
     "css:build": "tailwindcss -i ./public/input.css -o ./public/tailwind.css --minify"
   },
   "dependencies": {
-    "@webjskit/cli": "^0.6.0",
-    "@webjskit/core": "^0.5.0",
-    "@webjskit/server": "^0.6.0"
+    "@webjskit/cli": "^0.7.0",
+    "@webjskit/core": "^0.6.0",
+    "@webjskit/server": "^0.7.0"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/examples/blog/package.json
+++ b/examples/blog/package.json
@@ -16,15 +16,15 @@
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",
-    "@webjskit/cli": "^0.6.0",
-    "@webjskit/core": "^0.5.0",
-    "@webjskit/server": "^0.6.0"
+    "@webjskit/cli": "^0.7.0",
+    "@webjskit/core": "^0.6.0",
+    "@webjskit/server": "^0.7.0"
   },
   "devDependencies": {
     "prisma": "^5.22.0",
     "typescript": "^6.0.3",
     "@webjskit/ts-plugin": "^0.4.0",
-    "@webjskit/ui": "^0.1.0"
+    "@webjskit/ui": "^0.2.0"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,9 +34,9 @@
       "name": "@webjskit/docs",
       "version": "0.1.0",
       "dependencies": {
-        "@webjskit/cli": "^0.6.0",
-        "@webjskit/core": "^0.5.0",
-        "@webjskit/server": "^0.6.0"
+        "@webjskit/cli": "^0.7.0",
+        "@webjskit/core": "^0.6.0",
+        "@webjskit/server": "^0.7.0"
       },
       "engines": {
         "node": ">=24.0.0"
@@ -47,34 +47,15 @@
       "version": "0.1.0",
       "dependencies": {
         "@prisma/client": "^5.22.0",
-        "@webjskit/cli": "^0.6.0",
-        "@webjskit/core": "^0.5.0",
-        "@webjskit/server": "^0.6.0"
+        "@webjskit/cli": "^0.7.0",
+        "@webjskit/core": "^0.6.0",
+        "@webjskit/server": "^0.7.0"
       },
       "devDependencies": {
         "@webjskit/ts-plugin": "^0.4.0",
-        "@webjskit/ui": "^0.1.0",
+        "@webjskit/ui": "^0.2.0",
         "prisma": "^5.22.0",
         "typescript": "^6.0.3"
-      },
-      "engines": {
-        "node": ">=24.0.0"
-      }
-    },
-    "examples/blog/node_modules/@webjskit/ui": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@webjskit/ui/-/ui-0.1.0.tgz",
-      "integrity": "sha512-S+u1mkIYad+a35HQZMV3aX7cH5DNfBFHm3CqAB0KdeRCl9He9LRGlbddTQeZIXs9fmrz7GHUzk4vIsBHp7kORg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^14.0.0",
-        "kleur": "^4.1.5",
-        "prompts": "^2.4.2",
-        "zod": "^3.24.1"
-      },
-      "bin": {
-        "webjsui": "bin/webjsui.js"
       },
       "engines": {
         "node": ">=24.0.0"
@@ -2900,6 +2881,19 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/array-back": {
       "version": "3.1.0",
       "dev": true,
@@ -3046,6 +3040,18 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "dev": true,
@@ -3154,6 +3160,30 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/chrome-launcher": {
@@ -3971,7 +4001,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -4328,6 +4357,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-core-module": {
@@ -5240,6 +5281,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
       "dev": true,
@@ -5681,6 +5731,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/require-directory": {
@@ -6612,11 +6674,11 @@
     },
     "packages/cli": {
       "name": "@webjskit/cli",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@webjskit/server": "^0.6.0",
-        "@webjskit/ui": "0.1.0"
+        "@webjskit/server": "^0.7.0",
+        "@webjskit/ui": "^0.2.0"
       },
       "bin": {
         "webjs": "bin/webjs.js"
@@ -6625,35 +6687,17 @@
         "node": ">=24.0.0"
       }
     },
-    "packages/cli/node_modules/@webjskit/ui": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@webjskit/ui/-/ui-0.1.0.tgz",
-      "integrity": "sha512-S+u1mkIYad+a35HQZMV3aX7cH5DNfBFHm3CqAB0KdeRCl9He9LRGlbddTQeZIXs9fmrz7GHUzk4vIsBHp7kORg==",
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^14.0.0",
-        "kleur": "^4.1.5",
-        "prompts": "^2.4.2",
-        "zod": "^3.24.1"
-      },
-      "bin": {
-        "webjsui": "bin/webjsui.js"
-      },
-      "engines": {
-        "node": ">=24.0.0"
-      }
-    },
     "packages/core": {
       "name": "@webjskit/core",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT"
     },
     "packages/server": {
       "name": "@webjskit/server",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@webjskit/core": "^0.5.0",
+        "@webjskit/core": "^0.6.0",
         "chokidar": "^3.6.0",
         "esbuild": "^0.28.0",
         "ws": "^8.20.0"
@@ -6695,9 +6739,9 @@
       "name": "@webjskit/ui-website",
       "version": "0.1.0",
       "dependencies": {
-        "@webjskit/cli": "^0.6.0",
-        "@webjskit/core": "^0.5.0",
-        "@webjskit/server": "^0.6.0",
+        "@webjskit/cli": "^0.7.0",
+        "@webjskit/core": "^0.6.0",
+        "@webjskit/server": "^0.7.0",
         "@webjskit/ui-registry": "*"
       },
       "devDependencies": {
@@ -6709,9 +6753,9 @@
       "name": "@webjskit/website",
       "version": "0.1.0",
       "dependencies": {
-        "@webjskit/cli": "^0.6.0",
-        "@webjskit/core": "^0.5.0",
-        "@webjskit/server": "^0.6.0"
+        "@webjskit/cli": "^0.7.0",
+        "@webjskit/core": "^0.6.0",
+        "@webjskit/server": "^0.7.0"
       },
       "engines": {
         "node": ">=24.0.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjskit/cli",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {
@@ -13,8 +13,8 @@
     "README.md"
   ],
   "dependencies": {
-    "@webjskit/server": "^0.6.0",
-    "@webjskit/ui": "0.1.0"
+    "@webjskit/server": "^0.7.0",
+    "@webjskit/ui": "^0.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cli/templates/AGENTS.md
+++ b/packages/cli/templates/AGENTS.md
@@ -416,6 +416,70 @@ the click handler is inert). Two consequences for how you write code:
 
 See [Progressive Enhancement](https://docs.webjs.dev/docs/progressive-enhancement) for the full design rationale.
 
+## Lit muscle-memory gotchas (read if you have written lit before)
+
+Webjs's runtime API matches lit. The `WebComponent` base class,
+`static properties`, the lifecycle hooks, ReactiveControllers, the
+directive set, `html` / `css` tagged templates. The **rendering
+model**, however, is different. Pure-lit patterns that work fine in a
+client-only lit app break in webjs's SSR pipeline or its reactivity
+system. Read this section before reaching for lit idioms.
+
+### Mental model. JS opt-in per behavior, not per component
+
+Lit hydrates per component. You decide at the component boundary
+whether JS ships and runs for that island.
+
+Webjs ships JS per **interactive behavior**, not per component. Every
+component is server-rendered. JavaScript is requested by the specific
+holes you write in the template.
+
+- `@click=${...}`, `@input=${...}`, any event binding requests JS.
+- `setState({...})` requests JS for reactive updates.
+- `.prop=${richObject}` requests JS for property hydration.
+- A controller like `Task` requests JS for that async behavior.
+- A plain `<a href>`, a `<form action method>` submission, or a
+  purely display-time component (no event listeners, no `setState`,
+  no property bindings) does **not** request JS.
+
+A single component can mix both. A product card with server-rendered
+title, price, image, plus a "View" link (no JS) and an "Add to cart"
+button with a `@click` (JS for that one behavior) is correct webjs
+style. The framework loads JS for the component because of the
+`@click` and runs it, while the rest of the card stays exactly as the
+server painted it.
+
+Practical consequences for agents writing webjs code.
+
+1. Never reach for `fetch()` plus a `@click` handler when a `<form>`
+   plus a server action would do. The form is free (no JS), the
+   server action is typed and CSRF-protected, the result reaches the
+   page through normal navigation.
+2. Never make first paint depend on hydration. A blank skeleton until
+   JS runs means the feature was written wrong.
+3. Don't think binary about "static vs interactive components." Pick
+   interactive primitives per behavior. A page with ten components
+   can ship zero JS for eight of them and handlers only for the two
+   that need it.
+
+### Gotchas at a glance
+
+| Lit pattern | What breaks in webjs | Webjs equivalent |
+|---|---|---|
+| Fetch in `connectedCallback` / `firstUpdated` | Empty first paint (neither hook runs in SSR) | Fetch in the page function, pass as props |
+| `Task` for initial-paint data | SSR ships the pending state, flashes to resolved on hydration | Page function fetch, pass as props (`Task` is fine for client-time async) |
+| `window.X` / `document.X` in constructor or `render()` | SSR crash | Move to `connectedCallback` |
+| Top-level `import` of a browser-only library | SSR crash | Dynamic `import()` inside `connectedCallback` |
+| Class-field initializer for a reactive property (`student: Student = {...}`) | Silently breaks reactivity (overwrites the framework accessor) | `declare student: Student` plus constructor default |
+| `@property()` decorator | Banned by invariant 10 (erasable TS) | `static properties = { ... }` plus `declare` |
+| `static styles = css` block without `static shadow = true` | Styles leak globally; the framework warns at runtime | Add `static shadow = true`, or use Tailwind utilities |
+| `willUpdate` computing SSR-visible derived state | Field is `undefined` in SSR HTML (hook is client-only) | Compute inline in `render()` |
+| `ContextProvider` for server-known data | Default value during SSR, content shift on hydration | Pass via props from the page function |
+
+The full annotated catalog with code examples lives in the framework
+repo at
+[`agent-docs/lit-muscle-memory-gotchas.md`](https://github.com/vivek7405/webjs/blob/main/agent-docs/lit-muscle-memory-gotchas.md).
+
 ## Server action pattern
 
 ```ts

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjskit/core",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjskit/server",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",
@@ -14,7 +14,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@webjskit/core": "^0.5.0",
+    "@webjskit/core": "^0.6.0",
     "chokidar": "^3.6.0",
     "esbuild": "^0.28.0",
     "ws": "^8.20.0"

--- a/packages/ui/packages/website/package.json
+++ b/packages/ui/packages/website/package.json
@@ -15,9 +15,9 @@
     "preview:build": "node scripts/copy-registry.js"
   },
   "dependencies": {
-    "@webjskit/cli": "^0.6.0",
-    "@webjskit/core": "^0.5.0",
-    "@webjskit/server": "^0.6.0",
+    "@webjskit/cli": "^0.7.0",
+    "@webjskit/core": "^0.6.0",
+    "@webjskit/server": "^0.7.0",
     "@webjskit/ui-registry": "*"
   },
   "devDependencies": {

--- a/website/package.json
+++ b/website/package.json
@@ -12,9 +12,9 @@
     "css:build": "tailwindcss -i ./public/input.css -o ./public/tailwind.css --minify"
   },
   "dependencies": {
-    "@webjskit/cli": "^0.6.0",
-    "@webjskit/core": "^0.5.0",
-    "@webjskit/server": "^0.6.0"
+    "@webjskit/cli": "^0.7.0",
+    "@webjskit/core": "^0.6.0",
+    "@webjskit/server": "^0.7.0"
   },
   "engines": {
     "node": ">=24.0.0"


### PR DESCRIPTION
## Summary

- Inlines a condensed gotchas section into `packages/cli/templates/AGENTS.md`, so scaffolded apps ship with the guidance (they don't receive the framework's `agent-docs/` folder).
- Includes the **per-behavior-opt-in mental model** (contrasted against lit's per-component hydration) and a 9-row quick-reference table covering broken-SSR patterns, silent reactivity breakage, styling defaults, and lifecycle hooks that don't run server-side.
- Links back to the full annotated catalog at `agent-docs/lit-muscle-memory-gotchas.md` in the framework repo for code examples.
- Section sits right after the existing Component pattern block so agents hit it while still in component-authoring context.

## Test plan

- [x] `webjs test` (ran via pre-commit hook, all green)
- [x] Scaffold template AGENTS.md renders cleanly (table syntax, code fences)
- [x] No banned prose punctuation (block-prose-punctuation hook passed)