### PR TITLE
chore(release): bump core 0.7.0, cli 0.8.0, ui 0.3.0

### DIFF
--- a/changelog/cli/0.8.0.md
+++ b/changelog/cli/0.8.0.md
@@ -1,0 +1,13 @@
+---
+package: "@webjskit/cli"
+version: 0.8.0
+date: 2026-05-21
+commit_count: 1
+---
+## Breaking
+
+- **signals replace this.state / setState across the stack** ([#43](https://github.com/vivek7405/webjs/pull/43)) [`09436ee`](https://github.com/vivek7405/webjs/commit/09436ee)
+  * feat(core): signal primitive (TC39 Stage-1 shape, no runtime deps)
+  
+  Hand-rolled signal/computed/effect/batch in plain JS with JSDoc.
+  Surface mirrors the TC39 Signals proposal so when it lands in

--- a/changelog/core/0.7.0.md
+++ b/changelog/core/0.7.0.md
@@ -1,0 +1,21 @@
+---
+package: "@webjskit/core"
+version: 0.7.0
+date: 2026-05-21
+commit_count: 2
+---
+## Breaking
+
+- **signals replace this.state / setState across the stack** ([#43](https://github.com/vivek7405/webjs/pull/43)) [`09436ee`](https://github.com/vivek7405/webjs/commit/09436ee)
+  * feat(core): signal primitive (TC39 Stage-1 shape, no runtime deps)
+  
+  Hand-rolled signal/computed/effect/batch in plain JS with JSDoc.
+  Surface mirrors the TC39 Signals proposal so when it lands in
+
+## Fixes
+
+- **filter framework records in light-DOM slot observer** ([#44](https://github.com/vivek7405/webjs/pull/44)) [`9b28427`](https://github.com/vivek7405/webjs/commit/9b28427)
+  * fix(core): filter framework records in light-DOM slot observer
+  
+  The slot host's MutationObserver could not distinguish renderer-driven
+  childList mutations (createInstance / child-part template swaps) from

--- a/changelog/ui/0.3.0.md
+++ b/changelog/ui/0.3.0.md
@@ -1,0 +1,34 @@
+---
+package: "@webjskit/ui"
+version: 0.3.0
+date: 2026-05-21
+commit_count: 4
+---
+## Breaking
+
+- **signals replace this.state / setState across the stack** ([#43](https://github.com/vivek7405/webjs/pull/43)) [`09436ee`](https://github.com/vivek7405/webjs/commit/09436ee)
+  * feat(core): signal primitive (TC39 Stage-1 shape, no runtime deps)
+  
+  Hand-rolled signal/computed/effect/batch in plain JS with JSDoc.
+  Surface mirrors the TC39 Signals proposal so when it lands in
+
+## Features
+
+- **env-driven sibling URLs with localhost dev fallbacks** ([#42](https://github.com/vivek7405/webjs/pull/42)) [`b74151d`](https://github.com/vivek7405/webjs/commit/b74151d)
+  The UI website hardcoded `https://webjs.dev` and `https://docs.webjs.dev`
+  as the defaults for its header + footer links. Local dev navigated off
+  the localhost dev cluster as soon as you clicked the Webjs / Docs links,
+  which broke the flow when working across all three apps simultaneously.
+- **per-package per-version changelog + /changelog page + auto-enforce on version bumps** ([#49](https://github.com/vivek7405/webjs/pull/49)) [`1ac9e1c`](https://github.com/vivek7405/webjs/commit/1ac9e1c)
+  * feat(changelog): per-package per-version changelog + backfill from git
+  
+  Introduce a changelog/ directory at the repo root with one md file
+  per (package, version) tuple:
+
+## Fixes
+
+- **align @webjskit/* deps to workspace versions** ([#35](https://github.com/vivek7405/webjs/pull/35)) [`61a25fa`](https://github.com/vivek7405/webjs/commit/61a25fa)
+  ui-website pinned `@webjskit/server: ^0.5.2`, `@webjskit/core: ^0.4.1`,
+  `@webjskit/cli: ^0.5.2` while the monorepo workspaces are at 0.6.0,
+  0.5.0, 0.6.0. npm therefore installed published 0.5.x tarballs into
+  packages/ui/node_modules/@webjskit/* and skipped the workspace

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,8 +12,8 @@
     "css:build": "tailwindcss -i ./public/input.css -o ./public/tailwind.css --minify"
   },
   "dependencies": {
-    "@webjskit/cli": "^0.7.0",
-    "@webjskit/core": "^0.6.0",
+    "@webjskit/cli": "^0.8.0",
+    "@webjskit/core": "^0.7.0",
     "@webjskit/server": "^0.7.0"
   },
   "engines": {

--- a/examples/blog/package.json
+++ b/examples/blog/package.json
@@ -16,15 +16,15 @@
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",
-    "@webjskit/cli": "^0.7.0",
-    "@webjskit/core": "^0.6.0",
+    "@webjskit/cli": "^0.8.0",
+    "@webjskit/core": "^0.7.0",
     "@webjskit/server": "^0.7.0"
   },
   "devDependencies": {
     "prisma": "^5.22.0",
     "typescript": "^6.0.3",
     "@webjskit/ts-plugin": "^0.4.0",
-    "@webjskit/ui": "^0.2.0"
+    "@webjskit/ui": "^0.3.0"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,8 +34,8 @@
       "name": "@webjskit/docs",
       "version": "0.1.0",
       "dependencies": {
-        "@webjskit/cli": "^0.7.0",
-        "@webjskit/core": "^0.6.0",
+        "@webjskit/cli": "^0.8.0",
+        "@webjskit/core": "^0.7.0",
         "@webjskit/server": "^0.7.0"
       },
       "engines": {
@@ -47,13 +47,13 @@
       "version": "0.1.0",
       "dependencies": {
         "@prisma/client": "^5.22.0",
-        "@webjskit/cli": "^0.7.0",
-        "@webjskit/core": "^0.6.0",
+        "@webjskit/cli": "^0.8.0",
+        "@webjskit/core": "^0.7.0",
         "@webjskit/server": "^0.7.0"
       },
       "devDependencies": {
         "@webjskit/ts-plugin": "^0.4.0",
-        "@webjskit/ui": "^0.2.0",
+        "@webjskit/ui": "^0.3.0",
         "prisma": "^5.22.0",
         "typescript": "^6.0.3"
       },
@@ -6674,11 +6674,11 @@
     },
     "packages/cli": {
       "name": "@webjskit/cli",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@webjskit/server": "^0.7.0",
-        "@webjskit/ui": "^0.2.0"
+        "@webjskit/ui": "^0.3.0"
       },
       "bin": {
         "webjs": "bin/webjs.js"
@@ -6689,7 +6689,7 @@
     },
     "packages/core": {
       "name": "@webjskit/core",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT"
     },
     "packages/server": {
@@ -6697,7 +6697,7 @@
       "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
-        "@webjskit/core": "^0.6.0",
+        "@webjskit/core": "^0.7.0",
         "chokidar": "^3.6.0",
         "esbuild": "^0.28.0",
         "ws": "^8.20.0"
@@ -6719,7 +6719,7 @@
     },
     "packages/ui": {
       "name": "@webjskit/ui",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.0",
@@ -6739,8 +6739,8 @@
       "name": "@webjskit/ui-website",
       "version": "0.1.0",
       "dependencies": {
-        "@webjskit/cli": "^0.7.0",
-        "@webjskit/core": "^0.6.0",
+        "@webjskit/cli": "^0.8.0",
+        "@webjskit/core": "^0.7.0",
         "@webjskit/server": "^0.7.0",
         "@webjskit/ui-registry": "*"
       },
@@ -6753,8 +6753,8 @@
       "name": "@webjskit/website",
       "version": "0.1.0",
       "dependencies": {
-        "@webjskit/cli": "^0.7.0",
-        "@webjskit/core": "^0.6.0",
+        "@webjskit/cli": "^0.8.0",
+        "@webjskit/core": "^0.7.0",
         "@webjskit/server": "^0.7.0"
       },
       "engines": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjskit/cli",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "@webjskit/server": "^0.7.0",
-    "@webjskit/ui": "^0.2.0"
+    "@webjskit/ui": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjskit/core",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,7 +14,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@webjskit/core": "^0.6.0",
+    "@webjskit/core": "^0.7.0",
     "chokidar": "^3.6.0",
     "esbuild": "^0.28.0",
     "ws": "^8.20.0"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjskit/ui",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "description": "An AI-first component library - class-helper functions for visuals, custom elements only where state matters. Source-copied into your repo, you own it. Works with any Tailwind v4 project.",
   "bin": {

--- a/packages/ui/packages/website/package.json
+++ b/packages/ui/packages/website/package.json
@@ -15,8 +15,8 @@
     "preview:build": "node scripts/copy-registry.js"
   },
   "dependencies": {
-    "@webjskit/cli": "^0.7.0",
-    "@webjskit/core": "^0.6.0",
+    "@webjskit/cli": "^0.8.0",
+    "@webjskit/core": "^0.7.0",
     "@webjskit/server": "^0.7.0",
     "@webjskit/ui-registry": "*"
   },

--- a/website/package.json
+++ b/website/package.json
@@ -12,8 +12,8 @@
     "css:build": "tailwindcss -i ./public/input.css -o ./public/tailwind.css --minify"
   },
   "dependencies": {
-    "@webjskit/cli": "^0.7.0",
-    "@webjskit/core": "^0.6.0",
+    "@webjskit/cli": "^0.8.0",
+    "@webjskit/core": "^0.7.0",
     "@webjskit/server": "^0.7.0"
   },
   "engines": {


### PR DESCRIPTION
## Summary

Three packages have accumulated user-facing changes since their last published version. Bumping to release them through the auto-publish pipeline.

| Package | From | To | Drivers |
|---|---|---|---|
| `@webjskit/core` | 0.6.0 | **0.7.0** | Breaking: signals replace `this.state` / `setState` (#43). Fix: light-DOM slot projection cycle (#44). |
| `@webjskit/cli` | 0.7.0 | **0.8.0** | Scaffold templates updated for the signals migration (#43); a newly-scaffolded app now ships signal-based state out of the box. |
| `@webjskit/ui` | 0.2.0 | **0.3.0** | Env-driven sibling URLs (#42), workspace dep alignment (#35), signals migration in registry components + ui-website (#43), changelog system + mobile menu (#49). |

`@webjskit/server` and `@webjskit/ts-plugin` had no qualifying commits since their last bump; not touched.

## What changed in this PR

- `packages/{core,cli,ui}/package.json` version field bumped.
- Cross-package dep ranges updated to track:
  - `^0.6.0` → `^0.7.0` for `@webjskit/core` in website, docs, blog, ui-website, server.
  - `^0.7.0` → `^0.8.0` for `@webjskit/cli` in website, docs, blog, ui-website.
  - `^0.2.0` → `^0.3.0` for `@webjskit/ui` in blog and the cli package itself.
- `package-lock.json` regenerated to match (workspace symlinks unchanged; only the resolved-version metadata refreshed).
- `changelog/core/0.7.0.md`, `changelog/cli/0.8.0.md`, `changelog/ui/0.3.0.md` auto-generated by the pre-commit hook from the conventional-commit history.

## What happens on merge

`.github/workflows/release.yml` will trigger because three new files landed under `changelog/**`. For each:

1. `scripts/publish-npm.js` → `npm publish --workspace=@webjskit/<pkg>` (uses `NPM_TOKEN`).
2. `scripts/publish-release.js` → `gh release create <pkg>@<version>` (uses `GITHUB_TOKEN`).

Result: `@webjskit/core@0.7.0`, `@webjskit/cli@0.8.0`, `@webjskit/ui@0.3.0` on npmjs.com, plus 3 matching entries on https://github.com/vivek7405/webjs/releases.

Both scripts are idempotent (skip if already published / release tag already exists), so transient retries / force-pushes don't error.

## Test plan

- [x] `npm test` passes locally after the bump.
- [x] Pre-commit hook auto-generated the 3 changelog files; content reviewed.
- [ ] After merge: confirm npm registry shows the 3 new versions and GitHub Releases has the 3 new entries.