### PR TITLE
fix(website): sort same-day changelog entries by version desc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,21 @@ jobs:
         id: diff
         run: |
           set -euo pipefail
-          mapfile -t NEW < <(git diff --name-only --diff-filter=A HEAD~1 HEAD -- 'changelog/**.md')
+          # Sort by the `date:` timestamp inside each file's
+          # frontmatter, ASCending. GitHub Releases lists releases by
+          # created_at DESC, so publishing oldest-first means newest
+          # entries end up at the top of the Releases page. Files
+          # with the same timestamp (e.g. multiple packages bumped in
+          # one PR) keep their stable input order.
+          mapfile -t NEW < <(
+            git diff --name-only --diff-filter=A HEAD~1 HEAD -- 'changelog/**.md' \
+              | while read -r f; do
+                  ts=$(awk '/^date:/ { print $2; exit }' "$f")
+                  printf '%s\t%s\n' "$ts" "$f"
+                done \
+              | sort \
+              | cut -f2-
+          )
           if [ ${#NEW[@]} -eq 0 ]; then
             echo "No new changelog files in this push; skipping."
             echo "count=0" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,16 +62,21 @@ jobs:
           # Sort by the `date:` timestamp inside each file's
           # frontmatter, ASCending. GitHub Releases lists releases by
           # created_at DESC, so publishing oldest-first means newest
-          # entries end up at the top of the Releases page. Files
-          # with the same timestamp (e.g. multiple packages bumped in
-          # one PR) keep their stable input order.
+          # entries end up at the top of the Releases page.
+          #
+          # Within tied timestamps (multiple packages bumped in one
+          # PR), sort the filename DESC so the alphabetically-first
+          # package publishes LAST, gets the latest created_at, and
+          # ends up at the top of the GH list. The website's
+          # /changelog page iterates package dirs alphabetically
+          # too, so this produces matching order on both surfaces.
           mapfile -t NEW < <(
             git diff --name-only --diff-filter=A HEAD~1 HEAD -- 'changelog/**.md' \
               | while read -r f; do
                   ts=$(awk '/^date:/ { print $2; exit }' "$f")
                   printf '%s\t%s\n' "$ts" "$f"
                 done \
-              | sort \
+              | sort -k1,1 -k2,2r \
               | cut -f2-
           )
           if [ ${#NEW[@]} -eq 0 ]; then

--- a/changelog/cli/0.1.1.md
+++ b/changelog/cli/0.1.1.md
@@ -1,7 +1,7 @@
 ---
 package: "@webjskit/cli"
 version: 0.1.1
-date: 2026-04-22
+date: 2026-04-22T01:07:47+05:30
 commit_count: 27
 ---
 

--- a/changelog/cli/0.1.2.md
+++ b/changelog/cli/0.1.2.md
@@ -1,7 +1,7 @@
 ---
 package: "@webjskit/cli"
 version: 0.1.2
-date: 2026-04-27
+date: 2026-04-27T13:25:46+05:30
 commit_count: 1
 ---
 

--- a/changelog/cli/0.1.4.md
+++ b/changelog/cli/0.1.4.md
@@ -1,7 +1,7 @@
 ---
 package: "@webjskit/cli"
 version: 0.1.4
-date: 2026-04-27
+date: 2026-04-27T19:54:29+05:30
 commit_count: 1
 ---
 

--- a/changelog/cli/0.2.0.md
+++ b/changelog/cli/0.2.0.md
@@ -1,7 +1,7 @@
 ---
 package: "@webjskit/cli"
 version: 0.2.0
-date: 2026-04-28
+date: 2026-04-28T12:15:37+05:30
 commit_count: 1
 ---
 

--- a/changelog/cli/0.2.1.md
+++ b/changelog/cli/0.2.1.md
@@ -1,7 +1,7 @@
 ---
 package: "@webjskit/cli"
 version: 0.2.1
-date: 2026-04-28
+date: 2026-04-28T12:20:33+05:30
 commit_count: 1
 ---
 

--- a/changelog/cli/0.3.0.md
+++ b/changelog/cli/0.3.0.md
@@ -1,7 +1,7 @@
 ---
 package: "@webjskit/cli"
 version: 0.3.0
-date: 2026-04-28
+date: 2026-04-28T13:09:00+05:30
 commit_count: 1
 ---
 

--- a/changelog/cli/0.6.0.md
+++ b/changelog/cli/0.6.0.md
@@ -1,7 +1,7 @@
 ---
 package: "@webjskit/cli"
 version: 0.6.0
-date: 2026-05-19
+date: 2026-05-19T02:28:39+05:30
 commit_count: 1
 ---
 

--- a/changelog/cli/0.7.0.md
+++ b/changelog/cli/0.7.0.md
@@ -1,7 +1,7 @@
 ---
 package: "@webjskit/cli"
 version: 0.7.0
-date: 2026-05-21
+date: 2026-05-21T04:25:09+05:30
 commit_count: 9
 ---
 

--- a/changelog/cli/0.8.0.md
+++ b/changelog/cli/0.8.0.md
@@ -1,7 +1,7 @@
 ---
 package: "@webjskit/cli"
 version: 0.8.0
-date: 2026-05-21
+date: 2026-05-21T22:21:06+05:30
 commit_count: 1
 ---
 ## Breaking

--- a/changelog/core/0.2.0.md
+++ b/changelog/core/0.2.0.md
@@ -1,7 +1,7 @@
 ---
 package: "@webjskit/core"
 version: 0.2.0
-date: 2026-04-28
+date: 2026-04-28T12:20:33+05:30
 commit_count: 43
 ---
 

--- a/changelog/core/0.3.0.md
+++ b/changelog/core/0.3.0.md
@@ -1,7 +1,7 @@
 ---
 package: "@webjskit/core"
 version: 0.3.0
-date: 2026-04-28
+date: 2026-04-28T13:09:00+05:30
 commit_count: 1
 ---
 

--- a/changelog/core/0.4.1.md
+++ b/changelog/core/0.4.1.md
@@ -1,7 +1,7 @@
 ---
 package: "@webjskit/core"
 version: 0.4.1
-date: 2026-05-17
+date: 2026-05-17T12:55:47+05:30
 commit_count: 2
 ---
 

--- a/changelog/core/0.5.0.md
+++ b/changelog/core/0.5.0.md
@@ -1,7 +1,7 @@
 ---
 package: "@webjskit/core"
 version: 0.5.0
-date: 2026-05-19
+date: 2026-05-19T02:28:39+05:30
 commit_count: 5
 ---
 

--- a/changelog/core/0.6.0.md
+++ b/changelog/core/0.6.0.md
@@ -1,7 +1,7 @@
 ---
 package: "@webjskit/core"
 version: 0.6.0
-date: 2026-05-21
+date: 2026-05-21T04:25:09+05:30
 commit_count: 4
 ---
 

--- a/changelog/core/0.7.0.md
+++ b/changelog/core/0.7.0.md
@@ -1,7 +1,7 @@
 ---
 package: "@webjskit/core"
 version: 0.7.0
-date: 2026-05-21
+date: 2026-05-21T22:21:06+05:30
 commit_count: 2
 ---
 ## Breaking

--- a/changelog/server/0.1.1.md
+++ b/changelog/server/0.1.1.md
@@ -1,7 +1,7 @@
 ---
 package: "@webjskit/server"
 version: 0.1.1
-date: 2026-04-27
+date: 2026-04-27T19:54:29+05:30
 commit_count: 25
 ---
 

--- a/changelog/server/0.2.0.md
+++ b/changelog/server/0.2.0.md
@@ -1,7 +1,7 @@
 ---
 package: "@webjskit/server"
 version: 0.2.0
-date: 2026-04-28
+date: 2026-04-28T12:15:37+05:30
 commit_count: 1
 ---
 

--- a/changelog/server/0.2.1.md
+++ b/changelog/server/0.2.1.md
@@ -1,7 +1,7 @@
 ---
 package: "@webjskit/server"
 version: 0.2.1
-date: 2026-04-28
+date: 2026-04-28T12:20:33+05:30
 commit_count: 1
 ---
 

--- a/changelog/server/0.3.0.md
+++ b/changelog/server/0.3.0.md
@@ -1,7 +1,7 @@
 ---
 package: "@webjskit/server"
 version: 0.3.0
-date: 2026-04-28
+date: 2026-04-28T13:09:00+05:30
 commit_count: 1
 ---
 

--- a/changelog/server/0.3.1.md
+++ b/changelog/server/0.3.1.md
@@ -1,7 +1,7 @@
 ---
 package: "@webjskit/server"
 version: 0.3.1
-date: 2026-05-04
+date: 2026-05-04T11:57:37+05:30
 commit_count: 1
 ---
 

--- a/changelog/server/0.4.0.md
+++ b/changelog/server/0.4.0.md
@@ -1,7 +1,7 @@
 ---
 package: "@webjskit/server"
 version: 0.4.0
-date: 2026-05-11
+date: 2026-05-11T20:05:47+05:30
 commit_count: 1
 ---
 

--- a/changelog/server/0.5.1.md
+++ b/changelog/server/0.5.1.md
@@ -1,7 +1,7 @@
 ---
 package: "@webjskit/server"
 version: 0.5.1
-date: 2026-05-17
+date: 2026-05-17T12:23:39+05:30
 commit_count: 1
 ---
 

--- a/changelog/server/0.6.0.md
+++ b/changelog/server/0.6.0.md
@@ -1,7 +1,7 @@
 ---
 package: "@webjskit/server"
 version: 0.6.0
-date: 2026-05-19
+date: 2026-05-19T02:28:39+05:30
 commit_count: 2
 ---
 

--- a/changelog/server/0.7.0.md
+++ b/changelog/server/0.7.0.md
@@ -1,7 +1,7 @@
 ---
 package: "@webjskit/server"
 version: 0.7.0
-date: 2026-05-21
+date: 2026-05-21T04:25:09+05:30
 commit_count: 6
 ---
 

--- a/changelog/server/0.7.1.md
+++ b/changelog/server/0.7.1.md
@@ -1,7 +1,7 @@
 ---
 package: "@webjskit/server"
 version: 0.7.1
-date: 2026-05-21
+date: 2026-05-21T12:20:21+05:30
 commit_count: 1
 ---
 

--- a/changelog/ts-plugin/0.2.0.md
+++ b/changelog/ts-plugin/0.2.0.md
@@ -1,7 +1,7 @@
 ---
 package: "@webjskit/ts-plugin"
 version: 0.2.0
-date: 2026-05-04
+date: 2026-05-04T14:39:59+05:30
 commit_count: 2
 ---
 

--- a/changelog/ts-plugin/0.3.0.md
+++ b/changelog/ts-plugin/0.3.0.md
@@ -1,7 +1,7 @@
 ---
 package: "@webjskit/ts-plugin"
 version: 0.3.0
-date: 2026-05-04
+date: 2026-05-04T15:22:29+05:30
 commit_count: 1
 ---
 

--- a/changelog/ui/0.2.0.md
+++ b/changelog/ui/0.2.0.md
@@ -1,7 +1,7 @@
 ---
 package: "@webjskit/ui"
 version: 0.2.0
-date: 2026-05-20
+date: 2026-05-20T20:56:37+05:30
 commit_count: 6
 ---
 

--- a/changelog/ui/0.3.0.md
+++ b/changelog/ui/0.3.0.md
@@ -1,7 +1,7 @@
 ---
 package: "@webjskit/ui"
 version: 0.3.0
-date: 2026-05-21
+date: 2026-05-21T22:21:06+05:30
 commit_count: 4
 ---
 ## Breaking

--- a/scripts/backfill-changelog.js
+++ b/scripts/backfill-changelog.js
@@ -63,7 +63,11 @@ function versionTimeline(pkg) {
       cur = { sha: '', date: '' };
       const [sha, date] = line.slice(3).split('\t');
       cur.sha = sha;
-      cur.date = date.slice(0, 10);
+      // Store the FULL ISO timestamp (not just YYYY-MM-DD) so the
+      // renderer can sort by commit time, not just calendar day.
+      // This is the difference between "the order they shipped" and
+      // "the day they shipped, then arbitrary tiebreak".
+      cur.date = date;
       continue;
     }
     if (!cur) continue;
@@ -91,7 +95,10 @@ function versionTimeline(pkg) {
     if (stagedVersion !== lastCommittedVersion) {
       out.push({
         sha: 'HEAD',
-        date: new Date().toISOString().slice(0, 10),
+        // Full ISO timestamp (not just YYYY-MM-DD) so the renderer
+        // can sort by commit time, matching how committed entries
+        // are recorded above.
+        date: new Date().toISOString(),
         version: stagedVersion,
         staged: true,
       });

--- a/scripts/publish-release.js
+++ b/scripts/publish-release.js
@@ -100,9 +100,19 @@ if (exists.status === 0) {
 // Create the release. Body is piped via stdin so we don't need a
 // temp file and we don't run into shell-quoting issues with
 // multi-line markdown.
+//
+// Optional --target <sha>: anchors the release tag to a specific
+// commit (e.g. the version-bump commit recovered from git history).
+// Without it, gh tags HEAD-of-default-branch, which puts every tag
+// at the same commit and makes GitHub's web UI fall back to
+// alphabetical sort when releases are otherwise indistinguishable.
+const targetIdx = process.argv.indexOf('--target');
+const target = targetIdx > 0 ? process.argv[targetIdx + 1] : null;
+const args = ['release', 'create', tag, '--title', title, '--notes-file', '-'];
+if (target) args.push('--target', target);
 const create = spawnSync(
   'gh',
-  ['release', 'create', tag, '--title', title, '--notes-file', '-'],
+  args,
   { input: body, encoding: 'utf8', stdio: ['pipe', 'inherit', 'inherit'] },
 );
 if (create.status !== 0) {

--- a/website/app/changelog/page.ts
+++ b/website/app/changelog/page.ts
@@ -72,29 +72,15 @@ async function loadEntries(): Promise<Entry[]> {
       });
     }
   }
-  // Sort by full commit timestamp DESC. The `date` field in
-  // frontmatter is now an ISO 8601 string (e.g.
-  // 2026-05-21T22:21:06+05:30), so packages bumped together in one
-  // commit naturally cluster, with alphabetical package name as the
-  // tiebreak inside a cluster. Within same timestamp + same package
-  // (extremely rare), prefer the higher version.
-  entries.sort((a, b) =>
-    Date.parse(b.date) - Date.parse(a.date)
-    || a.shortPkg.localeCompare(b.shortPkg)
-    || compareVersionsDesc(a.version, b.version)
-  );
+  // Sort by full commit timestamp DESC. No alphabetical or version
+  // tiebreaker: entries that share an exact timestamp (e.g. multiple
+  // packages bumped in the same commit) keep their stable readdir
+  // order, which is typically alphabetical on every common
+  // filesystem. Matching policy on the GitHub Releases page (the
+  // workflow publishes oldest-first so GH's created_at DESC sort
+  // ends up with the same order).
+  entries.sort((a, b) => Date.parse(b.date) - Date.parse(a.date));
   return entries;
-}
-
-/** Compare two semver-shaped strings ("0.7.0", "0.8.0") with newer first. */
-function compareVersionsDesc(a: string, b: string): number {
-  const pa = a.split('.').map((n) => Number.parseInt(n, 10) || 0);
-  const pb = b.split('.').map((n) => Number.parseInt(n, 10) || 0);
-  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
-    const d = (pb[i] ?? 0) - (pa[i] ?? 0);
-    if (d !== 0) return d;
-  }
-  return 0;
 }
 
 /** Tiny inline-markdown renderer: links, bold, italic, inline code. */

--- a/website/app/changelog/page.ts
+++ b/website/app/changelog/page.ts
@@ -72,12 +72,14 @@ async function loadEntries(): Promise<Entry[]> {
       });
     }
   }
