### PR TITLE
chore(release): bump all packages to publish under @webjsdev

### DIFF
--- a/changelog/cli/0.8.1.md
+++ b/changelog/cli/0.8.1.md
@@ -1,0 +1,10 @@
+---
+package: "@webjsdev/cli"
+version: 0.8.1
+date: 2026-05-22T00:56:25+05:30
+commit_count: 1
+---
+## Breaking
+
+- **Rescope from `@webjskit/cli` to `@webjsdev/cli`** ([#62](https://github.com/vivek7405/webjs/pull/62))
+  The npm scope now matches the canonical `webjs.dev` domain (and the `@webjsdev` org we own on npm). Functionally identical to the prior `@webjskit/cli@0.8.0` publish, no CLI behavior change. Existing global installs (`npm i -g @webjskit/cli`) keep working; new users should `npm i -g @webjsdev/cli`. Scaffold templates now emit `@webjsdev/*` dependencies. The legacy `@webjskit/*` packages stay installable, but will be marked deprecated on the registry to redirect new installers here.

--- a/changelog/core/0.7.1.md
+++ b/changelog/core/0.7.1.md
@@ -1,0 +1,10 @@
+---
+package: "@webjsdev/core"
+version: 0.7.1
+date: 2026-05-22T00:56:25+05:30
+commit_count: 1
+---
+## Breaking
+
+- **Rescope from `@webjskit/core` to `@webjsdev/core`** ([#62](https://github.com/vivek7405/webjs/pull/62))
+  The npm scope now matches the canonical `webjs.dev` domain (and the `@webjsdev` org we own on npm). Functionally identical to the prior `@webjskit/core@0.7.0` publish, no API or runtime change. Migrate by find-replacing every `@webjskit/` reference with `@webjsdev/` in source, imports, and `package.json` dependency keys. The legacy `@webjskit/*` packages stay installable, but will be marked deprecated on the registry to redirect new installers here.

--- a/changelog/server/0.7.2.md
+++ b/changelog/server/0.7.2.md
@@ -1,0 +1,10 @@
+---
+package: "@webjsdev/server"
+version: 0.7.2
+date: 2026-05-22T00:56:25+05:30
+commit_count: 1
+---
+## Breaking
+
+- **Rescope from `@webjskit/server` to `@webjsdev/server`** ([#62](https://github.com/vivek7405/webjs/pull/62))
+  The npm scope now matches the canonical `webjs.dev` domain (and the `@webjsdev` org we own on npm). Functionally identical to the prior `@webjskit/server@0.7.1` publish, no API or runtime change. Migrate by find-replacing every `@webjskit/` reference with `@webjsdev/` in source, imports, and `package.json` dependency keys. The legacy `@webjskit/*` packages stay installable, but will be marked deprecated on the registry to redirect new installers here.

--- a/changelog/ts-plugin/0.4.1.md
+++ b/changelog/ts-plugin/0.4.1.md
@@ -1,0 +1,10 @@
+---
+package: "@webjsdev/ts-plugin"
+version: 0.4.1
+date: 2026-05-22T00:56:25+05:30
+commit_count: 1
+---
+## Breaking
+
+- **Rescope from `@webjskit/ts-plugin` to `@webjsdev/ts-plugin`** ([#62](https://github.com/vivek7405/webjs/pull/62))
+  The npm scope now matches the canonical `webjs.dev` domain (and the `@webjsdev` org we own on npm). Functionally identical to the prior `@webjskit/ts-plugin@0.4.0` publish, no plugin behavior change. Update your `tsconfig.json` `plugins` entry from `@webjskit/ts-plugin` to `@webjsdev/ts-plugin` and reinstall. The legacy `@webjskit/*` packages stay installable, but will be marked deprecated on the registry to redirect new installers here.

--- a/changelog/ui/0.3.1.md
+++ b/changelog/ui/0.3.1.md
@@ -1,0 +1,10 @@
+---
+package: "@webjsdev/ui"
+version: 0.3.1
+date: 2026-05-22T00:56:25+05:30
+commit_count: 1
+---
+## Breaking
+
+- **Rescope from `@webjskit/ui` to `@webjsdev/ui`** ([#62](https://github.com/vivek7405/webjs/pull/62))
+  The npm scope now matches the canonical `webjs.dev` domain (and the `@webjsdev` org we own on npm). Functionally identical to the prior `@webjskit/ui@0.3.0` publish, no component or CLI behavior change. The `webjs ui add` command now writes imports from `@webjsdev/core` into added components. Update existing `lib/utils/ui.ts` and any other manually-imported references from `@webjskit/ui` to `@webjsdev/ui`. The legacy `@webjskit/*` packages stay installable, but will be marked deprecated on the registry to redirect new installers here.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7473,11 +7473,11 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
-        "@webjsdev/server": "^0.7.0",
-        "@webjsdev/ui": "^0.3.0"
+        "@webjsdev/server": "^0.7.2",
+        "@webjsdev/ui": "^0.3.1"
       },
       "bin": {
         "webjs": "bin/webjs.js"
@@ -7488,15 +7488,15 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT"
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
-        "@webjsdev/core": "^0.7.0",
+        "@webjsdev/core": "^0.7.1",
         "chokidar": "^3.6.0",
         "esbuild": "^0.28.0",
         "ws": "^8.20.0"
@@ -7576,7 +7576,7 @@
     },
     "packages/ts-plugin": {
       "name": "@webjsdev/ts-plugin",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "ts-lit-plugin": "^2.0.2"
@@ -7587,7 +7587,7 @@
     },
     "packages/ui": {
       "name": "@webjsdev/ui",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {
@@ -13,8 +13,8 @@
     "README.md"
   ],
   "dependencies": {
-    "@webjsdev/server": "^0.7.0",
-    "@webjsdev/ui": "^0.3.0"
+    "@webjsdev/server": "^0.7.2",
+    "@webjsdev/ui": "^0.3.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",
@@ -14,7 +14,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@webjsdev/core": "^0.7.0",
+    "@webjsdev/core": "^0.7.1",
     "chokidar": "^3.6.0",
     "esbuild": "^0.28.0",
     "ws": "^8.20.0"

--- a/packages/ts-plugin/package.json
+++ b/packages/ts-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/ts-plugin",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "commonjs",
   "description": "TypeScript language-service plugin for webjs - bundles ts-lit-plugin internally so users install one plugin instead of two. Adds webjs-aware go-to-definition, ts-lit-plugin diagnostic suppression for Class.register('tag') elements, attribute auto-complete from `static properties`, and attribute-value type-check against `declare` annotations.",
   "main": "src/index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/ui",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "description": "An AI-first component library - class-helper functions for visuals, custom elements only where state matters. Source-copied into your repo, you own it. Works with any Tailwind v4 project.",
   "bin": {


### PR DESCRIPTION
## Summary

First publish on the new `@webjsdev` scope after the rescope landed in #62. Each package bumps one patch level so the Auto-release workflow detects new `changelog/<pkg>/<version>.md` files and fires `npm publish` + `gh release create` under the new scope.

| Package | Old (`@webjskit`) | New (`@webjsdev`) |
|---|---|---|
| `core` | 0.7.0 | 0.7.1 |
| `server` | 0.7.1 | 0.7.2 |
| `cli` | 0.8.0 | 0.8.1 |
| `ts-plugin` | 0.4.0 | 0.4.1 |
| `ui` | 0.3.0 | 0.3.1 |

Functionally identical to the prior publishes; only the npm scope changes. Each changelog entry frames it as one Breaking change and points consumers at the find-replace migration.

Cross-package dep refs bumped too: `cli` floors `@webjsdev/server` at ^0.7.2 and `@webjsdev/ui` at ^0.3.1; `server` floors `@webjsdev/core` at ^0.7.1. Apps (examples/blog, website, docs) keep `^0.7.0` etc., since they're workspaces and resolve to the local version regardless.

Hand-writing the changelog files is necessary because the rescope commit itself was a `refactor:`, which the changelog generator skips. With the files staged before the bump, the pre-commit hook sees them already on disk and lets the bump through.

## Auto-release flow after merge

For each new `changelog/<pkg>/<version>.md` file on main:
1. `scripts/publish-npm.js` checks `npm view @webjsdev/<pkg>@<ver>` (404 expected, first publish), then `npm publish --workspace=@webjsdev/<pkg> --access=public`.
2. `scripts/publish-release.js` creates `<pkg>@<ver>` git tag + GitHub Release.

Requires `NPM_TOKEN` (already a repo secret) to be valid for the `@webjsdev` org. Should be fine since you own both orgs under the same user account.

## Test plan

- [x] `npm test` passes (pre-commit gate; full suite, 1151 tests).
- [x] Cross-package version refs updated in `packages/cli/package.json` and `packages/server/package.json`.
- [x] Lockfile regenerated to pick up the bumped ranges.
- [ ] After merge, watch [Auto-release workflow](https://github.com/vivek7405/webjs/actions/workflows/release.yml) for 5 successful publishes.

## Follow-up after publish

`npm deprecate @webjskit/<pkg> "Renamed to @webjsdev/<pkg>"` on each of the 5 legacy packages so the registry shows a yellow redirect warning. (Has to wait until the new versions are live so the message can point at them.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)