### PR TITLE
feat(ui-website): env-driven sibling URLs with localhost dev fallbacks

### DIFF
--- a/packages/ui/packages/website/.env.example
+++ b/packages/ui/packages/website/.env.example
@@ -1,0 +1,7 @@
+# Sibling-app URLs surfaced in the UI website's header + footer.
+# Copy this file to `.env` (`cp .env.example .env`) for local dev.
+# Canonical localhost dev ports (one source of truth alongside the
+# matching fallbacks in app/layout.ts). Deployments override these
+# with real public URLs (e.g. via Railway's service env vars).
+WEBSITE_URL=http://localhost:5000
+DOCS_URL=http://localhost:4000

--- a/packages/ui/packages/website/AGENTS.md
+++ b/packages/ui/packages/website/AGENTS.md
@@ -103,6 +103,21 @@ The `predev` hook runs `scripts/copy-registry.js` to populate
 something to import. Re-running `npm run dev` re-populates from the
 current registry state.
 
+### Sibling-app URLs (header, footer)
+
+Sibling-app links in the header + footer (Webjs site, Docs) read from
+`WEBSITE_URL` / `DOCS_URL` env vars. Fallbacks are the canonical
+localhost dev ports so local `npm run dev` works with zero setup. Deploy
+by overriding via the service env (e.g. Railway's variables):
+
+| Env var | Local fallback | Production value |
+|---|---|---|
+| `WEBSITE_URL` | `http://localhost:5000` | `https://webjs.dev` |
+| `DOCS_URL` | `http://localhost:4000` | `https://docs.webjs.dev` |
+
+`.env.example` in this directory documents the same defaults. Copy it to
+`.env` only if you need to override locally; the fallbacks already match.
+
 ---
 
 Framework-wide rules and the framework API reference:

--- a/packages/ui/packages/website/app/layout.ts
+++ b/packages/ui/packages/website/app/layout.ts
@@ -1,9 +1,20 @@
 import { html } from '@webjskit/core';
 import './_components/theme-toggle.ts';
 
+/**
+ * Sibling-app URLs are read from env so the same code works in
+ * `webjs dev` (localhost) and in deployment (real hosts). Fallbacks
+ * are the canonical localhost dev ports (matching the matching apps'
+ * `webjs:dev --port` flags). Deploy by overriding WEBSITE_URL /
+ * DOCS_URL in the service env (Railway, etc.); `.env.example` in
+ * this directory documents the same defaults for visibility.
+ *
+ * Guarded against `process` being undefined: this file also loads
+ * on the client during hydration.
+ */
 const env = (globalThis as any).process?.env ?? {};
-const WEBSITE_URL = env.WEBSITE_URL || 'https://webjs.dev';
-const DOCS_URL = env.DOCS_URL || 'https://docs.webjs.dev';
+const WEBSITE_URL = env.WEBSITE_URL || 'http://localhost:5000';
+const DOCS_URL = env.DOCS_URL || 'http://localhost:4000';
 
 const TITLE = 'Webjs UI: AI-first component library';
 const DESCRIPTION =
@@ -310,7 +321,7 @@ export default function Layout({ children }: { children: any }) {
 
     <footer class="border-t mt-20 py-8 text-center" style="color: var(--fg-subtle); font-size: 13px">
       <div class="max-w-5xl mx-auto px-6">
-        <a class="text-brand no-underline hover:underline" href="https://webjs.dev" target="_blank">Webjs</a> ·
+        <a class="text-brand no-underline hover:underline" href=${WEBSITE_URL} target="_blank">Webjs</a> ·
         <a class="text-brand no-underline hover:underline" href=${DOCS_URL} target="_blank">Docs</a> ·
         <a class="text-brand no-underline hover:underline" href="https://github.com/vivek7405/webjs" target="_blank">GitHub</a>
       </div>


### PR DESCRIPTION
## Why

Running the three apps locally (\`npm run dev\` in \`website/\`, \`docs/\`, and \`packages/ui/packages/website/\`), clicking Webjs or Docs in the UI website's header / footer navigated off the localhost dev cluster to \`https://webjs.dev\` / \`https://docs.webjs.dev\`. The hosts were hardcoded as the defaults, with only the env vars (already wired) able to override.

\`website/app/layout.ts\` already solved this: env vars with **localhost** fallbacks. Deploy overrides via service env. Same pattern, mirrored here.

## What changed

\`packages/ui/packages/website/\`:

1. \`app/layout.ts\`:
   - \`WEBSITE_URL\` default: \`https://webjs.dev\` -> \`http://localhost:5000\`
   - \`DOCS_URL\` default: \`https://docs.webjs.dev\` -> \`http://localhost:4000\`
   - Footer "Webjs" link was the only hardcoded \`https://webjs.dev\`; rebound to \`\${WEBSITE_URL}\`.
2. \`.env.example\`: new file documenting the same defaults (mirrors \`website/.env.example\`).
3. \`AGENTS.md\`: env-var table (var, local fallback, production value) under the Dev section.

## Deploy note

The Railway service for ui.webjs.dev **must** set:
\`\`\`
WEBSITE_URL=https://webjs.dev
DOCS_URL=https://docs.webjs.dev
\`\`\`
Without those, production will render localhost links. Same shape as the existing \`DOCS_URL\` / \`BLOG_URL\` / \`UI_URL\` deploy-time overrides on the root webjs.dev service.

## Verification

- Local dev: \`curl http://localhost:5001/ | grep -oE 'href="..."' | grep webjs.dev\` returns nothing.
- Local dev rendered hrefs in header + footer point at \`http://localhost:5000\` and \`http://localhost:4000\`.
- Schema URL in \`_lib/registry.server.ts\` (\`https://ui.webjs.dev/schema/registry-item.json\`) is intentionally kept as-is, that's a content-type identifier in registry JSON, not a navigation URL.