-  // Sort: most recent first; tie-break by package name, then by
-  // version DESC so two same-day entries of the same package (e.g.
-  // cli 0.8.0 and cli 0.7.0 both bumped on the same day) render
-  // newest-on-top.
+  // Sort by full commit timestamp DESC. The `date` field in
+  // frontmatter is now an ISO 8601 string (e.g.
+  // 2026-05-21T22:21:06+05:30), so packages bumped together in one
+  // commit naturally cluster, with alphabetical package name as the
+  // tiebreak inside a cluster. Within same timestamp + same package
+  // (extremely rare), prefer the higher version.
   entries.sort((a, b) =>
-    b.date.localeCompare(a.date)
+    Date.parse(b.date) - Date.parse(a.date)
     || a.shortPkg.localeCompare(b.shortPkg)
     || compareVersionsDesc(a.version, b.version)
   );
@@ -202,7 +204,7 @@ export default async function Changelog() {
               <header class="flex flex-wrap items-baseline gap-x-3 gap-y-1 mb-3">
                 ${pkgBadge(e.shortPkg)}
                 <h2 class="font-mono text-[18px] font-semibold text-fg tracking-tight m-0">v${e.version}</h2>
-                <time class="font-mono text-[11.5px] text-fg-subtle tracking-tight">${e.date}</time>
+                <time class="font-mono text-[11.5px] text-fg-subtle tracking-tight">${e.date.slice(0, 10)}</time>
                 <span class="text-[11.5px] text-fg-subtle">${e.commitCount} change${e.commitCount === 1 ? '' : 's'}</span>
               </header>
               <div>${unsafeHTML(renderBody(e.body))}</div>

--- a/website/app/changelog/page.ts
+++ b/website/app/changelog/page.ts
@@ -72,9 +72,27 @@ async function loadEntries(): Promise<Entry[]> {
       });
     }
   }
