### PR TITLE
chore(scaffold,examples/blog): ship .gitignore as a template file

### DIFF
--- a/examples/blog/.gitignore
+++ b/examples/blog/.gitignore
@@ -1,1 +1,25 @@
+# deps
+node_modules/
+
+# webjs / framework caches
 .webjs/
+
+# generated Tailwind CSS, built from public/input.css via npm run dev / start
+public/tailwind.css
+
+# env (the example reads from .env.example fallbacks in dev; never commit the real .env)
+.env
+.env.*
+!.env.example
+
+# prisma local db
+prisma/dev.db
+prisma/dev.db-journal
+
+# logs
+*.log
+npm-debug.log*
+
+# OS
+.DS_Store
+Thumbs.db

--- a/packages/cli/lib/create.js
+++ b/packages/cli/lib/create.js
@@ -257,11 +257,17 @@ export async function scaffoldApp(name, cwd, opts = {}) {
     'AGENTS.md',
     'CONVENTIONS.md',
     'CLAUDE.md',
-    'test/unit/example.test.ts',
-    'test/browser/example.test.js',
+    // Starter tests under the new feature-folder layout.
+    'test/hello/hello.test.ts',
+    'test/hello/browser/hello.test.js',
+    'test/hello/e2e/hello.test.ts',
     'web-test-runner.config.js',
     // Environment variables
     '.env.example',
+    // Project-level gitignore (node_modules, .webjs, .env, OS junk).
+    // The Prisma dev.db rule is appended programmatically below so it
+    // only appears in templates that actually use SQLite.
+    '.gitignore',
     // Git hooks (blocks commits on main)
     '.hooks/pre-commit',
     // Claude Code config + hooks

--- a/packages/cli/templates/.gitignore
+++ b/packages/cli/templates/.gitignore
@@ -1,0 +1,36 @@
+# deps
+node_modules/
+
+# webjs / framework caches
+.webjs/
+
+# generated Tailwind CSS, built from public/input.css via npm run dev / start
+public/tailwind.css
+
+# env (.env.example stays tracked; the real .env never is)
+.env
+.env.*
+!.env.example
+
+# logs
+*.log
+npm-debug.log*
+
+# OS
+.DS_Store
+Thumbs.db
+
+# editors
+.vscode/
+.idea/
+
+# test artifacts
+coverage/
+
+# AI assistants: local session state, scheduled-task locks, etc.
+# Repo-shared config (settings.json + hooks scripts) stays tracked so
+# every contributor and agent gets the same PreToolUse rules.
+.claude/*
+!.claude/settings.json
+!.claude/hooks/
+!.claude/hooks/**


### PR DESCRIPTION
## Summary

You flagged that `examples/blog/node_modules` looked like it might be tracked. **It isn't.** Zero files under any `node_modules/` are tracked anywhere in the repo (the root `.gitignore` has `node_modules/` which is recursive). Two real gaps still deserved a fix:

1. `examples/blog/.gitignore` only listed `.webjs/`. Adding `node_modules/` etc. explicitly makes the per-app intent obvious without forcing the reader to cross-reference the root.
2. The scaffold templates directory had no `.gitignore` file. New apps got one via a programmatic write in `packages/cli/lib/create.js`. Works, but undiscoverable. Now `.gitignore` is a real template file copied verbatim like every other scaffold dotfile (`.editorconfig`, `.cursorrules`, etc.), and the programmatic logic just appends the Prisma `dev.db` rule on top.
3. **Latent regression fix:** the post-#45 `templateFiles` list still referenced `test/unit/example.test.ts` and `test/browser/example.test.js`. After PR #45 those paths moved to `test/hello/`. Existing `existsSync` checks silently false'd, so newly-scaffolded apps lost their starter tests. Updated to the new paths.

## Verification

Ran the scaffold end-to-end:

- `webjs create demo` produces a `.gitignore` containing `node_modules/`, `.webjs/`, `.env`, `public/tailwind.css`, plus the Prisma `dev.db` rule appended programmatically.
- `test/hello/hello.test.ts`, `test/hello/browser/hello.test.js`, `test/hello/e2e/hello.test.ts` are all present.
- All 12 `test/scaffolds/*.test.js` still pass.

## Test plan

- [x] `node --test test/scaffolds/*.test.js`, 12/12 pass.
- [x] Manual `webjs create demo` produces the expected file tree + `.gitignore` content.