### PR TITLE
fix(deploy): copy changelog/ into the production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,10 @@ COPY packages  ./packages
 COPY examples  ./examples
 COPY website   ./website
 COPY docs      ./docs
+# website/app/changelog/page.ts reads ../../../changelog/<pkg>/*.md at
+# SSR time. Without copying the changelog tree into the image, the
+# deployed page renders "No entries yet."
+COPY changelog ./changelog
 
 # --- 3. Build-time work --------------------------------------------------
 # Blog: generate Prisma client (needs schema.prisma in context).


### PR DESCRIPTION
## Summary

`https://webjs.dev/changelog` rendered "No entries yet." because the production `Dockerfile` only copies `packages`, `examples`, `website`, and `docs` into the image. `website/app/changelog/page.ts` reads `<repo>/changelog/<pkg>/*.md` at SSR time, so on the deployed image the directory simply didn't exist and `readdir()` returned an empty list.

Add `COPY changelog ./changelog` to the Dockerfile so the deployed website resolves the same tree it does locally.

## Why this happened only in production

Locally, the website runs from inside the repo so `resolve(__dirname, '..', '..', '..', 'changelog')` finds the real directory. In the image, `__dirname` is `/app/website/app/changelog` and we never copied `/app/changelog`, so the path didn't resolve.

## Test plan

- [x] Local SSR still renders the entries (unchanged code path).
- [ ] After this PR merges and Railway rebuilds the image, https://webjs.dev/changelog should show the per-package per-version entries.