### PR TITLE
docs(website): document /changelog dependency on the repo-root tree

### DIFF
--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -13,14 +13,20 @@ This file only covers what's specific to the landing site.
 ```
 website/
   app/
-    layout.ts        root layout (head, OG/Twitter metadata,
-                     header/footer chrome, Tailwind tokens)
-    page.ts          /  → the entire one-page landing site.
-                         Hero, features grid, code samples, agent
-                         badges, and footer all live here.
+    layout.ts          root layout (head, OG/Twitter metadata,
+                       header/footer chrome, Tailwind tokens)
+    page.ts            /  → the entire one-page landing site.
+                           Hero, features grid, code samples, agent
+                           badges, and footer all live here.
+    changelog/page.ts  /changelog. Reads ../../../changelog/<pkg>/*.md
+                       at SSR time and renders the unified release
+                       feed. The deployment image must include the
+                       changelog/ tree at the repo root, the
+                       Dockerfile's `COPY changelog ./changelog` line
+                       is what ships it on Railway.
   components/
-    theme-toggle.ts  light/dark cycle
-  public/            favicon, og image, static assets
+    theme-toggle.ts    light/dark cycle
+  public/              favicon, og image, static assets
 ```
 
 The site is intentionally one page in long-form scroll. When you edit


### PR DESCRIPTION
## Why

PR #51 merged the Dockerfile fix that ships the `changelog/` tree into the production image, but the website service on Railway didn't auto-deploy from it because its watch paths are scoped to `website/**`. Since #51 only touched the repo-root `Dockerfile`, the merge didn't trigger a new website build. The dashboard "Redeploy" button just re-ran the prior commit (#50). https://webjs.dev/changelog still shows "No entries yet."

This commit touches a `website/` file (so Railway's watch path matches) and pulls in everything on `main` (including the Dockerfile fix) via a fresh build from HEAD. The actual content of the change is a useful note documenting the coupling between `website/app/changelog/page.ts` and the repo-root `changelog/` tree, so future agents don't break the link.

## Follow-up

Worth considering: relax the per-service watch paths so root-level changes (`Dockerfile`, `package.json`, etc.) trigger redeploys for every service. Filed mentally; happy to do that in a separate PR if you want.

## Test plan

- [ ] After merge, Railway should auto-deploy the website service from `main` HEAD, picking up the `COPY changelog ./changelog` Dockerfile line.
- [ ] https://webjs.dev/changelog should render the per-package per-version entries.