### PR TITLE
test: cover lit-parity to webjs-feature integration gaps

### DIFF
--- a/test/browser/slot.test.js
+++ b/test/browser/slot.test.js
@@ -568,4 +568,128 @@ suite('Light-DOM slot projection (browser)', () => {
     assert.equal(secondSlot.children[0], firstChild, 'same Node ref after re-mount');
     host.remove();
   });
+
+  // ===========================================================================
+  // Slot projection timing vs lifecycle hooks (lit-parity integration)
+  //
+  // Pins down a subtle webjs-vs-lit divergence. In shadow DOM, slot projection
+  // is native and synchronous, so by the time `firstUpdated` runs the slot's
+  // assigned-nodes list is populated. In webjs light DOM, projection is
+  // microtask-deferred to AFTER the render commit, which means `firstUpdated`
+  // and `updated` see the <slot> element in the DOM but its `assignedNodes()`
+  // is still empty. Components that need projected children must read them on
+  // the next microtask, via `slotchange`, or in `updated()` after a subsequent
+  // re-render.
+  //
+  // Documented in agent-docs/lit-muscle-memory-gotchas.md gotcha #8.
+  // ===========================================================================
+
+  test('firstUpdated sees the <slot> element but light-DOM projection has NOT yet populated it', async () => {
+    const tag = tagName('first-updated-vs-projection');
+    const log = {};
+    class C extends WebComponent {
+      firstUpdated() {
+        const slot = this.querySelector('slot[data-webjs-light]');
+        log.slotExists = !!slot;
+        log.assignedAtFirstUpdated = slot ? slot.assignedNodes().length : -1;
+        log.slotChildrenAtFirstUpdated = slot ? slot.children.length : -1;
+      }
+      updated() {
+        // Same render cycle as firstUpdated; same timing.
+        const slot = this.querySelector('slot[data-webjs-light]');
+        log.assignedAtUpdated = slot ? slot.assignedNodes().length : -1;
+      }
+      render() { return html`<div><slot></slot></div>`; }
+    }
+    C.register(tag);
+
+    const host = document.createElement(tag);
+    host.innerHTML = '<h1>A</h1><p>B</p><span>C</span>';
+    document.body.appendChild(host);
+    await tick();
+
+    assert.equal(log.slotExists, true,
+      'slot element exists in firstUpdated (the render committed before the hook fired)');
+    assert.equal(log.assignedAtFirstUpdated, 0,
+      'light-DOM projection is deferred to a follow-up microtask, so assignedNodes is empty in firstUpdated');
+    assert.equal(log.slotChildrenAtFirstUpdated, 0,
+      'the slot has no DOM children yet either (projection populates them)');
+    assert.equal(log.assignedAtUpdated, 0,
+      'updated() runs in the same render cycle as firstUpdated, same empty-slot observation');
+
+    // After projection has run, the slot reflects the projected children.
+    // This is the supported way to read assignedNodes synchronously: wait
+    // past the projection microtask, OR use slotchange.
+    const slot = host.querySelector('slot[data-webjs-light]');
+    assert.equal(slot.assignedNodes().length, 3,
+      'after projection, slot reports the three projected nodes');
+    assert.equal(slot.children.length, 3,
+      'projection materialised the three children as actual DOM children of the slot');
+
+    host.remove();
+  });
+
+  test('updated() on a re-render AFTER projection sees the populated slot', async () => {
+    // Authoring pattern: if a component needs to read assignedNodes from a
+    // lifecycle hook, trigger a re-render after projection completes (e.g.
+    // by setState from a slotchange listener) and read in `updated()`. The
+    // second `updated()` call observes the populated slot.
+    const tag = tagName('updated-after-projection');
+    const seenAtUpdate = [];
+    class C extends WebComponent {
+      updated() {
+        const slot = this.querySelector('slot[data-webjs-light]');
+        seenAtUpdate.push(slot ? slot.assignedNodes().length : -1);
+      }
+      render() { return html`<div><slot></slot></div>`; }
+    }
+    C.register(tag);
+
+    const host = document.createElement(tag);
+    host.innerHTML = '<i>x</i><i>y</i>';
+    document.body.appendChild(host);
+    await tick();
+
+    // Force a second render. The renderer is idempotent on no-op patches,
+    // so seed a state field that the render() body doesn't reference; the
+    // second render still commits and fires updated() again.
+    host.setState({ tick: 1 });
+    await tick();
+
+    assert.equal(seenAtUpdate.length >= 2, true,
+      'updated() fired for the first and at least one subsequent render');
+    assert.equal(seenAtUpdate[0], 0,
+      'first updated() observed an empty slot (projection deferred)');
+    assert.equal(seenAtUpdate[seenAtUpdate.length - 1], 2,
+      'a later updated() (after projection) observes the populated slot');
+
+    host.remove();
+  });
+
+  test('shadow-DOM contrast: firstUpdated sees populated assignedNodes (native synchronous projection)', async () => {
+    // Counterpoint to the light-DOM tests above. In shadow DOM the browser
+    // does slot projection natively and synchronously, so firstUpdated
+    // observes the populated assigned-nodes list with no extra ticks.
+    const tag = tagName('shadow-first-updated');
+    const log = {};
+    class C extends WebComponent {
+      static shadow = true;
+      firstUpdated() {
+        const slot = this.shadowRoot.querySelector('slot');
+        log.assignedAtFirstUpdated = slot ? slot.assignedNodes().length : -1;
+      }
+      render() { return html`<div><slot></slot></div>`; }
+    }
+    C.register(tag);
+
+    const host = document.createElement(tag);
+    host.innerHTML = '<h1>A</h1><h2>B</h2>';
+    document.body.appendChild(host);
+    await tick();
+
+    assert.equal(log.assignedAtFirstUpdated, 2,
+      'shadow DOM: native projection means firstUpdated already sees assigned nodes');
+
+    host.remove();
+  });
 });

