### PR TITLE
feat(release): auto-publish to npm on version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,28 @@
 name: Auto-release
 
 # Every push to main that lands a new `changelog/<pkg>/<version>.md`
-# file becomes a GitHub Release for that (package, version) tuple.
-# The matching workflow:
+# file becomes a published npm package AND a GitHub Release for
+# that (package, version) tuple.
 #
-#   1. Checks out main with two-commit depth so we can diff the new
-#      head against its parent.
-#   2. Finds files added under `changelog/**.md` in that diff.
-#   3. Invokes `scripts/publish-release.js` once per file. The script
-#      is idempotent (skips when the tag already exists), so retries
-#      / force-pushes do not error.
+# Flow per new changelog file:
+#   1. scripts/publish-npm.js     → npm publish @webjskit/<pkg>@<version>
+#   2. scripts/publish-release.js → gh release create <pkg>@<version>
 #
-# Triggered only on changelog changes so unrelated pushes do not run
-# the job. Cost on public repos: $0 (GitHub Actions has unlimited
+# Both scripts are idempotent: they skip when the version is
+# already on the registry / a release with the tag already exists.
+# So workflow retries and force-pushes never duplicate or error on
+# previously-published versions.
+#
+# Order matters: npm runs first. If npm publish fails (auth,
+# network, transient registry error), the GH release step is
+# skipped and the workflow fails. After fixing, re-running picks
+# up where it left off; the npm-side idempotency check makes the
+# completed package a no-op.
+#
+# Triggered only on changelog/** changes so unrelated pushes do
+# not run the job. Cost on public repos: $0 (Actions has unlimited
 # free minutes for public repos on ubuntu-latest).
+
 on:
   push:
     branches: [main]
@@ -31,11 +40,22 @@ jobs:
         with:
           fetch-depth: 2
 
+      # setup-node writes an .npmrc with the standard
+      # //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN} line, so
+      # subsequent `npm publish` invocations pick up the token from
+      # the env var.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
       - name: Find new changelog files
         id: diff
         run: |
           set -euo pipefail
