### PR TITLE
fix(examples/blog): chat-box shows neutral 'Connecting…' on first paint

### DIFF
--- a/examples/blog/modules/chat/components/chat-box.ts
+++ b/examples/blog/modules/chat/components/chat-box.ts
@@ -7,12 +7,19 @@ type ChatMessage =
   | { kind: 'say'; text: string; at: number }
   | { kind: 'join' | 'leave'; count: number };
 
+// 'initial' is the SSR-emitted state, "we haven't tried to connect
+// yet"; we show "Connecting…" with a neutral indicator so the first
+// paint doesn't look like a broken reconnect. 'live' is after the
+// first successful open. 'reconnecting' is after a real close, which
+// is the only state where the alarming warning indicator should show.
+type ChatStatus = 'initial' | 'live' | 'reconnecting';
+
 /**
  * `<chat-box>`: terminal-leaning live chat panel against /api/chat.
  */
 export class ChatBox extends WebComponent {
   lines = signal<Line[]>([]);
-  connected = signal(false);
+  status = signal<ChatStatus>('initial');
   count = signal(0);
 
   _conn: ReturnType<typeof connectWS> | null = null;
@@ -21,8 +28,8 @@ export class ChatBox extends WebComponent {
   connectedCallback() {
     super.connectedCallback();
     this._conn = connectWS('/api/chat', {
-      onOpen:  () => { this.connected.set(true); },
-      onClose: () => { this.connected.set(false); },
+      onOpen:  () => { this.status.set('live'); },
+      onClose: () => { this.status.set('reconnecting'); },
       onMessage: (msg: ChatMessage) => {
         const lines = this.lines.get().slice();
         if (msg.kind === 'say') {
@@ -56,15 +63,32 @@ export class ChatBox extends WebComponent {
 
   render() {
     const lines = this.lines.get();
-    const connected = this.connected.get();
+    const status = this.status.get();
+    const live = status === 'live';
     const count = this.count.get();
+    // SSR-emitted initial state shows a neutral "Connecting…" instead
+    // of the alarming "Reconnecting…" copy. The warning state only
+    // appears after a real close event, which is the only time the
+    // user has actually lost connectivity.
+    const dotClass =
+      status === 'live'
+        ? 'w-[7px] h-[7px] rounded-full bg-success shadow-[0_0_0_3px_color-mix(in_oklch,var(--success)_30%,transparent)]'
+        : status === 'reconnecting'
+          ? 'w-[7px] h-[7px] rounded-full bg-accent'
+          : 'w-[7px] h-[7px] rounded-full bg-fg-subtle/40 animate-pulse';
+    const statusText =
+      status === 'live'
+        ? html`Live · ${Math.max(0, count - 1)} other${count - 1 !== 1 ? 's' : ''} online`
+        : status === 'reconnecting'
+          ? html`Reconnecting…`
+          : html`Connecting…`;
+    const placeholder =
+      status === 'live' ? 'Say hi…' : status === 'reconnecting' ? 'Disconnected' : 'Connecting…';
     return html`
       <div class="block border border-border rounded-xl bg-bg-elev shadow overflow-hidden font-sans">
         <div class="flex items-center gap-2 px-4 py-3 border-b border-border bg-bg-subtle font-mono text-[10px] font-semibold uppercase tracking-[0.15em] text-fg-subtle">
-          <span class="${connected
-            ? 'w-[7px] h-[7px] rounded-full bg-success shadow-[0_0_0_3px_color-mix(in_oklch,var(--success)_30%,transparent)]'
-            : 'w-[7px] h-[7px] rounded-full bg-accent'}"></span>
-          ${connected ? html`Live · ${Math.max(0, count - 1)} other${count - 1 !== 1 ? 's' : ''} online` : html`Reconnecting…`}
+          <span class=${dotClass}></span>
+          ${statusText}
         </div>
         <div class="h-[220px] overflow-y-auto p-4 text-sm leading-relaxed font-sans scroll-smooth bg-bg-sunken">
           ${lines.length === 0
@@ -76,9 +100,9 @@ export class ChatBox extends WebComponent {
         </div>
         <form class="flex gap-2 px-4 py-3 border-t border-border bg-bg-subtle" @submit=${(e) => this.onSubmit(e)}>
           <input class="${inputClass()} flex-1"
-                 placeholder=${connected ? 'Say hi…' : 'Disconnected'}
-                 ?disabled=${!connected} autocomplete="off">
-          <button class=${buttonClass({ size: 'sm' })} ?disabled=${!connected}>Send</button>
+                 placeholder=${placeholder}
+                 ?disabled=${!live} autocomplete="off">
+          <button class=${buttonClass({ size: 'sm' })} ?disabled=${!live}>Send</button>
         </form>
       </div>
     `;

--- a/test/examples/blog/smoke/blog-smoke.test.js
+++ b/test/examples/blog/smoke/blog-smoke.test.js
@@ -149,4 +149,17 @@ describe('Blog smoke (Tier-1/Tier-2 migration)', { skip: skip && 'blog or its DB
     const json = await r.json();
     assert.equal(typeof json.hello, 'string');
   });
+
+  test('/ chat-box SSR shows "Connecting…" (not the alarming "Reconnecting…") before JS runs', async () => {
+    // Before the chat-box fix the initial SSR copy was "Reconnecting…"
+    // with an accent warning dot. A user landing on a cold page saw
+    // that for the ~500ms it took the WS handshake to complete and
+    // mistakenly read the page as broken. The component now SSRs a
+    // neutral "Connecting…" state and only transitions to
+    // "Reconnecting…" after a real close event.
+    const html = await fetch(baseUrl + '/').then((r) => r.text());
+    assert.match(html, /<chat-box\b/, 'chat-box element should be present');
+    assert.match(html, /Connecting…/, 'SSR should render "Connecting…" before JS hydration');
+    assert.doesNotMatch(html, /Reconnecting…/, 'SSR must NOT render "Reconnecting…" on first paint');
+  });
 });


### PR DESCRIPTION
## Summary

User reported that on a cold load of https://example-blog.webjs.dev/ the live chat showed "Disconnected" and the counter looked inert; a refresh fixed both.

Investigation (puppeteer-core against the deployed site + a local timing trace):

- The counter actually works at every measured delay; it's not broken.
- The chat-box's SSR-emitted initial state was `connected = false`, which rendered "Reconnecting…" with an accent (orange) warning dot. During the ~500ms WS handshake on a cold load, the user sees that copy and reads the whole page as broken. Refresh hides the issue because the JS modules are now cached and the handshake completes before the user looks.

The bug is a misleading initial state. Nothing has actually "reconnected" yet; we haven't even tried to connect once.

## Fix

Split the chat-box status into three values:

| Status | When | UI |
|---|---|---|
| `initial` | SSR + before first WS open/close | Muted pulse dot + "Connecting…" |
| `live` | first WS open onwards | Green dot + "Live · N others online" |
| `reconnecting` | only after a real close event | Accent dot + "Reconnecting…" |

The alarming color and copy now appear only when there has been an actual disconnect.

## Test plan

- [x] New smoke assertion: `/` SSR HTML contains "Connecting…" and NOT "Reconnecting…".
- [x] Existing 5 smoke tests still pass.
- [x] `examples/blog`'s 43 node tests still pass.
- [x] Manual repro via puppeteer at delays 50ms → 5s confirmed counter is unchanged (it was never broken).