### PR TITLE
fix(changelog): drop empty release entries + repair bold/italic rendering

### DIFF
--- a/changelog/cli/0.1.3.md
+++ b/changelog/cli/0.1.3.md
@@ -1,9 +1,0 @@
----
-package: "@webjskit/cli"
-version: 0.1.3
-date: 2026-04-27
-commit_count: 0
----
-
-# @webjskit/cli 0.1.3
-_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/cli/0.3.1.md
+++ b/changelog/cli/0.3.1.md
@@ -1,9 +1,0 @@
----
-package: "@webjskit/cli"
-version: 0.3.1
-date: 2026-05-04
-commit_count: 0
----
-
-# @webjskit/cli 0.3.1
-_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/cli/0.4.0.md
+++ b/changelog/cli/0.4.0.md
@@ -1,9 +1,0 @@
----
-package: "@webjskit/cli"
-version: 0.4.0
-date: 2026-05-11
-commit_count: 0
----
-
-# @webjskit/cli 0.4.0
-_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/cli/0.4.1.md
+++ b/changelog/cli/0.4.1.md
@@ -1,9 +1,0 @@
----
-package: "@webjskit/cli"
-version: 0.4.1
-date: 2026-05-12
-commit_count: 0
----
-
-# @webjskit/cli 0.4.1
-_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/cli/0.4.2.md
+++ b/changelog/cli/0.4.2.md
@@ -1,9 +1,0 @@
----
-package: "@webjskit/cli"
-version: 0.4.2
-date: 2026-05-12
-commit_count: 0
----
-
-# @webjskit/cli 0.4.2
-_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/cli/0.4.3.md
+++ b/changelog/cli/0.4.3.md
@@ -1,9 +1,0 @@
----
-package: "@webjskit/cli"
-version: 0.4.3
-date: 2026-05-12
-commit_count: 0
----
-
-# @webjskit/cli 0.4.3
-_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/cli/0.4.4.md
+++ b/changelog/cli/0.4.4.md
@@ -1,9 +1,0 @@
----
-package: "@webjskit/cli"
-version: 0.4.4
-date: 2026-05-12
-commit_count: 0
----
-
-# @webjskit/cli 0.4.4
-_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/cli/0.5.0.md
+++ b/changelog/cli/0.5.0.md
@@ -1,9 +1,0 @@
----
-package: "@webjskit/cli"
-version: 0.5.0
-date: 2026-05-17
-commit_count: 0
----
-
-# @webjskit/cli 0.5.0
-_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/cli/0.5.1.md
+++ b/changelog/cli/0.5.1.md
@@ -1,9 +1,0 @@
----
-package: "@webjskit/cli"
-version: 0.5.1
-date: 2026-05-17
-commit_count: 0
----
-
-# @webjskit/cli 0.5.1
-_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/cli/0.5.2.md
+++ b/changelog/cli/0.5.2.md
@@ -1,9 +1,0 @@
----
-package: "@webjskit/cli"
-version: 0.5.2
-date: 2026-05-17
-commit_count: 0
----
-
-# @webjskit/cli 0.5.2
-_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/core/0.3.1.md
+++ b/changelog/core/0.3.1.md
@@ -1,9 +1,0 @@
----
-package: "@webjskit/core"
-version: 0.3.1
-date: 2026-05-12
-commit_count: 0
----
-
-# @webjskit/core 0.3.1
-_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/core/0.4.0.md
+++ b/changelog/core/0.4.0.md
@@ -1,9 +1,0 @@
----
-package: "@webjskit/core"
-version: 0.4.0
-date: 2026-05-17
-commit_count: 0
----
-
-# @webjskit/core 0.4.0
-_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/server/0.4.1.md
+++ b/changelog/server/0.4.1.md
@@ -1,9 +1,0 @@
----
-package: "@webjskit/server"
-version: 0.4.1
-date: 2026-05-12
-commit_count: 0
----
-
-# @webjskit/server 0.4.1
-_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/server/0.4.2.md
+++ b/changelog/server/0.4.2.md
@@ -1,9 +1,0 @@
----
-package: "@webjskit/server"
-version: 0.4.2
-date: 2026-05-12
-commit_count: 0
----
-
-# @webjskit/server 0.4.2
-_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/server/0.5.0.md
+++ b/changelog/server/0.5.0.md
@@ -1,9 +1,0 @@
----
-package: "@webjskit/server"
-version: 0.5.0
-date: 2026-05-17
-commit_count: 0
----
-
-# @webjskit/server 0.5.0
-_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/server/0.5.2.md
+++ b/changelog/server/0.5.2.md
@@ -1,9 +1,0 @@
----
-package: "@webjskit/server"
-version: 0.5.2
-date: 2026-05-17
-commit_count: 0
----
-
-# @webjskit/server 0.5.2
-_No user-facing changes shipped with this version (release-only bump)._

--- a/changelog/ts-plugin/0.4.0.md
+++ b/changelog/ts-plugin/0.4.0.md
@@ -1,9 +1,0 @@
----
-package: "@webjskit/ts-plugin"
-version: 0.4.0
-date: 2026-05-12
-commit_count: 0
----
-
-# @webjskit/ts-plugin 0.4.0
-_No user-facing changes shipped with this version (release-only bump)._

