### PR TITLE
refactor: rename example-blog workspace under the @webjsdev scope

### DIFF
--- a/examples/blog/package.json
+++ b/examples/blog/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@webjsdev-examples/blog",
+  "name": "@webjsdev/example-blog",
   "version": "0.1.0",
   "type": "module",
   "private": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
       }
     },
     "examples/blog": {
-      "name": "@webjsdev-examples/blog",
+      "name": "@webjsdev/example-blog",
       "version": "0.1.0",
       "dependencies": {
         "@prisma/client": "^5.22.0",
@@ -2842,10 +2842,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@webjsdev-examples/blog": {
-      "resolved": "examples/blog",
-      "link": true
-    },
     "node_modules/@webjsdev/cli": {
       "resolved": "packages/cli",
       "link": true
@@ -2856,6 +2852,10 @@
     },
     "node_modules/@webjsdev/docs": {
       "resolved": "docs",
+      "link": true
+    },
+    "node_modules/@webjsdev/example-blog": {
+      "resolved": "examples/blog",
       "link": true
     },
     "node_modules/@webjsdev/server": {


### PR DESCRIPTION
## Summary

Renames the workspace from `@webjsdev-examples/blog` to `@webjsdev/example-blog` so all four monorepo apps share the same `@webjsdev/` scope (website, docs, ui-website, example-blog). The old `@webjsdev-examples` was a leftover from the earlier @webjskit naming.

## What this does NOT touch

- `compose.yaml` uses `working_dir: /app/examples/blog` (path-based, no workspace name reference).
- `Dockerfile` is path-based.
- No source code or scaffold templates reference the old name.

## After merge

Update the Railway blog service start command from
`npm run start --workspace=@webjsdev-examples/blog`
to
`npm run start --workspace=@webjsdev/example-blog`.

## Test plan

- [x] `npm install` regenerated lockfile cleanly.
- [x] `git grep '@webjsdev-examples'` returns 0 hits after the rename.
- [ ] After merge, redeploy the Railway blog service with updated start command and verify it boots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)