### PR TITLE
fix(server): drop immutable cache-control on /__webjs/core/*

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6694,7 +6694,7 @@
     },
     "packages/server": {
       "name": "@webjskit/server",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "@webjskit/core": "^0.6.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjskit/server",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",

--- a/packages/server/src/dev.js
+++ b/packages/server/src/dev.js
@@ -389,11 +389,23 @@ async function handleCore(req, ctx) {
   }
 
   // Core module: /__webjs/core/*
+  //
+  // ETag + ~1h max-age, NOT immutable. The URL path is un-versioned
+  // (`/__webjs/core/src/render-client.js` etc.), so bumping
+  // `@webjskit/core` ships different bytes at the same URL. An
+  // `immutable` cache-control directive at an edge CDN (Cloudflare,
+  // Vercel, Fly) keeps the prior bytes pinned for up to a year, which
+  // silently bricks the next deploy: browsers load the old client
+  // renderer against a server emitting the new SSR shape, and any
+  // exports added in the bump (e.g., the slot.js entry points landed
+  // for 0.6.0) resolve to undefined in the cached file.
+  // Regression: 2026-05-20, ui.webjs.dev tier-2 components after
+  // @webjskit/core 0.5.0 -> 0.6.0 republish.
   if (path.startsWith('/__webjs/core/')) {
     const rel = path.slice('/__webjs/core/'.length);
     const abs = resolve(coreDir, rel);
     if (!abs.startsWith(coreDir)) return new Response('forbidden', { status: 403 });
-    return fileResponse(abs, { dev, immutable: !dev });
+    return fileResponse(abs, { dev, immutable: false });
   }
 
   // Vendor bundles: /__webjs/vendor/<pkg>.js: generic auto-bundler


### PR DESCRIPTION
## Root cause

The dev/prod server hands every file under `/__webjs/core/*` a `cache-control: public, max-age=31536000, immutable` response header in production. The path is un-versioned, so the next `@webjskit/core` bump publishes different bytes at the same URL. Edge CDNs honor `immutable` literally and pin the prior bytes for up to a year.

Concrete symptom (ui.webjs.dev, 2026-05-20): after publishing `@webjskit/core` 0.5.0 -> 0.6.0 and redeploying, Cloudflare's edge kept serving the 0.5.0 `render-client.js`. That file had no `import from './slot.js'`. Browsers loaded it against the new SSR shape (which expects light-DOM slot projection through `slot.js`), so:

- `slot.js` never fetched -> `captureAuthoredChildren` / `projectChildren` never run
- Tier-2 components (alert-dialog, dialog, tabs, dropdown-menu, ...) renders to `<div><slot></slot></div>` with nothing projected into the slot
- Previews on /docs/components/<name> render empty
- Sonner survives because it has no slot projection

## Fix

Drop `immutable` for `/__webjs/core/*`. ETag + ~1h max-age until URLs carry a version hash (follow-up tracked).

Also bumps `@webjskit/server` 0.7.0 -> 0.7.1.

## Test plan

- [x] `npm test` (978 / 978 pass)
- [ ] After publish + redeploy + CF purge: re-verify https://ui.webjs.dev/docs/components/alert-dialog preview renders with the Delete account button visible.