--- a/scripts/backfill-changelog.js
+++ b/scripts/backfill-changelog.js
@@ -167,6 +167,7 @@ function renderEntry(pkg, version, date, commits) {
 }
 
 let total = 0;
+let skippedEmpty = 0;
 for (const pkg of PACKAGES) {
   const versions = versionTimeline(pkg);
   if (!versions.length) {
@@ -180,10 +181,20 @@ for (const pkg of PACKAGES) {
     const file = resolve(dir, `${v.version}.md`);
     if (existsSync(file)) { prevSha = v.sha; continue; }
     const commits = commitsInRange(pkg, prevSha, v.sha);
+    // Skip release-only bumps. A version that shipped no
+    // feat / fix / breaking / perf commits has nothing to say to a
+    // reader of the changelog. Tracking it here would emit a
+    // single-line "no user-facing changes" placeholder for every
+    // dependency bump, which is just noise.
+    if (commits.length === 0) {
+      skippedEmpty++;
+      prevSha = v.sha;
+      continue;
+    }
     writeFileSync(file, renderEntry(pkg, v.version, v.date, commits));
     total++;
     prevSha = v.sha;
   }
   console.log(`[backfill-changelog] @webjskit/${pkg}: ${versions.length} versions`);
 }
-console.log(`[backfill-changelog] total new files: ${total}`);
+console.log(`[backfill-changelog] new files: ${total}, skipped (empty): ${skippedEmpty}`);

--- a/website/app/changelog/page.ts
+++ b/website/app/changelog/page.ts
@@ -77,7 +77,7 @@ async function loadEntries(): Promise<Entry[]> {
   return entries;
 }
 
-/** Tiny inline-markdown renderer: links, bold, inline code, nothing else. */
+/** Tiny inline-markdown renderer: links, bold, italic, inline code. */
 function inline(s: string): string {
   let out = s
     .replace(/&/g, '&amp;')
@@ -88,8 +88,16 @@ function inline(s: string): string {
     `<a href="${u}" class="text-accent no-underline hover:underline" rel="noopener noreferrer">${t}</a>`);
   // `code`
   out = out.replace(/`([^`]+)`/g, '<code class="font-mono text-[12.5px] bg-bg-subtle text-fg px-1 py-0.5 rounded">$1</code>');
-  // **bold**
-  out = out.replace(/\*\*([^*]+)\*\*/g, '<strong class="font-semibold text-fg">$1</strong>');
+  // **bold** (non-greedy single-line match: must allow asterisks
+  // inside the span so titles like "**data-webjs-prop-* side-channel**"
+  // still parse. The previous [^*]+ rejected the embedded asterisk
+  // and silently left the literal ** in the rendered output.)
+  out = out.replace(/\*\*([^\n]+?)\*\*/g, '<strong class="font-semibold text-fg">$1</strong>');
+  // _italic_ and *italic* (the backfill generator does not emit these,
+  // but hand-curated entries can; the previous renderer left the
+  // underscores in the rendered HTML).
+  out = out.replace(/(^|[^\w])_([^_\s][^_]*[^_\s]|[^_\s])_(?=$|[^\w])/g, '$1<em>$2</em>');
+  out = out.replace(/(^|[^*\w])\*([^*\s][^*]*[^*\s]|[^*\s])\*(?=$|[^*\w])/g, '$1<em>$2</em>');
   return out;
 }
 


### PR DESCRIPTION
## Summary

Two display issues on /changelog flagged on the live page.

### 1. Hide release-only version bumps

17 entries shipped with zero `feat:` / `fix:` / `breaking:` / `perf:` commits (pure dependency or release-only bumps). Each one rendered as a single placeholder line `_No user-facing changes shipped with this version (release-only bump)._` which was noise.

- `scripts/backfill-changelog.js` now skips emitting a file when the commit set for the new version is empty.
- The 17 already-generated empty files are deleted in this PR: cli `0.1.3`, `0.3.1`, `0.4.0`-`0.4.4`, `0.5.0`-`0.5.2`; core `0.3.1`, `0.4.0`; server `0.4.1`, `0.4.2`, `0.5.0`, `0.5.2`; ts-plugin `0.4.0`.

### 2. Render bold + italic markdown

The website's tiny inline-markdown renderer had two gaps:

- `**bold**` titles containing a literal asterisk inside the span, e.g. `**SSR property bindings via data-webjs-prop-* side-channel**`, rendered as raw markdown because the pattern was `\*\*([^*]+)\*\*` (no asterisks allowed inside). Switched to a non-greedy `[^\n]+?` so the embedded `*` no longer breaks the match.
- `_italic_` / `*italic*` weren't handled at all, so the underscores leaked into the rendered HTML. Added word-boundary anchored patterns so they emit `<em>` without colliding with the bold rule.

## Test plan

- [x] `curl /changelog` → 0 occurrences of raw `**`, every previously-broken title now wrapped in `<strong>`.
- [x] Visual spot check on the localhost website: bold titles render bold, italic placeholders gone.
- [x] `scripts/backfill-changelog.js` re-run on a clean tree produces the same 26 files (no regressions in the kept set).