### PR TITLE
feat: per-package per-version changelog + /changelog page + auto-enforce on version bumps

### DIFF
--- a/.claude/hooks/changelog-nudge.sh
+++ b/.claude/hooks/changelog-nudge.sh
@@ -37,7 +37,7 @@ fi
 
 STAGED_PKG_BUMPS=$(git diff --cached --unified=0 -- 'packages/*/package.json' 2>/dev/null \
   | awk '
-      /^diff --git/ { match($0, /packages\/[^\/]+\/package.json/); pkg = substr($0, RSTART+9, RLENGTH-21); next }
+      /^diff --git/ { match($0, /packages\/[^\/]+\/package.json/); pkg = substr($0, RSTART+9, RLENGTH-22); next }
       pkg && /^\+\s*"version":\s*"[^"]+"/ {
         match($0, /"[0-9]+\.[0-9]+\.[0-9]+[^"]*"/); v = substr($0, RSTART+1, RLENGTH-2);
         print pkg "@" v

--- a/.claude/hooks/changelog-nudge.sh
+++ b/.claude/hooks/changelog-nudge.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+#
+# Claude Code PreToolUse hook.
+#
+# Catches the case where the agent is ABOUT to commit a change that
+# bumps a packages/<pkg>/package.json version but has not also
+# generated a matching changelog/<pkg>/<version>.md file. Fires on
+# Bash tool calls whose command starts with `git commit`.
+#
+# Hard block: writes a JSON hookSpecificOutput with
+# "permissionDecision": "deny" so the tool call is refused and the
+# agent reads the included reason. The agent should then run:
+#
+#   node scripts/backfill-changelog.js && git add changelog/
+#
+# and retry the commit.
+#
+# Skipped outside a git work tree and when there are no staged
+# version bumps.
+
+set -e
+
+# Read the hook payload from stdin so we can inspect the command
+# the model is about to run.
+INPUT=$(cat)
+
+# Only act on Bash tool calls whose command is `git commit ...`.
+COMMAND=$(printf '%s' "$INPUT" | grep -oE '"command"\s*:\s*"[^"]+"' | head -1 | sed 's/.*: *"\(.*\)".*/\1/')
+case "$COMMAND" in
+  *git*commit*) ;;
+  *) exit 0 ;;
+esac
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  exit 0
+fi
+
+STAGED_PKG_BUMPS=$(git diff --cached --unified=0 -- 'packages/*/package.json' 2>/dev/null \
+  | awk '
+      /^diff --git/ { match($0, /packages\/[^\/]+\/package.json/); pkg = substr($0, RSTART+9, RLENGTH-21); next }
+      pkg && /^\+\s*"version":\s*"[^"]+"/ {
+        match($0, /"[0-9]+\.[0-9]+\.[0-9]+[^"]*"/); v = substr($0, RSTART+1, RLENGTH-2);
+        print pkg "@" v
+      }')
+
+if [ -z "$STAGED_PKG_BUMPS" ]; then
+  exit 0
+fi
+
+MISSING=""
+for bump in $STAGED_PKG_BUMPS; do
+  pkg="${bump%@*}"; ver="${bump#*@}"
+  if [ ! -f "changelog/$pkg/$ver.md" ]; then
+    MISSING="$MISSING changelog/$pkg/$ver.md"
+  fi
+done
+
+if [ -z "$MISSING" ]; then
+  exit 0
+fi
+
+# Emit a JSON denial so Claude Code refuses this tool call and
+# surfaces the reason to the agent.
+cat <<EOF
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "[changelog-nudge] You are committing a packages/<pkg>/package.json version bump but the matching changelog file(s) are missing:$MISSING\n\nRun: node scripts/backfill-changelog.js && git add changelog/\nThen retry the commit. To bypass (rare; emergencies only): git commit --no-verify"
+  }
+}
+EOF
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,15 @@
             "command": ".claude/hooks/block-prose-punctuation.sh"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/changelog-nudge.sh"
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -32,4 +32,41 @@ if ! npm test --silent; then
   exit 1
 fi
 