-          # All changelog md files added in this push.
           mapfile -t NEW < <(git diff --name-only --diff-filter=A HEAD~1 HEAD -- 'changelog/**.md')
           if [ ${#NEW[@]} -eq 0 ]; then
             echo "No new changelog files in this push; skipping."
@@ -43,12 +63,21 @@ jobs:
             exit 0
           fi
           printf '  + %s\n' "${NEW[@]}"
-          # Persist the list across steps via a workspace file. GITHUB_OUTPUT
-          # has a per-line size cap that we'd hit on big bulk-backfill PRs.
           printf '%s\n' "${NEW[@]}" > .new-changelog-files.txt
           echo "count=${#NEW[@]}" >> "$GITHUB_OUTPUT"
 
-      - name: Publish releases
+      - name: Publish to npm
+        if: steps.diff.outputs.count != '0'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            node scripts/publish-npm.js "$f"
+          done < .new-changelog-files.txt
+
+      - name: Create GitHub Releases
         if: steps.diff.outputs.count != '0'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,14 @@ If the package has zero `feat:` / `fix:` / `breaking:` / `perf:` commits in the 
 
 The whole flow is tool-agnostic: the universal pre-commit hook fires for every `git commit`, regardless of who or what is running it. AI agents using Claude Code, Cursor, Copilot, Aider, etc. all get the same behavior, as do human contributors.
 
-**GitHub Releases are auto-created from the same files.** The `.github/workflows/release.yml` workflow watches for new `changelog/**.md` files added in a push to `main`. For each new file, it runs `scripts/publish-release.js`, which parses the frontmatter (`package`, `version`, `date`), composes a tag `<pkg>@<version>` (e.g. `core@0.6.0`), title `@webjskit/<pkg> <version>`, and body (the markdown after frontmatter), then runs `gh release create`. Idempotent: existing release tags are skipped, so retries and force-pushes are safe. Free for public repos.
+**npm publishes AND GitHub Releases are auto-created from the same files.** The `.github/workflows/release.yml` workflow watches for new `changelog/**.md` files added in a push to `main`. For each new file:
+
+1. `scripts/publish-npm.js` parses the frontmatter, checks `npm view @webjskit/<pkg>@<version>`; if the version is not yet on the registry, it runs `npm publish --workspace=@webjskit/<pkg> --access=public`. Idempotent: already-published versions are skipped.
+2. `scripts/publish-release.js` composes a tag `<pkg>@<version>` (e.g. `core@0.6.0`), title `@webjskit/<pkg> <version>`, body (the markdown after frontmatter), then runs `gh release create`. Idempotent: existing release tags are skipped.
+
+npm runs first; if it fails (auth, network, transient registry error), the GitHub Release step is skipped and the workflow fails. After fixing, a re-run picks up where it left off: the npm-side check makes the completed package a no-op and only the missing release lands.
+
+The workflow uses `NPM_TOKEN` (repo secret) and the auto-provisioned `GITHUB_TOKEN`. Free for public repos.
 
 ---
 

--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * Publish ONE package version to npm, driven by a changelog file.
+ *
+ *   node scripts/publish-npm.js changelog/core/0.6.0.md
+ *
+ * The companion to scripts/publish-release.js. Same idempotency
+ * shape: parse the file's frontmatter, derive package + version,
+ * check whether that version is already on the npm registry, skip
+ * if yes, publish if no.
+ *
+ * Auth: relies on the standard `npm publish` token resolution
+ * (NODE_AUTH_TOKEN env var via setup-node's .npmrc on CI, or
+ * `npm login` locally). The script does not write any .npmrc.
+ *
+ * The workspace flag (`--workspace=@webjskit/<pkg>`) tells npm to
+ * publish that specific package out of the monorepo. `--access public`
+ * is a belt-and-braces alongside the per-package
+ * `publishConfig: { access: "public" }`, in case a package forgot
+ * to set it.
+ */
+import { spawnSync } from 'node:child_process';
+import { readFileSync, existsSync } from 'node:fs';
+import { basename, resolve } from 'node:path';
+
+const file = process.argv[2];
+if (!file) {
+  console.error('usage: node scripts/publish-npm.js <changelog/<pkg>/<version>.md>');
+  process.exit(2);
+}
+if (!existsSync(file)) {
+  console.error(`[publish-npm] file not found: ${file}`);
+  process.exit(2);
+}
+
+const raw = readFileSync(resolve(file), 'utf8');
+const m = raw.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+if (!m) {
+  console.error(`[publish-npm] ${file}: no frontmatter block`);
+  process.exit(2);
+}
+const fm = {};
+for (const line of m[1].split('\n')) {
+  const idx = line.indexOf(':');
+  if (idx < 0) continue;
+  const k = line.slice(0, idx).trim();
+  let v = line.slice(idx + 1).trim();
+  if (v.startsWith('"') && v.endsWith('"')) v = v.slice(1, -1);
+  fm[k] = v;
+}
+
+const pkgName = fm.package; // "@webjskit/core"
+const version = fm.version;
+if (!pkgName || !version) {
+  console.error(`[publish-npm] ${file}: missing package or version in frontmatter`);
+  process.exit(2);
+}
+
+// Idempotency: is this version already on the registry?
+// `npm view <pkg>@<version> version` prints the version on success,
+// non-zero exit on 404. We swallow stderr to avoid noisy "E404" log.
+const view = spawnSync(
+  'npm', ['view', `${pkgName}@${version}`, 'version'],
+  { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+);
+if (view.status === 0 && view.stdout.trim() === version) {
+  console.log(`[publish-npm] skip ${pkgName}@${version}: already on registry`);
+  process.exit(0);
+}
+
+// Publish. --workspace targets the package within the monorepo, so we
+// can run this from the repo root without cd'ing into packages/<pkg>/.
+const pub = spawnSync(
+  'npm',
+  ['publish', `--workspace=${pkgName}`, '--access=public', '--ignore-scripts=false'],
+  { stdio: 'inherit' },
+);
+if (pub.status !== 0) {
+  console.error(`[publish-npm] npm publish failed for ${pkgName}@${version}`);
+  process.exit(pub.status || 1);
+}
+console.log(`[publish-npm] published ${pkgName}@${version} (${basename(file)})`);


### PR DESCRIPTION
## Summary

Extends the existing release workflow so that each new `changelog/<pkg>/<version>.md` triggers BOTH:

1. `npm publish --workspace=@webjskit/<pkg> --access=public`, AND
2. `gh release create <pkg>@<version>` (already shipped in PR #55).

End-to-end pipeline after this lands:

```
bump packages/<pkg>/package.json version
  ↓ git commit  (pre-commit hook auto-runs scripts/backfill-changelog.js)
new changelog/<pkg>/<version>.md staged + committed
  ↓ git push, PR merge to main
push to main with paths: changelog/**
  ↓ .github/workflows/release.yml
  ├─ scripts/publish-npm.js     →  npm publish @webjskit/<pkg>@<version>
  └─ scripts/publish-release.js →  gh release create <pkg>@<version>
🎁 package on npmjs.com + entry on GitHub Releases
```

Both scripts are idempotent (skip if already published / release already exists), so workflow retries and force-pushes do not duplicate.

Order: npm first, GH release second. If npm publish fails (auth, network, transient registry error), the GH release step is skipped and the workflow fails loud. Re-running picks up where it left off because each step's idempotency check turns the completed package into a no-op.

## Setup required (one-time)

This needs an `NPM_TOKEN` repo secret. Steps:

1. Go to https://www.npmjs.com/settings/<your-username>/tokens, create a **Granular Access Token** scoped to `@webjskit/*` with **Read and write** permissions.
2. Add it as a repo secret:
   ```bash
   gh secret set NPM_TOKEN --repo vivek7405/webjs
   ```
   Or via dashboard: https://github.com/vivek7405/webjs/settings/secrets/actions, **New repository secret**, name `NPM_TOKEN`.

After that, future framework version bumps publish automatically.

## Test plan

- [ ] After this PR merges and `NPM_TOKEN` is set, the next framework version bump should trigger:
  - `npm view @webjskit/<pkg>@<new-version>` returns the new version, AND
  - https://github.com/vivek7405/webjs/releases gets the matching entry.
- [ ] Idempotency: re-run the workflow on the same commit (e.g. manual workflow_dispatch); both steps skip cleanly.