### PR TITLE
chore(ci): bump checkout + setup-node to v6 (Node 24 runtime)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,10 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # Pinned to v6: both actions ship a Node 24 runtime, which is
+      # what GitHub Actions will default to from June 2nd, 2026. v4
+      # / v5 ran on Node 20 and triggered the deprecation banner.
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 2
 
@@ -44,7 +47,7 @@ jobs:
       # //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN} line, so
       # subsequent `npm publish` invocations pick up the token from
       # the env var.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Why

GitHub flagged the Auto-release workflow with a deprecation banner:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/checkout@v4`, `actions/setup-node@v4`. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

## Fix

Bump both actions to `@v6`, which is the latest stable major that ships the Node 24 runtime:

- `actions/checkout@v4` → `@v6`
- `actions/setup-node@v4` → `@v6`

(Verified via `gh release list --repo actions/checkout --limit 1` and the same for `actions/setup-node`: latest tags are `v6.0.2` and `v6.4.0` respectively.)

No other workflow changes. The behavior of both actions is unchanged between v4 and v6 for the flags we use (`fetch-depth: 2`, `node-version`, `registry-url`).

## Test plan

- [ ] After merge, the next Auto-release run uses Node 24 underneath and the deprecation banner is gone.