--- a/test/router-client.test.js
+++ b/test/router-client.test.js
@@ -31,7 +31,8 @@ let _collect, _longest, _keyOf, _diffEl, _reconcile,
   _onSubmit, _getSubmitMethod, _getSubmitAction, _buildSubmitFormData,
   _restoreOptimistic, _navToken, _bumpNavToken,
   _currentPageUrl, _setCurrentPageUrl,
-  enableClientRouter, disableClientRouter, revalidate;
+  enableClientRouter, disableClientRouter, revalidate,
+  WebComponent, html;
 
 before(async () => {
   const { window } = parseHTML('<!doctype html><html><head></head><body></body></html>');
@@ -85,6 +86,8 @@ before(async () => {
     enableClientRouter,
     disableClientRouter,
   } = await import('../packages/core/src/router-client.js'));
+
+  ({ WebComponent, html } = await import('../packages/core/index.js'));
 });
 
 /* ====================================================================
@@ -1555,5 +1558,223 @@ test('popstate: page being LEFT is snapshotted under its own URL (so forward-nav
     _setCurrentPageUrl(prevPageUrl);
     globalThis.location = origLoc;
     globalThis.fetch = origFetch;
+  }
+});
+
+/* ====================================================================
+ * Partial-swap nav + component lifecycle (lit-parity integration)
+ *
+ * The critical client-router invariant. When navigation lands inside a
+ * nested layout, the OUTER layout's component instances (and their
+ * controllers' hostConnected) are NOT re-fired, because their DOM is
+ * preserved verbatim. Only components inside the deepest swapped
+ * marker pair go through disconnect / connect.
+ *
+ * These tests pin that down for components with ReactiveControllers
+ * attached. Task / ContextProvider / ContextConsumer share the same
+ * dispatch path, so the controller-level assertion is the right level
+ * to verify the invariant once.
+ * ==================================================================== */
+
+let __nextTrackerN = 0;
+function makeTracker(records) {
+  const tag = `nav-tracker-${++__nextTrackerN}`;
+  class Tracker extends WebComponent {
+    constructor() {
+      super();
+      this.addController({
+        hostConnected: () => records.push(`connect:${this.id || '?'}`),
+        hostDisconnected: () => records.push(`disconnect:${this.id || '?'}`),
+      });
+    }
+    render() { return html`<span>${this.id || '?'}</span>`; }
+  }
+  Tracker.register(tag);
+  return tag;
+}
+
+test('partial-swap: outer-layout component instance survives when inner segment changes', async () => {
+  const records = [];
+  const tag = makeTracker(records);
+
+  document.body.innerHTML = '';
+
+  // Build the OLD body. Outer tracker sits BEFORE the / marker so it's
+  // entirely outside any layout slot. Middle tracker sits inside / but
+  // outside /docs. Inner tracker sits inside /docs.
+  const outer = document.createElement(tag);
+  outer.id = 'outer-tracker';
+  document.body.appendChild(outer);
+
+  document.body.appendChild(document.createComment('wj:children:/'));
+
+  const middle = document.createElement(tag);
+  middle.id = 'middle-tracker';
+  document.body.appendChild(middle);
+
+  document.body.appendChild(document.createComment('wj:children:/docs'));
+
+  const innerOld = document.createElement(tag);
+  innerOld.id = 'inner-old';
+  document.body.appendChild(innerOld);
+
+  document.body.appendChild(document.createComment('/wj:children'));
+  document.body.appendChild(document.createComment('/wj:children'));
+
+  await Promise.resolve();
+  await Promise.resolve();
+
+  // Sanity. All three trackers connected once, none disconnected.
+  assert.deepEqual(
+    records.filter((r) => r.startsWith('connect:')).sort(),
+    ['connect:inner-old', 'connect:middle-tracker', 'connect:outer-tracker'],
+    'all three trackers connected on initial mount'
+  );
+  assert.equal(
+    records.filter((r) => r.startsWith('disconnect:')).length,
+    0,
+    'no disconnects before nav'
+  );
+
+  records.length = 0;
+
+  // Incoming HTML keeps outer + middle (same id) and swaps inner for a
+  // fresh element with a different id.
+  const newBody =
+    `<${tag} id="outer-tracker"></${tag}>` +
+    '<!--wj:children:/-->' +
+      `<${tag} id="middle-tracker"></${tag}>` +
+      '<!--wj:children:/docs-->' +
+        `<${tag} id="inner-new"></${tag}>` +
+      '<!--/wj:children-->' +
+    '<!--/wj:children-->';
+
+  const { redirect, restore } = installNavigationMocks({
+    contentType: 'text/html; charset=utf-8',
+    body: `<!doctype html><html><head></head><body>${newBody}</body></html>`,
+  });
+
+  try {
+    await navigate('http://localhost/docs/new');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assert.equal(redirect.href, null,
+      'partial-swap should not trigger location.href fallback');
+
+    // Outer tracker. Untouched. Lives outside every layout slot, so
+    // never enters reconcileSiblings.
+    assert.equal(
+      records.filter((r) => r === 'connect:outer-tracker').length, 0,
+      'outer tracker must NOT re-connect (it was outside the swap range)'
+    );
+    assert.equal(
+      records.filter((r) => r === 'disconnect:outer-tracker').length, 0,
+      'outer tracker must NOT disconnect'
+    );
+
+    // Middle tracker. Inside / but outside /docs. Deepest shared path
+    // is /docs, so the swap range is bounded by the /docs markers and
+    // middle is never reconciled.
+    assert.equal(
+      records.filter((r) => r === 'connect:middle-tracker').length, 0,
+      'middle tracker must NOT re-connect (outside the /docs swap range)'
+    );
+    assert.equal(
+      records.filter((r) => r === 'disconnect:middle-tracker').length, 0,
+      'middle tracker must NOT disconnect'
+    );
+
+    // Inner. Different ids means no key match in reconcileSiblings, so
+    // this is a real swap.
+    assert.equal(
+      records.filter((r) => r === 'disconnect:inner-old').length, 1,
+      'inner-old must disconnect (no key match against inner-new)'
+    );
+    assert.equal(
+      records.filter((r) => r === 'connect:inner-new').length, 1,
+      'inner-new must connect after the swap inserts + upgrades it'
+    );
+
+    // Node identity assertions catch any future regression where the
+    // router wholesale-replaces preserved-range nodes.
+    assert.equal(
+      document.getElementById('outer-tracker'), outer,
+      'outer tracker DOM identity preserved'
+    );
+    assert.equal(
+      document.getElementById('middle-tracker'), middle,
+      'middle tracker DOM identity preserved'
+    );
+  } finally {
+    restore();
+    document.body.innerHTML = '';
+  }
+});
+
+test('partial-swap: keyed inner element preserves DOM identity inside the swap range', async () => {
+  const records = [];
+  const tag = makeTracker(records);
+
+  document.body.innerHTML = '';
+
+  // Single-layout setup. The "kept" element shares its id with the
+  // incoming element, the "removed" element does not.
+  document.body.appendChild(document.createComment('wj:children:/'));
+
+  const kept = document.createElement(tag);
+  kept.id = 'kept';
+  document.body.appendChild(kept);
+
+  const removed = document.createElement(tag);
+  removed.id = 'removed-old';
+  document.body.appendChild(removed);
+
+  document.body.appendChild(document.createComment('/wj:children'));
+
+  await Promise.resolve();
+  await Promise.resolve();
+
+  records.length = 0;
+
+  const newBody =
+    '<!--wj:children:/-->' +
+      `<${tag} id="kept"></${tag}>` +
+      `<${tag} id="added"></${tag}>` +
+    '<!--/wj:children-->';
+
+  const { restore } = installNavigationMocks({
+    contentType: 'text/html; charset=utf-8',
+    body: `<!doctype html><html><head></head><body>${newBody}</body></html>`,
+  });
+
+  try {
+    await navigate('http://localhost/swap');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // id-keyed reuse means the same DOM Node ref must survive. This is
+    // the load-bearing assertion. (Lifecycle counts for in-parent
+    // re-insertion are implementation-defined across DOM hosts; per
+    // the DOM spec, real browsers do not fire disconnect/connect when
+    // a connected node is re-inserted under the same parent. Test
+    // identity here, leave lifecycle assertions to test/browser/.)
+    assert.equal(document.getElementById('kept'), kept,
+      'kept DOM identity preserved across partial-swap');
+
+    // Removed: gone, fires disconnect.
+    assert.equal(
+      records.filter((r) => r === 'disconnect:removed-old').length, 1,
+      'removed-old must disconnect'
+    );
+
+    // Added: brand-new id, fires connect.
+    assert.equal(
+      records.filter((r) => r === 'connect:added').length, 1,
+      'added must connect'
+    );
+  } finally {
+    restore();
+    document.body.innerHTML = '';
   }
 });


