### PR TITLE
chore(deploy): config-as-code railway.json + per-service watch path docs

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile",
+    "watchPatterns": ["**/*"]
+  },
+  "deploy": {
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}

--- a/railway.json
+++ b/railway.json
@@ -2,8 +2,7 @@
   "$schema": "https://railway.com/railway.schema.json",
   "build": {
     "builder": "DOCKERFILE",
-    "dockerfilePath": "Dockerfile",
-    "watchPatterns": ["**/*"]
+    "dockerfilePath": "Dockerfile"
   },
   "deploy": {
     "restartPolicyType": "ON_FAILURE",


### PR DESCRIPTION
## Problem

The 4 Railway services in this repo each have a per-subdir watch path. Root-level changes (Dockerfile, root configs) only fire the service whose list happens to mention them. PR #51's Dockerfile fix reached `ui-website` but not website/docs/blog, which is why `webjs.dev/changelog` stayed broken even after the merge.

Mapped what each runtime actually depends on (imports, not prose mentions):

| Service | Imports from packages/ |
|---|---|
| `website` | core, cli |
| `docs` | core, cli, server |
| `blog` (examples/) | core, server |
| `ui-website` | core, cli, ui |

(`ts-plugin` is editor-only, no runtime use, so it's intentionally excluded. The docs site mentions `@webjskit/ui` in prose on the UI doc page but does not import it, so ui is not a runtime dep there.)

Plus everyone is built from the same `Dockerfile` and runs `webjs start`, so cli/core/server transitively land in every image.

## Fix

Two parts.

### 1. `railway.json` at the repo root

Adds a shared, file-controlled record of the build (`builder: DOCKERFILE`, `dockerfilePath: Dockerfile`) and the deploy restart policy. `watchPatterns` is **not** in this file because a single value at the repo root would apply identically to all four services and the whole point is to make each service trigger on a different set.

### 2. Per-service watch paths (one-time dashboard cleanup)

For each service: open **Settings → Source → Watch Paths**, clear the existing list, paste the matching list below, and save.

#### `@webjskit/website` (webjs.dev)
```
/website/**
/changelog/**
/Dockerfile
/package.json
/package-lock.json
/railway.json
/packages/cli/**
/packages/core/**
/packages/server/**
```

#### `@webjskit/docs` (docs.webjs.dev)
```
/docs/**
/Dockerfile
/package.json
/package-lock.json
/railway.json
/packages/cli/**
/packages/core/**
/packages/server/**
```

#### `@webjskit-examples/blog` (example-blog.webjs.dev)
```
/examples/blog/**
/Dockerfile
/package.json
/package-lock.json
/railway.json
/packages/cli/**
/packages/core/**
/packages/server/**
```

#### `@webjskit/ui-website` (ui.webjs.dev)
```
/packages/ui/**
/Dockerfile
/package.json
/package-lock.json
/railway.json
/packages/cli/**
/packages/core/**
/packages/server/**
```

## After the dashboard cleanup

- A change to `website/app/page.ts` → only the website rebuilds.
- A change to `Dockerfile` or root `package.json` → all four rebuild.
- A change to `packages/core/**` or `packages/server/**` → all four rebuild (they all run on the framework).
- A change to `packages/ui/**` → only ui-website rebuilds.
- A change to `changelog/<pkg>/<version>.md` → only the website rebuilds (the page that reads it).

## Test plan

- [ ] After dashboard cleanup + this PR merges, push a website-only commit and confirm only the website service rebuilds.
- [ ] Push a Dockerfile-only commit and confirm all four rebuild.
- [ ] Confirm `https://webjs.dev/changelog` finally renders the per-package entries (the deferred fix from PR #51).