### PR TITLE
feat(release): auto-publish GitHub Releases from changelog files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Auto-release
+
+# Every push to main that lands a new `changelog/<pkg>/<version>.md`
+# file becomes a GitHub Release for that (package, version) tuple.
+# The matching workflow:
+#
+#   1. Checks out main with two-commit depth so we can diff the new
+#      head against its parent.
+#   2. Finds files added under `changelog/**.md` in that diff.
+#   3. Invokes `scripts/publish-release.js` once per file. The script
+#      is idempotent (skips when the tag already exists), so retries
+#      / force-pushes do not error.
+#
+# Triggered only on changelog changes so unrelated pushes do not run
+# the job. Cost on public repos: $0 (GitHub Actions has unlimited
+# free minutes for public repos on ubuntu-latest).
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'changelog/**'
+
+permissions:
+  contents: write   # gh release create needs write access to the repo
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Find new changelog files
+        id: diff
+        run: |
+          set -euo pipefail
+          # All changelog md files added in this push.
+          mapfile -t NEW < <(git diff --name-only --diff-filter=A HEAD~1 HEAD -- 'changelog/**.md')
+          if [ ${#NEW[@]} -eq 0 ]; then
+            echo "No new changelog files in this push; skipping."
+            echo "count=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          printf '  + %s\n' "${NEW[@]}"
+          # Persist the list across steps via a workspace file. GITHUB_OUTPUT
+          # has a per-line size cap that we'd hit on big bulk-backfill PRs.
+          printf '%s\n' "${NEW[@]}" > .new-changelog-files.txt
+          echo "count=${#NEW[@]}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish releases
+        if: steps.diff.outputs.count != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            node scripts/publish-release.js "$f"
+          done < .new-changelog-files.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,8 @@ If the package has zero `feat:` / `fix:` / `breaking:` / `perf:` commits in the 
 
 The whole flow is tool-agnostic: the universal pre-commit hook fires for every `git commit`, regardless of who or what is running it. AI agents using Claude Code, Cursor, Copilot, Aider, etc. all get the same behavior, as do human contributors.
 
+**GitHub Releases are auto-created from the same files.** The `.github/workflows/release.yml` workflow watches for new `changelog/**.md` files added in a push to `main`. For each new file, it runs `scripts/publish-release.js`, which parses the frontmatter (`package`, `version`, `date`), composes a tag `<pkg>@<version>` (e.g. `core@0.6.0`), title `@webjskit/<pkg> <version>`, and body (the markdown after frontmatter), then runs `gh release create`. Idempotent: existing release tags are skipped, so retries and force-pushes are safe. Free for public repos.
+
 ---
 
 ## What webjs is

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -110,6 +110,22 @@ The AGENTS.md rule that AI agents follow on every code-commit:
 > for `breaking` entries that need migration notes. Then commit the
 > changelog file alongside the version bump.
 
+## GitHub Releases are auto-published from the same files
+
+The `.github/workflows/release.yml` workflow watches for new
+`changelog/**.md` files added in any push to `main`. For each new
+file it runs `scripts/publish-release.js`, which parses the
+frontmatter, composes a release tag of the shape `<pkg>@<version>`
+(e.g. `core@0.6.0`) with title `@webjskit/<pkg> <version>` and the
+markdown body as release notes, and calls `gh release create`.
+
+The publish step is idempotent: it skips any tag that already
+exists, so workflow retries and force-pushes are safe. Hand-editing
+a `changelog/<pkg>/<version>.md` after the release was published
+does NOT update the release on GitHub. If you need to amend a
+published release, edit it on the GitHub Releases UI directly (or
+delete the release tag and let a fresh workflow run recreate it).
+
 ## What if the same change ships across packages
 
 A commit that touches more than one package (e.g. a refactor that

--- a/changelog/cli/0.1.1.md
+++ b/changelog/cli/0.1.1.md
@@ -5,7 +5,6 @@ date: 2026-04-22
 commit_count: 27
 ---
 
-# @webjskit/cli 0.1.1
 ## Features
 
 - **webjs test, webjs check, webjs create with AI guardrails** [`6e85e5d`](https://github.com/vivek7405/webjs/commit/6e85e5d)

--- a/changelog/cli/0.1.2.md
+++ b/changelog/cli/0.1.2.md
@@ -5,7 +5,6 @@ date: 2026-04-27
 commit_count: 1
 ---
 
-# @webjskit/cli 0.1.2
 ## Features
 
 - **use icon-only theme toggle in scaffold** [`195614c`](https://github.com/vivek7405/webjs/commit/195614c)

--- a/changelog/cli/0.1.4.md
+++ b/changelog/cli/0.1.4.md
@@ -5,7 +5,6 @@ date: 2026-04-27
 commit_count: 1
 ---
 
-# @webjskit/cli 0.1.4
 ## Fixes
 
 - **resolve esbuild from app dir, not server dir** [`8e8207d`](https://github.com/vivek7405/webjs/commit/8e8207d)

--- a/changelog/cli/0.2.0.md
+++ b/changelog/cli/0.2.0.md
@@ -5,7 +5,6 @@ date: 2026-04-28
 commit_count: 1
 ---
 
-# @webjskit/cli 0.2.0
 ## Features
 
 - **use esbuild for TS on both SSR + hydration; default to no build** [`4dc8b91`](https://github.com/vivek7405/webjs/commit/4dc8b91)

--- a/changelog/cli/0.2.1.md
+++ b/changelog/cli/0.2.1.md
@@ -5,7 +5,6 @@ date: 2026-04-28
 commit_count: 1
 ---
 
-# @webjskit/cli 0.2.1
 ## Fixes
 
 - **share component registry across module instances** [`5bda8c7`](https://github.com/vivek7405/webjs/commit/5bda8c7)

--- a/changelog/cli/0.3.0.md
+++ b/changelog/cli/0.3.0.md
@@ -5,7 +5,6 @@ date: 2026-04-28
 commit_count: 1
 ---
 
-# @webjskit/cli 0.3.0
 ## Features
 
 - **drop superjson, ship built-in ESM rich-type serializer** [`4c2b704`](https://github.com/vivek7405/webjs/commit/4c2b704)

--- a/changelog/cli/0.6.0.md
+++ b/changelog/cli/0.6.0.md
@@ -5,7 +5,6 @@ date: 2026-05-19
 commit_count: 1
 ---
 
-# @webjskit/cli 0.6.0
 ## Features
 
 - **erasable-typescript-only rule + ship erasableSyntaxOnly in tsconfigs** [`01d1b18`](https://github.com/vivek7405/webjs/commit/01d1b18)

--- a/changelog/cli/0.7.0.md
+++ b/changelog/cli/0.7.0.md
@@ -5,7 +5,6 @@ date: 2026-05-21
 commit_count: 9
 ---
 
-# @webjskit/cli 0.7.0
 ## Features
 
 - **webjs check --rules shows enabled/disabled state per project** [`a5e7067`](https://github.com/vivek7405/webjs/commit/a5e7067)

--- a/changelog/core/0.2.0.md
+++ b/changelog/core/0.2.0.md
@@ -5,7 +5,6 @@ date: 2026-04-28
 commit_count: 43
 ---
 
-# @webjskit/core 0.2.0
 ## Features
 
 - **add essential directives (unsafeHTML, live) with renderer integration** [`3d8a253`](https://github.com/vivek7405/webjs/commit/3d8a253)

--- a/changelog/core/0.3.0.md
+++ b/changelog/core/0.3.0.md
@@ -5,7 +5,6 @@ date: 2026-04-28
 commit_count: 1
 ---
 
-# @webjskit/core 0.3.0
 ## Features
 
 - **drop superjson, ship built-in ESM rich-type serializer** [`4c2b704`](https://github.com/vivek7405/webjs/commit/4c2b704)

--- a/changelog/core/0.4.1.md
+++ b/changelog/core/0.4.1.md
@@ -5,7 +5,6 @@ date: 2026-05-17
 commit_count: 2
 ---
 
-# @webjskit/core 0.4.1
 ## Fixes
 
 - **preserve cached snapshot on popstate; manual scrollRestoration** [`231cd8f`](https://github.com/vivek7405/webjs/commit/231cd8f)

--- a/changelog/core/0.5.0.md
+++ b/changelog/core/0.5.0.md
@@ -5,7 +5,6 @@ date: 2026-05-19
 commit_count: 5
 ---
 
-# @webjskit/core 0.5.0
 ## Features
 
 - **light-DOM slot runtime foundation (slot.js)** [`7331ce2`](https://github.com/vivek7405/webjs/commit/7331ce2)

--- a/changelog/core/0.6.0.md
+++ b/changelog/core/0.6.0.md
@@ -5,7 +5,6 @@ date: 2026-05-21
 commit_count: 4
 ---
 
-# @webjskit/core 0.6.0
 ## Features
 
 - **SSR property bindings via data-webjs-prop-* side-channel** [`56f502f`](https://github.com/vivek7405/webjs/commit/56f502f)

--- a/changelog/server/0.1.1.md
+++ b/changelog/server/0.1.1.md
@@ -5,7 +5,6 @@ date: 2026-04-27
 commit_count: 25
 ---
 
-# @webjskit/server 0.1.1
 ## Features
 
 - **auto-vendor npm deps, module graph, lazy loading** [`266d041`](https://github.com/vivek7405/webjs/commit/266d041)

--- a/changelog/server/0.2.0.md
+++ b/changelog/server/0.2.0.md
@@ -5,7 +5,6 @@ date: 2026-04-28
 commit_count: 1
 ---
 
-# @webjskit/server 0.2.0
 ## Features
 
 - **use esbuild for TS on both SSR + hydration; default to no build** [`4dc8b91`](https://github.com/vivek7405/webjs/commit/4dc8b91)

--- a/changelog/server/0.2.1.md
+++ b/changelog/server/0.2.1.md
@@ -5,7 +5,6 @@ date: 2026-04-28
 commit_count: 1
 ---
 
-# @webjskit/server 0.2.1
 ## Fixes
 
 - **share component registry across module instances** [`5bda8c7`](https://github.com/vivek7405/webjs/commit/5bda8c7)

--- a/changelog/server/0.3.0.md
+++ b/changelog/server/0.3.0.md
@@ -5,7 +5,6 @@ date: 2026-04-28
 commit_count: 1
 ---
 
-# @webjskit/server 0.3.0
 ## Features
 
 - **drop superjson, ship built-in ESM rich-type serializer** [`4c2b704`](https://github.com/vivek7405/webjs/commit/4c2b704)

--- a/changelog/server/0.3.1.md
+++ b/changelog/server/0.3.1.md
@@ -5,7 +5,6 @@ date: 2026-05-04
 commit_count: 1
 ---
 
-# @webjskit/server 0.3.1
 ## Fixes
 
 - **hoist <link> from layout body into <head>** [`96e97b4`](https://github.com/vivek7405/webjs/commit/96e97b4)

--- a/changelog/server/0.4.0.md
+++ b/changelog/server/0.4.0.md
@@ -5,7 +5,6 @@ date: 2026-05-11
 commit_count: 1
 ---
 
-# @webjskit/server 0.4.0
 ## Features
 
 - **rule reactive-props-use-declare flags class-field foot-gun** [`7b14eeb`](https://github.com/vivek7405/webjs/commit/7b14eeb)

--- a/changelog/server/0.5.1.md
+++ b/changelog/server/0.5.1.md
@@ -5,7 +5,6 @@ date: 2026-05-17
 commit_count: 1
 ---
 
-# @webjskit/server 0.5.1
 ## Fixes
 
 - **honor X-Forwarded-Proto/Host when building ctx.url** [`41939b4`](https://github.com/vivek7405/webjs/commit/41939b4)

--- a/changelog/server/0.6.0.md
+++ b/changelog/server/0.6.0.md
@@ -5,7 +5,6 @@ date: 2026-05-19
 commit_count: 2
 ---
 
-# @webjskit/server 0.6.0
 ## Features
 
 - **hybrid TS stripper (Node strip-types + esbuild fallback)** [`a68760f`](https://github.com/vivek7405/webjs/commit/a68760f)

--- a/changelog/server/0.7.0.md
+++ b/changelog/server/0.7.0.md
@@ -5,7 +5,6 @@ date: 2026-05-21
 commit_count: 6
 ---
 
-# @webjskit/server 0.7.0
 ## Features
 
 - **drop webjs.conventions.js + legacy fallbacks, only support pkg.webjs.conventions** [`622caa7`](https://github.com/vivek7405/webjs/commit/622caa7)

--- a/changelog/server/0.7.1.md
+++ b/changelog/server/0.7.1.md
@@ -5,7 +5,6 @@ date: 2026-05-21
 commit_count: 1
 ---
 
-# @webjskit/server 0.7.1
 ## Fixes
 
 - **stop sending immutable cache-control on /__webjs/core/*** ([#38](https://github.com/vivek7405/webjs/pull/38)) [`ce8ab2e`](https://github.com/vivek7405/webjs/commit/ce8ab2e)

--- a/changelog/ts-plugin/0.2.0.md
+++ b/changelog/ts-plugin/0.2.0.md
@@ -5,7 +5,6 @@ date: 2026-05-04
 commit_count: 2
 ---
 
-# @webjskit/ts-plugin 0.2.0
 ## Features
 
 - **rebrand webjs-plugin → @webjskit/ts-plugin, ready for npm** [`cf89060`](https://github.com/vivek7405/webjs/commit/cf89060)

--- a/changelog/ts-plugin/0.3.0.md
+++ b/changelog/ts-plugin/0.3.0.md
@@ -5,7 +5,6 @@ date: 2026-05-04
 commit_count: 1
 ---
 
-# @webjskit/ts-plugin 0.3.0
 ## Features
 
 - **type-check <webjs-tag attr=\${expr}> interpolations** [`844d04e`](https://github.com/vivek7405/webjs/commit/844d04e)

--- a/changelog/ui/0.2.0.md
+++ b/changelog/ui/0.2.0.md
@@ -5,7 +5,6 @@ date: 2026-05-20
 commit_count: 6
 ---
 
-# @webjskit/ui 0.2.0
 ## Features
 
 - **add tier classifier for registry items** [`f15c852`](https://github.com/vivek7405/webjs/commit/f15c852)

--- a/scripts/backfill-changelog.js
+++ b/scripts/backfill-changelog.js
@@ -161,6 +161,10 @@ function renderEntry(pkg, version, date, commits) {
   }
   const order = [...grouped.keys()].sort((a, b) => TYPE_ORDER[a] - TYPE_ORDER[b]);
 
+  // No h1 in the body. The website's /changelog page emits its own
+  // card header (package badge + version + date), and GitHub Releases
+  // uses the release title for the heading on each entry. An h1 here
+  // duplicates one or the other on every surface.
   const fm = [
     '---',
     `package: "@webjskit/${pkg}"`,
@@ -168,8 +172,6 @@ function renderEntry(pkg, version, date, commits) {
     `date: ${date}`,
     `commit_count: ${commits.length}`,
     '---',
-    '',
-    `# @webjskit/${pkg} ${version}`,
     '',
   ].join('\n');
 

--- a/scripts/publish-release.js
+++ b/scripts/publish-release.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * Publish ONE changelog file as a GitHub Release via the gh CLI.
+ *
+ *   node scripts/publish-release.js changelog/core/0.6.0.md
+ *
+ * Idempotent: skips when a release with the computed tag already
+ * exists. Re-runs (e.g. workflow retries, force-pushes to main)
+ * are safe.
+ *
+ * Tag convention: `<short_pkg>@<version>`, e.g. `core@0.6.0`. Matches
+ * the npm dist-tag flavour. Title: `@webjskit/<short_pkg> <version>`.
+ * Body: the markdown body of the file (frontmatter stripped).
+ *
+ * The script shells out to `gh`. The workflow injects GH_TOKEN via
+ * the auto-provisioned GITHUB_TOKEN; locally, `gh auth login` works
+ * the same way.
+ */
+import { spawnSync } from 'node:child_process';
+import { readFileSync, existsSync } from 'node:fs';
+import { basename, resolve } from 'node:path';
+
+const file = process.argv[2];
+if (!file) {
+  console.error('usage: node scripts/publish-release.js <changelog/<pkg>/<version>.md>');
+  process.exit(2);
+}
+if (!existsSync(file)) {
+  console.error(`[publish-release] file not found: ${file}`);
+  process.exit(2);
+}
+
+// Parse frontmatter + body. The schema is the same one
+// scripts/backfill-changelog.js emits.
+const raw = readFileSync(resolve(file), 'utf8');
+const m = raw.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+if (!m) {
+  console.error(`[publish-release] ${file}: no frontmatter block`);
+  process.exit(2);
+}
+const fm = {};
+for (const line of m[1].split('\n')) {
+  const idx = line.indexOf(':');
+  if (idx < 0) continue;
+  const k = line.slice(0, idx).trim();
+  let v = line.slice(idx + 1).trim();
+  if (v.startsWith('"') && v.endsWith('"')) v = v.slice(1, -1);
+  fm[k] = v;
+}
+const body = m[2].trim();
+
+const pkg = (fm.package || '').replace(/^@webjskit\//, '');
+const version = fm.version;
+if (!pkg || !version) {
+  console.error(`[publish-release] ${file}: missing package or version in frontmatter`);
+  process.exit(2);
+}
+
+const tag = `${pkg}@${version}`;
+const title = `@webjskit/${pkg} ${version}`;
+
+function gh(args, opts = {}) {
+  return spawnSync('gh', args, {
+    encoding: 'utf8',
+    stdio: opts.stdio || ['ignore', 'pipe', 'pipe'],
+    ...opts,
+  });
+}
+
+// Idempotency check: if a release with this tag already exists, skip.
+const exists = gh(['release', 'view', tag, '--json', 'tagName']);
+if (exists.status === 0) {
+  console.log(`[publish-release] skip ${tag}: release already exists`);
+  process.exit(0);
+}
+
+// Create the release. Body is piped via stdin so we don't need a
+// temp file and we don't run into shell-quoting issues with
+// multi-line markdown.
+const create = spawnSync(
+  'gh',
+  ['release', 'create', tag, '--title', title, '--notes-file', '-'],
+  { input: body, encoding: 'utf8', stdio: ['pipe', 'inherit', 'inherit'] },
+);
+if (create.status !== 0) {
+  console.error(`[publish-release] gh release create failed for ${tag}`);
+  process.exit(create.status || 1);
+}
+console.log(`[publish-release] created release ${tag} (${basename(file)})`);

--- a/scripts/publish-release.js
+++ b/scripts/publish-release.js
@@ -47,7 +47,12 @@ for (const line of m[1].split('\n')) {
   if (v.startsWith('"') && v.endsWith('"')) v = v.slice(1, -1);
   fm[k] = v;
 }
-const body = m[2].trim();
+// Strip the leading h1 (e.g. `# @webjskit/core 0.6.0`) if present.
+// The release page already shows the title (from --title), so the h1
+// in the body was a duplicate header on every release page. Older
+// changelog files include this line; the current backfill generator
+// no longer emits it.
+const body = m[2].replace(/^#\s+[^\n]*\n+/, '').trim();
 
 const pkg = (fm.package || '').replace(/^@webjskit\//, '');
 const version = fm.version;
@@ -67,10 +72,28 @@ function gh(args, opts = {}) {
   });
 }
 
-// Idempotency check: if a release with this tag already exists, skip.
+// Idempotency check: if a release with this tag already exists, skip,
+// unless --update is passed (in which case we overwrite its notes via
+// `gh release edit`). --update is for back-out scenarios like the
+// duplicate-header fix; default behaviour stays no-op so workflow
+// retries don't churn.
+const wantUpdate = process.argv.includes('--update');
 const exists = gh(['release', 'view', tag, '--json', 'tagName']);
 if (exists.status === 0) {
-  console.log(`[publish-release] skip ${tag}: release already exists`);
+  if (!wantUpdate) {
+    console.log(`[publish-release] skip ${tag}: release already exists (pass --update to overwrite notes)`);
+    process.exit(0);
+  }
+  const edit = spawnSync(
+    'gh',
+    ['release', 'edit', tag, '--title', title, '--notes-file', '-'],
+    { input: body, encoding: 'utf8', stdio: ['pipe', 'inherit', 'inherit'] },
+  );
+  if (edit.status !== 0) {
+    console.error(`[publish-release] gh release edit failed for ${tag}`);
+    process.exit(edit.status || 1);
+  }
+  console.log(`[publish-release] updated release ${tag} (${basename(file)})`);
   process.exit(0);
 }
 


### PR DESCRIPTION
## Summary

Same pattern as the auto-changelog flow, one layer up. Every push to `main` that lands a new `changelog/<pkg>/<version>.md` file becomes a published GitHub Release for that (package, version) tuple.

### Pieces

1. **`scripts/publish-release.js`**: given one changelog md file, parses the YAML-ish frontmatter (`package`, `version`), composes a tag `<pkg>@<version>` (e.g. `core@0.6.0`), title `@webjskit/<pkg> <version>`, and uses the markdown body (after the frontmatter block) as the release notes. Pipes the body to `gh release create` via stdin so multi-line markdown survives shell quoting. **Idempotent**: skips the publish if a release with that tag already exists.

2. **`.github/workflows/release.yml`**: triggered on push to main with paths filter `changelog/**`. Checks out at depth 2, diffs `HEAD~1..HEAD` to find added changelog files, invokes the script once per file. Uses the auto-provisioned `GITHUB_TOKEN`. Free on public repos (unlimited Actions minutes for `ubuntu-latest`).

3. **`AGENTS.md` + `changelog/README.md`** updated so future agents and humans know the flow.

### The whole pipeline now

```
bump packages/<pkg>/package.json version
  ↓ git commit (pre-commit hook auto-runs scripts/backfill-changelog.js)
new changelog/<pkg>/<version>.md staged + committed
  ↓ git push, PR merge to main
push to main with paths: changelog/**
  ↓ release.yml workflow
scripts/publish-release.js
  ↓ gh release create
🎁 https://github.com/vivek7405/webjs/releases
```

### Tradeoffs

- **Editing a published release**: hand-editing the `changelog/<pkg>/<version>.md` after the release lands on main does NOT update the release on GitHub. Documented in `changelog/README.md`. If amendment is needed, edit the release on the UI or delete the tag and re-run.
- **No npm publish**: this PR only ships GitHub Releases. Adding `npm publish` for the matching package would require an `NPM_TOKEN` secret and a small extra step; I left it out so the change stays narrow. Worth a follow-up if you want one-step releases.

### Test plan

- [x] `scripts/publish-release.js` against an existing release tag, prints `skip ... release already exists` and exits 0 (idempotent path verified with a stubbed `gh`).
- [x] Script against a non-existent changelog file, prints a clear error and exits 2.
- [ ] After merge: any future framework version bump should produce both the changelog file AND a matching release at https://github.com/vivek7405/webjs/releases.