### PR DESCRIPTION
## Summary

Closes two integration-test gaps the recent lit-parity audit surfaced.

### 1. Partial-swap navigation preserves outer-layout component instances

The critical client-router invariant: when navigation lands inside a nested layout, outer-layout component instances (and their controllers' `hostConnected`) are NOT re-fired. Only components inside the deepest swapped marker pair go through disconnect/connect.

Adds two tests to `test/router-client.test.js`:

- **outer-layout component instance survives when inner segment changes** verifies that with nested `/` and `/docs` markers, a tracker outside the `/` marker and a tracker inside `/` but outside `/docs` neither re-fire `hostConnected` nor fire `hostDisconnected` when a `/docs/new` partial-swap nav fires. The inner tracker (different id) gets a proper disconnect+connect.
- **keyed inner element preserves DOM identity inside the swap range** verifies id-keyed reuse retains the same DOM node ref across the swap. Lifecycle counts for in-parent re-insertion are implementation-defined and deferred to browser tests (linkedom fires `connectedCallback` on `insertBefore` of a connected node; real browsers do not, per the DOM spec).

### 2. Slot projection timing vs lifecycle hooks

In light DOM, slot projection is microtask-deferred to AFTER the render commit, which means `firstUpdated` and `updated` see the `<slot>` in the DOM but `slot.assignedNodes()` is still empty. This is a real divergence from shadow-DOM semantics where projection is native and synchronous.

Adds three tests to `test/browser/slot.test.js`:

- **firstUpdated sees the slot element but light-DOM projection has NOT yet populated it** pins the empty-slot observation in `firstUpdated` and `updated` of the first render cycle.
- **updated() on a re-render AFTER projection sees the populated slot** documents the authoring pattern (trigger a re-render past the projection microtask) to read assignedNodes from a lifecycle hook.
- **shadow-DOM contrast: firstUpdated sees populated assignedNodes** verifies the shadow-DOM counterpoint (native synchronous projection means `firstUpdated` sees the populated assigned-nodes list).

The divergence is documented in `agent-docs/lit-muscle-memory-gotchas.md` gotcha #8.

## Test plan

- [x] `npm test` (980 node tests, all green, including the 2 new router-client tests)
- [x] `npx wtr` (239 browser tests, all green, including the 3 new slot tests)
- [x] Pre-commit hook ran `webjs test` cleanly