### PR TITLE
refactor(ui): tier-2 components onto updated() + queueMicrotask

### DIFF
--- a/packages/ui/packages/registry/components/alert-dialog.ts
+++ b/packages/ui/packages/registry/components/alert-dialog.ts
@@ -136,8 +136,6 @@ export class UiAlertDialog extends WebComponent {
   };
   declare open: boolean;
 
-  _lastOpen: boolean = false;
-
   constructor() {
     super();
     this.open = false;
@@ -163,16 +161,22 @@ export class UiAlertDialog extends WebComponent {
   get isOpen(): boolean { return this.open; }
 
   render() {
-    if (this._lastOpen !== this.open) {
-      this._lastOpen = this.open;
-      if (typeof requestAnimationFrame !== 'undefined') requestAnimationFrame(() => {
-        if (this.open) this._setup();
-        else this._teardown();
-      });
-    }
     return html`<div data-slot="alert-dialog" data-state=${this.open ? 'open' : 'closed'}>
       <slot></slot>
     </div>`;
+  }
+
+  updated(changedProperties: Map<string, unknown>): void {
+    if (!changedProperties.has('open')) return;
+    // Skip the constructor's initial open=false set so we don't fire
+    // teardown for the closed-on-mount state.
+    if (changedProperties.get('open') === undefined) return;
+    // Defer one microtask so the content child has rendered its inner
+    // native <dialog>; that's where showModal() / close() act.
+    queueMicrotask(() => {
+      if (this.open) this._setup();
+      else this._teardown();
+    });
   }
 
   get _content(): UiAlertDialogContent | null {

--- a/packages/ui/packages/registry/components/dialog.ts
+++ b/packages/ui/packages/registry/components/dialog.ts
@@ -162,8 +162,6 @@ export class UiDialog extends WebComponent {
   };
   declare open: boolean;
 
-  _lastOpen: boolean = false;
-
   constructor() {
     super();
     this.open = false;
@@ -190,22 +188,26 @@ export class UiDialog extends WebComponent {
   get isOpen(): boolean { return this.open; }
 
   render() {
-    // Track open transitions and ask the content child to open/close
-    // its native <dialog>. RAF defers until the content has rendered
-    // its own template (where the <dialog> lives).
-    if (this._lastOpen !== this.open) {
-      this._lastOpen = this.open;
-      if (typeof requestAnimationFrame !== 'undefined') requestAnimationFrame(() => {
-        if (this.open) this._setup();
-        else this._teardown();
-        this.dispatchEvent(
-          new CustomEvent('ui-open-change', { detail: { open: this.open }, bubbles: true }),
-        );
-      });
-    }
     return html`<div data-slot="dialog" data-state=${this.open ? 'open' : 'closed'}>
       <slot></slot>
     </div>`;
+  }
+
+  updated(changedProperties: Map<string, unknown>): void {
+    if (!changedProperties.has('open')) return;
+    // Constructor sets open=false, which records a (undefined -> false)
+    // transition in the first update. Skip it so the dialog doesn't
+    // emit a teardown + ui-open-change for the initial state.
+    if (changedProperties.get('open') === undefined) return;
+    // Defer one microtask so the content child has committed its own
+    // render (the native <dialog> element lives in the content's template).
+    queueMicrotask(() => {
+      if (this.open) this._setup();
+      else this._teardown();
+      this.dispatchEvent(
+        new CustomEvent('ui-open-change', { detail: { open: this.open }, bubbles: true }),
+      );
+    });
   }
 
   get _content(): UiDialogContent | null {

--- a/packages/ui/packages/registry/components/dropdown-menu.ts
+++ b/packages/ui/packages/registry/components/dropdown-menu.ts
@@ -122,7 +122,6 @@ export class UiDropdownMenu extends WebComponent {
   };
   declare open: boolean;
 
-  _lastOpen: boolean = false;
   _typeBuffer = '';
   _typeBufferTimer: number | undefined;
 
@@ -145,13 +144,16 @@ export class UiDropdownMenu extends WebComponent {
   hide(): void { this.open = false; }
 
   render() {
-    if (this._lastOpen !== this.open) {
-      this._lastOpen = this.open;
-      if (typeof requestAnimationFrame !== 'undefined') requestAnimationFrame(() => this._afterRender());
-    }
     return html`<div data-slot="dropdown-menu" data-state=${this.open ? 'open' : 'closed'}>
       <slot></slot>
     </div>`;
+  }
+
+  updated(changedProperties: Map<string, unknown>): void {
+    if (!changedProperties.has('open')) return;
+    if (changedProperties.get('open') === undefined) return;
+    // Wait one microtask for <ui-dropdown-menu-content>'s [popover] to commit.
+    queueMicrotask(() => this._afterRender());
   }
 
   _afterRender(): void {
@@ -456,7 +458,6 @@ export class UiDropdownMenuSub extends WebComponent {
   };
   declare open: boolean;
 
-  _lastOpen: boolean = false;
   _closeTimer: number | undefined;
 
   constructor() {
@@ -474,16 +475,18 @@ export class UiDropdownMenuSub extends WebComponent {
   toggle(): void { if (this.open) this.hide(); else this.show(); }
 
   render() {
-    if (this._lastOpen !== this.open) {
-      this._lastOpen = this.open;
-      if (typeof requestAnimationFrame !== 'undefined') requestAnimationFrame(() => this._afterRender());
-    }
     return html`<div
       data-slot="dropdown-menu-sub"
       data-state=${this.open ? 'open' : 'closed'}
       @pointerenter=${this._cancelCloseHandler}
       @pointerleave=${this._scheduleCloseHandler}
     ><slot></slot></div>`;
+  }
+
+  updated(changedProperties: Map<string, unknown>): void {
+    if (!changedProperties.has('open')) return;
+    if (changedProperties.get('open') === undefined) return;
+    queueMicrotask(() => this._afterRender());
   }
 
   _afterRender(): void {

--- a/packages/ui/packages/registry/components/hover-card.ts
+++ b/packages/ui/packages/registry/components/hover-card.ts
@@ -60,7 +60,6 @@ export class UiHoverCard extends WebComponent {
 
   _showTimer: number | undefined;
   _hideTimer: number | undefined;
-  _lastOpen: boolean = false;
 
   constructor() {
     super();
@@ -83,14 +82,18 @@ export class UiHoverCard extends WebComponent {
   }
 
   render() {
-    if (this._lastOpen !== this.open) {
-      this._lastOpen = this.open;
-      if (typeof requestAnimationFrame !== 'undefined') requestAnimationFrame(() => this._syncContent());
-    }
     return html`<div
       data-slot="hover-card"
       data-state=${this.open ? 'open' : 'closed'}
     ><slot></slot></div>`;
+  }
+
+  updated(changedProperties: Map<string, unknown>): void {
+    if (!changedProperties.has('open')) return;
+    if (changedProperties.get('open') === undefined) return;
+    // Wait one microtask for <ui-hover-card-content>'s inner [popover]
+    // element to commit; we drive its showPopover() / hidePopover().
+    queueMicrotask(() => this._syncContent());
   }
 
   _syncContent(): void {

--- a/packages/ui/packages/registry/components/tabs.ts
+++ b/packages/ui/packages/registry/components/tabs.ts
@@ -100,8 +100,6 @@ export class UiTabs extends WebComponent {
   declare value: string;
   declare orientation: 'horizontal' | 'vertical';
 
-  _lastValue: string = '';
-
   constructor() {
     super();
     this.value = '';
@@ -109,29 +107,25 @@ export class UiTabs extends WebComponent {
   }
 
   render() {
-    // Side effects: dispatch ui-value-change + broadcast to children
-    // when value transitions. Both require a real DOM (CustomEvent,
-    // dispatchEvent, requestAnimationFrame) so guard against SSR where
-    // linkedom doesn't implement them.
-    if (this._lastValue !== this.value) {
-      const prev = this._lastValue;
-      this._lastValue = this.value;
-      if (typeof window !== 'undefined') {
-        if (prev !== '' || this.value !== '') {
-          queueMicrotask(() => {
-            this.dispatchEvent(
-              new CustomEvent('ui-value-change', { detail: { value: this.value }, bubbles: true }),
-            );
-          });
-        }
-        requestAnimationFrame(() => this._broadcast());
-      }
-    }
     return html`<div
       data-slot="tabs"
       data-orientation=${this.orientation}
       class=${TABS_BASE}
     ><slot></slot></div>`;
+  }
+
+  updated(changedProperties: Map<string, unknown>): void {
+    if (!changedProperties.has('value')) return;
+    const prev = (changedProperties.get('value') ?? '') as string;
+    // Skip the initial undefined -> '' (or '' -> '') no-op set; only
+    // dispatch + broadcast on real value transitions.
+    if (prev === '' && this.value === '') return;
+    queueMicrotask(() => {
+      this.dispatchEvent(
+        new CustomEvent('ui-value-change', { detail: { value: this.value }, bubbles: true }),
+      );
+      this._broadcast();
+    });
   }
 
   _broadcast(): void {

--- a/packages/ui/packages/registry/components/toggle-group.ts
+++ b/packages/ui/packages/registry/components/toggle-group.ts
@@ -60,9 +60,10 @@ const ITEM_EXTRA =
 // <ui-toggle-group>
 // Renders a wrapping <div role="group"> with the @ui-toggle-item-click
 // listener bound declaratively. Children project through the slot. Item
-// state (data-state, aria-pressed) is reflected after each render via
-// a single requestAnimationFrame deferral to give the descendant
-// <ui-toggle-group-item> components time to settle their own renders.
+// state (data-state, aria-pressed) is reflected from updated() so the
+// effect runs after the host's commit. A queueMicrotask defer inside
+// gives the descendant <ui-toggle-group-item> components time to commit
+// their own renders before we read / write their state.
 // --------------------------------------------------------------------------
 
 export class UiToggleGroup extends WebComponent {
@@ -98,10 +99,6 @@ export class UiToggleGroup extends WebComponent {
 
   render() {
     const gap = this.spacing === '0' ? '' : 'gap-1';
-    // Items live under <slot>, but their state needs to be reflected
-    // after they have finished their own first render. One frame is
-    // enough; this is the same RAF-defer pattern used by tabs.
-    if (typeof requestAnimationFrame !== 'undefined') requestAnimationFrame(() => this._reflectItems());
     return html`<div
       data-slot="toggle-group"
       role="group"
@@ -112,6 +109,12 @@ export class UiToggleGroup extends WebComponent {
       data-orientation=${this.orientation}
       @ui-toggle-item-click=${this._onItemClick}
     ><slot></slot></div>`;
+  }
+
+  updated(): void {
+    // Reflect group state onto each <ui-toggle-group-item>. One microtask
+    // gives the items time to commit their own renders first.
+    queueMicrotask(() => this._reflectItems());
   }
 
   _reflectItems(): void {

--- a/packages/ui/packages/registry/components/tooltip.ts
+++ b/packages/ui/packages/registry/components/tooltip.ts
@@ -69,7 +69,6 @@ export class UiTooltip extends WebComponent {
 
   _showTimer: number | undefined;
   _hideTimer: number | undefined;
-  _lastOpen: boolean = false;
 
   constructor() {
     super();
@@ -102,17 +101,19 @@ export class UiTooltip extends WebComponent {
   }
 
   render() {
-    // Toggle popover open/closed on the descendant <ui-tooltip-content>
-    // after slot projection has settled (one frame). Side-effect; do not
-    // call from render() body itself.
-    if (this._lastOpen !== this.open) {
-      this._lastOpen = this.open;
-      if (typeof requestAnimationFrame !== 'undefined') requestAnimationFrame(() => this._syncContent());
-    }
     return html`<div
       data-slot="tooltip"
       data-state=${this.open ? 'open' : 'closed'}
     ><slot></slot></div>`;
+  }
+
+  updated(changedProperties: Map<string, unknown>): void {
+    if (!changedProperties.has('open')) return;
+    // Skip the constructor's initial open=false set.
+    if (changedProperties.get('open') === undefined) return;
+    // Defer one microtask so the content child's [popover] inner element
+    // has committed; we drive its showPopover() / hidePopover() from here.
+    queueMicrotask(() => this._syncContent());
   }
 
   _syncContent(): void {


### PR DESCRIPTION
## Why

The framework's lit-API parity pass (0.6.0) added `updated(changedProperties)`. Tier-2 stateful components were originally written against the pre-parity runtime, so they emulated `updated()` with a `_lastX` field, a render-time diff, and a `requestAnimationFrame` deferral:

\`\`\`ts
_lastOpen: boolean = false;
render() {
  if (this._lastOpen !== this.open) {        // emulate changedProperties.has('open')
    this._lastOpen = this.open;
    requestAnimationFrame(() => {            // wait for slotted-child commit
      if (this.open) this._setup();
      else this._teardown();
    });
  }
  return html\`...\`;
}
\`\`\`

Workaround no longer needed. Move the effect to where lit-trained agents expect it.

## After

\`\`\`ts
render() {
  return html\`...\`;
}
updated(changedProperties) {
  if (!changedProperties.has('open')) return;
  if (changedProperties.get('open') === undefined) return; // skip constructor initial set
  queueMicrotask(() => {                                    // wait for slotted-child commit
    if (this.open) this._setup();
    else this._teardown();
  });
}
\`\`\`

\`render()\` becomes purely declarative. Side effects live in \`updated()\`. The \`_last*\` fields go away. The \`typeof requestAnimationFrame !== 'undefined'\` SSR guards go away (updated() is client-only).

## Components touched (7)

- \`dialog.ts\` (UiDialog)
- \`alert-dialog.ts\` (UiAlertDialog)
- \`tooltip.ts\` (UiTooltip)
- \`hover-card.ts\` (UiHoverCard)
- \`dropdown-menu.ts\` (UiDropdownMenu + UiDropdownMenuSub)
- \`tabs.ts\` (UiTabs)
- \`toggle-group.ts\` (UiToggleGroup, also dropped one-shot rAF in render)

## Verification

- \`node --test test/*.test.js\`: 980 / 980 pass
- Per-component smoke (Playwright against \`http://localhost:3000/docs/components/<name>\`):
  - dialog: trigger click opens native dialog
  - alert-dialog: same
  - tabs: trigger click flips reflected \`value\`
  - tooltip: \`.show()\` opens, popover-open
  - hover-card: \`.show()\` opens, popover-open
  - dropdown-menu: trigger click sets \`open\`
  - toggle-group: item click flips reflected \`value\`
- SSR shape unchanged (\`data-slot=...\` matrix identical across all 7 components)
- No public API change (the \`_lastOpen\` field was internal)