-  // Sort: most recent first; tie-break by package name.
-  entries.sort((a, b) => (b.date.localeCompare(a.date)) || a.shortPkg.localeCompare(b.shortPkg));
+  // Sort: most recent first; tie-break by package name, then by
+  // version DESC so two same-day entries of the same package (e.g.
+  // cli 0.8.0 and cli 0.7.0 both bumped on the same day) render
+  // newest-on-top.
+  entries.sort((a, b) =>
+    b.date.localeCompare(a.date)
+    || a.shortPkg.localeCompare(b.shortPkg)
+    || compareVersionsDesc(a.version, b.version)
+  );
   return entries;
+}
+
+/** Compare two semver-shaped strings ("0.7.0", "0.8.0") with newer first. */
+function compareVersionsDesc(a: string, b: string): number {
+  const pa = a.split('.').map((n) => Number.parseInt(n, 10) || 0);
+  const pb = b.split('.').map((n) => Number.parseInt(n, 10) || 0);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const d = (pb[i] ?? 0) - (pa[i] ?? 0);
+    if (d !== 0) return d;
+  }
+  return 0;
 }
 
 /** Tiny inline-markdown renderer: links, bold, italic, inline code. */


### PR DESCRIPTION
## Summary

On `/changelog`, two same-day entries for the same package rendered newest-at-bottom instead of newest-at-top:

| Position | Package | Version | Date |
|---|---|---|---|
| 1 | cli | 0.7.0 | 2026-05-21 |
| 2 | cli | 0.8.0 | 2026-05-21 |

Cause: the existing sort key was `(date DESC, shortPkg ASC)`. Both entries tied on both keys, so Node's stable sort fell back to `readdir` order, which is alphabetical by filename. `0.7.0.md` precedes `0.8.0.md`, hence the wrong-way-round display.

## Fix

Add a third tie-breaker: when both date and package match, compare versions numerically and prefer the higher one. The helper parses the dotted version into ints so `0.10.0` correctly sorts above `0.9.0` (a string sort would mis-order those).

## Test plan

- [ ] After merge + deploy, `/changelog` shows `cli 0.8.0` above `cli 0.7.0` (and similar for any other same-day twin entries).