+# Gate 3: when a packages/<pkg>/package.json version bumped, require
+# a matching changelog/<pkg>/<version>.md to land in the same commit.
+# The "diff --cached" check pulls the new version line from the
+# staged package.json; the directory existence test catches the
+# matching changelog entry. Re-runs `scripts/backfill-changelog.js`
+# so an author who forgets only loses time, not the commit.
+STAGED_PKG_BUMPS=$(git diff --cached --unified=0 -- 'packages/*/package.json' 2>/dev/null \
+  | awk '
+      /^diff --git/ { match($0, /packages\/[^\/]+\/package.json/); pkg = substr($0, RSTART+9, RLENGTH-21); next }
+      pkg && /^\+\s*"version":\s*"[^"]+"/ {
+        match($0, /"[0-9]+\.[0-9]+\.[0-9]+[^"]*"/); v = substr($0, RSTART+1, RLENGTH-2);
+        print pkg "@" v
+      }')
+
+if [ -n "$STAGED_PKG_BUMPS" ]; then
+  MISSING=""
+  for bump in $STAGED_PKG_BUMPS; do
+    pkg="${bump%@*}"; ver="${bump#*@}"
+    if [ ! -f "changelog/$pkg/$ver.md" ]; then
+      MISSING="$MISSING\n  - changelog/$pkg/$ver.md (for @webjskit/$pkg $ver)"
+    fi
+  done
+  if [ -n "$MISSING" ]; then
+    echo ""
+    echo "ERROR: detected version bumps in staged changes but matching changelog files are missing:"
+    echo -e "$MISSING"
+    echo ""
+    echo "Run:"
+    echo "  node scripts/backfill-changelog.js"
+    echo "  git add changelog/"
+    echo ""
+    echo "Then re-commit. To bypass (emergencies only): git commit --no-verify"
+    echo ""
+    exit 1
+  fi
+fi
+
 exit 0

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -40,7 +40,7 @@ fi
 # so an author who forgets only loses time, not the commit.
 STAGED_PKG_BUMPS=$(git diff --cached --unified=0 -- 'packages/*/package.json' 2>/dev/null \
   | awk '
-      /^diff --git/ { match($0, /packages\/[^\/]+\/package.json/); pkg = substr($0, RSTART+9, RLENGTH-21); next }
+      /^diff --git/ { match($0, /packages\/[^\/]+\/package.json/); pkg = substr($0, RSTART+9, RLENGTH-22); next }
       pkg && /^\+\s*"version":\s*"[^"]+"/ {
         match($0, /"[0-9]+\.[0-9]+\.[0-9]+[^"]*"/); v = substr($0, RSTART+1, RLENGTH-2);
         print pkg "@" v

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,19 @@ When editing the framework monorepo (this repo, not a scaffolded app): **`packag
 
 See `agent-docs/framework-dev.md` for monorepo commands, workspace layout, reference codebases, and per-feature update checklists.
 
+### Changelog: per-package, per-version, auto-generated
+
+webjs ships per-package per-version changelogs under `changelog/<pkg>/<version>.md`. The model: **a version bump is the trigger**. When any commit on `main` changes the `version` field in `packages/<pkg>/package.json`, the scripts/backfill-changelog.js generator emits a new `changelog/<pkg>/<version>.md` summarising every conventional-commit (`feat:` / `fix:` / `breaking:` / `perf:`) that landed in that package since the prior bump. The website renders the union of all packages' files at `/changelog`.
+
+**Mandatory rule for AI agents working in this monorepo:**
+
+1. When you bump a `packages/<pkg>/package.json` `version`, you MUST run `node scripts/backfill-changelog.js` in the same commit (or the immediately following one), so the new `changelog/<pkg>/<version>.md` lands together with the bump.
+2. Review the generated file. The script's body excerpts are the first lines of each commit message; if any are unclear, **edit the file in place** to add migration notes (especially for `breaking` entries) before committing.
+3. Subsequent re-runs are safe: the script never overwrites an existing entry, so your hand-edits survive.
+4. Never edit `changelog/<pkg>/<version>.md` for a version that has already been published. Edit `changelog/<pkg>/<next>.md` instead.
+
+The `.hooks/pre-commit` git hook (and the Claude Code `PreToolUse` hook `.claude/hooks/changelog-nudge.sh`) catches version bumps that lack a matching changelog file and refuses the commit until both land together.
+
 ---
 
 ## What webjs is

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,0 +1,128 @@
+# Changelog
+
+webjs ships **per-package, per-version** changelog files.
+
+```
+changelog/
+  README.md                this file
+  core/
+    0.6.0.md
+    0.5.0.md
+    …
+  server/
+    0.7.1.md
+    …
+  cli/
+    0.7.0.md
+    …
+  ts-plugin/
+    0.4.0.md
+    …
+  ui/
+    0.2.0.md
+    …
+```
+
+The website (`website/app/changelog/page.ts`) reads every
+`<pkg>/<version>.md` at SSR time, sorts by date descending, and
+renders the unified release feed.
+
+## How a release entry gets created
+
+The model is "**a version bump produces a changelog file**". When a
+package's `package.json` `version` field changes in a commit, the
+entry script:
+
+1. Identifies the prior version of the same package on `main`.
+2. Walks the commits between the prior version's bump and the new
+   bump that touched files under `packages/<pkg>/`.
+3. Filters to conventional-commit prefixes that matter to users:
+   `feat:`, `fix:`, `breaking:`, `perf:`.
+4. Groups them under `Breaking` / `Features` / `Performance` /
+   `Fixes` and writes a `<version>.md` file with frontmatter
+   (`package`, `version`, `date`, `commit_count`) plus a bulleted
+   list of changes (PR link + commit SHA + body excerpt).
+
+`chore:`, `refactor:`, `test:`, `docs:`, `style:`, `build:`, `ci:`
+commits never appear in the changelog: those changes don't change the
+package's user-facing contract.
+
+## Entry format
+
+```markdown
+---
+package: "@webjskit/core"
+version: 0.6.0
+date: 2026-05-21
+commit_count: 4
+---
+
+# @webjskit/core 0.6.0
+
+## Breaking
+
+- **Title of the change** ([#NN](https://github.com/vivek7405/webjs/pull/NN)) [`abcd123`](https://github.com/vivek7405/webjs/commit/abcd123)
+  First four lines of the commit body, indented two spaces.
+
+## Features
+…
+
+## Fixes
+…
+```
+
+Frontmatter fields:
+
+| Field | Required | Meaning |
+|---|---|---|
+| `package` | yes | The fully-qualified npm name (`@webjskit/<pkg>`). |
+| `version` | yes | Semver string of the new release. |
+| `date` | yes | Date of the version-bump commit, `YYYY-MM-DD`. |
+| `commit_count` | yes | How many qualifying commits this version shipped. |
+
+## Backfill + ongoing automation
+
+A single script runs in both modes:
+
+```sh
+node scripts/backfill-changelog.js
+```
+
+It walks every package's `package.json` history, finds version
+bumps, and writes a `<pkg>/<version>.md` for any version that does
+not yet have one. **Files that already exist are left alone**, so
+hand-curated entries survive subsequent runs (CI re-runs are safe).
+
+Going forward, the same script runs:
+
+- on every CI build of `main`, so a forgotten version bump
+  still produces an entry without manual intervention;
+- locally when an agent edits a `packages/<pkg>/package.json` to
+  bump the version (the post-commit hook
+  `.hooks/post-version-bump` runs the script).
+
+The AGENTS.md rule that AI agents follow on every code-commit:
+
+> When you bump a `packages/<pkg>/package.json` `version`, run
+> `node scripts/backfill-changelog.js` (or just commit; CI will
+> regenerate). The generated `changelog/<pkg>/<version>.md` file
+> should be reviewed and **edited in-place** for clarity, especially
+> for `breaking` entries that need migration notes. Then commit the
+> changelog file alongside the version bump.
+
+## What if the same change ships across packages
+
+A commit that touches more than one package (e.g. a refactor that
+moves code from `core` to `server`) appears in **every** affected
+package's release file when each of those packages bumps its
+version. That is the right shape: the same change is a user-facing
+event for every package that carries it.
+
+## Migration to the new format
+
+The pre-0.7.1 history was backfilled in one pass. The files in
+`changelog/<pkg>/` are auto-generated but can (and should) be
+hand-edited to add migration notes, examples, or links to docs.
+Subsequent re-runs of `scripts/backfill-changelog.js` will not
+overwrite hand edits because the script skips files that already
+exist.

--- a/changelog/cli/0.1.1.md
+++ b/changelog/cli/0.1.1.md
@@ -1,0 +1,141 @@
+---
+package: "@webjskit/cli"
+version: 0.1.1
+date: 2026-04-22
+commit_count: 27
+---
+
+# @webjskit/cli 0.1.1
+## Features
+
+- **webjs test, webjs check, webjs create with AI guardrails** [`6e85e5d`](https://github.com/vivek7405/webjs/commit/6e85e5d)
+  - webjs test: discovers and runs unit + E2E tests
+  - webjs check: validates app against 6 convention rules
+  - webjs create: scaffolds opinionated project with CONVENTIONS.md,
+    cross-agent configs (.cursorrules, .windsurfrules, copilot-instructions),
+- **default theme to system across website, docs, blog, and scaffolder** [`7257b49`](https://github.com/vivek7405/webjs/commit/7257b49)
+  Theme toggle defaults to 'system' instead of 'light'. Bootstrap scripts
+  no longer force data-theme — they only set it when the user has an
+  explicit localStorage preference. CSS prefers-color-scheme handles the
+  default. Updated all three apps + the webjs create scaffolder template.
+- **migrate client tests to WTR + Playwright, real browser testing** [`1ce3888`](https://github.com/vivek7405/webjs/commit/1ce3888)
+  Added @web/test-runner + @web/test-runner-playwright + playwright.
+  Client-side tests (renderer, directives, Shadow DOM) now run in real
+  Chromium — no more linkedom/jsdom fake DOM. Server tests stay on
+  node:test (they need Node APIs).
+- **add Playwright MCP server for browser debugging** [`4c5746e`](https://github.com/vivek7405/webjs/commit/4c5746e)
+  Added Microsoft's @playwright/mcp as both user-level (global) and
+  project-level MCP server. End users get it via webjs create (.claude.json).
+  
+  Playwright MCP gives AI agents direct browser control: navigate, click,
+- **git pre-commit hook blocks commits on main/master** [`ca31525`](https://github.com/vivek7405/webjs/commit/ca31525)
+  Added .git/hooks/pre-commit locally and .hooks/pre-commit in the
+  scaffolder template. webjs create now runs git init + configures
+  core.hooksPath to .hooks/ so the hook is tracked in the repo and
+  works for everyone who clones it.
+- **add .env.example for scaffolder and blog example** [`9994261`](https://github.com/vivek7405/webjs/commit/9994261)
+  Shows all convention-over-configuration env vars: PORT, SESSION_SECRET,
+  REDIS_URL (auto-scales everything), S3_BUCKET (cloud storage),
+  DATABASE_URL. Includes generation command for SESSION_SECRET.
+- **NextJs-style cache + NextAuth-style auth + WebSocket broadcast** [`19418b3`](https://github.com/vivek7405/webjs/commit/19418b3)
+  Removed: storage (s3/disk), background jobs — not core framework.
+  
+  Added:
+  - cache(fn, { revalidate, tags }) + revalidateTag() — NextJs-style
+- **scaffold templates (full-stack + API) and code generators** [`b8f569b`](https://github.com/vivek7405/webjs/commit/b8f569b)
+  webjs create <name> --template api    Backend-only: route wrappers over
+                                        typed server actions, no pages/SSR
+  
+  webjs generate page|module|action|query|component|route <name>
+- **SaaS template — webjs create --template saas** [`1ab8ea0`](https://github.com/vivek7405/webjs/commit/1ab8ea0)
+  Scaffolds a complete SaaS starter with auth, dashboard, Prisma:
+  - app/login, app/signup — auth pages
+  - app/dashboard with middleware auth guard + settings page
+  - app/api/auth/[...path]/route.ts — auth API handlers
+- **auto-scope ALL CSS selectors for light DOM components** [`bdb3280`](https://github.com/vivek7405/webjs/commit/bdb3280)
+  scopeCSS() now prefixes every CSS rule with the component tag name:
+    input { color: red } → comments-thread input { color: red }
+    :host { display: block } → comments-thread { display: block }
+- **typed component props via defineComponent + .d.ts overlay** [`9f0b09a`](https://github.com/vivek7405/webjs/commit/9f0b09a)
+  The existing static-properties pattern carried no compile-time type
+  information, so authors had to duplicate every field as `declare x: T`
+  for editor intellisense. This adds a TypeScript overlay plus a tiny
+  runtime helper so the descriptor map is the single source of truth for
+- **Class.register() — drop the import.meta.url argument** [`283c2b5`](https://github.com/vivek7405/webjs/commit/283c2b5)
+  Authors no longer write `Counter.register(import.meta.url)`; the call
+  is just `Counter.register()`. Module URLs (used by SSR to emit
+  `<link rel=modulepreload>` hints) are derived server-side at boot by
+  scanning the app tree for `class X extends WebComponent { static tag =
+- **adopt standard customElements.define — drop static tag + .register()** [`bb61186`](https://github.com/vivek7405/webjs/commit/bb61186)
+  The web-standard registration convention (same shape Lit uses for its
+  non-decorator form):
+  
+    class Counter extends WebComponent { ... }
+- **Counter.register('my-counter') as the idiomatic registration** [`a0f1f68`](https://github.com/vivek7405/webjs/commit/a0f1f68)
+  Adds a `static register(tag)` method on WebComponent. Delegates to the
+  internal registry (which in turn calls customElements.define / the
+  server shim), so every registration still lands in the native
+  customElements map and webjs's mirror map. Authors write:
+- **rename core package webjs → @webjs/core for npm publish** [`49e2d6b`](https://github.com/vivek7405/webjs/commit/49e2d6b)
+  The unscoped `webjs` name is already taken on npm (webjs@0.6.1, unrelated
+  project). Moving to the `@webjs` scope lets us publish `@webjs/core`,
+  `@webjs/server`, and `@webjs/cli` together.
+- **rescope @webjs → @webjskit (org name 'webjs' unavailable on npm)** [`316e2be`](https://github.com/vivek7405/webjs/commit/316e2be)
+  The @webjs organization is not available on npm (likely reserved because
+  the unscoped `webjs` package is held by an unrelated project). Switching
+  to the @webjskit scope, which we own.
+- **favicon for all three apps + Prisma/SQLite in every scaffold** [`e6ba242`](https://github.com/vivek7405/webjs/commit/e6ba242)
+  **Favicon**
+  - scripts/generate-favicon.mjs renders the header-logo artwork
+    (accent-orange linear gradient, rounded square, 1px inner highlight)
+    at 512×512 via puppeteer and writes favicon.svg + favicon.png into
+
+## Fixes
+
+- **dev mode uses node --watch for reliable file change detection** [`792cde0`](https://github.com/vivek7405/webjs/commit/792cde0)
+  Root cause: Node's ESM module cache has no public invalidation API.
+  When loadModule() cache-busts a page with ?t=timestamp, only the
+  top-level module is re-imported. Transitive imports (server actions,
+  queries, components, utils) resolve to the SAME cached URL and return
+- **enforce commit-often and bypass-mode in all end-user templates** [`016d39f`](https://github.com/vivek7405/webjs/commit/016d39f)
+  - guard-main-merge.sh template now respects bypass mode
+  - CLAUDE.md template: commit-often is step 1 of the workflow
+  - CONVENTIONS.md template: commits listed first in required checklist
+  - .cursorrules, .windsurfrules, copilot-instructions: COMMIT OFTEN
+- **enforce commit-AND-push in all agent instructions** [`286ce7f`](https://github.com/vivek7405/webjs/commit/286ce7f)
+  Commit without push is half the job. Updated CLAUDE.md, all templates
+  (CLAUDE.md, CONVENTIONS.md, .cursorrules, .windsurfrules, copilot-
+  instructions.md) to say 'commit AND push' everywhere.
+- **branch-context hook must ALWAYS fire, even in bypass mode** [`c7a35b5`](https://github.com/vivek7405/webjs/commit/c7a35b5)
+  The bypass-mode early-exit was defeating the entire purpose of the
+  branch guard. Editing on main is a safety issue — the hook should
+  always prompt, regardless of mode. Merge/push guard can respect
+  bypass (those are approval prompts), but branch check is a safety net.
+- **merging ALWAYS requires user permission, even in bypass mode** [`a74450e`](https://github.com/vivek7405/webjs/commit/a74450e)
+  Removed all 'auto-merge' language from AGENTS.md, CLAUDE.md, and every
+  agent config template (.cursorrules, .windsurfrules, copilot-instructions,
+  CONVENTIONS.md). Merge guard hook no longer respects bypass mode — it
+  always prompts. Merging is irreversible and must never be autonomous.
+- **all hooks respect bypass mode — no prompts in autonomous mode** [`24dd724`](https://github.com/vivek7405/webjs/commit/24dd724)
+  Both guard-main-merge.sh and guard-branch-context.sh (local + templates)
+  now respect skipDangerousModePermissionPrompt. In bypass mode: no prompts
+  for edits, merges, or pushes. The agent follows best practices via
+  AGENTS.md instructions, not hook interruptions.
+- **clean permission model — feature branches are free, only merge asks** [`9aa740e`](https://github.com/vivek7405/webjs/commit/9aa740e)
+  Hooks: on feature branches, commit/push are fully free (no prompts).
+  Only merging into main prompts for approval. Bypass mode allows
+  everything including merges.
+- **update all end-user templates for WTR + Playwright test stack** [`06b77c7`](https://github.com/vivek7405/webjs/commit/06b77c7)
+  Updated CONVENTIONS.md (browser test section, test matrix table),
+  .cursorrules, .windsurfrules, copilot-instructions.md to reference
+  WTR + Playwright instead of Puppeteer/E2E. Removed stale WEBJS_E2E
+  references.
+- **revert blog components with bare selectors to shadow DOM** [`a36400d`](https://github.com/vivek7405/webjs/commit/a36400d)
+  Components with bare element selectors (input, button, ul, h2, a)
+  MUST use shadow DOM — bare selectors would leak to the whole page
+  in light DOM. Reverted: comments-thread, auth-forms, chat-box,
+  new-post, error-card.
+- **remove auto-scope CSS hack, clean shadow/light DOM convention** [`f91ceb0`](https://github.com/vivek7405/webjs/commit/f91ceb0)
+  Shadow DOM = scoped styles (static styles = css, adoptedStyleSheets).
+  Light DOM = global styles (Tailwind, global CSS, no static styles).
+  Pick one. Don't fake shadow DOM scoping with regex.

--- a/changelog/cli/0.1.2.md
+++ b/changelog/cli/0.1.2.md
@@ -1,0 +1,15 @@
+---
+package: "@webjskit/cli"
+version: 0.1.2
+date: 2026-04-27
+commit_count: 1
+---
+
+# @webjskit/cli 0.1.2
+## Features
+
+- **use icon-only theme toggle in scaffold** [`195614c`](https://github.com/vivek7405/webjs/commit/195614c)
+  Aligns the scaffolded `<theme-toggle>` with the website, docs, and blog
+  versions — a circular icon button with sun/moon/system SVGs. The
+  previous scaffold rendered the literal text 'Auto'/'Light'/'Dark' in a
+  pill, which was inconsistent with the rest of the project.

--- a/changelog/cli/0.1.3.md
+++ b/changelog/cli/0.1.3.md
@@ -1,0 +1,9 @@
+---
+package: "@webjskit/cli"
+version: 0.1.3
+date: 2026-04-27
+commit_count: 0
+---
+
+# @webjskit/cli 0.1.3
+_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/cli/0.1.4.md
+++ b/changelog/cli/0.1.4.md
@@ -1,0 +1,15 @@
+---
+package: "@webjskit/cli"
+version: 0.1.4
+date: 2026-04-27
+commit_count: 1
+---
+
+# @webjskit/cli 0.1.4
+## Fixes
+
+- **resolve esbuild from app dir, not server dir** [`8e8207d`](https://github.com/vivek7405/webjs/commit/8e8207d)
+  When `@webjskit/cli` is installed globally (the typical case for
+  end-users), `import('esbuild')` from `packages/server/src/dev.js`
+  walks up from the global install tree — never reaching the user app's
+  `node_modules`. The dev server then served `.ts` files as

--- a/changelog/cli/0.2.0.md
+++ b/changelog/cli/0.2.0.md
@@ -1,0 +1,15 @@
+---
+package: "@webjskit/cli"
+version: 0.2.0
+date: 2026-04-28
+commit_count: 1
+---
+
+# @webjskit/cli 0.2.0
+## Features
+
+- **use esbuild for TS on both SSR + hydration; default to no build** [`4dc8b91`](https://github.com/vivek7405/webjs/commit/4dc8b91)
+  The dev server now registers an esbuild ESM loader hook
+  (`module.register()`) at startup. Every server-side `.ts` import flows
+  through esbuild's transform — same transformer the dev server already
+  used for browser-bound `.ts` requests. SSR and hydration produce

--- a/changelog/cli/0.2.1.md
+++ b/changelog/cli/0.2.1.md
@@ -1,0 +1,15 @@
+---
+package: "@webjskit/cli"
+version: 0.2.1
+date: 2026-04-28
+commit_count: 1
+---
+
+# @webjskit/cli 0.2.1
+## Fixes
+
+- **share component registry across module instances** [`5bda8c7`](https://github.com/vivek7405/webjs/commit/5bda8c7)
+  When the cli is installed globally (or hoisted at a different level
+  than the user's app), Node resolves `@webjskit/core` from each
+  importer's location and may load TWO instances of the package — one
+  for `@webjskit/server` (server-side) and one for the user's app

--- a/changelog/cli/0.3.0.md
+++ b/changelog/cli/0.3.0.md
@@ -1,0 +1,15 @@
+---
+package: "@webjskit/cli"
+version: 0.3.0
+date: 2026-04-28
+commit_count: 1
+---
+
+# @webjskit/cli 0.3.0
+## Features
+
+- **drop superjson, ship built-in ESM rich-type serializer** [`4c2b704`](https://github.com/vivek7405/webjs/commit/4c2b704)
+  Replaces `superjson` with a pure-ESM, dependency-free serializer in
+  `@webjskit/core` (`packages/core/src/serialize.js`). Tagged-inline wire
+  format, async sync API. Single async `stringify`/`serialize` so AI
+  agents can't pick the wrong variant; `parse`/`deserialize` stay sync.

--- a/changelog/cli/0.3.1.md
+++ b/changelog/cli/0.3.1.md
@@ -1,0 +1,9 @@
+---
+package: "@webjskit/cli"
+version: 0.3.1
+date: 2026-05-04
+commit_count: 0
+---
+
+# @webjskit/cli 0.3.1
+_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/cli/0.4.0.md
+++ b/changelog/cli/0.4.0.md
@@ -1,0 +1,9 @@
+---
+package: "@webjskit/cli"
+version: 0.4.0
+date: 2026-05-11
+commit_count: 0
+---
+
+# @webjskit/cli 0.4.0
+_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/cli/0.4.1.md
+++ b/changelog/cli/0.4.1.md
@@ -1,0 +1,9 @@
+---
+package: "@webjskit/cli"
+version: 0.4.1
+date: 2026-05-12
+commit_count: 0
+---
+
+# @webjskit/cli 0.4.1
+_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/cli/0.4.2.md
+++ b/changelog/cli/0.4.2.md
@@ -1,0 +1,9 @@
+---
+package: "@webjskit/cli"
+version: 0.4.2
+date: 2026-05-12
+commit_count: 0
+---
+
+# @webjskit/cli 0.4.2
+_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/cli/0.4.3.md
+++ b/changelog/cli/0.4.3.md
@@ -1,0 +1,9 @@
+---
+package: "@webjskit/cli"
+version: 0.4.3
+date: 2026-05-12
+commit_count: 0
+---
+
+# @webjskit/cli 0.4.3
+_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/cli/0.4.4.md
+++ b/changelog/cli/0.4.4.md
@@ -1,0 +1,9 @@
+---
+package: "@webjskit/cli"
+version: 0.4.4
+date: 2026-05-12
+commit_count: 0
+---
+
+# @webjskit/cli 0.4.4
+_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/cli/0.5.0.md
+++ b/changelog/cli/0.5.0.md
@@ -1,0 +1,9 @@
+---
+package: "@webjskit/cli"
+version: 0.5.0
+date: 2026-05-17
+commit_count: 0
+---
+
+# @webjskit/cli 0.5.0
+_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/cli/0.5.1.md
+++ b/changelog/cli/0.5.1.md
@@ -1,0 +1,9 @@
+---
+package: "@webjskit/cli"
+version: 0.5.1
+date: 2026-05-17
+commit_count: 0
+---
+
+# @webjskit/cli 0.5.1
+_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/cli/0.5.2.md
+++ b/changelog/cli/0.5.2.md
@@ -1,0 +1,9 @@
+---
+package: "@webjskit/cli"
+version: 0.5.2
+date: 2026-05-17
+commit_count: 0
+---
+
+# @webjskit/cli 0.5.2
+_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/cli/0.6.0.md
+++ b/changelog/cli/0.6.0.md
@@ -1,0 +1,15 @@
+---
+package: "@webjskit/cli"
+version: 0.6.0
+date: 2026-05-19
+commit_count: 1
+---
+
+# @webjskit/cli 0.6.0
+## Features
+
+- **erasable-typescript-only rule + ship erasableSyntaxOnly in tsconfigs** [`01d1b18`](https://github.com/vivek7405/webjs/commit/01d1b18)
+  Adds compilerOptions.erasableSyntaxOnly to: the scaffold tsconfig
+  generator (packages/cli/lib/create.js), the blog example, the docs
+  site, the marketing site. TypeScript 5.8+ rejects enum, namespace
+  with values, constructor parameter properties, legacy decorators

--- a/changelog/cli/0.7.0.md
+++ b/changelog/cli/0.7.0.md
@@ -1,0 +1,55 @@
+---
+package: "@webjskit/cli"
+version: 0.7.0
+date: 2026-05-21
+commit_count: 9
+---
+
+# @webjskit/cli 0.7.0
+## Features
+
+- **webjs check --rules shows enabled/disabled state per project** [`a5e7067`](https://github.com/vivek7405/webjs/commit/a5e7067)
+  Reads the project's overrides via loadConventionOverrides(), then
+  annotates each rule line as [enabled] or [disabled by override].
+  Header text states the default-on invariant explicitly so AI
+  agents reading the output cannot misinterpret it.
+- **nudge-uncommitted hook ships in every scaffolded app** [`309de79`](https://github.com/vivek7405/webjs/commit/309de79)
+  Mirrors the framework-repo hook into the scaffold templates so
+  end-user webjs apps inherit the same commit-frequency
+  enforcement out of the box. Three pieces:
+- **pre-commit runs webjs test + webjs check** [`f789ef5`](https://github.com/vivek7405/webjs/commit/f789ef5)
+  Tool-agnostic git-level enforcement. Fires on every commit
+  regardless of agent (Claude, Cursor, Windsurf, Copilot, human).
+  Blocks commits that fail tests or convention checks.
+- **Gemini CLI nudge-uncommitted hook** [`ed8e692`](https://github.com/vivek7405/webjs/commit/ed8e692)
+  Adds the same commit-frequency enforcement to scaffolded apps for
+  Gemini CLI users. The hook output shape (hookSpecificOutput.
+  additionalContext) is identical to Claude Code's, so the body is
+  nearly a copy of the Claude version.
+- **Cursor nudge-uncommitted hook** [`1a69f56`](https://github.com/vivek7405/webjs/commit/1a69f56)
+  Cursor 1.7+ ships a hooks system at .cursor/hooks.json. The
+  afterFileEdit event fires after Cursor's edit/write tools and
+  accepts a top-level additional_context field (snake_case) to
+  inject a soft reminder into the agent's context.
+- **block-prose-punctuation hook ships in every scaffolded app** [`d6689f4`](https://github.com/vivek7405/webjs/commit/d6689f4)
+  Mirrors the framework-repo prose hook into scaffolded apps so end
+  users get the same enforcement of AGENTS.md invariant 11 (no
+  em-dashes, no hyphen-as-pause, no semicolon-as-pause, no
+  xyz():-then-prose). The rule is already documented in
+- **OpenCode commit-nudge plugin** [`9396fe6`](https://github.com/vivek7405/webjs/commit/9396fe6)
+  OpenCode does not have shell-script hooks; it uses TS plugin
+  modules loaded as-is by Bun. This plugin is the counterpart of
+  the .claude/, .gemini/, .cursor/ hooks already in the scaffold.
+- **Tier-2 components -> WebComponent + render() + <slot> (rebased)** ([#28](https://github.com/vivek7405/webjs/pull/28)) [`101d1ee`](https://github.com/vivek7405/webjs/commit/101d1ee)
+  * refactor(ui): toggle.ts -> WebComponent + render() + <slot>
+  
+  First Tier-2 component converted from extends Base to extends
+  WebComponent. This is the pattern-locking conversion; remaining
+
+## Fixes
+
+- **drop guard-main-merge hook so end users can merge to main locally** [`3ab47b2`](https://github.com/vivek7405/webjs/commit/3ab47b2)
+  This hook prompted on every 'git merge' and every 'git push ... main'
+  through Claude's Bash tool. That matches the framework dev's preference
+  for a strict GitHub-PR-only workflow, but it is the wrong default for
+  end users. Scaffolded webjs apps may use GitLab, Bitbucket, plain git,

--- a/changelog/core/0.2.0.md
+++ b/changelog/core/0.2.0.md
@@ -1,0 +1,216 @@
+---
+package: "@webjskit/core"
+version: 0.2.0
+date: 2026-04-28
+commit_count: 43
+---
+
+# @webjskit/core 0.2.0
+## Features
+
+- **add essential directives (unsafeHTML, live) with renderer integration** [`3d8a253`](https://github.com/vivek7405/webjs/commit/3d8a253)
+  Only three directives in webjs — each solves a problem with no native
+  alternative. unsafeHTML for trusted raw HTML, live for input value
+  dirty-checking, repeat (already existed) for keyed lists. Both client
+  and server renderers now process directive markers correctly instead
+- **full lifecycle, controllers, error boundaries, selective hydration** [`231bc4c`](https://github.com/vivek7405/webjs/commit/231bc4c)
+  Add shouldUpdate, willUpdate, firstUpdated, updated, changedProperties
+  tracking. Add ReactiveController pattern (addController/removeController).
+  Add client-side error boundaries (renderError lifecycle hook). Add
+  static hydrate='visible' for IntersectionObserver-based deferred
+- **add Context Protocol and Task controller** [`d68b207`](https://github.com/vivek7405/webjs/commit/d68b207)
+  Context: createContext, ContextProvider, ContextConsumer for cross-
+  component data sharing without prop drilling. Uses W3C Context Protocol
+  (DOM events, crosses shadow DOM).
+- **auto-vendor npm deps, module graph, lazy loading** [`266d041`](https://github.com/vivek7405/webjs/commit/266d041)
+  Auto-vendor: scan client imports for bare specifiers, bundle via esbuild,
+  serve at /__webjs/vendor/<pkg>.js, auto-populate import map.
+  
+  Module graph: build dependency graph at startup, emit transitive
+- **webjs test, webjs check, webjs create with AI guardrails** [`6e85e5d`](https://github.com/vivek7405/webjs/commit/6e85e5d)
+  - webjs test: discovers and runs unit + E2E tests
+  - webjs check: validates app against 6 convention rules
+  - webjs create: scaffolds opinionated project with CONVENTIONS.md,
+    cross-agent configs (.cursorrules, .windsurfrules, copilot-instructions),
+- **light DOM SSR + hydration — zero flash, mixed shadow/light DOM** [`cf155d7`](https://github.com/vivek7405/webjs/commit/cf155d7)
+  SSR fix: light DOM components (static shadow = false) now have their
+  render() called during SSR. Content is injected directly as children
+  with a <!--webjs-hydrate--> marker (no DSD template wrapper).
+- **light DOM tests, blog migration, auto-scoped styles** [`75f6d17`](https://github.com/vivek7405/webjs/commit/75f6d17)
+  Tests:
+  - test/light-dom-ssr.test.js: 5 unit tests for SSR (light DOM content,
+    hydration marker, shadow DSD, mixed page, async render)
+  - test/browser/light-dom-hydration.test.js: 3 browser tests (hydration
+- **auto-scope ALL CSS selectors for light DOM components** [`bdb3280`](https://github.com/vivek7405/webjs/commit/bdb3280)
+  scopeCSS() now prefixes every CSS rule with the component tag name:
+    input { color: red } → comments-thread input { color: red }
+    :host { display: block } → comments-thread { display: block }
+- **support mixed attribute interpolation in client renderer** [`893c99f`](https://github.com/vivek7405/webjs/commit/893c99f)
+  Quoted attributes with embedded holes (class="static ${dynamic}")
+  previously dropped the dynamic portion on client re-render. The
+  renderer now tracks these as 'attr-mixed' parts that reconstruct
+  the full attribute value from static pieces + dynamic values on
+- **default components to light DOM, shadow DOM is opt-in** [`01b55c2`](https://github.com/vivek7405/webjs/commit/01b55c2)
+  Change static shadow default from true to false. Components now
+  render to light DOM by default. Set static shadow = true to opt
+  into shadow DOM with adoptedStyleSheets.
+- **auto-wrap layout output with data-layout for client router** [`306c512`](https://github.com/vivek7405/webjs/commit/306c512)
+  The SSR pipeline now automatically wraps the outermost layout's
+  rendered output in <div data-layout="LAYOUT_ID">. Users no longer
+  need to add data-layout manually — the framework handles it.
+- **SSR pages default to no-store, caching is opt-in** [`5a4468c`](https://github.com/vivek7405/webjs/commit/5a4468c)
+  SSR responses now send Cache-Control: no-store by default. Pages
+  are dynamic — the developer opts in to caching explicitly via
+  metadata.cacheControl (e.g. 'public, max-age=60'). This ensures
+  client-side navigation always gets fresh content without needing
+- **typed component props via defineComponent + .d.ts overlay** [`9f0b09a`](https://github.com/vivek7405/webjs/commit/9f0b09a)
+  The existing static-properties pattern carried no compile-time type
+  information, so authors had to duplicate every field as `declare x: T`
+  for editor intellisense. This adds a TypeScript overlay plus a tiny
+  runtime helper so the descriptor map is the single source of truth for
+- **Class.register() — drop the import.meta.url argument** [`283c2b5`](https://github.com/vivek7405/webjs/commit/283c2b5)
+  Authors no longer write `Counter.register(import.meta.url)`; the call
+  is just `Counter.register()`. Module URLs (used by SSR to emit
+  `<link rel=modulepreload>` hints) are derived server-side at boot by
+  scanning the app tree for `class X extends WebComponent { static tag =
+- **adopt standard customElements.define — drop static tag + .register()** [`bb61186`](https://github.com/vivek7405/webjs/commit/bb61186)
+  The web-standard registration convention (same shape Lit uses for its
+  non-decorator form):
+  
+    class Counter extends WebComponent { ... }
+- **Counter.register('my-counter') as the idiomatic registration** [`a0f1f68`](https://github.com/vivek7405/webjs/commit/a0f1f68)
+  Adds a `static register(tag)` method on WebComponent. Delegates to the
+  internal registry (which in turn calls customElements.define / the
+  server shim), so every registration still lands in the native
+  customElements map and webjs's mirror map. Authors write:
+- **rename core package webjs → @webjs/core for npm publish** [`49e2d6b`](https://github.com/vivek7405/webjs/commit/49e2d6b)
+  The unscoped `webjs` name is already taken on npm (webjs@0.6.1, unrelated
+  project). Moving to the `@webjs` scope lets us publish `@webjs/core`,
+  `@webjs/server`, and `@webjs/cli` together.
+- **rescope @webjs → @webjskit (org name 'webjs' unavailable on npm)** [`316e2be`](https://github.com/vivek7405/webjs/commit/316e2be)
+  The @webjs organization is not available on npm (likely reserved because
+  the unscoped `webjs` package is held by an unrelated project). Switching
+  to the @webjskit scope, which we own.
+
+## Fixes
+
+- **DSD injection regex now handles slashes inside attribute values** [`c792b6e`](https://github.com/vivek7405/webjs/commit/c792b6e)
+  Bug: <auth-forms then=\"/dashboard\"> rendered as an EMPTY custom element
+  with no shadow root — the sign-in and sign-up pages appeared blank.
+  Root cause: the DSD-injection regex in render-server.js used
+  `[^>/]*` to bound the attribute section, which stopped matching the
+- **quoted-attr interpolation no longer crashes client re-renders** [`df2a952`](https://github.com/vivek7405/webjs/commit/df2a952)
+  Bug: clicking the 'Sign up' tab on /login did nothing. The <auth-forms>
+  component used a hole inside a quoted attribute —
+  \`autocomplete=\"\${mode === 'login' ? 'current-password' : 'new-password'}\"\` —
+  and the client compiler was recording a \`{ kind: 'attr', path: [] }\` part
+- **boolean attribute SSR coercion — empty value means true** [`016d5b5`](https://github.com/vivek7405/webjs/commit/016d5b5)
+  Bug: <comments-thread ?signed-in=\${true}> rendered the comment form as
+  "Sign in to comment" instead of the input+Post form, even when the user
+  was logged in.
+- **filter DSD template from client-navigation swap + update rubric** [`a026010`](https://github.com/vivek7405/webjs/commit/a026010)
+  Client router: when swapping the layout shell's light-DOM children on
+  navigation, the new body from DOMParser contains a
+  <template shadowrootmode="open"> element (the SSR's Declarative Shadow
+  DOM). DOMParser doesn't process DSD, so it stays as a regular DOM element.
+- **flicker-free navigation via View Transitions + visibility fallback** [`5f5553c`](https://github.com/vivek7405/webjs/commit/5f5553c)
+  The blog's top navbar flickered during client navigation because
+  replaceChildren on a custom element with a shadow root and <slot>
+  triggers slot redistribution — the browser briefly renders an empty
+  <main> between removing old children and inserting new ones.
+- **eliminate navbar flicker during client navigation** [`4f213d1`](https://github.com/vivek7405/webjs/commit/4f213d1)
+  Two fixes working together:
+  
+  1. Client router: changed swap strategy from replaceChildren (empties
+     slot, then fills — one-frame empty state) to append-then-remove
+- **layout-aware navigation — only swap page content, never touch layout** [`5875ed6`](https://github.com/vivek7405/webjs/commit/5875ed6)
+  Root cause: the client router was calling mergeHead() (which removes/adds
+  <link>, <script> tags in <head>) and reactivateScripts() (which clones
+  <script> elements in <body>) on every navigation. These DOM mutations
+  triggered browser style recalculation and brief repaints of the layout
+- **client router now intercepts clicks inside shadow DOM** [`d89e7bb`](https://github.com/vivek7405/webjs/commit/d89e7bb)
+  ROOT CAUSE FOUND: the navbar flicker was a full browser navigation, not
+  a rendering bug. The client router's click handler used e.target to find
+  the <a> element, but click events from inside shadow DOM are retargeted
+  — e.target points to the shadow HOST (<blog-shell>), not the <a> inside
+- **use DSD-aware parsing in client router** [`991d8d0`](https://github.com/vivek7405/webjs/commit/991d8d0)
+  Neither innerHTML nor DOMParser process Declarative Shadow DOM — custom
+  elements navigated to via the client router had no shadow roots, losing
+  their layout/sidebar/styles entirely.
+- **theme toggle TDZ, light theme default, client router View Transitions race** [`08312a9`](https://github.com/vivek7405/webjs/commit/08312a9)
+  - Move ICONS before register() to fix temporal dead zone error on
+    components in light DOM (website theme toggle broken)
+  - Default to light theme across all three apps
+  - Dark theme accent hue aligned to match light theme (55 amber)
+- **rename data-webjs to data-webjs-styles-for — self-documenting** [`47b5168`](https://github.com/vivek7405/webjs/commit/47b5168)
+  The attribute on light DOM <style> elements now clearly says what it
+  does: identifies which component owns the style block. Prevents
+  duplicate injection. Added JSDoc for AI agents: do not set manually.
+- **remove auto-scope CSS hack, clean shadow/light DOM convention** [`f91ceb0`](https://github.com/vivek7405/webjs/commit/f91ceb0)
+  Shadow DOM = scoped styles (static styles = css, adoptedStyleSheets).
+  Light DOM = global styles (Tailwind, global CSS, no static styles).
+  Pick one. Don't fake shadow DOM scoping with regex.
+- **warn when static styles used with light DOM (silently ignored before)** [`7bcb656`](https://github.com/vivek7405/webjs/commit/7bcb656)
+  static styles + static shadow = false is a mistake — adoptedStyleSheets
+  requires a shadow root. Now logs a clear warning telling the developer
+  to use global CSS or <style> in render() instead.
+- **ensure custom elements upgrade after client-side navigation** [`b357e56`](https://github.com/vivek7405/webjs/commit/b357e56)
+  Document.parseHTMLUnsafe() creates elements in a detached document with
+  an empty customElements registry. When those nodes are moved to the live
+  document via replaceChildren, Chromium can silently skip the custom
+  element upgrade — leaving _renderRoot null and connectedCallback unfired.
+- **inject DSD with inline styles for nested custom elements** [`b012c38`](https://github.com/vivek7405/webjs/commit/b012c38)
+  The SSR pipeline's injectDSD() was not recursively processing custom
+  elements nested inside other components' shadow DOM. A <theme-toggle>
+  inside <blog-shell>'s render output was emitted as an empty element
+  with no DSD template — no styles, no content until JS upgraded it.
+- **traverse shadow roots in upgradeCustomElements and handle View Transitions** [`0d9be29`](https://github.com/vivek7405/webjs/commit/0d9be29)
+  Two improvements to the custom element upgrade logic in the client router:
+  
+  1. upgradeCustomElements now recursively walks into shadow roots.
+     querySelectorAll('*') only searches light DOM — elements like
+- **hoist scripts/styles to head + data-layout for router detection** [`7bcebf0`](https://github.com/vivek7405/webjs/commit/7bcebf0)
+  Two fixes for client-side navigation with light DOM layouts:
+  
+  1. SSR hoistHeadTags: leading <script> and <style> tags from the body
+     are moved to <head>. Tailwind browser script, @theme styles, and
+- **remove View Transitions from same-layout swap + cache-bust fetches** [`1c5a06a`](https://github.com/vivek7405/webjs/commit/1c5a06a)
+  Two fixes:
+  - Remove startViewTransition from swapSlotContent to eliminate race
+    conditions where custom elements aren't upgraded during the
+    transition animation. Add a deferred microtask upgrade pass instead.
+- **MutationObserver safety net for custom element upgrades** [`2d260dc`](https://github.com/vivek7405/webjs/commit/2d260dc)
+  Add a global MutationObserver that watches for any custom element
+  inserted into the document and calls customElements.upgrade() on it.
+  This catches elements that the browser fails to auto-upgrade after
+  DOM operations like replaceChildren — regardless of timing, View
+- **load page component modules on same-layout navigation** [`a04a974`](https://github.com/vivek7405/webjs/commit/a04a974)
+  Root cause of both bugs: on client-side navigation within the same
+  layout, the router swapped <main> content but did NOT load the new
+  page's component modules. Components like <new-post> appeared in the
+  DOM as plain HTMLElement — never upgraded, no event handlers, no
+- **use add-only head merge for same-layout navigation** [`8e9948c`](https://github.com/vivek7405/webjs/commit/8e9948c)
+  mergeHead() was removing the Tailwind-generated <style> tag from
+  <head> during same-layout navigation because it wasn't in the
+  server-rendered HTML (it's generated at runtime by the Tailwind
+  browser CDN).
+- **forward streamed Suspense resolvers on same-layout nav** [`09c06e3`](https://github.com/vivek7405/webjs/commit/09c06e3)
+  Streamed Suspense templates (<template data-webjs-resolve="...">) are
+  emitted at body level, AFTER the </div> that closes the data-layout
+  wrapper. During same-layout navigation the router swaps only the
+  <main> contents inside the wrapper, so those resolvers were dropped
+- **skip non-HTML responses and extensions; document data-no-router** [`9af54bf`](https://github.com/vivek7405/webjs/commit/9af54bf)
+  Three gaps in the same-origin interception logic that produced a
+  broken/hung/blank page:
+  
+  1. Non-HTML extensions — /foo.pdf, /data.zip, /feed.xml, /posts.json,
+- **render-client compile() crashed on holes inside comments / raw-text** [`2311969`](https://github.com/vivek7405/webjs/commit/2311969)
+  The client-side `compile()` function destructures only `strings` from the
+  template result, but two branches (state==='comment' and state==='rawtext')
+  referenced an undefined `values` binding. Any template with an interpolation
+  inside an HTML comment or <script>/<style> body would throw
+- **share component registry across module instances** [`5bda8c7`](https://github.com/vivek7405/webjs/commit/5bda8c7)
+  When the cli is installed globally (or hoisted at a different level
+  than the user's app), Node resolves `@webjskit/core` from each
+  importer's location and may load TWO instances of the package — one
+  for `@webjskit/server` (server-side) and one for the user's app

--- a/changelog/core/0.3.0.md
+++ b/changelog/core/0.3.0.md
@@ -1,0 +1,15 @@
+---
+package: "@webjskit/core"
+version: 0.3.0
+date: 2026-04-28
+commit_count: 1
+---
+
+# @webjskit/core 0.3.0
+## Features
+
+- **drop superjson, ship built-in ESM rich-type serializer** [`4c2b704`](https://github.com/vivek7405/webjs/commit/4c2b704)
+  Replaces `superjson` with a pure-ESM, dependency-free serializer in
+  `@webjskit/core` (`packages/core/src/serialize.js`). Tagged-inline wire
+  format, async sync API. Single async `stringify`/`serialize` so AI
+  agents can't pick the wrong variant; `parse`/`deserialize` stay sync.

--- a/changelog/core/0.3.1.md
+++ b/changelog/core/0.3.1.md
@@ -1,0 +1,9 @@
+---
+package: "@webjskit/core"
+version: 0.3.1
+date: 2026-05-12
+commit_count: 0
+---
+
+# @webjskit/core 0.3.1
+_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/core/0.4.0.md
+++ b/changelog/core/0.4.0.md
@@ -1,0 +1,9 @@
+---
+package: "@webjskit/core"
+version: 0.4.0
+date: 2026-05-17
+commit_count: 0
+---
+
+# @webjskit/core 0.4.0
+_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/core/0.4.1.md
+++ b/changelog/core/0.4.1.md
@@ -1,0 +1,20 @@
+---
+package: "@webjskit/core"
+version: 0.4.1
+date: 2026-05-17
+commit_count: 2
+---
+
+# @webjskit/core 0.4.1
+## Fixes
+
+- **preserve cached snapshot on popstate; manual scrollRestoration** [`231cd8f`](https://github.com/vivek7405/webjs/commit/231cd8f)
+  Two bugs combined to break back-button scroll restoration:
+  
+  1. snapshotCurrent(location.href) at performNavigation entry ran on
+     EVERY navigation including popstate. But on popstate, the browser
+- **scroll to top on cache-miss popstate** [`21108bf`](https://github.com/vivek7405/webjs/commit/21108bf)
+  Companion to the previous commit. Setting history.scrollRestoration
+  = 'manual' takes the browser out of the scroll-restoration game on
+  back/forward — which is great when we have a cached snapshot (we
+  restore exactly where the user left off) but leaves the cache-miss

--- a/changelog/core/0.5.0.md
+++ b/changelog/core/0.5.0.md
@@ -1,0 +1,36 @@
+---
+package: "@webjskit/core"
+version: 0.5.0
+date: 2026-05-19
+commit_count: 5
+---
+
+# @webjskit/core 0.5.0
+## Features
+
+- **light-DOM slot runtime foundation (slot.js)** [`7331ce2`](https://github.com/vivek7405/webjs/commit/7331ce2)
+  First slice of the light-DOM slot work. Adds the standalone runtime
+  file owning the slot semantics. Subsequent commits wire it into the
+  compiler, component lifecycle, and SSR pipeline.
+- **slot part in compiler + client renderer + fallback swap hook** [`4340558`](https://github.com/vivek7405/webjs/commit/4340558)
+  Second slice. Wires light-DOM <slot> elements through the existing
+  template compile, bind, apply, and clear pipeline using a new SLOT
+  part kind. Adds the small slot.js hook that swaps fallback content
+  into the slot when projection state is "fallback".
+- **slot lifecycle in WebComponent + per-instance fallback clone** [`e8dfe11`](https://github.com/vivek7405/webjs/commit/e8dfe11)
+  Third slice. Wires the slot runtime into the WebComponent lifecycle and
+  refines render-client.js's slot bind so fallback content is captured
+  once at compile time and cloned freshly per instance.
+- **SSR slot substitution in injectDSD** [`1b66c5a`](https://github.com/vivek7405/webjs/commit/1b66c5a)
+  Fourth slice. Upgrades injectDSD to project authored children into
+  <slot> positions during server-side rendering for light-DOM
+  WebComponents, with full parity to the client-side projection rules
+  and the shadow-DOM <slot> spec.
+
+## Fixes
+
+- **6 browser failures fixed, all 26 browser tests pass** [`cf90daa`](https://github.com/vivek7405/webjs/commit/cf90daa)
+  Four real bugs surfaced in the browser test suite and are fixed:
+  
+  1. captureAuthoredChildren ran on every connectedCallback, including
+     on re-connection of a previously-mounted element. The second

--- a/changelog/core/0.6.0.md
+++ b/changelog/core/0.6.0.md
@@ -1,0 +1,33 @@
+---
+package: "@webjskit/core"
+version: 0.6.0
+date: 2026-05-21
+commit_count: 4
+---
+
+# @webjskit/core 0.6.0
+## Features
+
+- **SSR property bindings via data-webjs-prop-* side-channel** [`56f502f`](https://github.com/vivek7405/webjs/commit/56f502f)
+  A property hole (.prop=${val}) on any element used to be dropped
+  silently at SSR. The data was lost between page function and
+  child component, breaking the natural "fetch data, pass to
+  component" pattern unless authors manually JSON.stringify into
+- **client hydrates data-webjs-prop-* attributes, then strips** [`c95c753`](https://github.com/vivek7405/webjs/commit/c95c753)
+  Completes the SSR property-binding round-trip. The server emits
+  data-webjs-prop-<kebab>="<wire-encoded>" for each .prop=${val}
+  hole in PR-WIP commit 56f502f. This commit teaches WebComponent
+  to consume those attributes on the browser side.
+- **full lit-API parity (ReactiveController + lifecycle + directives + 127 lit-ported tests)** ([#31](https://github.com/vivek7405/webjs/pull/31)) [`8b10849`](https://github.com/vivek7405/webjs/commit/8b10849)
+  * feat(core): rename ReactiveController hooks to lit names
+  
+  onMount → hostConnected
+  onUnmount → hostDisconnected
+
+## Fixes
+
+- **skip property-attribute emission for native elements + decode HTML entities on server walker read** [`4786384`](https://github.com/vivek7405/webjs/commit/4786384)
+  Two related fixes to the property-binding SSR path.
+  
+  1. Native-element guard. Property bindings on tags without a hyphen
+     (`<input .value=${v}>`) used to emit a `data-webjs-prop-value`

--- a/changelog/server/0.1.1.md
+++ b/changelog/server/0.1.1.md
@@ -1,0 +1,128 @@
+---
+package: "@webjskit/server"
+version: 0.1.1
+date: 2026-04-27
+commit_count: 25
+---
+
+# @webjskit/server 0.1.1
+## Features
+
+- **auto-vendor npm deps, module graph, lazy loading** [`266d041`](https://github.com/vivek7405/webjs/commit/266d041)
+  Auto-vendor: scan client imports for bare specifiers, bundle via esbuild,
+  serve at /__webjs/vendor/<pkg>.js, auto-populate import map.
+  
+  Module graph: build dependency graph at startup, emit transitive
+- **abstract wire serializer, decouple from superjson** [`81ab2eb`](https://github.com/vivek7405/webjs/commit/81ab2eb)
+  New Serializer interface with getSerializer/setSerializer. superjson
+  is the default but can be swapped via webjs.config.js. Decouples the
+  RPC layer from a single dependency.
+- **optional catch-all, nested not-found, loading→Suspense, metadata routes** [`332f41f`](https://github.com/vivek7405/webjs/commit/332f41f)
+  - [[...slug]] optional catch-all matches with and without params
+  - not-found.ts collected at every segment level (nearest wins)
+  - loading.ts auto-wraps page in Suspense boundary with loading as fallback
+  - Metadata routes: sitemap.ts, robots.ts, manifest.ts, icon.ts,
+- **webjs test, webjs check, webjs create with AI guardrails** [`6e85e5d`](https://github.com/vivek7405/webjs/commit/6e85e5d)
+  - webjs test: discovers and runs unit + E2E tests
+  - webjs check: validates app against 6 convention rules
+  - webjs create: scaffolds opinionated project with CONVENTIONS.md,
+    cross-agent configs (.cursorrules, .windsurfrules, copilot-instructions),
+- **batteries included — sessions, jobs, pub/sub, storage, cache** [`6292558`](https://github.com/vivek7405/webjs/commit/6292558)
+  Convention over configuration, like Rails:
+  - Set REDIS_URL → cache, sessions, rate limiter, pub/sub, and jobs
+    all use Redis automatically. Zero config.
+  - Set S3_BUCKET → file storage uses S3. Otherwise local disk.
+- **NextJs-style cache + NextAuth-style auth + WebSocket broadcast** [`19418b3`](https://github.com/vivek7405/webjs/commit/19418b3)
+  Removed: storage (s3/disk), background jobs — not core framework.
+  
+  Added:
+  - cache(fn, { revalidate, tags }) + revalidateTag() — NextJs-style
+- **HTTP Cache-Control on SSR pages via metadata export** [`74edab3`](https://github.com/vivek7405/webjs/commit/74edab3)
+  Pages can now set Cache-Control headers via the metadata export:
+  
+    export const metadata = {
+      title: 'Blog',
+- **cache() function for server-side RPC query caching** [`504a982`](https://github.com/vivek7405/webjs/commit/504a982)
+  Simple, explicit, no magic:
+  
+    export const listPosts = cache(
+      async () => prisma.post.findMany(),
+- **auto-wrap layout output with data-layout for client router** [`306c512`](https://github.com/vivek7405/webjs/commit/306c512)
+  The SSR pipeline now automatically wraps the outermost layout's
+  rendered output in <div data-layout="LAYOUT_ID">. Users no longer
+  need to add data-layout manually — the framework handles it.
+- **SSR pages default to no-store, caching is opt-in** [`5a4468c`](https://github.com/vivek7405/webjs/commit/5a4468c)
+  SSR responses now send Cache-Control: no-store by default. Pages
+  are dynamic — the developer opts in to caching explicitly via
+  metadata.cacheControl (e.g. 'public, max-age=60'). This ensures
+  client-side navigation always gets fresh content without needing
+- **Class.register() — drop the import.meta.url argument** [`283c2b5`](https://github.com/vivek7405/webjs/commit/283c2b5)
+  Authors no longer write `Counter.register(import.meta.url)`; the call
+  is just `Counter.register()`. Module URLs (used by SSR to emit
+  `<link rel=modulepreload>` hints) are derived server-side at boot by
+  scanning the app tree for `class X extends WebComponent { static tag =
+- **adopt standard customElements.define — drop static tag + .register()** [`bb61186`](https://github.com/vivek7405/webjs/commit/bb61186)
+  The web-standard registration convention (same shape Lit uses for its
+  non-decorator form):
+  
+    class Counter extends WebComponent { ... }
+- **Counter.register('my-counter') as the idiomatic registration** [`a0f1f68`](https://github.com/vivek7405/webjs/commit/a0f1f68)
+  Adds a `static register(tag)` method on WebComponent. Delegates to the
+  internal registry (which in turn calls customElements.define / the
+  server shim), so every registration still lands in the native
+  customElements map and webjs's mirror map. Authors write:
+- **rename core package webjs → @webjs/core for npm publish** [`49e2d6b`](https://github.com/vivek7405/webjs/commit/49e2d6b)
+  The unscoped `webjs` name is already taken on npm (webjs@0.6.1, unrelated
+  project). Moving to the `@webjs` scope lets us publish `@webjs/core`,
+  `@webjs/server`, and `@webjs/cli` together.
+- **rescope @webjs → @webjskit (org name 'webjs' unavailable on npm)** [`316e2be`](https://github.com/vivek7405/webjs/commit/316e2be)
+  The @webjs organization is not available on npm (likely reserved because
+  the unscoped `webjs` package is held by an unrelated project). Switching
+  to the @webjskit scope, which we own.
+- **social-preview cards for website, docs, and blog** [`b16fc68`](https://github.com/vivek7405/webjs/commit/b16fc68)
+  Adds proper Open Graph + Twitter summary_large_image metadata so the
+  three apps preview cleanly when shared on WhatsApp, Twitter/X, LinkedIn,
+  Slack, Discord, etc.
+
+## Fixes
+
+- **decode percent-encoded URL paths before filesystem lookups** [`72caa14`](https://github.com/vivek7405/webjs/commit/72caa14)
+  Root cause of ALL client-side interactivity failing in production:
+  
+  The SSR shell emits module imports with literal filesystem paths:
+    import "/app/blog/[slug]/page.ts"
+- **bundle superjson into a single ESM file for the browser** [`a13cbea`](https://github.com/vivek7405/webjs/commit/a13cbea)
+  Root cause of ALL client-side JS failing:
+  
+  superjson internally imports \`copy-anything\` which imports \`is-what\` —
+  both as bare specifiers. The browser's import map only had an entry for
+- **production hardening — cache eviction + CSP nonce support** [`c559de2`](https://github.com/vivek7405/webjs/commit/c559de2)
+  Cache eviction: TS transform cache capped at 500 entries, vendor
+  bundle cache at 100. FIFO eviction prevents unbounded memory growth
+  in long-running servers.
+- **remove all auto-detection magic from session and cache** [`3a52624`](https://github.com/vivek7405/webjs/commit/3a52624)
+  Cleaned up REDIS_URL auto-detection references from session.js and
+  cache.js JSDoc. Session defaults to cookie (explicit, stateless).
+  Cache defaults to memory (explicit). User switches to Redis by
+  calling setStore/passing storeSession — no env var magic.
+- **export Session class from @webjs/server** [`eae64cb`](https://github.com/vivek7405/webjs/commit/eae64cb)
+- **hoist scripts/styles to head + data-layout for router detection** [`7bcebf0`](https://github.com/vivek7405/webjs/commit/7bcebf0)
+  Two fixes for client-side navigation with light DOM layouts:
+  
+  1. SSR hoistHeadTags: leading <script> and <style> tags from the body
+     are moved to <head>. Tailwind browser script, @theme styles, and
+- **exclude server-only modules from <link rel=modulepreload>** [`36ea61b`](https://github.com/vivek7405/webjs/commit/36ea61b)
+  Server-only files (either .server.{js,ts,mjs,mts} or plain .ts with a
+  'use server' directive) were appearing in modulepreload links because
+  the transitive-deps walk treats them the same as any other import.
+  Browsers fetched them on every page load — the response body is a
+- **hard guardrail — never serve server-file source to the client** [`a4df002`](https://github.com/vivek7405/webjs/commit/a4df002)
+  The dev HTTP layer used to look up .server.* / 'use server' files via
+  the action index built at boot; on index miss it fell through to
+  tsResponse() and returned the RAW SOURCE. That's a serious leak
+  vector: DB credentials, scrypt routines, privileged business logic
+- **resolve esbuild from app dir, not server dir** [`8e8207d`](https://github.com/vivek7405/webjs/commit/8e8207d)
+  When `@webjskit/cli` is installed globally (the typical case for
+  end-users), `import('esbuild')` from `packages/server/src/dev.js`
+  walks up from the global install tree — never reaching the user app's
+  `node_modules`. The dev server then served `.ts` files as

--- a/changelog/server/0.2.0.md
+++ b/changelog/server/0.2.0.md
@@ -1,0 +1,15 @@
+---
+package: "@webjskit/server"
+version: 0.2.0
+date: 2026-04-28
+commit_count: 1
+---
+
+# @webjskit/server 0.2.0
+## Features
+
+- **use esbuild for TS on both SSR + hydration; default to no build** [`4dc8b91`](https://github.com/vivek7405/webjs/commit/4dc8b91)
+  The dev server now registers an esbuild ESM loader hook
+  (`module.register()`) at startup. Every server-side `.ts` import flows
+  through esbuild's transform — same transformer the dev server already
+  used for browser-bound `.ts` requests. SSR and hydration produce

--- a/changelog/server/0.2.1.md
+++ b/changelog/server/0.2.1.md
@@ -1,0 +1,15 @@
+---
+package: "@webjskit/server"
+version: 0.2.1
+date: 2026-04-28
+commit_count: 1
+---
+
+# @webjskit/server 0.2.1
+## Fixes
+
+- **share component registry across module instances** [`5bda8c7`](https://github.com/vivek7405/webjs/commit/5bda8c7)
+  When the cli is installed globally (or hoisted at a different level
+  than the user's app), Node resolves `@webjskit/core` from each
+  importer's location and may load TWO instances of the package — one
+  for `@webjskit/server` (server-side) and one for the user's app

--- a/changelog/server/0.3.0.md
+++ b/changelog/server/0.3.0.md
@@ -1,0 +1,15 @@
+---
+package: "@webjskit/server"
+version: 0.3.0
+date: 2026-04-28
+commit_count: 1
+---
+
+# @webjskit/server 0.3.0
+## Features
+
+- **drop superjson, ship built-in ESM rich-type serializer** [`4c2b704`](https://github.com/vivek7405/webjs/commit/4c2b704)
+  Replaces `superjson` with a pure-ESM, dependency-free serializer in
+  `@webjskit/core` (`packages/core/src/serialize.js`). Tagged-inline wire
+  format, async sync API. Single async `stringify`/`serialize` so AI
+  agents can't pick the wrong variant; `parse`/`deserialize` stay sync.

--- a/changelog/server/0.3.1.md
+++ b/changelog/server/0.3.1.md
@@ -1,0 +1,15 @@
+---
+package: "@webjskit/server"
+version: 0.3.1
+date: 2026-05-04
+commit_count: 1
+---
+
+# @webjskit/server 0.3.1
+## Fixes
+
+- **hoist <link> from layout body into <head>** [`96e97b4`](https://github.com/vivek7405/webjs/commit/96e97b4)
+  Layouts emit <link rel="icon">, <link rel="stylesheet">, etc. in their
+  template body, but the SSR pipeline wraps that body in
+  <div data-layout="..."> before the existing hoister ran — so the
+  hoister (a) never saw <link>, and (b) couldn't reach past the wrapper

--- a/changelog/server/0.4.0.md
+++ b/changelog/server/0.4.0.md
@@ -1,0 +1,15 @@
+---
+package: "@webjskit/server"
+version: 0.4.0
+date: 2026-05-11
+commit_count: 1
+---
+
+# @webjskit/server 0.4.0
+## Features
+
+- **rule reactive-props-use-declare flags class-field foot-gun** [`7b14eeb`](https://github.com/vivek7405/webjs/commit/7b14eeb)
+  A reactive property listed in `static properties = { … }` MUST be
+  typed via `declare propName: Type` and have its default set inside
+  `constructor()`. A plain class-field initializer
+  (`propName = value` or `propName: Type = value`) compiles under

--- a/changelog/server/0.4.1.md
+++ b/changelog/server/0.4.1.md
@@ -1,0 +1,9 @@
+---
+package: "@webjskit/server"
+version: 0.4.1
+date: 2026-05-12
+commit_count: 0
+---
+
+# @webjskit/server 0.4.1
+_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/server/0.4.2.md
+++ b/changelog/server/0.4.2.md
@@ -1,0 +1,9 @@
+---
+package: "@webjskit/server"
+version: 0.4.2
+date: 2026-05-12
+commit_count: 0
+---
+
+# @webjskit/server 0.4.2
+_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/server/0.5.0.md
+++ b/changelog/server/0.5.0.md
@@ -1,0 +1,9 @@
+---
+package: "@webjskit/server"
+version: 0.5.0
+date: 2026-05-17
+commit_count: 0
+---
+
+# @webjskit/server 0.5.0
+_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/server/0.5.1.md
+++ b/changelog/server/0.5.1.md
@@ -1,0 +1,15 @@
+---
+package: "@webjskit/server"
+version: 0.5.1
+date: 2026-05-17
+commit_count: 1
+---
+
+# @webjskit/server 0.5.1
+## Fixes
+
+- **honor X-Forwarded-Proto/Host when building ctx.url** [`41939b4`](https://github.com/vivek7405/webjs/commit/41939b4)
+  webjs apps deployed behind a TLS-terminating reverse proxy (Railway,
+  Fly, Render, Vercel, Cloudflare, nginx, Caddy, Traefik — the typical
+  no-build deployment topology) receive plain HTTP at the container with
+  X-Forwarded-Proto: https + X-Forwarded-Host: <public-domain> headers

--- a/changelog/server/0.5.2.md
+++ b/changelog/server/0.5.2.md
@@ -1,0 +1,9 @@
+---
+package: "@webjskit/server"
+version: 0.5.2
+date: 2026-05-17
+commit_count: 0
+---
+
+# @webjskit/server 0.5.2
+_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/server/0.6.0.md
+++ b/changelog/server/0.6.0.md
@@ -1,0 +1,20 @@
+---
+package: "@webjskit/server"
+version: 0.6.0
+date: 2026-05-19
+commit_count: 2
+---
+
+# @webjskit/server 0.6.0
+## Features
+
+- **hybrid TS stripper (Node strip-types + esbuild fallback)** [`a68760f`](https://github.com/vivek7405/webjs/commit/a68760f)
+  Server-side .ts imports now use Node 24+'s default type-stripping
+  natively. The module.register('./esbuild-loader.js') hook and the
+  loader file itself are deleted: SSR and the test runner both pick
+  up .ts files without any framework bootstrap.
+- **erasable-typescript-only rule + ship erasableSyntaxOnly in tsconfigs** [`01d1b18`](https://github.com/vivek7405/webjs/commit/01d1b18)
+  Adds compilerOptions.erasableSyntaxOnly to: the scaffold tsconfig
+  generator (packages/cli/lib/create.js), the blog example, the docs
+  site, the marketing site. TypeScript 5.8+ rejects enum, namespace
+  with values, constructor parameter properties, legacy decorators

--- a/changelog/server/0.7.0.md
+++ b/changelog/server/0.7.0.md
@@ -1,0 +1,43 @@
+---
+package: "@webjskit/server"
+version: 0.7.0
+date: 2026-05-21
+commit_count: 6
+---
+
+# @webjskit/server 0.7.0
+## Features
+
+- **drop webjs.conventions.js + legacy fallbacks, only support pkg.webjs.conventions** [`622caa7`](https://github.com/vivek7405/webjs/commit/622caa7)
+  loadOverrides now reads exactly one place: package.json
+  "webjs": { "conventions": { … } }. Returns {} when the key is
+  absent (every default rule active). Removes the old top-level
+  "conventions" fallback, the webjs.conventions.js file path, and
+- **WEBJS_PUBLIC_* env vars accessible as process.env.* in browser** [`c65cccc`](https://github.com/vivek7405/webjs/commit/c65cccc)
+  Adds an SSR-injected inline script that defines window.process.env
+  with all server-side env vars whose name starts with WEBJS_PUBLIC_,
+  plus NODE_ENV based on dev/prod mode. Counterpart of Next.js's
+  NEXT_PUBLIC_ convention, without a build step.
+- **no-server-env-in-components lint rule** [`83790f7`](https://github.com/vivek7405/webjs/commit/83790f7)
+  Flags process.env.X reads in component files where X is not
+  WEBJS_PUBLIC_* and not NODE_ENV. The SSR shim only exposes
+  those two categories to the browser; any other read either
+  leaks a secret into the SSR'd HTML or reads as undefined
+- **split .server.ts source-protection from 'use server' RPC marker** [`9cf8af7`](https://github.com/vivek7405/webjs/commit/9cf8af7)
+  The two markers are now complementary instead of interchangeable:
+  
+    .server.{js,ts}        path-level boundary: file router refuses to
+                           serve the source to the browser.
+- **add use-server-needs-extension lint rule** [`b366f6a`](https://github.com/vivek7405/webjs/commit/b366f6a)
+  The rule catches files that declare `'use server'` at the top but
+  lack the `.server.{js,ts,mts,mjs}` extension. Under the two-marker
+  convention, the directive alone is silently ignored: the file serves
+  to the browser as plain source, exports are not registered as RPC,
+
+## Fixes
+
+- **remove no-server-imports-in-components lint rule entirely** [`cf23b2d`](https://github.com/vivek7405/webjs/commit/cf23b2d)
+  The convention 'server-only code goes in .server.ts, route.ts, or
+  middleware.ts; never in pages, layouts, or components' is real
+  and important, but pure static lint enforcement is the wrong
+  mechanism:

--- a/changelog/server/0.7.1.md
+++ b/changelog/server/0.7.1.md
@@ -1,0 +1,15 @@
+---
+package: "@webjskit/server"
+version: 0.7.1
+date: 2026-05-21
+commit_count: 1
+---
+
+# @webjskit/server 0.7.1
+## Fixes
+
+- **stop sending immutable cache-control on /__webjs/core/*** ([#38](https://github.com/vivek7405/webjs/pull/38)) [`ce8ab2e`](https://github.com/vivek7405/webjs/commit/ce8ab2e)
+  The /__webjs/core/* paths are un-versioned: every bump of
+  @webjskit/core ships different bytes at the same URL. Sending
+  `cache-control: public, max-age=31536000, immutable` instructed
+  edge CDNs (Cloudflare in our case) to pin the prior bytes for up

--- a/changelog/ts-plugin/0.2.0.md
+++ b/changelog/ts-plugin/0.2.0.md
@@ -1,0 +1,19 @@
+---
+package: "@webjskit/ts-plugin"
+version: 0.2.0
+date: 2026-05-04
+commit_count: 2
+---
+
+# @webjskit/ts-plugin 0.2.0
+## Features
+
+- **rebrand webjs-plugin → @webjskit/ts-plugin, ready for npm** [`cf89060`](https://github.com/vivek7405/webjs/commit/cf89060)
+  Matches the scope of the three published packages (@webjskit/core,
+  @webjskit/server, @webjskit/cli). The ts-* naming suffix mirrors the
+  tsserver-plugin convention (cf. ts-lit-plugin).
+- **suppress lit-plugin "unknown tag/attr" + complete attrs** [`7617b78`](https://github.com/vivek7405/webjs/commit/7617b78)
+  ts-lit-plugin doesn't recognise webjs components — they're registered
+  at runtime via Class.register('tag') with no @customElement decorator
+  or HTMLElementTagNameMap augmentation — so it fires "Unknown tag" /
+  "Unknown attribute" diagnostics on every webjs element used inside

--- a/changelog/ts-plugin/0.3.0.md
+++ b/changelog/ts-plugin/0.3.0.md
@@ -1,0 +1,15 @@
+---
+package: "@webjskit/ts-plugin"
+version: 0.3.0
+date: 2026-05-04
+commit_count: 1
+---
+
+# @webjskit/ts-plugin 0.3.0
+## Features
+
+- **type-check <webjs-tag attr=\${expr}> interpolations** [`844d04e`](https://github.com/vivek7405/webjs/commit/844d04e)
+  Extend the plugin with a fourth resolver: for every \${expr}
+  interpolation in attribute-value position of a reachable webjs tag,
+  look up the matching `declare attr: T` field on the component class
+  and assignability-check the expression's type against T using the

--- a/changelog/ts-plugin/0.4.0.md
+++ b/changelog/ts-plugin/0.4.0.md
@@ -1,0 +1,9 @@
+---
+package: "@webjskit/ts-plugin"
+version: 0.4.0
+date: 2026-05-12
+commit_count: 0
+---
+
+# @webjskit/ts-plugin 0.4.0
+_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/ui/0.2.0.md
+++ b/changelog/ui/0.2.0.md
@@ -1,0 +1,42 @@
+---
+package: "@webjskit/ui"
+version: 0.2.0
+date: 2026-05-20
+commit_count: 6
+---
+
+# @webjskit/ui 0.2.0
+## Features
+
+- **add tier classifier for registry items** [`f15c852`](https://github.com/vivek7405/webjs/commit/f15c852)
+  New _lib/tier.ts module exports TIER_2_NAMES (the 12 stateful custom
+  elements), tierOf(item), and splitByTier(items). Kept outside the
+  *.server.ts RPC-stub rewrite path so the helper can be imported from
+  any context.
+- **split homepage component grid by tier** [`b15dd13`](https://github.com/vivek7405/webjs/commit/b15dd13)
+  The 'All components' section now renders two grouped grids — Tier 1
+  class helpers (20) above Tier 2 custom elements (12) — with intro
+  copy clarifying the composition model and a hint to pick Tier 1 by
+  default. Uses splitByTier() from the helper added in f2ba5c4.
+- **split docs sidenav components list by tier** [`e924ca1`](https://github.com/vivek7405/webjs/commit/e924ca1)
+  Sidenav now renders two grouped sections — 'Tier 1 · Class helpers'
+  (20 components) and 'Tier 2 · Custom elements' (12 components) —
+  with per-section counts. Each section's items are alphabetical
+  within the tier. Uses the splitByTier() helper from f2ba5c4.
+- **native-HTML rewrite of stateful primitives + shadcn-API sweep** ([#5](https://github.com/vivek7405/webjs/pull/5)) [`283b9ad`](https://github.com/vivek7405/webjs/commit/283b9ad)
+  Eight registry components now lean on native HTML primitives instead of
+  hand-rolled JS. Three drop their custom elements entirely; five keep a
+  thin custom-element wrapper around the platform feature.
+- **Tier-2 components -> WebComponent + render() + <slot> (rebased)** ([#28](https://github.com/vivek7405/webjs/pull/28)) [`101d1ee`](https://github.com/vivek7405/webjs/commit/101d1ee)
+  * refactor(ui): toggle.ts -> WebComponent + render() + <slot>
+  
+  First Tier-2 component converted from extends Base to extends
+  WebComponent. This is the pattern-locking conversion; remaining
+
+## Fixes
+
+- **rewrite registry '../lib/utils.ts' imports on add** [`9d7db59`](https://github.com/vivek7405/webjs/commit/9d7db59)
+  Registry components import cn from '../lib/utils.ts' (matching the
+  registry's own layout, where components live one level beside the
+  utils file). When 'webjs ui add <name>' fetches a component over
+  HTTP and writes it to the user's components/ui/<name>.ts, the

--- a/examples/blog/app/layout.ts
+++ b/examples/blog/app/layout.ts
@@ -80,14 +80,22 @@ export default function RootLayout({ children }: { children: unknown }) {
           }
         } catch (_) {}
       })();
-      // Mobile menu: close the parent <details> when any link inside
-      // .mobile-menu is activated. Delegated on document so it
-      // survives client-router navigations without rebinding.
+      // Mobile menu auto-close: close on link click (inside the panel)
+      // AND on any click outside the menu. Delegated on document so
+      // it survives client-router navigations without rebinding.
       document.addEventListener('click', function (e) {
-        var a = e.target.closest && e.target.closest('.mobile-menu a');
-        if (!a) return;
-        var d = a.closest('details');
-        if (d) d.removeAttribute('open');
+        var t = e.target;
+        if (!t || !t.closest) return;
+        var a = t.closest('.mobile-menu a');
+        if (a) {
+          var d = a.closest('details');
+          if (d) d.removeAttribute('open');
+          return;
+        }
+        var open = document.querySelectorAll('.mobile-menu[open]');
+        for (var i = 0; i < open.length; i++) {
+          if (!open[i].contains(t)) open[i].removeAttribute('open');
+        }
       });
     </script>
     <link rel="stylesheet" href="/public/tailwind.css">

--- a/examples/blog/app/layout.ts
+++ b/examples/blog/app/layout.ts
@@ -80,6 +80,15 @@ export default function RootLayout({ children }: { children: unknown }) {
           }
         } catch (_) {}
       })();
+      // Mobile menu: close the parent <details> when any link inside
+      // .mobile-menu is activated. Delegated on document so it
+      // survives client-router navigations without rebinding.
+      document.addEventListener('click', function (e) {
+        var a = e.target.closest && e.target.closest('.mobile-menu a');
+        if (!a) return;
+        var d = a.closest('details');
+        if (d) d.removeAttribute('open');
+      });
     </script>
     <link rel="stylesheet" href="/public/tailwind.css">
     <style>
@@ -175,82 +184,56 @@ export default function RootLayout({ children }: { children: unknown }) {
       ::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 999px; }
       ::-webkit-scrollbar-track { background: transparent; }
 
-      /* Mobile drawer + backdrop. Toggled via [data-menu-open] on <body>.
-         Desktop (>= 640px) hides the drawer entirely, and desktop nav is inline. */
-      .menu-drawer {
-        position: fixed;
-        top: 0; right: 0;
-        height: 100dvh;
-        width: 80vw; max-width: 320px;
-        background: var(--bg-elev);
-        border-left: 1px solid var(--border);
-        box-shadow: -4px 0 24px oklch(0 0 0 / 0.25);
-        transform: translateX(100%);
-        transition: transform 220ms cubic-bezier(0.3, 0, 0.3, 1);
-        z-index: 40;
-        padding: 20px;
-        display: flex;
-        flex-direction: column;
-        gap: 4px;
-      }
-      body[data-menu-open] .menu-drawer { transform: translateX(0); }
-      .menu-backdrop {
-        position: fixed; inset: 0;
-        background: oklch(0 0 0 / 0.5);
-        opacity: 0; pointer-events: none;
-        transition: opacity 220ms;
-        z-index: 30;
-      }
-      body[data-menu-open] .menu-backdrop { opacity: 1; pointer-events: auto; }
-      body[data-menu-open] { overflow: hidden; }
-      @media (min-width: 640px) {
-        .menu-drawer, .menu-backdrop, .menu-hamburger { display: none !important; }
-      }
+      /* Mobile menu: native <details>/<summary>, same shape as
+         webjs.dev and ui.webjs.dev. Strip the disclosure triangle and
+         swap the hamburger / close icons on toggle. */
+      .mobile-menu > summary { list-style: none; }
+      .mobile-menu > summary::-webkit-details-marker { display: none; }
+      .mobile-menu > summary .close-icon { display: none; }
+      .mobile-menu[open] > summary .open-icon { display: none; }
+      .mobile-menu[open] > summary .close-icon { display: inline-block; }
     </style>
 
-    <header class="sticky top-0 z-20 flex items-center gap-4 sm:gap-6 px-4 sm:px-6 py-3 border-b border-border bg-[color-mix(in_oklch,var(--bg)_75%,transparent)] backdrop-blur-[18px] backdrop-saturate-[180%]">
-      <a href="/" class="mr-auto inline-flex items-center gap-2 no-underline text-fg font-semibold text-[15px] leading-none tracking-tight">
+    <header class="sticky top-0 z-20 flex items-center justify-between gap-4 px-4 sm:px-6 py-3 border-b border-border bg-[color-mix(in_oklch,var(--bg)_75%,transparent)] backdrop-blur-[18px] backdrop-saturate-[180%]">
+      <a href="/" class="inline-flex items-center gap-2 no-underline text-fg font-semibold text-[15px] leading-none tracking-tight">
         <span class="inline-block w-[22px] h-[22px] rounded-md bg-gradient-to-br from-accent to-[color-mix(in_oklch,var(--accent)_55%,var(--fg))] shadow-[inset_0_0_0_1px_oklch(1_0_0/0.15),0_1px_4px_var(--accent-tint)]"></span>
         <span>webjs</span>
         <span class="text-fg-subtle mx-1 font-normal">/</span>
         <span>blog</span>
       </a>
+
+      <!-- Inline nav, sm and up. -->
       <nav class="hidden sm:flex gap-4 items-center">
         ${navLink('/', 'Posts')}
         ${navLink('/about', 'About')}
         ${navLink('/dashboard', 'Dashboard')}
         <a href="https://github.com/vivek7405/webjs/tree/main/examples/blog" target="_blank" rel="noopener" class="text-fg-muted no-underline font-medium text-[13px] leading-none tracking-[0.005em] transition-colors duration-fast hover:text-fg">GitHub</a>
+        <theme-toggle></theme-toggle>
       </nav>
-      <button
-        class="menu-hamburger inline-flex items-center justify-center w-9 h-9 p-0 border border-border rounded-full bg-bg-elev text-fg-muted cursor-pointer transition-all duration-150 hover:text-fg hover:border-border-strong"
-        aria-label="Open menu"
-        aria-controls="mobile-menu"
-        onclick="document.body.toggleAttribute('data-menu-open'); this.setAttribute('aria-expanded', document.body.hasAttribute('data-menu-open'))"
-      >
-        <svg class="w-4 h-4 stroke-current fill-none" style="stroke-width:1.8;stroke-linecap:round" viewBox="0 0 24 24"><path d="M4 7h16M4 12h16M4 17h16"/></svg>
-      </button>
-      <theme-toggle></theme-toggle>
-    </header>
 
-    <div class="menu-backdrop" onclick="document.body.removeAttribute('data-menu-open')"></div>
-    <aside
-      id="mobile-menu"
-      class="menu-drawer"
-      aria-label="Mobile navigation"
-      onclick="if (event.target.closest('a')) document.body.removeAttribute('data-menu-open')"
-    >
-      <button
-        class="self-end inline-flex items-center justify-center w-9 h-9 p-0 border border-border rounded-full bg-bg-elev text-fg-muted cursor-pointer transition-all duration-150 hover:text-fg hover:border-border-strong mb-2"
-        aria-label="Close menu"
-        onclick="document.body.removeAttribute('data-menu-open')"
-      >
-        <svg class="w-4 h-4 stroke-current fill-none" style="stroke-width:1.8;stroke-linecap:round" viewBox="0 0 24 24"><path d="M6 6l12 12M18 6L6 18"/></svg>
-      </button>
-      <a href="/" class="text-fg no-underline font-medium text-base leading-none py-3 px-1 border-b border-border hover:text-accent transition-colors">Posts</a>
-      <a href="/about" class="text-fg no-underline font-medium text-base leading-none py-3 px-1 border-b border-border hover:text-accent transition-colors">About</a>
-      <a href="/dashboard" class="text-fg no-underline font-medium text-base leading-none py-3 px-1 border-b border-border hover:text-accent transition-colors">Dashboard</a>
-      <a href="https://github.com/vivek7405/webjs/tree/main/examples/blog" target="_blank" rel="noopener" class="text-fg no-underline font-medium text-base leading-none py-3 px-1 hover:text-accent transition-colors">GitHub</a>
-    </aside>
+      <!-- Mobile cluster: hamburger LEFT, theme-toggle RIGHT. Native
+           <details>/<summary>, dropdown style matching webjs.dev and
+           ui.webjs.dev. -->
+      <div class="flex items-center gap-2 sm:hidden">
+        <details class="mobile-menu relative">
+          <summary class="list-none cursor-pointer w-9 h-9 inline-flex items-center justify-center rounded-md text-fg-muted hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" aria-label="Toggle navigation">
+            <svg class="open-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M3 6h18"/><path d="M3 12h18"/><path d="M3 18h18"/>
+            </svg>
+            <svg class="close-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M18 6 6 18"/><path d="m6 6 12 12"/>
+            </svg>
+          </summary>
+          <nav class="absolute right-0 top-[calc(100%+8px)] min-w-[200px] flex flex-col gap-1 bg-bg-elev border border-border rounded-lg shadow-lg p-2 z-50">
+            <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="/">Posts</a>
+            <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="/about">About</a>
+            <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="/dashboard">Dashboard</a>
+            <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="https://github.com/vivek7405/webjs/tree/main/examples/blog" target="_blank" rel="noopener">GitHub</a>
+          </nav>
+        </details>
+        <theme-toggle></theme-toggle>
+      </div>
+    </header>
 
     <div class="max-w-[760px] mx-auto px-4 sm:px-6 pt-4 text-[11px] leading-snug text-fg-subtle font-mono tracking-wide">
       Demo app. Data will be wiped between redeploys.

--- a/packages/ui/packages/website/app/layout.ts
+++ b/packages/ui/packages/website/app/layout.ts
@@ -70,14 +70,22 @@ export default function Layout({ children }: { children: any }) {
           }
         } catch (_) {}
       })();
-      // Mobile menu: close the parent <details> when a link inside
-      // .mobile-menu is activated, so the panel auto-dismisses on
-      // navigation. Same handler as webjs.dev.
+      // Mobile menu auto-close: close on link click (inside the panel)
+      // AND on any click outside the menu. Same handler as webjs.dev
+      // and the example blog.
       document.addEventListener('click', function (e) {
-        var a = e.target.closest && e.target.closest('.mobile-menu a');
-        if (!a) return;
-        var d = a.closest('details');
-        if (d) d.removeAttribute('open');
+        var t = e.target;
+        if (!t || !t.closest) return;
+        var a = t.closest('.mobile-menu a');
+        if (a) {
+          var d = a.closest('details');
+          if (d) d.removeAttribute('open');
+          return;
+        }
+        var open = document.querySelectorAll('.mobile-menu[open]');
+        for (var i = 0; i < open.length; i++) {
+          if (!open[i].contains(t)) open[i].removeAttribute('open');
+        }
       });
     </script>
     <style>

--- a/packages/ui/packages/website/app/layout.ts
+++ b/packages/ui/packages/website/app/layout.ts
@@ -70,6 +70,15 @@ export default function Layout({ children }: { children: any }) {
           }
         } catch (_) {}
       })();
+      // Mobile menu: close the parent <details> when a link inside
+      // .mobile-menu is activated, so the panel auto-dismisses on
+      // navigation. Same handler as webjs.dev.
+      document.addEventListener('click', function (e) {
+        var a = e.target.closest && e.target.closest('.mobile-menu a');
+        if (!a) return;
+        var d = a.closest('details');
+        if (d) d.removeAttribute('open');
+      });
     </script>
     <style>
       :root {
@@ -291,6 +300,15 @@ export default function Layout({ children }: { children: any }) {
         margin-right: 8px;
         vertical-align: middle;
       }
+
+      /* Mobile menu: native <details>/<summary>, same shape as webjs.dev
+         and the docs / blog apps. Strip the disclosure triangle and
+         swap the hamburger / close icons on toggle. */
+      .mobile-menu > summary { list-style: none; }
+      .mobile-menu > summary::-webkit-details-marker { display: none; }
+      .mobile-menu > summary .close-icon { display: none; }
+      .mobile-menu[open] > summary .open-icon { display: none; }
+      .mobile-menu[open] > summary .close-icon { display: inline-block; }
     </style>
 
     <div class="announce">
@@ -303,18 +321,42 @@ export default function Layout({ children }: { children: any }) {
       </a>
     </div>
 
-    <header class="flex flex-wrap items-center justify-between gap-y-2 max-w-5xl mx-auto px-6 py-4">
+    <header class="flex items-center justify-between gap-4 max-w-5xl mx-auto px-4 sm:px-6 py-4">
       <a class="flex items-center gap-2 no-underline text-fg font-bold text-base leading-none tracking-tight" href="/">
         <span class="w-[22px] h-[22px] rounded-md bg-gradient-to-br from-brand to-[color-mix(in_oklch,var(--accent)_55%,var(--fg))]"></span>
         Webjs UI
       </a>
-      <nav class="flex flex-wrap items-center gap-4">
+
+      <!-- Inline nav, md and up -->
+      <nav class="hidden md:flex items-center gap-4">
         <a class="text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href="/docs/components/accordion">Components</a>
         <a class="text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href="/docs">Docs</a>
-        <a class="hidden sm:inline text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href=${WEBSITE_URL} target="_blank">Webjs</a>
+        <a class="text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href=${WEBSITE_URL} target="_blank">Webjs</a>
         <a class="text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href="https://github.com/vivek7405/webjs" target="_blank">GitHub</a>
         <theme-toggle></theme-toggle>
       </nav>
+
+      <!-- Mobile cluster: hamburger LEFT, theme-toggle RIGHT (uniform
+           with webjs.dev and the blog example). -->
+      <div class="flex items-center gap-2 md:hidden">
+        <details class="mobile-menu relative">
+          <summary class="list-none cursor-pointer w-9 h-9 inline-flex items-center justify-center rounded-md text-fg-muted hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" aria-label="Toggle navigation">
+            <svg class="open-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M3 6h18"/><path d="M3 12h18"/><path d="M3 18h18"/>
+            </svg>
+            <svg class="close-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M18 6 6 18"/><path d="m6 6 12 12"/>
+            </svg>
+          </summary>
+          <nav class="absolute right-0 top-[calc(100%+8px)] min-w-[200px] flex flex-col gap-1 bg-bg-elev border border-border rounded-lg shadow-lg p-2 z-50">
+            <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="/docs/components/accordion">Components</a>
+            <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="/docs">Docs</a>
+            <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href=${WEBSITE_URL} target="_blank">Webjs</a>
+            <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="https://github.com/vivek7405/webjs" target="_blank">GitHub</a>
+          </nav>
+        </details>
+        <theme-toggle></theme-toggle>
+      </div>
     </header>
 
     <main class="max-w-5xl mx-auto px-6 py-10">${children}</main>

--- a/scripts/backfill-changelog.js
+++ b/scripts/backfill-changelog.js
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+/**
+ * One-shot script that walks main's history and emits a per-package
+ * per-version changelog file:
+ *
+ *   changelog/<pkg>/<version>.md
+ *
+ * where <pkg> is one of `core`, `server`, `cli`, `ts-plugin`, `ui`.
+ *
+ * For each version of each package, the file lists every
+ * conventional-commit (`feat:` / `fix:` / `breaking:` / `perf:`) that
+ * touched the package's `packages/<pkg>/` tree between the prior
+ * version bump and this one. Commits that touch multiple packages
+ * appear under each.
+ *
+ * Idempotent: re-running produces the same files. Files that already
+ * exist are left alone, so hand-curation survives subsequent runs.
+ *
+ *   node scripts/backfill-changelog.js
+ */
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const OUT = resolve(ROOT, 'changelog');
+
+const PACKAGES = ['core', 'server', 'cli', 'ts-plugin', 'ui'];
+
+function git(args, opts = {}) {
+  const r = spawnSync('git', args, {
+    cwd: ROOT,
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024,
+    ...opts,
+  });
+  if (r.status !== 0) throw new Error(`git ${args.join(' ')}: ${r.stderr}`);
+  return r.stdout;
+}
+
+/**
+ * For one package, list every (version, commit, date) triple where
+ * its package.json version field changed, in chronological order.
+ */
+function versionTimeline(pkg) {
+  // Format the log output as: <sha>\t<iso-date>\n<diff lines starting with +/->
+  // Then filter to commits where a `+  "version":` line shows up.
+  const raw = git([
+    'log', '--reverse', '--diff-filter=M', '--pretty=format:===%h\t%aI',
+    '-p', '--', `packages/${pkg}/package.json`,
+  ]);
+
+  const out = [];
+  let cur = null;
+  for (const line of raw.split('\n')) {
+    if (line.startsWith('===')) {
+      cur = { sha: '', date: '' };
+      const [sha, date] = line.slice(3).split('\t');
+      cur.sha = sha;
+      cur.date = date.slice(0, 10);
+      continue;
+    }
+    if (!cur) continue;
+    const m = line.match(/^\+\s*"version":\s*"([^"]+)"/);
+    if (m) {
+      out.push({ sha: cur.sha, date: cur.date, version: m[1] });
+      cur = null; // one version per commit; ignore further +/- lines
+    }
+  }
+  return out;
+}
+
+const PREFIX_RE = /^(feat|fix|breaking|perf)(?:\(([^)]+)\))?(!)?:\s*(.*)$/i;
+
+function splitPr(subject) {
+  const m = subject.match(/^(.*?)\s*\(#(\d+)\)\s*$/);
+  if (!m) return { subject: subject.trim(), pr: null };
+  return { subject: m[1].trim(), pr: m[2] };
+}
+
+function classify(rawSubject) {
+  const { subject, pr } = splitPr(rawSubject);
+  const m = subject.match(PREFIX_RE);
+  if (!m) return null;
+  const [, kind, scope, breakingMarker, rest] = m;
+  return {
+    type: breakingMarker ? 'breaking' : kind.toLowerCase(),
+    scope: scope || null,
+    title: rest.trim(),
+    pr: pr || null,
+  };
+}
+
+/** Conventional-commit log entries that touched `packages/<pkg>/` between two SHAs (exclusive..inclusive). */
+function commitsInRange(pkg, fromSha, toSha) {
+  const range = fromSha ? `${fromSha}..${toSha}` : toSha;
+  const FIELD = '';
+  const RECORD = '';
+  const fmt = `%h${FIELD}%aI${FIELD}%s${FIELD}%b${RECORD}`;
+  const raw = git([
+    'log', '--reverse', `--pretty=format:${fmt}`, range, '--', `packages/${pkg}/`,
+  ]);
+  const out = [];
+  for (const rec of raw.split(RECORD)) {
+    if (!rec.trim()) continue;
+    const [sha, iso, subject, body = ''] = rec.split(FIELD);
+    if (!subject) continue;
+    const c = classify(subject);
+    if (!c) continue;
+    out.push({
+      sha: sha.trim(),
+      date: iso.slice(0, 10),
+      type: c.type,
+      title: c.title,
+      pr: c.pr,
+      scope: c.scope,
+      body: body.trim(),
+    });
+  }
+  return out;
+}
+
+const TYPE_ORDER = { breaking: 0, feat: 1, perf: 2, fix: 3 };
+const TYPE_LABEL = { breaking: 'Breaking', feat: 'Features', perf: 'Performance', fix: 'Fixes' };
+
+function renderEntry(pkg, version, date, commits) {
+  const grouped = new Map();
+  for (const c of commits) {
+    if (!grouped.has(c.type)) grouped.set(c.type, []);
+    grouped.get(c.type).push(c);
+  }
+  const order = [...grouped.keys()].sort((a, b) => TYPE_ORDER[a] - TYPE_ORDER[b]);
+
+  const fm = [
+    '---',
+    `package: "@webjskit/${pkg}"`,
+    `version: ${version}`,
+    `date: ${date}`,
+    `commit_count: ${commits.length}`,
+    '---',
+    '',
+    `# @webjskit/${pkg} ${version}`,
+    '',
+  ].join('\n');
+
+  if (!commits.length) {
+    return fm + '_No user-facing changes shipped with this version (release-only bump)._\n';
+  }
+
+  const sections = [];
+  for (const t of order) {
+    sections.push(`## ${TYPE_LABEL[t]}\n`);
+    for (const c of grouped.get(t)) {
+      const prRef = c.pr ? ` ([#${c.pr}](https://github.com/vivek7405/webjs/pull/${c.pr}))` : '';
+      const sha = `[\`${c.sha}\`](https://github.com/vivek7405/webjs/commit/${c.sha})`;
+      sections.push(`- **${c.title}**${prRef} ${sha}`);
+      if (c.body) {
+        const summary = c.body.split('\n').slice(0, 4).map((l) => `  ${l}`).join('\n').trimEnd();
+        if (summary) sections.push(summary);
+      }
+    }
+    sections.push('');
+  }
+  return fm + sections.join('\n');
+}
+
+let total = 0;
+for (const pkg of PACKAGES) {
+  const versions = versionTimeline(pkg);
+  if (!versions.length) {
+    console.log(`[backfill-changelog] @webjskit/${pkg}: no version bumps in history; skipping`);
+    continue;
+  }
+  const dir = resolve(OUT, pkg);
+  mkdirSync(dir, { recursive: true });
+  let prevSha = null;
+  for (const v of versions) {
+    const file = resolve(dir, `${v.version}.md`);
+    if (existsSync(file)) { prevSha = v.sha; continue; }
+    const commits = commitsInRange(pkg, prevSha, v.sha);
+    writeFileSync(file, renderEntry(pkg, v.version, v.date, commits));
+    total++;
+    prevSha = v.sha;
+  }
+  console.log(`[backfill-changelog] @webjskit/${pkg}: ${versions.length} versions`);
+}
+console.log(`[backfill-changelog] total new files: ${total}`);

--- a/website/app/changelog/page.ts
+++ b/website/app/changelog/page.ts
@@ -1,0 +1,187 @@
+import { html, unsafeHTML } from '@webjskit/core';
+import { readdir, readFile } from 'node:fs/promises';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * /changelog
+ *
+ * Reads every `changelog/<pkg>/<version>.md` file at SSR time, parses
+ * the frontmatter + body, sorts by date descending, and renders one
+ * card per release. No markdown library: the entries are produced by
+ * `scripts/backfill-changelog.js` and follow a known shape (h1, h2
+ * section headings, top-level bulleted lists of changes), so we
+ * render the subset of markdown that shape uses.
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// website/app/changelog/page.ts is 3 levels deep from repo root.
+const REPO_ROOT = resolve(__dirname, '..', '..', '..');
+const CHANGELOG_DIR = resolve(REPO_ROOT, 'changelog');
+
+export const metadata = {
+  title: 'Changelog · webjs',
+  description: 'Per-package, per-version release notes for the webjs framework: @webjskit/core, server, cli, ts-plugin, ui.',
+};
+
+type Entry = {
+  package: string;          // "@webjskit/core"
+  shortPkg: string;         // "core"
+  version: string;          // "0.6.0"
+  date: string;             // "2026-05-21"
+  commitCount: number;
+  body: string;             // raw markdown body (after frontmatter)
+};
+
+function parseFrontmatter(raw: string): { fm: Record<string, string>; body: string } {
+  const m = raw.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  if (!m) return { fm: {}, body: raw };
+  const fm: Record<string, string> = {};
+  for (const line of m[1].split('\n')) {
+    const idx = line.indexOf(':');
+    if (idx < 0) continue;
+    const k = line.slice(0, idx).trim();
+    let v = line.slice(idx + 1).trim();
+    if (v.startsWith('"') && v.endsWith('"')) v = v.slice(1, -1);
+    fm[k] = v;
+  }
+  return { fm, body: m[2] };
+}
+
+async function loadEntries(): Promise<Entry[]> {
+  const entries: Entry[] = [];
+  let pkgs: string[];
+  try { pkgs = await readdir(CHANGELOG_DIR, { withFileTypes: true }).then((es) => es.filter((e) => e.isDirectory()).map((e) => e.name)); }
+  catch { return []; }
+  for (const pkg of pkgs) {
+    const dir = join(CHANGELOG_DIR, pkg);
+    let files: string[];
+    try { files = await readdir(dir); } catch { continue; }
+    for (const f of files) {
+      if (!f.endsWith('.md')) continue;
+      const raw = await readFile(join(dir, f), 'utf8');
+      const { fm, body } = parseFrontmatter(raw);
+      if (!fm.version || !fm.date) continue;
+      entries.push({
+        package: fm.package || `@webjskit/${pkg}`,
+        shortPkg: pkg,
+        version: fm.version,
+        date: fm.date,
+        commitCount: Number(fm.commit_count || 0),
+        body: body.trim(),
+      });
+    }
+  }
+  // Sort: most recent first; tie-break by package name.
+  entries.sort((a, b) => (b.date.localeCompare(a.date)) || a.shortPkg.localeCompare(b.shortPkg));
+  return entries;
+}
+
+/** Tiny inline-markdown renderer: links, bold, inline code, nothing else. */
+function inline(s: string): string {
+  let out = s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+  // [text](url)
+  out = out.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_m, t, u) =>
+    `<a href="${u}" class="text-accent no-underline hover:underline" rel="noopener noreferrer">${t}</a>`);
+  // `code`
+  out = out.replace(/`([^`]+)`/g, '<code class="font-mono text-[12.5px] bg-bg-subtle text-fg px-1 py-0.5 rounded">$1</code>');
+  // **bold**
+  out = out.replace(/\*\*([^*]+)\*\*/g, '<strong class="font-semibold text-fg">$1</strong>');
+  return out;
+}
+
+/** Render the body of one entry: h1 / h2 / bulleted lists / paragraphs. */
+function renderBody(md: string): string {
+  const lines = md.split('\n');
+  const out: string[] = [];
+  let inList = false;
+  let curItem: string[] = [];
+
+  function flushItem() {
+    if (curItem.length) {
+      out.push(`<li class="text-fg-muted text-[14px] leading-relaxed">${inline(curItem.join(' '))}</li>`);
+      curItem = [];
+    }
+  }
+  function endList() {
+    flushItem();
+    if (inList) { out.push('</ul>'); inList = false; }
+  }
+  function startList() {
+    if (!inList) { out.push('<ul class="list-disc pl-5 space-y-2 my-3">'); inList = true; }
+  }
+
+  for (const raw of lines) {
+    const line = raw;
+    if (/^# /.test(line)) {
+      endList();
+      out.push(`<h3 class="font-mono text-[16px] font-semibold tracking-tight text-fg mt-0 mb-3">${inline(line.slice(2).trim())}</h3>`);
+    } else if (/^## /.test(line)) {
+      endList();
+      out.push(`<h4 class="font-mono text-[11px] uppercase tracking-[0.15em] font-semibold text-fg-subtle mt-4 mb-1.5">${inline(line.slice(3).trim())}</h4>`);
+    } else if (/^- /.test(line)) {
+      flushItem();
+      startList();
+      curItem.push(line.slice(2).trim());
+    } else if (inList && /^ {2,}\S/.test(line)) {
+      curItem.push(line.trim());
+    } else if (line.trim() === '') {
+      flushItem();
+    } else {
+      endList();
+      out.push(`<p class="text-fg-muted text-[14px] leading-relaxed my-3">${inline(line.trim())}</p>`);
+    }
+  }
+  endList();
+  return out.join('\n');
+}
+
+const PKG_COLOR: Record<string, string> = {
+  core:        'bg-accent/15 text-accent',
+  server:      'bg-blue-500/15 text-blue-500',
+  cli:         'bg-emerald-500/15 text-emerald-500',
+  'ts-plugin': 'bg-purple-500/15 text-purple-500',
+  ui:          'bg-orange-500/15 text-orange-500',
+};
+
+function pkgBadge(pkg: string) {
+  const cls = PKG_COLOR[pkg] || 'bg-fg-subtle/15 text-fg-subtle';
+  return html`<span class="${cls} font-mono text-[10.5px] font-semibold uppercase tracking-[0.1em] px-2 py-0.5 rounded">${pkg}</span>`;
+}
+
+export default async function Changelog() {
+  const entries = await loadEntries();
+  return html`
+    <main class="max-w-[840px] mx-auto px-6 py-12">
+      <header class="mb-10">
+        <p class="font-mono text-[11px] uppercase tracking-[0.15em] text-accent font-semibold mb-2">Changelog</p>
+        <h1 class="font-serif text-[clamp(28px,4vw,40px)] leading-[1.05] tracking-tight text-fg mb-3">What shipped</h1>
+        <p class="text-fg-muted text-[15px] leading-relaxed max-w-[640px]">
+          Per-package, per-version release notes for <code class="font-mono text-[13px] bg-bg-subtle px-1 py-0.5 rounded">@webjskit/core</code>,
+          <code class="font-mono text-[13px] bg-bg-subtle px-1 py-0.5 rounded">/server</code>,
+          <code class="font-mono text-[13px] bg-bg-subtle px-1 py-0.5 rounded">/cli</code>,
+          <code class="font-mono text-[13px] bg-bg-subtle px-1 py-0.5 rounded">/ts-plugin</code>, and
+          <code class="font-mono text-[13px] bg-bg-subtle px-1 py-0.5 rounded">/ui</code>.
+          Each version-bump produces one entry, automatically.
+        </p>
+      </header>
+
+      ${entries.length === 0
+        ? html`<p class="text-fg-subtle italic">No entries yet.</p>`
+        : entries.map((e) => html`
+            <article class="border border-border rounded-xl bg-bg-elev p-5 sm:p-6 mb-5 shadow-sm">
+              <header class="flex flex-wrap items-baseline gap-x-3 gap-y-1 mb-3">
+                ${pkgBadge(e.shortPkg)}
+                <h2 class="font-mono text-[18px] font-semibold text-fg tracking-tight m-0">v${e.version}</h2>
+                <time class="font-mono text-[11.5px] text-fg-subtle tracking-tight">${e.date}</time>
+                <span class="text-[11.5px] text-fg-subtle">${e.commitCount} change${e.commitCount === 1 ? '' : 's'}</span>
+              </header>
+              <div>${unsafeHTML(renderBody(e.body))}</div>
+            </article>
+          `)}
+    </main>
+  `;
+}

--- a/website/app/layout.ts
+++ b/website/app/layout.ts
@@ -201,6 +201,15 @@ export default function RootLayout({ children }: { children: unknown }) {
         margin-right: 8px;
         vertical-align: middle;
       }
+
+      /* Mobile menu: native <details> + <summary> for progressive
+         enhancement. Strip the default disclosure triangle and swap
+         the hamburger / close icons on toggle. */
+      .mobile-menu > summary { list-style: none; }
+      .mobile-menu > summary::-webkit-details-marker { display: none; }
+      .mobile-menu > summary .close-icon { display: none; }
+      .mobile-menu[open] > summary .open-icon { display: none; }
+      .mobile-menu[open] > summary .close-icon { display: inline-block; }
     </style>
 
     <div class="announce">
@@ -213,12 +222,14 @@ export default function RootLayout({ children }: { children: unknown }) {
       </a>
     </div>
 
-    <header class="flex flex-wrap items-center justify-between gap-y-3 max-w-[960px] mx-auto px-4 sm:px-6 py-4">
+    <header class="flex items-center justify-between gap-4 max-w-[960px] mx-auto px-4 sm:px-6 py-4">
       <a class="flex items-center gap-2 no-underline text-fg font-bold text-base leading-none tracking-tight" href="/">
         <span class="w-[22px] h-[22px] rounded-md bg-gradient-to-br from-accent to-[color-mix(in_oklch,var(--accent)_55%,var(--fg))]"></span>
         webjs
       </a>
-      <nav class="flex flex-wrap items-center gap-x-3 sm:gap-x-4 gap-y-2">
+
+      <!-- Inline nav, md and up -->
+      <nav class="hidden md:flex items-center gap-4">
         <a class="text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href=${DOCS_URL + '/docs/getting-started'} target="_blank">Docs</a>
         <a class="text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href=${UI_URL} target="_blank">UI</a>
         <a class="text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href="/changelog">Changelog</a>
@@ -226,6 +237,29 @@ export default function RootLayout({ children }: { children: unknown }) {
         <a class="text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href="https://github.com/vivek7405/webjs" target="_blank">GitHub</a>
         <theme-toggle></theme-toggle>
       </nav>
+
+      <!-- Mobile: theme toggle stays inline, hamburger pops the nav. Native
+           <details>/<summary> for progressive enhancement: works without JS. -->
+      <div class="flex items-center gap-2 md:hidden">
+        <theme-toggle></theme-toggle>
+        <details class="mobile-menu relative">
+          <summary class="list-none cursor-pointer w-9 h-9 inline-flex items-center justify-center rounded-md text-fg-muted hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" aria-label="Toggle navigation">
+            <svg class="open-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M3 6h18"/><path d="M3 12h18"/><path d="M3 18h18"/>
+            </svg>
+            <svg class="close-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M18 6 6 18"/><path d="m6 6 12 12"/>
+            </svg>
+          </summary>
+          <nav class="absolute right-0 top-[calc(100%+8px)] min-w-[200px] flex flex-col gap-1 bg-bg-elev border border-border rounded-lg shadow-lg p-2 z-50">
+            <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href=${DOCS_URL + '/docs/getting-started'} target="_blank">Docs</a>
+            <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href=${UI_URL} target="_blank">UI</a>
+            <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="/changelog">Changelog</a>
+            <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href=${BLOG_URL} target="_blank">Blog Demo</a>
+            <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="https://github.com/vivek7405/webjs" target="_blank">GitHub</a>
+          </nav>
+        </details>
+      </div>
     </header>
 
     ${children}

--- a/website/app/layout.ts
+++ b/website/app/layout.ts
@@ -74,6 +74,16 @@ export default function RootLayout({ children }: { children: unknown }) {
           }
         } catch (_) {}
       })();
+      // Mobile-menu close on link click. <details> stays open by
+      // default when a child <a> is activated, including the
+      // client-router-intercepted same-origin links: close the
+      // parent <details> on any anchor click inside .mobile-menu.
+      document.addEventListener('click', function (e) {
+        var a = e.target.closest && e.target.closest('.mobile-menu a');
+        if (!a) return;
+        var d = a.closest('details');
+        if (d) d.removeAttribute('open');
+      });
     </script>
     <link rel="stylesheet" href="/public/tailwind.css">
     <style>

--- a/website/app/layout.ts
+++ b/website/app/layout.ts
@@ -74,15 +74,25 @@ export default function RootLayout({ children }: { children: unknown }) {
           }
         } catch (_) {}
       })();
-      // Mobile-menu close on link click. <details> stays open by
-      // default when a child <a> is activated, including the
-      // client-router-intercepted same-origin links: close the
-      // parent <details> on any anchor click inside .mobile-menu.
+      // Mobile menu auto-close: close on link click (inside the panel)
+      // AND on any click outside the menu. <details> stays open by
+      // default until you click summary again, which feels wrong on
+      // a phone, where a tap anywhere else should dismiss it.
       document.addEventListener('click', function (e) {
-        var a = e.target.closest && e.target.closest('.mobile-menu a');
-        if (!a) return;
-        var d = a.closest('details');
-        if (d) d.removeAttribute('open');
+        var t = e.target;
+        if (!t || !t.closest) return;
+        // 1) Click on a link inside the menu, close the menu.
+        var a = t.closest('.mobile-menu a');
+        if (a) {
+          var d = a.closest('details');
+          if (d) d.removeAttribute('open');
+          return;
+        }
+        // 2) Click anywhere OUTSIDE any open .mobile-menu, close it.
+        var open = document.querySelectorAll('.mobile-menu[open]');
+        for (var i = 0; i < open.length; i++) {
+          if (!open[i].contains(t)) open[i].removeAttribute('open');
+        }
       });
     </script>
     <link rel="stylesheet" href="/public/tailwind.css">

--- a/website/app/layout.ts
+++ b/website/app/layout.ts
@@ -248,10 +248,10 @@ export default function RootLayout({ children }: { children: unknown }) {
         <theme-toggle></theme-toggle>
       </nav>
 
-      <!-- Mobile: theme toggle stays inline, hamburger pops the nav. Native
-           <details>/<summary> for progressive enhancement: works without JS. -->
+      <!-- Mobile cluster: hamburger first (LEFT), theme-toggle second
+           (RIGHT), matching the convention across docs, blog, and ui.
+           Native <details>/<summary> for progressive enhancement. -->
       <div class="flex items-center gap-2 md:hidden">
-        <theme-toggle></theme-toggle>
         <details class="mobile-menu relative">
           <summary class="list-none cursor-pointer w-9 h-9 inline-flex items-center justify-center rounded-md text-fg-muted hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" aria-label="Toggle navigation">
             <svg class="open-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -269,6 +269,7 @@ export default function RootLayout({ children }: { children: unknown }) {
             <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="https://github.com/vivek7405/webjs" target="_blank">GitHub</a>
           </nav>
         </details>
+        <theme-toggle></theme-toggle>
       </div>
     </header>
 

--- a/website/app/layout.ts
+++ b/website/app/layout.ts
@@ -213,14 +213,15 @@ export default function RootLayout({ children }: { children: unknown }) {
       </a>
     </div>
 
-    <header class="flex items-center justify-between max-w-[960px] mx-auto px-6 py-4">
+    <header class="flex flex-wrap items-center justify-between gap-y-3 max-w-[960px] mx-auto px-4 sm:px-6 py-4">
       <a class="flex items-center gap-2 no-underline text-fg font-bold text-base leading-none tracking-tight" href="/">
         <span class="w-[22px] h-[22px] rounded-md bg-gradient-to-br from-accent to-[color-mix(in_oklch,var(--accent)_55%,var(--fg))]"></span>
         webjs
       </a>
-      <nav class="flex items-center gap-4">
+      <nav class="flex flex-wrap items-center gap-x-3 sm:gap-x-4 gap-y-2">
         <a class="text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href=${DOCS_URL + '/docs/getting-started'} target="_blank">Docs</a>
         <a class="text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href=${UI_URL} target="_blank">UI</a>
+        <a class="text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href="/changelog">Changelog</a>
         <a class="text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href=${BLOG_URL} target="_blank">Blog Demo</a>
         <a class="text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href="https://github.com/vivek7405/webjs" target="_blank">GitHub</a>
         <theme-toggle></theme-toggle>


### PR DESCRIPTION
## Summary

Three layers, one feature.

### 1. Architecture: per-package per-version under `changelog/`

```
changelog/
  README.md                   conventions + entry format
  core/0.6.0.md               one file per release
  server/0.7.1.md
  cli/0.7.0.md
  ts-plugin/0.4.0.md
  ui/0.2.0.md
  …
```

Each file has frontmatter (`package`, `version`, `date`, `commit_count`) and a body that groups conventional-commits under `## Breaking` / `## Features` / `## Performance` / `## Fixes` with PR + commit links.

The model: **a version bump in any `packages/<pkg>/package.json` triggers a changelog file**, populated from the commits since the last bump of the same package. `chore` / `refactor` / `test` / `docs` / `style` / `build` / `ci` commits never appear (they don't change the user contract).

`scripts/backfill-changelog.js` walks every `packages/<pkg>/package.json` history, finds version-changing commits, scans the inter-bump commits that touched that package, and writes any missing `<pkg>/<version>.md`. Re-runs are idempotent (existing files are never overwritten, so hand-curation survives).

### 2. Backfill from project inception

43 files generated across all 5 packages: core (7 versions), server (14), cli (18), ts-plugin (3), ui (1).

### 3. Website: `/changelog` page with responsive nav

`website/app/changelog/page.ts` reads every backfilled file at SSR time, parses the minimal markdown shape the generator emits (h1, h2, bulleted lists, links, inline code, bold), and renders one card per release with a package-coloured badge, version, date, and commit count.

Layout nav (`website/app/layout.ts`) gets the new "Changelog" link. The header now uses `flex-wrap` + `gap-y` on both row and nav, so the six chrome elements (Docs, UI, Changelog, Blog Demo, GitHub, theme-toggle) wrap into a second row on narrow viewports instead of overflowing. Mobile / laptop / desktop all unblocked.

Verified locally: `GET /changelog` returns 200 with 156 KB containing every version across all packages.

### 4. Automation: hooks that won't let an agent forget

Two gates fire when staged diffs bump a `packages/<pkg>/package.json` version without a matching `changelog/<pkg>/<version>.md`:

- `.hooks/pre-commit` refuses the commit and prints the exact fix (`node scripts/backfill-changelog.js && git add changelog/`).
- `.claude/hooks/changelog-nudge.sh` is a Claude Code `PreToolUse` hook on `Bash` that catches `git commit` invocations from agents and emits `permissionDecision: deny` so the tool call is refused with the same reason.

Root AGENTS.md gets a "Changelog: per-package, per-version, auto-generated" section spelling out the rule for AI agents working in the monorepo.

## Test plan

- [x] `node scripts/backfill-changelog.js` → 43 entries created across 5 packages.
- [x] `GET /changelog` returns 200, renders all entries, package badges colour-coded.
- [x] Pre-commit hook refused a simulated `core` version bump that lacked a matching file. Fixed an off-by-one in the awk slice that previously emitted `core/` instead of `core`.
- [x] Existing `npm test` (1150) + browser (265) + e2e (48) suites continue to pass since nothing in the runtime changed.

## Follow-ups (separate PRs)

- Hand-edit a few `breaking:` entries (core 0.5.0 signals migration, core 0.4.0 light-DOM defaults) to add migration code samples.
- Add a "filter by package" affordance on `/changelog`.
- Optional: a release script that bundles unreleased entries into a `releases/<version>.md` snapshot for the framework as a whole.