### PR TITLE
refactor: update repo URL from vivek7405/webjs to webjsdev/webjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ webjs create my-api --template api
 webjs create my-app --template saas
 
 # or run everything in the monorepo (website + docs + blog together)
-git clone https://github.com/vivek7405/webjs
+git clone https://github.com/webjsdev/webjs
 cd webjs && npm install
 cd examples/blog && npx prisma migrate dev --name init && cd ..
 npm run dev

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -61,7 +61,7 @@ commit_count: 4
 
 ## Breaking
 
-- **Title of the change** ([#NN](https://github.com/vivek7405/webjs/pull/NN)) [`abcd123`](https://github.com/vivek7405/webjs/commit/abcd123)
+- **Title of the change** ([#NN](https://github.com/webjsdev/webjs/pull/NN)) [`abcd123`](https://github.com/webjsdev/webjs/commit/abcd123)
   First four lines of the commit body, indented two spaces.
 
 ## Features

--- a/changelog/cli/0.1.1.md
+++ b/changelog/cli/0.1.1.md
@@ -6,83 +6,83 @@ commit_count: 27
 ---
 ## Features
 
-- **webjs test, webjs check, webjs create with AI guardrails** [`6e85e5d`](https://github.com/vivek7405/webjs/commit/6e85e5d)
+- **webjs test, webjs check, webjs create with AI guardrails** [`6e85e5d`](https://github.com/webjsdev/webjs/commit/6e85e5d)
   - webjs test: discovers and runs unit + E2E tests
   - webjs check: validates app against 6 convention rules
   - webjs create: scaffolds opinionated project with CONVENTIONS.md,
     cross-agent configs (.cursorrules, .windsurfrules, copilot-instructions),
-- **default theme to system across website, docs, blog, and scaffolder** [`7257b49`](https://github.com/vivek7405/webjs/commit/7257b49)
+- **default theme to system across website, docs, blog, and scaffolder** [`7257b49`](https://github.com/webjsdev/webjs/commit/7257b49)
   Theme toggle defaults to 'system' instead of 'light'. Bootstrap scripts
   no longer force data-theme — they only set it when the user has an
   explicit localStorage preference. CSS prefers-color-scheme handles the
   default. Updated all three apps + the webjs create scaffolder template.
-- **migrate client tests to WTR + Playwright, real browser testing** [`1ce3888`](https://github.com/vivek7405/webjs/commit/1ce3888)
+- **migrate client tests to WTR + Playwright, real browser testing** [`1ce3888`](https://github.com/webjsdev/webjs/commit/1ce3888)
   Added @web/test-runner + @web/test-runner-playwright + playwright.
   Client-side tests (renderer, directives, Shadow DOM) now run in real
   Chromium — no more linkedom/jsdom fake DOM. Server tests stay on
   node:test (they need Node APIs).
-- **add Playwright MCP server for browser debugging** [`4c5746e`](https://github.com/vivek7405/webjs/commit/4c5746e)
+- **add Playwright MCP server for browser debugging** [`4c5746e`](https://github.com/webjsdev/webjs/commit/4c5746e)
   Added Microsoft's @playwright/mcp as both user-level (global) and
   project-level MCP server. End users get it via webjs create (.claude.json).
   
   Playwright MCP gives AI agents direct browser control: navigate, click,
-- **git pre-commit hook blocks commits on main/master** [`ca31525`](https://github.com/vivek7405/webjs/commit/ca31525)
+- **git pre-commit hook blocks commits on main/master** [`ca31525`](https://github.com/webjsdev/webjs/commit/ca31525)
   Added .git/hooks/pre-commit locally and .hooks/pre-commit in the
   scaffolder template. webjs create now runs git init + configures
   core.hooksPath to .hooks/ so the hook is tracked in the repo and
   works for everyone who clones it.
-- **add .env.example for scaffolder and blog example** [`9994261`](https://github.com/vivek7405/webjs/commit/9994261)
+- **add .env.example for scaffolder and blog example** [`9994261`](https://github.com/webjsdev/webjs/commit/9994261)
   Shows all convention-over-configuration env vars: PORT, SESSION_SECRET,
   REDIS_URL (auto-scales everything), S3_BUCKET (cloud storage),
   DATABASE_URL. Includes generation command for SESSION_SECRET.
-- **NextJs-style cache + NextAuth-style auth + WebSocket broadcast** [`19418b3`](https://github.com/vivek7405/webjs/commit/19418b3)
+- **NextJs-style cache + NextAuth-style auth + WebSocket broadcast** [`19418b3`](https://github.com/webjsdev/webjs/commit/19418b3)
   Removed: storage (s3/disk), background jobs — not core framework.
   
   Added:
   - cache(fn, { revalidate, tags }) + revalidateTag() — NextJs-style
-- **scaffold templates (full-stack + API) and code generators** [`b8f569b`](https://github.com/vivek7405/webjs/commit/b8f569b)
+- **scaffold templates (full-stack + API) and code generators** [`b8f569b`](https://github.com/webjsdev/webjs/commit/b8f569b)
   webjs create <name> --template api    Backend-only: route wrappers over
                                         typed server actions, no pages/SSR
   
   webjs generate page|module|action|query|component|route <name>
-- **SaaS template — webjs create --template saas** [`1ab8ea0`](https://github.com/vivek7405/webjs/commit/1ab8ea0)
+- **SaaS template — webjs create --template saas** [`1ab8ea0`](https://github.com/webjsdev/webjs/commit/1ab8ea0)
   Scaffolds a complete SaaS starter with auth, dashboard, Prisma:
   - app/login, app/signup — auth pages
   - app/dashboard with middleware auth guard + settings page
   - app/api/auth/[...path]/route.ts — auth API handlers
-- **auto-scope ALL CSS selectors for light DOM components** [`bdb3280`](https://github.com/vivek7405/webjs/commit/bdb3280)
+- **auto-scope ALL CSS selectors for light DOM components** [`bdb3280`](https://github.com/webjsdev/webjs/commit/bdb3280)
   scopeCSS() now prefixes every CSS rule with the component tag name:
     input { color: red } → comments-thread input { color: red }
     :host { display: block } → comments-thread { display: block }
-- **typed component props via defineComponent + .d.ts overlay** [`9f0b09a`](https://github.com/vivek7405/webjs/commit/9f0b09a)
+- **typed component props via defineComponent + .d.ts overlay** [`9f0b09a`](https://github.com/webjsdev/webjs/commit/9f0b09a)
   The existing static-properties pattern carried no compile-time type
   information, so authors had to duplicate every field as `declare x: T`
   for editor intellisense. This adds a TypeScript overlay plus a tiny
   runtime helper so the descriptor map is the single source of truth for
-- **Class.register() — drop the import.meta.url argument** [`283c2b5`](https://github.com/vivek7405/webjs/commit/283c2b5)
+- **Class.register() — drop the import.meta.url argument** [`283c2b5`](https://github.com/webjsdev/webjs/commit/283c2b5)
   Authors no longer write `Counter.register(import.meta.url)`; the call
   is just `Counter.register()`. Module URLs (used by SSR to emit
   `<link rel=modulepreload>` hints) are derived server-side at boot by
   scanning the app tree for `class X extends WebComponent { static tag =
-- **adopt standard customElements.define — drop static tag + .register()** [`bb61186`](https://github.com/vivek7405/webjs/commit/bb61186)
+- **adopt standard customElements.define — drop static tag + .register()** [`bb61186`](https://github.com/webjsdev/webjs/commit/bb61186)
   The web-standard registration convention (same shape Lit uses for its
   non-decorator form):
   
     class Counter extends WebComponent { ... }
-- **Counter.register('my-counter') as the idiomatic registration** [`a0f1f68`](https://github.com/vivek7405/webjs/commit/a0f1f68)
+- **Counter.register('my-counter') as the idiomatic registration** [`a0f1f68`](https://github.com/webjsdev/webjs/commit/a0f1f68)
   Adds a `static register(tag)` method on WebComponent. Delegates to the
   internal registry (which in turn calls customElements.define / the
   server shim), so every registration still lands in the native
   customElements map and webjs's mirror map. Authors write:
-- **rename core package webjs → @webjs/core for npm publish** [`49e2d6b`](https://github.com/vivek7405/webjs/commit/49e2d6b)
+- **rename core package webjs → @webjs/core for npm publish** [`49e2d6b`](https://github.com/webjsdev/webjs/commit/49e2d6b)
   The unscoped `webjs` name is already taken on npm (webjs@0.6.1, unrelated
   project). Moving to the `@webjs` scope lets us publish `@webjs/core`,
   `@webjs/server`, and `@webjs/cli` together.
-- **rescope @webjs → @webjskit (org name 'webjs' unavailable on npm)** [`316e2be`](https://github.com/vivek7405/webjs/commit/316e2be)
+- **rescope @webjs → @webjskit (org name 'webjs' unavailable on npm)** [`316e2be`](https://github.com/webjsdev/webjs/commit/316e2be)
   The @webjs organization is not available on npm (likely reserved because
   the unscoped `webjs` package is held by an unrelated project). Switching
   to the @webjskit scope, which we own.
-- **favicon for all three apps + Prisma/SQLite in every scaffold** [`e6ba242`](https://github.com/vivek7405/webjs/commit/e6ba242)
+- **favicon for all three apps + Prisma/SQLite in every scaffold** [`e6ba242`](https://github.com/webjsdev/webjs/commit/e6ba242)
   **Favicon**
   - scripts/generate-favicon.mjs renders the header-logo artwork
     (accent-orange linear gradient, rounded square, 1px inner highlight)
@@ -90,50 +90,50 @@ commit_count: 27
 
 ## Fixes
 
-- **dev mode uses node --watch for reliable file change detection** [`792cde0`](https://github.com/vivek7405/webjs/commit/792cde0)
+- **dev mode uses node --watch for reliable file change detection** [`792cde0`](https://github.com/webjsdev/webjs/commit/792cde0)
   Root cause: Node's ESM module cache has no public invalidation API.
   When loadModule() cache-busts a page with ?t=timestamp, only the
   top-level module is re-imported. Transitive imports (server actions,
   queries, components, utils) resolve to the SAME cached URL and return
-- **enforce commit-often and bypass-mode in all end-user templates** [`016d39f`](https://github.com/vivek7405/webjs/commit/016d39f)
+- **enforce commit-often and bypass-mode in all end-user templates** [`016d39f`](https://github.com/webjsdev/webjs/commit/016d39f)
   - guard-main-merge.sh template now respects bypass mode
   - CLAUDE.md template: commit-often is step 1 of the workflow
   - CONVENTIONS.md template: commits listed first in required checklist
   - .cursorrules, .windsurfrules, copilot-instructions: COMMIT OFTEN
-- **enforce commit-AND-push in all agent instructions** [`286ce7f`](https://github.com/vivek7405/webjs/commit/286ce7f)
+- **enforce commit-AND-push in all agent instructions** [`286ce7f`](https://github.com/webjsdev/webjs/commit/286ce7f)
   Commit without push is half the job. Updated CLAUDE.md, all templates
   (CLAUDE.md, CONVENTIONS.md, .cursorrules, .windsurfrules, copilot-
   instructions.md) to say 'commit AND push' everywhere.
-- **branch-context hook must ALWAYS fire, even in bypass mode** [`c7a35b5`](https://github.com/vivek7405/webjs/commit/c7a35b5)
+- **branch-context hook must ALWAYS fire, even in bypass mode** [`c7a35b5`](https://github.com/webjsdev/webjs/commit/c7a35b5)
   The bypass-mode early-exit was defeating the entire purpose of the
   branch guard. Editing on main is a safety issue — the hook should
   always prompt, regardless of mode. Merge/push guard can respect
   bypass (those are approval prompts), but branch check is a safety net.
-- **merging ALWAYS requires user permission, even in bypass mode** [`a74450e`](https://github.com/vivek7405/webjs/commit/a74450e)
+- **merging ALWAYS requires user permission, even in bypass mode** [`a74450e`](https://github.com/webjsdev/webjs/commit/a74450e)
   Removed all 'auto-merge' language from AGENTS.md, CLAUDE.md, and every
   agent config template (.cursorrules, .windsurfrules, copilot-instructions,
   CONVENTIONS.md). Merge guard hook no longer respects bypass mode — it
   always prompts. Merging is irreversible and must never be autonomous.
-- **all hooks respect bypass mode — no prompts in autonomous mode** [`24dd724`](https://github.com/vivek7405/webjs/commit/24dd724)
+- **all hooks respect bypass mode — no prompts in autonomous mode** [`24dd724`](https://github.com/webjsdev/webjs/commit/24dd724)
   Both guard-main-merge.sh and guard-branch-context.sh (local + templates)
   now respect skipDangerousModePermissionPrompt. In bypass mode: no prompts
   for edits, merges, or pushes. The agent follows best practices via
   AGENTS.md instructions, not hook interruptions.
-- **clean permission model — feature branches are free, only merge asks** [`9aa740e`](https://github.com/vivek7405/webjs/commit/9aa740e)
+- **clean permission model — feature branches are free, only merge asks** [`9aa740e`](https://github.com/webjsdev/webjs/commit/9aa740e)
   Hooks: on feature branches, commit/push are fully free (no prompts).
   Only merging into main prompts for approval. Bypass mode allows
   everything including merges.
-- **update all end-user templates for WTR + Playwright test stack** [`06b77c7`](https://github.com/vivek7405/webjs/commit/06b77c7)
+- **update all end-user templates for WTR + Playwright test stack** [`06b77c7`](https://github.com/webjsdev/webjs/commit/06b77c7)
   Updated CONVENTIONS.md (browser test section, test matrix table),
   .cursorrules, .windsurfrules, copilot-instructions.md to reference
   WTR + Playwright instead of Puppeteer/E2E. Removed stale WEBJS_E2E
   references.
-- **revert blog components with bare selectors to shadow DOM** [`a36400d`](https://github.com/vivek7405/webjs/commit/a36400d)
+- **revert blog components with bare selectors to shadow DOM** [`a36400d`](https://github.com/webjsdev/webjs/commit/a36400d)
   Components with bare element selectors (input, button, ul, h2, a)
   MUST use shadow DOM — bare selectors would leak to the whole page
   in light DOM. Reverted: comments-thread, auth-forms, chat-box,
   new-post, error-card.
-- **remove auto-scope CSS hack, clean shadow/light DOM convention** [`f91ceb0`](https://github.com/vivek7405/webjs/commit/f91ceb0)
+- **remove auto-scope CSS hack, clean shadow/light DOM convention** [`f91ceb0`](https://github.com/webjsdev/webjs/commit/f91ceb0)
   Shadow DOM = scoped styles (static styles = css, adoptedStyleSheets).
   Light DOM = global styles (Tailwind, global CSS, no static styles).
   Pick one. Don't fake shadow DOM scoping with regex.

--- a/changelog/cli/0.1.2.md
+++ b/changelog/cli/0.1.2.md
@@ -6,7 +6,7 @@ commit_count: 1
 ---
 ## Features
 
-- **use icon-only theme toggle in scaffold** [`eb90718`](https://github.com/vivek7405/webjs/commit/eb90718)
+- **use icon-only theme toggle in scaffold** [`eb90718`](https://github.com/webjsdev/webjs/commit/eb90718)
   Aligns the scaffolded `<theme-toggle>` with the website, docs, and blog
   versions — a circular icon button with sun/moon/system SVGs. The
   previous scaffold rendered the literal text 'Auto'/'Light'/'Dark' in a

--- a/changelog/cli/0.1.4.md
+++ b/changelog/cli/0.1.4.md
@@ -6,7 +6,7 @@ commit_count: 1
 ---
 ## Fixes
 
-- **resolve esbuild from app dir, not server dir** [`4987a04`](https://github.com/vivek7405/webjs/commit/4987a04)
+- **resolve esbuild from app dir, not server dir** [`4987a04`](https://github.com/webjsdev/webjs/commit/4987a04)
   When `@webjskit/cli` is installed globally (the typical case for
   end-users), `import('esbuild')` from `packages/server/src/dev.js`
   walks up from the global install tree — never reaching the user app's

--- a/changelog/cli/0.2.0.md
+++ b/changelog/cli/0.2.0.md
@@ -6,7 +6,7 @@ commit_count: 1
 ---
 ## Features
 
-- **use esbuild for TS on both SSR + hydration; default to no build** [`eb0b0ee`](https://github.com/vivek7405/webjs/commit/eb0b0ee)
+- **use esbuild for TS on both SSR + hydration; default to no build** [`eb0b0ee`](https://github.com/webjsdev/webjs/commit/eb0b0ee)
   The dev server now registers an esbuild ESM loader hook
   (`module.register()`) at startup. Every server-side `.ts` import flows
   through esbuild's transform — same transformer the dev server already

--- a/changelog/cli/0.2.1.md
+++ b/changelog/cli/0.2.1.md
@@ -6,7 +6,7 @@ commit_count: 1
 ---
 ## Fixes
 
-- **share component registry across module instances** [`f3757aa`](https://github.com/vivek7405/webjs/commit/f3757aa)
+- **share component registry across module instances** [`f3757aa`](https://github.com/webjsdev/webjs/commit/f3757aa)
   When the cli is installed globally (or hoisted at a different level
   than the user's app), Node resolves `@webjskit/core` from each
   importer's location and may load TWO instances of the package — one

--- a/changelog/cli/0.3.0.md
+++ b/changelog/cli/0.3.0.md
@@ -6,7 +6,7 @@ commit_count: 1
 ---
 ## Features
 
-- **drop superjson, ship built-in ESM rich-type serializer** [`4efefce`](https://github.com/vivek7405/webjs/commit/4efefce)
+- **drop superjson, ship built-in ESM rich-type serializer** [`4efefce`](https://github.com/webjsdev/webjs/commit/4efefce)
   Replaces `superjson` with a pure-ESM, dependency-free serializer in
   `@webjskit/core` (`packages/core/src/serialize.js`). Tagged-inline wire
   format, async sync API. Single async `stringify`/`serialize` so AI

--- a/changelog/cli/0.6.0.md
+++ b/changelog/cli/0.6.0.md
@@ -6,7 +6,7 @@ commit_count: 1
 ---
 ## Features
 
-- **erasable-typescript-only rule + ship erasableSyntaxOnly in tsconfigs** [`490372a`](https://github.com/vivek7405/webjs/commit/490372a)
+- **erasable-typescript-only rule + ship erasableSyntaxOnly in tsconfigs** [`490372a`](https://github.com/webjsdev/webjs/commit/490372a)
   Adds compilerOptions.erasableSyntaxOnly to: the scaffold tsconfig
   generator (packages/cli/lib/create.js), the blog example, the docs
   site, the marketing site. TypeScript 5.8+ rejects enum, namespace

--- a/changelog/cli/0.7.0.md
+++ b/changelog/cli/0.7.0.md
@@ -6,39 +6,39 @@ commit_count: 9
 ---
 ## Features
 
-- **webjs check --rules shows enabled/disabled state per project** [`ff0adcb`](https://github.com/vivek7405/webjs/commit/ff0adcb)
+- **webjs check --rules shows enabled/disabled state per project** [`ff0adcb`](https://github.com/webjsdev/webjs/commit/ff0adcb)
   Reads the project's overrides via loadConventionOverrides(), then
   annotates each rule line as [enabled] or [disabled by override].
   Header text states the default-on invariant explicitly so AI
   agents reading the output cannot misinterpret it.
-- **nudge-uncommitted hook ships in every scaffolded app** [`fd600ca`](https://github.com/vivek7405/webjs/commit/fd600ca)
+- **nudge-uncommitted hook ships in every scaffolded app** [`fd600ca`](https://github.com/webjsdev/webjs/commit/fd600ca)
   Mirrors the framework-repo hook into the scaffold templates so
   end-user webjs apps inherit the same commit-frequency
   enforcement out of the box. Three pieces:
-- **pre-commit runs webjs test + webjs check** [`11068f7`](https://github.com/vivek7405/webjs/commit/11068f7)
+- **pre-commit runs webjs test + webjs check** [`11068f7`](https://github.com/webjsdev/webjs/commit/11068f7)
   Tool-agnostic git-level enforcement. Fires on every commit
   regardless of agent (Claude, Cursor, Windsurf, Copilot, human).
   Blocks commits that fail tests or convention checks.
-- **Gemini CLI nudge-uncommitted hook** [`4c21aa8`](https://github.com/vivek7405/webjs/commit/4c21aa8)
+- **Gemini CLI nudge-uncommitted hook** [`4c21aa8`](https://github.com/webjsdev/webjs/commit/4c21aa8)
   Adds the same commit-frequency enforcement to scaffolded apps for
   Gemini CLI users. The hook output shape (hookSpecificOutput.
   additionalContext) is identical to Claude Code's, so the body is
   nearly a copy of the Claude version.
-- **Cursor nudge-uncommitted hook** [`5eb459c`](https://github.com/vivek7405/webjs/commit/5eb459c)
+- **Cursor nudge-uncommitted hook** [`5eb459c`](https://github.com/webjsdev/webjs/commit/5eb459c)
   Cursor 1.7+ ships a hooks system at .cursor/hooks.json. The
   afterFileEdit event fires after Cursor's edit/write tools and
   accepts a top-level additional_context field (snake_case) to
   inject a soft reminder into the agent's context.
-- **block-prose-punctuation hook ships in every scaffolded app** [`c63dacb`](https://github.com/vivek7405/webjs/commit/c63dacb)
+- **block-prose-punctuation hook ships in every scaffolded app** [`c63dacb`](https://github.com/webjsdev/webjs/commit/c63dacb)
   Mirrors the framework-repo prose hook into scaffolded apps so end
   users get the same enforcement of AGENTS.md invariant 11 (no
   em-dashes, no hyphen-as-pause, no semicolon-as-pause, no
   xyz():-then-prose). The rule is already documented in
-- **OpenCode commit-nudge plugin** [`2ee5e15`](https://github.com/vivek7405/webjs/commit/2ee5e15)
+- **OpenCode commit-nudge plugin** [`2ee5e15`](https://github.com/webjsdev/webjs/commit/2ee5e15)
   OpenCode does not have shell-script hooks; it uses TS plugin
   modules loaded as-is by Bun. This plugin is the counterpart of
   the .claude/, .gemini/, .cursor/ hooks already in the scaffold.
-- **Tier-2 components -> WebComponent + render() + <slot> (rebased)** ([#28](https://github.com/vivek7405/webjs/pull/28)) [`09a296e`](https://github.com/vivek7405/webjs/commit/09a296e)
+- **Tier-2 components -> WebComponent + render() + <slot> (rebased)** ([#28](https://github.com/webjsdev/webjs/pull/28)) [`09a296e`](https://github.com/webjsdev/webjs/commit/09a296e)
   * refactor(ui): toggle.ts -> WebComponent + render() + <slot>
   
   First Tier-2 component converted from extends Base to extends
@@ -46,7 +46,7 @@ commit_count: 9
 
 ## Fixes
 
-- **drop guard-main-merge hook so end users can merge to main locally** [`9b878a4`](https://github.com/vivek7405/webjs/commit/9b878a4)
+- **drop guard-main-merge hook so end users can merge to main locally** [`9b878a4`](https://github.com/webjsdev/webjs/commit/9b878a4)
   This hook prompted on every 'git merge' and every 'git push ... main'
   through Claude's Bash tool. That matches the framework dev's preference
   for a strict GitHub-PR-only workflow, but it is the wrong default for

--- a/changelog/cli/0.8.0.md
+++ b/changelog/cli/0.8.0.md
@@ -6,7 +6,7 @@ commit_count: 1
 ---
 ## Breaking
 
-- **signals replace this.state / setState across the stack** ([#43](https://github.com/vivek7405/webjs/pull/43)) [`6e50ae6`](https://github.com/vivek7405/webjs/commit/6e50ae6)
+- **signals replace this.state / setState across the stack** ([#43](https://github.com/webjsdev/webjs/pull/43)) [`6e50ae6`](https://github.com/webjsdev/webjs/commit/6e50ae6)
   * feat(core): signal primitive (TC39 Stage-1 shape, no runtime deps)
   
   Hand-rolled signal/computed/effect/batch in plain JS with JSDoc.

--- a/changelog/cli/0.8.1.md
+++ b/changelog/cli/0.8.1.md
@@ -6,5 +6,5 @@ commit_count: 1
 ---
 ## Breaking
 
-- **Rescope from `@webjskit/cli` to `@webjsdev/cli`** ([#62](https://github.com/vivek7405/webjs/pull/62))
+- **Rescope from `@webjskit/cli` to `@webjsdev/cli`** ([#62](https://github.com/webjsdev/webjs/pull/62))
   The npm scope now matches the canonical `webjs.dev` domain (and the `@webjsdev` org we own on npm). Functionally identical to the prior `@webjskit/cli@0.8.0` publish, no CLI behavior change. Existing global installs (`npm i -g @webjskit/cli`) keep working; new users should `npm i -g @webjsdev/cli`. Scaffold templates now emit `@webjsdev/*` dependencies. The legacy `@webjskit/*` packages stay installable, but will be marked deprecated on the registry to redirect new installers here.

--- a/changelog/core/0.2.0.md
+++ b/changelog/core/0.2.0.md
@@ -6,208 +6,208 @@ commit_count: 43
 ---
 ## Features
 
-- **add essential directives (unsafeHTML, live) with renderer integration** [`3d8a253`](https://github.com/vivek7405/webjs/commit/3d8a253)
+- **add essential directives (unsafeHTML, live) with renderer integration** [`3d8a253`](https://github.com/webjsdev/webjs/commit/3d8a253)
   Only three directives in webjs — each solves a problem with no native
   alternative. unsafeHTML for trusted raw HTML, live for input value
   dirty-checking, repeat (already existed) for keyed lists. Both client
   and server renderers now process directive markers correctly instead
-- **full lifecycle, controllers, error boundaries, selective hydration** [`231bc4c`](https://github.com/vivek7405/webjs/commit/231bc4c)
+- **full lifecycle, controllers, error boundaries, selective hydration** [`231bc4c`](https://github.com/webjsdev/webjs/commit/231bc4c)
   Add shouldUpdate, willUpdate, firstUpdated, updated, changedProperties
   tracking. Add ReactiveController pattern (addController/removeController).
   Add client-side error boundaries (renderError lifecycle hook). Add
   static hydrate='visible' for IntersectionObserver-based deferred
-- **add Context Protocol and Task controller** [`d68b207`](https://github.com/vivek7405/webjs/commit/d68b207)
+- **add Context Protocol and Task controller** [`d68b207`](https://github.com/webjsdev/webjs/commit/d68b207)
   Context: createContext, ContextProvider, ContextConsumer for cross-
   component data sharing without prop drilling. Uses W3C Context Protocol
   (DOM events, crosses shadow DOM).
-- **auto-vendor npm deps, module graph, lazy loading** [`266d041`](https://github.com/vivek7405/webjs/commit/266d041)
+- **auto-vendor npm deps, module graph, lazy loading** [`266d041`](https://github.com/webjsdev/webjs/commit/266d041)
   Auto-vendor: scan client imports for bare specifiers, bundle via esbuild,
   serve at /__webjs/vendor/<pkg>.js, auto-populate import map.
   
   Module graph: build dependency graph at startup, emit transitive
-- **webjs test, webjs check, webjs create with AI guardrails** [`6e85e5d`](https://github.com/vivek7405/webjs/commit/6e85e5d)
+- **webjs test, webjs check, webjs create with AI guardrails** [`6e85e5d`](https://github.com/webjsdev/webjs/commit/6e85e5d)
   - webjs test: discovers and runs unit + E2E tests
   - webjs check: validates app against 6 convention rules
   - webjs create: scaffolds opinionated project with CONVENTIONS.md,
     cross-agent configs (.cursorrules, .windsurfrules, copilot-instructions),
-- **light DOM SSR + hydration — zero flash, mixed shadow/light DOM** [`cf155d7`](https://github.com/vivek7405/webjs/commit/cf155d7)
+- **light DOM SSR + hydration — zero flash, mixed shadow/light DOM** [`cf155d7`](https://github.com/webjsdev/webjs/commit/cf155d7)
   SSR fix: light DOM components (static shadow = false) now have their
   render() called during SSR. Content is injected directly as children
   with a <!--webjs-hydrate--> marker (no DSD template wrapper).
-- **light DOM tests, blog migration, auto-scoped styles** [`75f6d17`](https://github.com/vivek7405/webjs/commit/75f6d17)
+- **light DOM tests, blog migration, auto-scoped styles** [`75f6d17`](https://github.com/webjsdev/webjs/commit/75f6d17)
   Tests:
   - test/light-dom-ssr.test.js: 5 unit tests for SSR (light DOM content,
     hydration marker, shadow DSD, mixed page, async render)
   - test/browser/light-dom-hydration.test.js: 3 browser tests (hydration
-- **auto-scope ALL CSS selectors for light DOM components** [`bdb3280`](https://github.com/vivek7405/webjs/commit/bdb3280)
+- **auto-scope ALL CSS selectors for light DOM components** [`bdb3280`](https://github.com/webjsdev/webjs/commit/bdb3280)
   scopeCSS() now prefixes every CSS rule with the component tag name:
     input { color: red } → comments-thread input { color: red }
     :host { display: block } → comments-thread { display: block }
-- **support mixed attribute interpolation in client renderer** [`893c99f`](https://github.com/vivek7405/webjs/commit/893c99f)
+- **support mixed attribute interpolation in client renderer** [`893c99f`](https://github.com/webjsdev/webjs/commit/893c99f)
   Quoted attributes with embedded holes (class="static ${dynamic}")
   previously dropped the dynamic portion on client re-render. The
   renderer now tracks these as 'attr-mixed' parts that reconstruct
   the full attribute value from static pieces + dynamic values on
-- **default components to light DOM, shadow DOM is opt-in** [`01b55c2`](https://github.com/vivek7405/webjs/commit/01b55c2)
+- **default components to light DOM, shadow DOM is opt-in** [`01b55c2`](https://github.com/webjsdev/webjs/commit/01b55c2)
   Change static shadow default from true to false. Components now
   render to light DOM by default. Set static shadow = true to opt
   into shadow DOM with adoptedStyleSheets.
-- **auto-wrap layout output with data-layout for client router** [`306c512`](https://github.com/vivek7405/webjs/commit/306c512)
+- **auto-wrap layout output with data-layout for client router** [`306c512`](https://github.com/webjsdev/webjs/commit/306c512)
   The SSR pipeline now automatically wraps the outermost layout's
   rendered output in <div data-layout="LAYOUT_ID">. Users no longer
   need to add data-layout manually — the framework handles it.
-- **SSR pages default to no-store, caching is opt-in** [`5a4468c`](https://github.com/vivek7405/webjs/commit/5a4468c)
+- **SSR pages default to no-store, caching is opt-in** [`5a4468c`](https://github.com/webjsdev/webjs/commit/5a4468c)
   SSR responses now send Cache-Control: no-store by default. Pages
   are dynamic — the developer opts in to caching explicitly via
   metadata.cacheControl (e.g. 'public, max-age=60'). This ensures
   client-side navigation always gets fresh content without needing
-- **typed component props via defineComponent + .d.ts overlay** [`9f0b09a`](https://github.com/vivek7405/webjs/commit/9f0b09a)
+- **typed component props via defineComponent + .d.ts overlay** [`9f0b09a`](https://github.com/webjsdev/webjs/commit/9f0b09a)
   The existing static-properties pattern carried no compile-time type
   information, so authors had to duplicate every field as `declare x: T`
   for editor intellisense. This adds a TypeScript overlay plus a tiny
   runtime helper so the descriptor map is the single source of truth for
-- **Class.register() — drop the import.meta.url argument** [`283c2b5`](https://github.com/vivek7405/webjs/commit/283c2b5)
+- **Class.register() — drop the import.meta.url argument** [`283c2b5`](https://github.com/webjsdev/webjs/commit/283c2b5)
   Authors no longer write `Counter.register(import.meta.url)`; the call
   is just `Counter.register()`. Module URLs (used by SSR to emit
   `<link rel=modulepreload>` hints) are derived server-side at boot by
   scanning the app tree for `class X extends WebComponent { static tag =
-- **adopt standard customElements.define — drop static tag + .register()** [`bb61186`](https://github.com/vivek7405/webjs/commit/bb61186)
+- **adopt standard customElements.define — drop static tag + .register()** [`bb61186`](https://github.com/webjsdev/webjs/commit/bb61186)
   The web-standard registration convention (same shape Lit uses for its
   non-decorator form):
   
     class Counter extends WebComponent { ... }
-- **Counter.register('my-counter') as the idiomatic registration** [`a0f1f68`](https://github.com/vivek7405/webjs/commit/a0f1f68)
+- **Counter.register('my-counter') as the idiomatic registration** [`a0f1f68`](https://github.com/webjsdev/webjs/commit/a0f1f68)
   Adds a `static register(tag)` method on WebComponent. Delegates to the
   internal registry (which in turn calls customElements.define / the
   server shim), so every registration still lands in the native
   customElements map and webjs's mirror map. Authors write:
-- **rename core package webjs → @webjs/core for npm publish** [`49e2d6b`](https://github.com/vivek7405/webjs/commit/49e2d6b)
+- **rename core package webjs → @webjs/core for npm publish** [`49e2d6b`](https://github.com/webjsdev/webjs/commit/49e2d6b)
   The unscoped `webjs` name is already taken on npm (webjs@0.6.1, unrelated
   project). Moving to the `@webjs` scope lets us publish `@webjs/core`,
   `@webjs/server`, and `@webjs/cli` together.
-- **rescope @webjs → @webjskit (org name 'webjs' unavailable on npm)** [`316e2be`](https://github.com/vivek7405/webjs/commit/316e2be)
+- **rescope @webjs → @webjskit (org name 'webjs' unavailable on npm)** [`316e2be`](https://github.com/webjsdev/webjs/commit/316e2be)
   The @webjs organization is not available on npm (likely reserved because
   the unscoped `webjs` package is held by an unrelated project). Switching
   to the @webjskit scope, which we own.
 
 ## Fixes
 
-- **DSD injection regex now handles slashes inside attribute values** [`c792b6e`](https://github.com/vivek7405/webjs/commit/c792b6e)
+- **DSD injection regex now handles slashes inside attribute values** [`c792b6e`](https://github.com/webjsdev/webjs/commit/c792b6e)
   Bug: <auth-forms then=\"/dashboard\"> rendered as an EMPTY custom element
   with no shadow root — the sign-in and sign-up pages appeared blank.
   Root cause: the DSD-injection regex in render-server.js used
   `[^>/]*` to bound the attribute section, which stopped matching the
-- **quoted-attr interpolation no longer crashes client re-renders** [`df2a952`](https://github.com/vivek7405/webjs/commit/df2a952)
+- **quoted-attr interpolation no longer crashes client re-renders** [`df2a952`](https://github.com/webjsdev/webjs/commit/df2a952)
   Bug: clicking the 'Sign up' tab on /login did nothing. The <auth-forms>
   component used a hole inside a quoted attribute —
   \`autocomplete=\"\${mode === 'login' ? 'current-password' : 'new-password'}\"\` —
   and the client compiler was recording a \`{ kind: 'attr', path: [] }\` part
-- **boolean attribute SSR coercion — empty value means true** [`016d5b5`](https://github.com/vivek7405/webjs/commit/016d5b5)
+- **boolean attribute SSR coercion — empty value means true** [`016d5b5`](https://github.com/webjsdev/webjs/commit/016d5b5)
   Bug: <comments-thread ?signed-in=\${true}> rendered the comment form as
   "Sign in to comment" instead of the input+Post form, even when the user
   was logged in.
-- **filter DSD template from client-navigation swap + update rubric** [`a026010`](https://github.com/vivek7405/webjs/commit/a026010)
+- **filter DSD template from client-navigation swap + update rubric** [`a026010`](https://github.com/webjsdev/webjs/commit/a026010)
   Client router: when swapping the layout shell's light-DOM children on
   navigation, the new body from DOMParser contains a
   <template shadowrootmode="open"> element (the SSR's Declarative Shadow
   DOM). DOMParser doesn't process DSD, so it stays as a regular DOM element.
-- **flicker-free navigation via View Transitions + visibility fallback** [`5f5553c`](https://github.com/vivek7405/webjs/commit/5f5553c)
+- **flicker-free navigation via View Transitions + visibility fallback** [`5f5553c`](https://github.com/webjsdev/webjs/commit/5f5553c)
   The blog's top navbar flickered during client navigation because
   replaceChildren on a custom element with a shadow root and <slot>
   triggers slot redistribution — the browser briefly renders an empty
   <main> between removing old children and inserting new ones.
-- **eliminate navbar flicker during client navigation** [`4f213d1`](https://github.com/vivek7405/webjs/commit/4f213d1)
+- **eliminate navbar flicker during client navigation** [`4f213d1`](https://github.com/webjsdev/webjs/commit/4f213d1)
   Two fixes working together:
   
   1. Client router: changed swap strategy from replaceChildren (empties
      slot, then fills — one-frame empty state) to append-then-remove
-- **layout-aware navigation — only swap page content, never touch layout** [`5875ed6`](https://github.com/vivek7405/webjs/commit/5875ed6)
+- **layout-aware navigation — only swap page content, never touch layout** [`5875ed6`](https://github.com/webjsdev/webjs/commit/5875ed6)
   Root cause: the client router was calling mergeHead() (which removes/adds
   <link>, <script> tags in <head>) and reactivateScripts() (which clones
   <script> elements in <body>) on every navigation. These DOM mutations
   triggered browser style recalculation and brief repaints of the layout
-- **client router now intercepts clicks inside shadow DOM** [`d89e7bb`](https://github.com/vivek7405/webjs/commit/d89e7bb)
+- **client router now intercepts clicks inside shadow DOM** [`d89e7bb`](https://github.com/webjsdev/webjs/commit/d89e7bb)
   ROOT CAUSE FOUND: the navbar flicker was a full browser navigation, not
   a rendering bug. The client router's click handler used e.target to find
   the <a> element, but click events from inside shadow DOM are retargeted
   — e.target points to the shadow HOST (<blog-shell>), not the <a> inside
-- **use DSD-aware parsing in client router** [`991d8d0`](https://github.com/vivek7405/webjs/commit/991d8d0)
+- **use DSD-aware parsing in client router** [`991d8d0`](https://github.com/webjsdev/webjs/commit/991d8d0)
   Neither innerHTML nor DOMParser process Declarative Shadow DOM — custom
   elements navigated to via the client router had no shadow roots, losing
   their layout/sidebar/styles entirely.
-- **theme toggle TDZ, light theme default, client router View Transitions race** [`08312a9`](https://github.com/vivek7405/webjs/commit/08312a9)
+- **theme toggle TDZ, light theme default, client router View Transitions race** [`08312a9`](https://github.com/webjsdev/webjs/commit/08312a9)
   - Move ICONS before register() to fix temporal dead zone error on
     components in light DOM (website theme toggle broken)
   - Default to light theme across all three apps
   - Dark theme accent hue aligned to match light theme (55 amber)
-- **rename data-webjs to data-webjs-styles-for — self-documenting** [`47b5168`](https://github.com/vivek7405/webjs/commit/47b5168)
+- **rename data-webjs to data-webjs-styles-for — self-documenting** [`47b5168`](https://github.com/webjsdev/webjs/commit/47b5168)
   The attribute on light DOM <style> elements now clearly says what it
   does: identifies which component owns the style block. Prevents
   duplicate injection. Added JSDoc for AI agents: do not set manually.
-- **remove auto-scope CSS hack, clean shadow/light DOM convention** [`f91ceb0`](https://github.com/vivek7405/webjs/commit/f91ceb0)
+- **remove auto-scope CSS hack, clean shadow/light DOM convention** [`f91ceb0`](https://github.com/webjsdev/webjs/commit/f91ceb0)
   Shadow DOM = scoped styles (static styles = css, adoptedStyleSheets).
   Light DOM = global styles (Tailwind, global CSS, no static styles).
   Pick one. Don't fake shadow DOM scoping with regex.
-- **warn when static styles used with light DOM (silently ignored before)** [`7bcb656`](https://github.com/vivek7405/webjs/commit/7bcb656)
+- **warn when static styles used with light DOM (silently ignored before)** [`7bcb656`](https://github.com/webjsdev/webjs/commit/7bcb656)
   static styles + static shadow = false is a mistake — adoptedStyleSheets
   requires a shadow root. Now logs a clear warning telling the developer
   to use global CSS or <style> in render() instead.
-- **ensure custom elements upgrade after client-side navigation** [`b357e56`](https://github.com/vivek7405/webjs/commit/b357e56)
+- **ensure custom elements upgrade after client-side navigation** [`b357e56`](https://github.com/webjsdev/webjs/commit/b357e56)
   Document.parseHTMLUnsafe() creates elements in a detached document with
   an empty customElements registry. When those nodes are moved to the live
   document via replaceChildren, Chromium can silently skip the custom
   element upgrade — leaving _renderRoot null and connectedCallback unfired.
-- **inject DSD with inline styles for nested custom elements** [`b012c38`](https://github.com/vivek7405/webjs/commit/b012c38)
+- **inject DSD with inline styles for nested custom elements** [`b012c38`](https://github.com/webjsdev/webjs/commit/b012c38)
   The SSR pipeline's injectDSD() was not recursively processing custom
   elements nested inside other components' shadow DOM. A <theme-toggle>
   inside <blog-shell>'s render output was emitted as an empty element
   with no DSD template — no styles, no content until JS upgraded it.
-- **traverse shadow roots in upgradeCustomElements and handle View Transitions** [`0d9be29`](https://github.com/vivek7405/webjs/commit/0d9be29)
+- **traverse shadow roots in upgradeCustomElements and handle View Transitions** [`0d9be29`](https://github.com/webjsdev/webjs/commit/0d9be29)
   Two improvements to the custom element upgrade logic in the client router:
   
   1. upgradeCustomElements now recursively walks into shadow roots.
      querySelectorAll('*') only searches light DOM — elements like
-- **hoist scripts/styles to head + data-layout for router detection** [`7bcebf0`](https://github.com/vivek7405/webjs/commit/7bcebf0)
+- **hoist scripts/styles to head + data-layout for router detection** [`7bcebf0`](https://github.com/webjsdev/webjs/commit/7bcebf0)
   Two fixes for client-side navigation with light DOM layouts:
   
   1. SSR hoistHeadTags: leading <script> and <style> tags from the body
      are moved to <head>. Tailwind browser script, @theme styles, and
-- **remove View Transitions from same-layout swap + cache-bust fetches** [`1c5a06a`](https://github.com/vivek7405/webjs/commit/1c5a06a)
+- **remove View Transitions from same-layout swap + cache-bust fetches** [`1c5a06a`](https://github.com/webjsdev/webjs/commit/1c5a06a)
   Two fixes:
   - Remove startViewTransition from swapSlotContent to eliminate race
     conditions where custom elements aren't upgraded during the
     transition animation. Add a deferred microtask upgrade pass instead.
-- **MutationObserver safety net for custom element upgrades** [`2d260dc`](https://github.com/vivek7405/webjs/commit/2d260dc)
+- **MutationObserver safety net for custom element upgrades** [`2d260dc`](https://github.com/webjsdev/webjs/commit/2d260dc)
   Add a global MutationObserver that watches for any custom element
   inserted into the document and calls customElements.upgrade() on it.
   This catches elements that the browser fails to auto-upgrade after
   DOM operations like replaceChildren — regardless of timing, View
-- **load page component modules on same-layout navigation** [`a04a974`](https://github.com/vivek7405/webjs/commit/a04a974)
+- **load page component modules on same-layout navigation** [`a04a974`](https://github.com/webjsdev/webjs/commit/a04a974)
   Root cause of both bugs: on client-side navigation within the same
   layout, the router swapped <main> content but did NOT load the new
   page's component modules. Components like <new-post> appeared in the
   DOM as plain HTMLElement — never upgraded, no event handlers, no
-- **use add-only head merge for same-layout navigation** [`8e9948c`](https://github.com/vivek7405/webjs/commit/8e9948c)
+- **use add-only head merge for same-layout navigation** [`8e9948c`](https://github.com/webjsdev/webjs/commit/8e9948c)
   mergeHead() was removing the Tailwind-generated <style> tag from
   <head> during same-layout navigation because it wasn't in the
   server-rendered HTML (it's generated at runtime by the Tailwind
   browser CDN).
-- **forward streamed Suspense resolvers on same-layout nav** [`09c06e3`](https://github.com/vivek7405/webjs/commit/09c06e3)
+- **forward streamed Suspense resolvers on same-layout nav** [`09c06e3`](https://github.com/webjsdev/webjs/commit/09c06e3)
   Streamed Suspense templates (<template data-webjs-resolve="...">) are
   emitted at body level, AFTER the </div> that closes the data-layout
   wrapper. During same-layout navigation the router swaps only the
   <main> contents inside the wrapper, so those resolvers were dropped
-- **skip non-HTML responses and extensions; document data-no-router** [`9af54bf`](https://github.com/vivek7405/webjs/commit/9af54bf)
+- **skip non-HTML responses and extensions; document data-no-router** [`9af54bf`](https://github.com/webjsdev/webjs/commit/9af54bf)
   Three gaps in the same-origin interception logic that produced a
   broken/hung/blank page:
   
   1. Non-HTML extensions — /foo.pdf, /data.zip, /feed.xml, /posts.json,
-- **render-client compile() crashed on holes inside comments / raw-text** [`2311969`](https://github.com/vivek7405/webjs/commit/2311969)
+- **render-client compile() crashed on holes inside comments / raw-text** [`2311969`](https://github.com/webjsdev/webjs/commit/2311969)
   The client-side `compile()` function destructures only `strings` from the
   template result, but two branches (state==='comment' and state==='rawtext')
   referenced an undefined `values` binding. Any template with an interpolation
   inside an HTML comment or <script>/<style> body would throw
-- **share component registry across module instances** [`f3757aa`](https://github.com/vivek7405/webjs/commit/f3757aa)
+- **share component registry across module instances** [`f3757aa`](https://github.com/webjsdev/webjs/commit/f3757aa)
   When the cli is installed globally (or hoisted at a different level
   than the user's app), Node resolves `@webjskit/core` from each
   importer's location and may load TWO instances of the package — one

--- a/changelog/core/0.3.0.md
+++ b/changelog/core/0.3.0.md
@@ -6,7 +6,7 @@ commit_count: 1
 ---
 ## Features
 
-- **drop superjson, ship built-in ESM rich-type serializer** [`4efefce`](https://github.com/vivek7405/webjs/commit/4efefce)
+- **drop superjson, ship built-in ESM rich-type serializer** [`4efefce`](https://github.com/webjsdev/webjs/commit/4efefce)
   Replaces `superjson` with a pure-ESM, dependency-free serializer in
   `@webjskit/core` (`packages/core/src/serialize.js`). Tagged-inline wire
   format, async sync API. Single async `stringify`/`serialize` so AI

--- a/changelog/core/0.4.1.md
+++ b/changelog/core/0.4.1.md
@@ -6,12 +6,12 @@ commit_count: 2
 ---
 ## Fixes
 
-- **preserve cached snapshot on popstate; manual scrollRestoration** [`5a3b684`](https://github.com/vivek7405/webjs/commit/5a3b684)
+- **preserve cached snapshot on popstate; manual scrollRestoration** [`5a3b684`](https://github.com/webjsdev/webjs/commit/5a3b684)
   Two bugs combined to break back-button scroll restoration:
   
   1. snapshotCurrent(location.href) at performNavigation entry ran on
      EVERY navigation including popstate. But on popstate, the browser
-- **scroll to top on cache-miss popstate** [`42142c2`](https://github.com/vivek7405/webjs/commit/42142c2)
+- **scroll to top on cache-miss popstate** [`42142c2`](https://github.com/webjsdev/webjs/commit/42142c2)
   Companion to the previous commit. Setting history.scrollRestoration
   = 'manual' takes the browser out of the scroll-restoration game on
   back/forward — which is great when we have a cached snapshot (we

--- a/changelog/core/0.5.0.md
+++ b/changelog/core/0.5.0.md
@@ -6,20 +6,20 @@ commit_count: 5
 ---
 ## Features
 
-- **light-DOM slot runtime foundation (slot.js)** [`b6cc3e8`](https://github.com/vivek7405/webjs/commit/b6cc3e8)
+- **light-DOM slot runtime foundation (slot.js)** [`b6cc3e8`](https://github.com/webjsdev/webjs/commit/b6cc3e8)
   First slice of the light-DOM slot work. Adds the standalone runtime
   file owning the slot semantics. Subsequent commits wire it into the
   compiler, component lifecycle, and SSR pipeline.
-- **slot part in compiler + client renderer + fallback swap hook** [`3258888`](https://github.com/vivek7405/webjs/commit/3258888)
+- **slot part in compiler + client renderer + fallback swap hook** [`3258888`](https://github.com/webjsdev/webjs/commit/3258888)
   Second slice. Wires light-DOM <slot> elements through the existing
   template compile, bind, apply, and clear pipeline using a new SLOT
   part kind. Adds the small slot.js hook that swaps fallback content
   into the slot when projection state is "fallback".
-- **slot lifecycle in WebComponent + per-instance fallback clone** [`c69615b`](https://github.com/vivek7405/webjs/commit/c69615b)
+- **slot lifecycle in WebComponent + per-instance fallback clone** [`c69615b`](https://github.com/webjsdev/webjs/commit/c69615b)
   Third slice. Wires the slot runtime into the WebComponent lifecycle and
   refines render-client.js's slot bind so fallback content is captured
   once at compile time and cloned freshly per instance.
-- **SSR slot substitution in injectDSD** [`595da6a`](https://github.com/vivek7405/webjs/commit/595da6a)
+- **SSR slot substitution in injectDSD** [`595da6a`](https://github.com/webjsdev/webjs/commit/595da6a)
   Fourth slice. Upgrades injectDSD to project authored children into
   <slot> positions during server-side rendering for light-DOM
   WebComponents, with full parity to the client-side projection rules
@@ -27,7 +27,7 @@ commit_count: 5
 
 ## Fixes
 
-- **6 browser failures fixed, all 26 browser tests pass** [`e99c33a`](https://github.com/vivek7405/webjs/commit/e99c33a)
+- **6 browser failures fixed, all 26 browser tests pass** [`e99c33a`](https://github.com/webjsdev/webjs/commit/e99c33a)
   Four real bugs surfaced in the browser test suite and are fixed:
   
   1. captureAuthoredChildren ran on every connectedCallback, including

--- a/changelog/core/0.6.0.md
+++ b/changelog/core/0.6.0.md
@@ -6,17 +6,17 @@ commit_count: 4
 ---
 ## Features
 
-- **SSR property bindings via data-webjs-prop-* side-channel** [`2c4c98e`](https://github.com/vivek7405/webjs/commit/2c4c98e)
+- **SSR property bindings via data-webjs-prop-* side-channel** [`2c4c98e`](https://github.com/webjsdev/webjs/commit/2c4c98e)
   A property hole (.prop=${val}) on any element used to be dropped
   silently at SSR. The data was lost between page function and
   child component, breaking the natural "fetch data, pass to
   component" pattern unless authors manually JSON.stringify into
-- **client hydrates data-webjs-prop-* attributes, then strips** [`e8e4383`](https://github.com/vivek7405/webjs/commit/e8e4383)
+- **client hydrates data-webjs-prop-* attributes, then strips** [`e8e4383`](https://github.com/webjsdev/webjs/commit/e8e4383)
   Completes the SSR property-binding round-trip. The server emits
   data-webjs-prop-<kebab>="<wire-encoded>" for each .prop=${val}
   hole in PR-WIP commit 2c4c98e. This commit teaches WebComponent
   to consume those attributes on the browser side.
-- **full lit-API parity (ReactiveController + lifecycle + directives + 127 lit-ported tests)** ([#31](https://github.com/vivek7405/webjs/pull/31)) [`5a23521`](https://github.com/vivek7405/webjs/commit/5a23521)
+- **full lit-API parity (ReactiveController + lifecycle + directives + 127 lit-ported tests)** ([#31](https://github.com/webjsdev/webjs/pull/31)) [`5a23521`](https://github.com/webjsdev/webjs/commit/5a23521)
   * feat(core): rename ReactiveController hooks to lit names
   
   onMount → hostConnected
@@ -24,7 +24,7 @@ commit_count: 4
 
 ## Fixes
 
-- **skip property-attribute emission for native elements + decode HTML entities on server walker read** [`a3e1132`](https://github.com/vivek7405/webjs/commit/a3e1132)
+- **skip property-attribute emission for native elements + decode HTML entities on server walker read** [`a3e1132`](https://github.com/webjsdev/webjs/commit/a3e1132)
   Two related fixes to the property-binding SSR path.
   
   1. Native-element guard. Property bindings on tags without a hyphen

--- a/changelog/core/0.7.0.md
+++ b/changelog/core/0.7.0.md
@@ -6,7 +6,7 @@ commit_count: 2
 ---
 ## Breaking
 
-- **signals replace this.state / setState across the stack** ([#43](https://github.com/vivek7405/webjs/pull/43)) [`6e50ae6`](https://github.com/vivek7405/webjs/commit/6e50ae6)
+- **signals replace this.state / setState across the stack** ([#43](https://github.com/webjsdev/webjs/pull/43)) [`6e50ae6`](https://github.com/webjsdev/webjs/commit/6e50ae6)
   * feat(core): signal primitive (TC39 Stage-1 shape, no runtime deps)
   
   Hand-rolled signal/computed/effect/batch in plain JS with JSDoc.
@@ -14,7 +14,7 @@ commit_count: 2
 
 ## Fixes
 
-- **filter framework records in light-DOM slot observer** ([#44](https://github.com/vivek7405/webjs/pull/44)) [`272d417`](https://github.com/vivek7405/webjs/commit/272d417)
+- **filter framework records in light-DOM slot observer** ([#44](https://github.com/webjsdev/webjs/pull/44)) [`272d417`](https://github.com/webjsdev/webjs/commit/272d417)
   * fix(core): filter framework records in light-DOM slot observer
   
   The slot host's MutationObserver could not distinguish renderer-driven

--- a/changelog/core/0.7.1.md
+++ b/changelog/core/0.7.1.md
@@ -6,5 +6,5 @@ commit_count: 1
 ---
 ## Breaking
 
-- **Rescope from `@webjskit/core` to `@webjsdev/core`** ([#62](https://github.com/vivek7405/webjs/pull/62))
+- **Rescope from `@webjskit/core` to `@webjsdev/core`** ([#62](https://github.com/webjsdev/webjs/pull/62))
   The npm scope now matches the canonical `webjs.dev` domain (and the `@webjsdev` org we own on npm). Functionally identical to the prior `@webjskit/core@0.7.0` publish, no API or runtime change. Migrate by find-replacing every `@webjskit/` reference with `@webjsdev/` in source, imports, and `package.json` dependency keys. The legacy `@webjskit/*` packages stay installable, but will be marked deprecated on the registry to redirect new installers here.

--- a/changelog/server/0.1.1.md
+++ b/changelog/server/0.1.1.md
@@ -6,120 +6,120 @@ commit_count: 25
 ---
 ## Features
 
-- **auto-vendor npm deps, module graph, lazy loading** [`266d041`](https://github.com/vivek7405/webjs/commit/266d041)
+- **auto-vendor npm deps, module graph, lazy loading** [`266d041`](https://github.com/webjsdev/webjs/commit/266d041)
   Auto-vendor: scan client imports for bare specifiers, bundle via esbuild,
   serve at /__webjs/vendor/<pkg>.js, auto-populate import map.
   
   Module graph: build dependency graph at startup, emit transitive
-- **abstract wire serializer, decouple from superjson** [`81ab2eb`](https://github.com/vivek7405/webjs/commit/81ab2eb)
+- **abstract wire serializer, decouple from superjson** [`81ab2eb`](https://github.com/webjsdev/webjs/commit/81ab2eb)
   New Serializer interface with getSerializer/setSerializer. superjson
   is the default but can be swapped via webjs.config.js. Decouples the
   RPC layer from a single dependency.
-- **optional catch-all, nested not-found, loading→Suspense, metadata routes** [`332f41f`](https://github.com/vivek7405/webjs/commit/332f41f)
+- **optional catch-all, nested not-found, loading→Suspense, metadata routes** [`332f41f`](https://github.com/webjsdev/webjs/commit/332f41f)
   - [[...slug]] optional catch-all matches with and without params
   - not-found.ts collected at every segment level (nearest wins)
   - loading.ts auto-wraps page in Suspense boundary with loading as fallback
   - Metadata routes: sitemap.ts, robots.ts, manifest.ts, icon.ts,
-- **webjs test, webjs check, webjs create with AI guardrails** [`6e85e5d`](https://github.com/vivek7405/webjs/commit/6e85e5d)
+- **webjs test, webjs check, webjs create with AI guardrails** [`6e85e5d`](https://github.com/webjsdev/webjs/commit/6e85e5d)
   - webjs test: discovers and runs unit + E2E tests
   - webjs check: validates app against 6 convention rules
   - webjs create: scaffolds opinionated project with CONVENTIONS.md,
     cross-agent configs (.cursorrules, .windsurfrules, copilot-instructions),
-- **batteries included — sessions, jobs, pub/sub, storage, cache** [`6292558`](https://github.com/vivek7405/webjs/commit/6292558)
+- **batteries included — sessions, jobs, pub/sub, storage, cache** [`6292558`](https://github.com/webjsdev/webjs/commit/6292558)
   Convention over configuration, like Rails:
   - Set REDIS_URL → cache, sessions, rate limiter, pub/sub, and jobs
     all use Redis automatically. Zero config.
   - Set S3_BUCKET → file storage uses S3. Otherwise local disk.
-- **NextJs-style cache + NextAuth-style auth + WebSocket broadcast** [`19418b3`](https://github.com/vivek7405/webjs/commit/19418b3)
+- **NextJs-style cache + NextAuth-style auth + WebSocket broadcast** [`19418b3`](https://github.com/webjsdev/webjs/commit/19418b3)
   Removed: storage (s3/disk), background jobs — not core framework.
   
   Added:
   - cache(fn, { revalidate, tags }) + revalidateTag() — NextJs-style
-- **HTTP Cache-Control on SSR pages via metadata export** [`74edab3`](https://github.com/vivek7405/webjs/commit/74edab3)
+- **HTTP Cache-Control on SSR pages via metadata export** [`74edab3`](https://github.com/webjsdev/webjs/commit/74edab3)
   Pages can now set Cache-Control headers via the metadata export:
   
     export const metadata = {
       title: 'Blog',
-- **cache() function for server-side RPC query caching** [`504a982`](https://github.com/vivek7405/webjs/commit/504a982)
+- **cache() function for server-side RPC query caching** [`504a982`](https://github.com/webjsdev/webjs/commit/504a982)
   Simple, explicit, no magic:
   
     export const listPosts = cache(
       async () => prisma.post.findMany(),
-- **auto-wrap layout output with data-layout for client router** [`306c512`](https://github.com/vivek7405/webjs/commit/306c512)
+- **auto-wrap layout output with data-layout for client router** [`306c512`](https://github.com/webjsdev/webjs/commit/306c512)
   The SSR pipeline now automatically wraps the outermost layout's
   rendered output in <div data-layout="LAYOUT_ID">. Users no longer
   need to add data-layout manually — the framework handles it.
-- **SSR pages default to no-store, caching is opt-in** [`5a4468c`](https://github.com/vivek7405/webjs/commit/5a4468c)
+- **SSR pages default to no-store, caching is opt-in** [`5a4468c`](https://github.com/webjsdev/webjs/commit/5a4468c)
   SSR responses now send Cache-Control: no-store by default. Pages
   are dynamic — the developer opts in to caching explicitly via
   metadata.cacheControl (e.g. 'public, max-age=60'). This ensures
   client-side navigation always gets fresh content without needing
-- **Class.register() — drop the import.meta.url argument** [`283c2b5`](https://github.com/vivek7405/webjs/commit/283c2b5)
+- **Class.register() — drop the import.meta.url argument** [`283c2b5`](https://github.com/webjsdev/webjs/commit/283c2b5)
   Authors no longer write `Counter.register(import.meta.url)`; the call
   is just `Counter.register()`. Module URLs (used by SSR to emit
   `<link rel=modulepreload>` hints) are derived server-side at boot by
   scanning the app tree for `class X extends WebComponent { static tag =
-- **adopt standard customElements.define — drop static tag + .register()** [`bb61186`](https://github.com/vivek7405/webjs/commit/bb61186)
+- **adopt standard customElements.define — drop static tag + .register()** [`bb61186`](https://github.com/webjsdev/webjs/commit/bb61186)
   The web-standard registration convention (same shape Lit uses for its
   non-decorator form):
   
     class Counter extends WebComponent { ... }
-- **Counter.register('my-counter') as the idiomatic registration** [`a0f1f68`](https://github.com/vivek7405/webjs/commit/a0f1f68)
+- **Counter.register('my-counter') as the idiomatic registration** [`a0f1f68`](https://github.com/webjsdev/webjs/commit/a0f1f68)
   Adds a `static register(tag)` method on WebComponent. Delegates to the
   internal registry (which in turn calls customElements.define / the
   server shim), so every registration still lands in the native
   customElements map and webjs's mirror map. Authors write:
-- **rename core package webjs → @webjs/core for npm publish** [`49e2d6b`](https://github.com/vivek7405/webjs/commit/49e2d6b)
+- **rename core package webjs → @webjs/core for npm publish** [`49e2d6b`](https://github.com/webjsdev/webjs/commit/49e2d6b)
   The unscoped `webjs` name is already taken on npm (webjs@0.6.1, unrelated
   project). Moving to the `@webjs` scope lets us publish `@webjs/core`,
   `@webjs/server`, and `@webjs/cli` together.
-- **rescope @webjs → @webjskit (org name 'webjs' unavailable on npm)** [`316e2be`](https://github.com/vivek7405/webjs/commit/316e2be)
+- **rescope @webjs → @webjskit (org name 'webjs' unavailable on npm)** [`316e2be`](https://github.com/webjsdev/webjs/commit/316e2be)
   The @webjs organization is not available on npm (likely reserved because
   the unscoped `webjs` package is held by an unrelated project). Switching
   to the @webjskit scope, which we own.
-- **social-preview cards for website, docs, and blog** [`b16fc68`](https://github.com/vivek7405/webjs/commit/b16fc68)
+- **social-preview cards for website, docs, and blog** [`b16fc68`](https://github.com/webjsdev/webjs/commit/b16fc68)
   Adds proper Open Graph + Twitter summary_large_image metadata so the
   three apps preview cleanly when shared on WhatsApp, Twitter/X, LinkedIn,
   Slack, Discord, etc.
 
 ## Fixes
 
-- **decode percent-encoded URL paths before filesystem lookups** [`72caa14`](https://github.com/vivek7405/webjs/commit/72caa14)
+- **decode percent-encoded URL paths before filesystem lookups** [`72caa14`](https://github.com/webjsdev/webjs/commit/72caa14)
   Root cause of ALL client-side interactivity failing in production:
   
   The SSR shell emits module imports with literal filesystem paths:
     import "/app/blog/[slug]/page.ts"
-- **bundle superjson into a single ESM file for the browser** [`a13cbea`](https://github.com/vivek7405/webjs/commit/a13cbea)
+- **bundle superjson into a single ESM file for the browser** [`a13cbea`](https://github.com/webjsdev/webjs/commit/a13cbea)
   Root cause of ALL client-side JS failing:
   
   superjson internally imports \`copy-anything\` which imports \`is-what\` —
   both as bare specifiers. The browser's import map only had an entry for
-- **production hardening — cache eviction + CSP nonce support** [`c559de2`](https://github.com/vivek7405/webjs/commit/c559de2)
+- **production hardening — cache eviction + CSP nonce support** [`c559de2`](https://github.com/webjsdev/webjs/commit/c559de2)
   Cache eviction: TS transform cache capped at 500 entries, vendor
   bundle cache at 100. FIFO eviction prevents unbounded memory growth
   in long-running servers.
-- **remove all auto-detection magic from session and cache** [`3a52624`](https://github.com/vivek7405/webjs/commit/3a52624)
+- **remove all auto-detection magic from session and cache** [`3a52624`](https://github.com/webjsdev/webjs/commit/3a52624)
   Cleaned up REDIS_URL auto-detection references from session.js and
   cache.js JSDoc. Session defaults to cookie (explicit, stateless).
   Cache defaults to memory (explicit). User switches to Redis by
   calling setStore/passing storeSession — no env var magic.
-- **export Session class from @webjs/server** [`eae64cb`](https://github.com/vivek7405/webjs/commit/eae64cb)
-- **hoist scripts/styles to head + data-layout for router detection** [`7bcebf0`](https://github.com/vivek7405/webjs/commit/7bcebf0)
+- **export Session class from @webjs/server** [`eae64cb`](https://github.com/webjsdev/webjs/commit/eae64cb)
+- **hoist scripts/styles to head + data-layout for router detection** [`7bcebf0`](https://github.com/webjsdev/webjs/commit/7bcebf0)
   Two fixes for client-side navigation with light DOM layouts:
   
   1. SSR hoistHeadTags: leading <script> and <style> tags from the body
      are moved to <head>. Tailwind browser script, @theme styles, and
-- **exclude server-only modules from <link rel=modulepreload>** [`36ea61b`](https://github.com/vivek7405/webjs/commit/36ea61b)
+- **exclude server-only modules from <link rel=modulepreload>** [`36ea61b`](https://github.com/webjsdev/webjs/commit/36ea61b)
   Server-only files (either .server.{js,ts,mjs,mts} or plain .ts with a
   'use server' directive) were appearing in modulepreload links because
   the transitive-deps walk treats them the same as any other import.
   Browsers fetched them on every page load — the response body is a
-- **hard guardrail — never serve server-file source to the client** [`a4df002`](https://github.com/vivek7405/webjs/commit/a4df002)
+- **hard guardrail — never serve server-file source to the client** [`a4df002`](https://github.com/webjsdev/webjs/commit/a4df002)
   The dev HTTP layer used to look up .server.* / 'use server' files via
   the action index built at boot; on index miss it fell through to
   tsResponse() and returned the RAW SOURCE. That's a serious leak
   vector: DB credentials, scrypt routines, privileged business logic
-- **resolve esbuild from app dir, not server dir** [`4987a04`](https://github.com/vivek7405/webjs/commit/4987a04)
+- **resolve esbuild from app dir, not server dir** [`4987a04`](https://github.com/webjsdev/webjs/commit/4987a04)
   When `@webjskit/cli` is installed globally (the typical case for
   end-users), `import('esbuild')` from `packages/server/src/dev.js`
   walks up from the global install tree — never reaching the user app's

--- a/changelog/server/0.2.0.md
+++ b/changelog/server/0.2.0.md
@@ -6,7 +6,7 @@ commit_count: 1
 ---
 ## Features
 
-- **use esbuild for TS on both SSR + hydration; default to no build** [`eb0b0ee`](https://github.com/vivek7405/webjs/commit/eb0b0ee)
+- **use esbuild for TS on both SSR + hydration; default to no build** [`eb0b0ee`](https://github.com/webjsdev/webjs/commit/eb0b0ee)
   The dev server now registers an esbuild ESM loader hook
   (`module.register()`) at startup. Every server-side `.ts` import flows
   through esbuild's transform — same transformer the dev server already

--- a/changelog/server/0.2.1.md
+++ b/changelog/server/0.2.1.md
@@ -6,7 +6,7 @@ commit_count: 1
 ---
 ## Fixes
 
-- **share component registry across module instances** [`f3757aa`](https://github.com/vivek7405/webjs/commit/f3757aa)
+- **share component registry across module instances** [`f3757aa`](https://github.com/webjsdev/webjs/commit/f3757aa)
   When the cli is installed globally (or hoisted at a different level
   than the user's app), Node resolves `@webjskit/core` from each
   importer's location and may load TWO instances of the package — one

--- a/changelog/server/0.3.0.md
+++ b/changelog/server/0.3.0.md
@@ -6,7 +6,7 @@ commit_count: 1
 ---
 ## Features
 
-- **drop superjson, ship built-in ESM rich-type serializer** [`4efefce`](https://github.com/vivek7405/webjs/commit/4efefce)
+- **drop superjson, ship built-in ESM rich-type serializer** [`4efefce`](https://github.com/webjsdev/webjs/commit/4efefce)
   Replaces `superjson` with a pure-ESM, dependency-free serializer in
   `@webjskit/core` (`packages/core/src/serialize.js`). Tagged-inline wire
   format, async sync API. Single async `stringify`/`serialize` so AI

--- a/changelog/server/0.3.1.md
+++ b/changelog/server/0.3.1.md
@@ -6,7 +6,7 @@ commit_count: 1
 ---
 ## Fixes
 
-- **hoist <link> from layout body into <head>** [`cfa4827`](https://github.com/vivek7405/webjs/commit/cfa4827)
+- **hoist <link> from layout body into <head>** [`cfa4827`](https://github.com/webjsdev/webjs/commit/cfa4827)
   Layouts emit <link rel="icon">, <link rel="stylesheet">, etc. in their
   template body, but the SSR pipeline wraps that body in
   <div data-layout="..."> before the existing hoister ran — so the

--- a/changelog/server/0.4.0.md
+++ b/changelog/server/0.4.0.md
@@ -6,7 +6,7 @@ commit_count: 1
 ---
 ## Features
 
-- **rule reactive-props-use-declare flags class-field foot-gun** [`4ef105f`](https://github.com/vivek7405/webjs/commit/4ef105f)
+- **rule reactive-props-use-declare flags class-field foot-gun** [`4ef105f`](https://github.com/webjsdev/webjs/commit/4ef105f)
   A reactive property listed in `static properties = { … }` MUST be
   typed via `declare propName: Type` and have its default set inside
   `constructor()`. A plain class-field initializer

--- a/changelog/server/0.5.1.md
+++ b/changelog/server/0.5.1.md
@@ -6,7 +6,7 @@ commit_count: 1
 ---
 ## Fixes
 
-- **honor X-Forwarded-Proto/Host when building ctx.url** [`952d414`](https://github.com/vivek7405/webjs/commit/952d414)
+- **honor X-Forwarded-Proto/Host when building ctx.url** [`952d414`](https://github.com/webjsdev/webjs/commit/952d414)
   webjs apps deployed behind a TLS-terminating reverse proxy (Railway,
   Fly, Render, Vercel, Cloudflare, nginx, Caddy, Traefik — the typical
   no-build deployment topology) receive plain HTTP at the container with

--- a/changelog/server/0.6.0.md
+++ b/changelog/server/0.6.0.md
@@ -6,12 +6,12 @@ commit_count: 2
 ---
 ## Features
 
-- **hybrid TS stripper (Node strip-types + esbuild fallback)** [`29f1645`](https://github.com/vivek7405/webjs/commit/29f1645)
+- **hybrid TS stripper (Node strip-types + esbuild fallback)** [`29f1645`](https://github.com/webjsdev/webjs/commit/29f1645)
   Server-side .ts imports now use Node 24+'s default type-stripping
   natively. The module.register('./esbuild-loader.js') hook and the
   loader file itself are deleted: SSR and the test runner both pick
   up .ts files without any framework bootstrap.
-- **erasable-typescript-only rule + ship erasableSyntaxOnly in tsconfigs** [`490372a`](https://github.com/vivek7405/webjs/commit/490372a)
+- **erasable-typescript-only rule + ship erasableSyntaxOnly in tsconfigs** [`490372a`](https://github.com/webjsdev/webjs/commit/490372a)
   Adds compilerOptions.erasableSyntaxOnly to: the scaffold tsconfig
   generator (packages/cli/lib/create.js), the blog example, the docs
   site, the marketing site. TypeScript 5.8+ rejects enum, namespace

--- a/changelog/server/0.7.0.md
+++ b/changelog/server/0.7.0.md
@@ -6,27 +6,27 @@ commit_count: 6
 ---
 ## Features
 
-- **drop webjs.conventions.js + legacy fallbacks, only support pkg.webjs.conventions** [`81bdf7c`](https://github.com/vivek7405/webjs/commit/81bdf7c)
+- **drop webjs.conventions.js + legacy fallbacks, only support pkg.webjs.conventions** [`81bdf7c`](https://github.com/webjsdev/webjs/commit/81bdf7c)
   loadOverrides now reads exactly one place: package.json
   "webjs": { "conventions": { … } }. Returns {} when the key is
   absent (every default rule active). Removes the old top-level
   "conventions" fallback, the webjs.conventions.js file path, and
-- **WEBJS_PUBLIC_* env vars accessible as process.env.* in browser** [`60eed0e`](https://github.com/vivek7405/webjs/commit/60eed0e)
+- **WEBJS_PUBLIC_* env vars accessible as process.env.* in browser** [`60eed0e`](https://github.com/webjsdev/webjs/commit/60eed0e)
   Adds an SSR-injected inline script that defines window.process.env
   with all server-side env vars whose name starts with WEBJS_PUBLIC_,
   plus NODE_ENV based on dev/prod mode. Counterpart of Next.js's
   NEXT_PUBLIC_ convention, without a build step.
-- **no-server-env-in-components lint rule** [`a0dc926`](https://github.com/vivek7405/webjs/commit/a0dc926)
+- **no-server-env-in-components lint rule** [`a0dc926`](https://github.com/webjsdev/webjs/commit/a0dc926)
   Flags process.env.X reads in component files where X is not
   WEBJS_PUBLIC_* and not NODE_ENV. The SSR shim only exposes
   those two categories to the browser; any other read either
   leaks a secret into the SSR'd HTML or reads as undefined
-- **split .server.ts source-protection from 'use server' RPC marker** [`41a61bb`](https://github.com/vivek7405/webjs/commit/41a61bb)
+- **split .server.ts source-protection from 'use server' RPC marker** [`41a61bb`](https://github.com/webjsdev/webjs/commit/41a61bb)
   The two markers are now complementary instead of interchangeable:
   
     .server.{js,ts}        path-level boundary: file router refuses to
                            serve the source to the browser.
-- **add use-server-needs-extension lint rule** [`7e543a6`](https://github.com/vivek7405/webjs/commit/7e543a6)
+- **add use-server-needs-extension lint rule** [`7e543a6`](https://github.com/webjsdev/webjs/commit/7e543a6)
   The rule catches files that declare `'use server'` at the top but
   lack the `.server.{js,ts,mts,mjs}` extension. Under the two-marker
   convention, the directive alone is silently ignored: the file serves
@@ -34,7 +34,7 @@ commit_count: 6
 
 ## Fixes
 
-- **remove no-server-imports-in-components lint rule entirely** [`2bca0dd`](https://github.com/vivek7405/webjs/commit/2bca0dd)
+- **remove no-server-imports-in-components lint rule entirely** [`2bca0dd`](https://github.com/webjsdev/webjs/commit/2bca0dd)
   The convention 'server-only code goes in .server.ts, route.ts, or
   middleware.ts; never in pages, layouts, or components' is real
   and important, but pure static lint enforcement is the wrong

--- a/changelog/server/0.7.1.md
+++ b/changelog/server/0.7.1.md
@@ -6,7 +6,7 @@ commit_count: 1
 ---
 ## Fixes
 
-- **stop sending immutable cache-control on /__webjs/core/*** ([#38](https://github.com/vivek7405/webjs/pull/38)) [`f6bd2d6`](https://github.com/vivek7405/webjs/commit/f6bd2d6)
+- **stop sending immutable cache-control on /__webjs/core/*** ([#38](https://github.com/webjsdev/webjs/pull/38)) [`f6bd2d6`](https://github.com/webjsdev/webjs/commit/f6bd2d6)
   The /__webjs/core/* paths are un-versioned: every bump of
   @webjskit/core ships different bytes at the same URL. Sending
   `cache-control: public, max-age=31536000, immutable` instructed

--- a/changelog/server/0.7.2.md
+++ b/changelog/server/0.7.2.md
@@ -6,5 +6,5 @@ commit_count: 1
 ---
 ## Breaking
 
-- **Rescope from `@webjskit/server` to `@webjsdev/server`** ([#62](https://github.com/vivek7405/webjs/pull/62))
+- **Rescope from `@webjskit/server` to `@webjsdev/server`** ([#62](https://github.com/webjsdev/webjs/pull/62))
   The npm scope now matches the canonical `webjs.dev` domain (and the `@webjsdev` org we own on npm). Functionally identical to the prior `@webjskit/server@0.7.1` publish, no API or runtime change. Migrate by find-replacing every `@webjskit/` reference with `@webjsdev/` in source, imports, and `package.json` dependency keys. The legacy `@webjskit/*` packages stay installable, but will be marked deprecated on the registry to redirect new installers here.

--- a/changelog/ts-plugin/0.2.0.md
+++ b/changelog/ts-plugin/0.2.0.md
@@ -6,11 +6,11 @@ commit_count: 2
 ---
 ## Features
 
-- **rebrand webjs-plugin → @webjskit/ts-plugin, ready for npm** [`cf89060`](https://github.com/vivek7405/webjs/commit/cf89060)
+- **rebrand webjs-plugin → @webjskit/ts-plugin, ready for npm** [`cf89060`](https://github.com/webjsdev/webjs/commit/cf89060)
   Matches the scope of the three published packages (@webjskit/core,
   @webjskit/server, @webjskit/cli). The ts-* naming suffix mirrors the
   tsserver-plugin convention (cf. ts-lit-plugin).
-- **suppress lit-plugin "unknown tag/attr" + complete attrs** [`25f9863`](https://github.com/vivek7405/webjs/commit/25f9863)
+- **suppress lit-plugin "unknown tag/attr" + complete attrs** [`25f9863`](https://github.com/webjsdev/webjs/commit/25f9863)
   ts-lit-plugin doesn't recognise webjs components — they're registered
   at runtime via Class.register('tag') with no @customElement decorator
   or HTMLElementTagNameMap augmentation — so it fires "Unknown tag" /

--- a/changelog/ts-plugin/0.3.0.md
+++ b/changelog/ts-plugin/0.3.0.md
@@ -6,7 +6,7 @@ commit_count: 1
 ---
 ## Features
 
-- **type-check <webjs-tag attr=\${expr}> interpolations** [`306bcb4`](https://github.com/vivek7405/webjs/commit/306bcb4)
+- **type-check <webjs-tag attr=\${expr}> interpolations** [`306bcb4`](https://github.com/webjsdev/webjs/commit/306bcb4)
   Extend the plugin with a fourth resolver: for every \${expr}
   interpolation in attribute-value position of a reachable webjs tag,
   look up the matching `declare attr: T` field on the component class

--- a/changelog/ts-plugin/0.4.1.md
+++ b/changelog/ts-plugin/0.4.1.md
@@ -6,5 +6,5 @@ commit_count: 1
 ---
 ## Breaking
 
-- **Rescope from `@webjskit/ts-plugin` to `@webjsdev/ts-plugin`** ([#62](https://github.com/vivek7405/webjs/pull/62))
+- **Rescope from `@webjskit/ts-plugin` to `@webjsdev/ts-plugin`** ([#62](https://github.com/webjsdev/webjs/pull/62))
   The npm scope now matches the canonical `webjs.dev` domain (and the `@webjsdev` org we own on npm). Functionally identical to the prior `@webjskit/ts-plugin@0.4.0` publish, no plugin behavior change. Update your `tsconfig.json` `plugins` entry from `@webjskit/ts-plugin` to `@webjsdev/ts-plugin` and reinstall. The legacy `@webjskit/*` packages stay installable, but will be marked deprecated on the registry to redirect new installers here.

--- a/changelog/ui/0.2.0.md
+++ b/changelog/ui/0.2.0.md
@@ -6,26 +6,26 @@ commit_count: 6
 ---
 ## Features
 
-- **add tier classifier for registry items** [`f263510`](https://github.com/vivek7405/webjs/commit/f263510)
+- **add tier classifier for registry items** [`f263510`](https://github.com/webjsdev/webjs/commit/f263510)
   New _lib/tier.ts module exports TIER_2_NAMES (the 12 stateful custom
   elements), tierOf(item), and splitByTier(items). Kept outside the
   *.server.ts RPC-stub rewrite path so the helper can be imported from
   any context.
-- **split homepage component grid by tier** [`7a7fc2b`](https://github.com/vivek7405/webjs/commit/7a7fc2b)
+- **split homepage component grid by tier** [`7a7fc2b`](https://github.com/webjsdev/webjs/commit/7a7fc2b)
   The 'All components' section now renders two grouped grids — Tier 1
   class helpers (20) above Tier 2 custom elements (12) — with intro
   copy clarifying the composition model and a hint to pick Tier 1 by
   default. Uses splitByTier() from the helper added in f2ba5c4.
-- **split docs sidenav components list by tier** [`542e638`](https://github.com/vivek7405/webjs/commit/542e638)
+- **split docs sidenav components list by tier** [`542e638`](https://github.com/webjsdev/webjs/commit/542e638)
   Sidenav now renders two grouped sections — 'Tier 1 · Class helpers'
   (20 components) and 'Tier 2 · Custom elements' (12 components) —
   with per-section counts. Each section's items are alphabetical
   within the tier. Uses the splitByTier() helper from f2ba5c4.
-- **native-HTML rewrite of stateful primitives + shadcn-API sweep** ([#5](https://github.com/vivek7405/webjs/pull/5)) [`f6a9dbf`](https://github.com/vivek7405/webjs/commit/f6a9dbf)
+- **native-HTML rewrite of stateful primitives + shadcn-API sweep** ([#5](https://github.com/webjsdev/webjs/pull/5)) [`f6a9dbf`](https://github.com/webjsdev/webjs/commit/f6a9dbf)
   Eight registry components now lean on native HTML primitives instead of
   hand-rolled JS. Three drop their custom elements entirely; five keep a
   thin custom-element wrapper around the platform feature.
-- **Tier-2 components -> WebComponent + render() + <slot> (rebased)** ([#28](https://github.com/vivek7405/webjs/pull/28)) [`09a296e`](https://github.com/vivek7405/webjs/commit/09a296e)
+- **Tier-2 components -> WebComponent + render() + <slot> (rebased)** ([#28](https://github.com/webjsdev/webjs/pull/28)) [`09a296e`](https://github.com/webjsdev/webjs/commit/09a296e)
   * refactor(ui): toggle.ts -> WebComponent + render() + <slot>
   
   First Tier-2 component converted from extends Base to extends
@@ -33,7 +33,7 @@ commit_count: 6
 
 ## Fixes
 
-- **rewrite registry '../lib/utils.ts' imports on add** [`aed0f53`](https://github.com/vivek7405/webjs/commit/aed0f53)
+- **rewrite registry '../lib/utils.ts' imports on add** [`aed0f53`](https://github.com/webjsdev/webjs/commit/aed0f53)
   Registry components import cn from '../lib/utils.ts' (matching the
   registry's own layout, where components live one level beside the
   utils file). When 'webjs ui add <name>' fetches a component over

--- a/changelog/ui/0.3.0.md
+++ b/changelog/ui/0.3.0.md
@@ -6,7 +6,7 @@ commit_count: 4
 ---
 ## Breaking
 
-- **signals replace this.state / setState across the stack** ([#43](https://github.com/vivek7405/webjs/pull/43)) [`6e50ae6`](https://github.com/vivek7405/webjs/commit/6e50ae6)
+- **signals replace this.state / setState across the stack** ([#43](https://github.com/webjsdev/webjs/pull/43)) [`6e50ae6`](https://github.com/webjsdev/webjs/commit/6e50ae6)
   * feat(core): signal primitive (TC39 Stage-1 shape, no runtime deps)
   
   Hand-rolled signal/computed/effect/batch in plain JS with JSDoc.
@@ -14,12 +14,12 @@ commit_count: 4
 
 ## Features
 
-- **env-driven sibling URLs with localhost dev fallbacks** ([#42](https://github.com/vivek7405/webjs/pull/42)) [`f433efc`](https://github.com/vivek7405/webjs/commit/f433efc)
+- **env-driven sibling URLs with localhost dev fallbacks** ([#42](https://github.com/webjsdev/webjs/pull/42)) [`f433efc`](https://github.com/webjsdev/webjs/commit/f433efc)
   The UI website hardcoded `https://webjs.dev` and `https://docs.webjs.dev`
   as the defaults for its header + footer links. Local dev navigated off
   the localhost dev cluster as soon as you clicked the Webjs / Docs links,
   which broke the flow when working across all three apps simultaneously.
-- **per-package per-version changelog + /changelog page + auto-enforce on version bumps** ([#49](https://github.com/vivek7405/webjs/pull/49)) [`3e5e573`](https://github.com/vivek7405/webjs/commit/3e5e573)
+- **per-package per-version changelog + /changelog page + auto-enforce on version bumps** ([#49](https://github.com/webjsdev/webjs/pull/49)) [`3e5e573`](https://github.com/webjsdev/webjs/commit/3e5e573)
   * feat(changelog): per-package per-version changelog + backfill from git
   
   Introduce a changelog/ directory at the repo root with one md file
@@ -27,7 +27,7 @@ commit_count: 4
 
 ## Fixes
 
-- **align @webjskit/* deps to workspace versions** ([#35](https://github.com/vivek7405/webjs/pull/35)) [`e2cb080`](https://github.com/vivek7405/webjs/commit/e2cb080)
+- **align @webjskit/* deps to workspace versions** ([#35](https://github.com/webjsdev/webjs/pull/35)) [`e2cb080`](https://github.com/webjsdev/webjs/commit/e2cb080)
   ui-website pinned `@webjskit/server: ^0.5.2`, `@webjskit/core: ^0.4.1`,
   `@webjskit/cli: ^0.5.2` while the monorepo workspaces are at 0.6.0,
   0.5.0, 0.6.0. npm therefore installed published 0.5.x tarballs into

--- a/changelog/ui/0.3.1.md
+++ b/changelog/ui/0.3.1.md
@@ -6,5 +6,5 @@ commit_count: 1
 ---
 ## Breaking
 
-- **Rescope from `@webjskit/ui` to `@webjsdev/ui`** ([#62](https://github.com/vivek7405/webjs/pull/62))
+- **Rescope from `@webjskit/ui` to `@webjsdev/ui`** ([#62](https://github.com/webjsdev/webjs/pull/62))
   The npm scope now matches the canonical `webjs.dev` domain (and the `@webjsdev` org we own on npm). Functionally identical to the prior `@webjskit/ui@0.3.0` publish, no component or CLI behavior change. The `webjs ui add` command now writes imports from `@webjsdev/core` into added components. Update existing `lib/utils/ui.ts` and any other manually-imported references from `@webjskit/ui` to `@webjsdev/ui`. The legacy `@webjskit/*` packages stay installable, but will be marked deprecated on the registry to redirect new installers here.

--- a/docs/app/docs/ai-first/page.ts
+++ b/docs/app/docs/ai-first/page.ts
@@ -168,6 +168,6 @@ Autonomous mode        ✅ defaults   ❌ n/a        ❌ n/a</pre>
 ## Advanced features (Suspense, bundling, rate limiting, WebSockets...)
 ## Runtime targets (Node, embedded, edge)
 ## Deliberately deferred (what NOT to implement)</pre>
-    <p>You can read the full <a href="https://github.com/vivek7405/webjs/blob/main/AGENTS.md">AGENTS.md on GitHub</a>.</p>
+    <p>You can read the full <a href="https://github.com/webjsdev/webjs/blob/main/AGENTS.md">AGENTS.md on GitHub</a>.</p>
   `;
 }

--- a/examples/blog/app/layout.ts
+++ b/examples/blog/app/layout.ts
@@ -215,7 +215,7 @@ export default function RootLayout({ children }: { children: unknown }) {
         ${navLink('/', 'Posts')}
         ${navLink('/about', 'About')}
         ${navLink('/dashboard', 'Dashboard')}
-        <a href="https://github.com/vivek7405/webjs/tree/main/examples/blog" target="_blank" rel="noopener" class="text-fg-muted no-underline font-medium text-[13px] leading-none tracking-[0.005em] transition-colors duration-fast hover:text-fg">GitHub</a>
+        <a href="https://github.com/webjsdev/webjs/tree/main/examples/blog" target="_blank" rel="noopener" class="text-fg-muted no-underline font-medium text-[13px] leading-none tracking-[0.005em] transition-colors duration-fast hover:text-fg">GitHub</a>
         <theme-toggle></theme-toggle>
       </nav>
 
@@ -236,7 +236,7 @@ export default function RootLayout({ children }: { children: unknown }) {
             <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="/">Posts</a>
             <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="/about">About</a>
             <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="/dashboard">Dashboard</a>
-            <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="https://github.com/vivek7405/webjs/tree/main/examples/blog" target="_blank" rel="noopener">GitHub</a>
+            <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="https://github.com/webjsdev/webjs/tree/main/examples/blog" target="_blank" rel="noopener">GitHub</a>
           </nav>
         </details>
         <theme-toggle></theme-toggle>

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # @webjsdev/cli
 
-CLI for [webjs](https://github.com/vivek7405/webjs): scaffold, develop,
+CLI for [webjs](https://github.com/webjsdev/webjs): scaffold, develop,
 build, and run webjs apps.
 
 Installing this package gives you the `webjs` command.
@@ -64,7 +64,7 @@ The scaffold seeds opinionated defaults so AI agents produce consistent code:
 - Tailwind CSS via CLI (no browser runtime at build time)
 - TypeScript, `.editorconfig`, `.gitignore`
 
-See the full framework docs at https://github.com/vivek7405/webjs.
+See the full framework docs at https://github.com/webjsdev/webjs.
 
 ## License
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,11 +21,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vivek7405/webjs.git",
+    "url": "git+https://github.com/webjsdev/webjs.git",
     "directory": "packages/cli"
   },
-  "homepage": "https://github.com/vivek7405/webjs#readme",
-  "bugs": "https://github.com/vivek7405/webjs/issues",
+  "homepage": "https://github.com/webjsdev/webjs#readme",
+  "bugs": "https://github.com/webjsdev/webjs/issues",
   "license": "MIT",
   "keywords": [
     "webjs",

--- a/packages/cli/templates/AGENTS.md
+++ b/packages/cli/templates/AGENTS.md
@@ -2,7 +2,7 @@
 
 Read this before editing any file. This is a webjs app: AI-first, web-
 components-first, no build step. The framework's own full API reference
-lives at https://github.com/vivek7405/webjs/blob/main/AGENTS.md and the
+lives at https://github.com/webjsdev/webjs/blob/main/AGENTS.md and the
 full hosted documentation (every API, recipe, and example) lives at
 **https://docs.webjs.com**. Treat this file as the app-scoped
 companion and reach for docs.webjs.com whenever you need more detail.
@@ -483,7 +483,7 @@ Practical consequences for agents writing webjs code.
 
 The full annotated catalog with code examples lives in the framework
 repo at
-[`agent-docs/lit-muscle-memory-gotchas.md`](https://github.com/vivek7405/webjs/blob/main/agent-docs/lit-muscle-memory-gotchas.md).
+[`agent-docs/lit-muscle-memory-gotchas.md`](https://github.com/webjsdev/webjs/blob/main/agent-docs/lit-muscle-memory-gotchas.md).
 
 ## Server action pattern
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,6 @@
 # @webjsdev/core
 
-Isomorphic core runtime for [webjs](https://github.com/vivek7405/webjs), the
+Isomorphic core runtime for [webjs](https://github.com/webjsdev/webjs), the
 AI-first, web-components-first, no-build web framework.
 
 This package ships the tagged-template `html` / `css` helpers, the
@@ -48,7 +48,7 @@ import { createContext } from '@webjsdev/core/context';
 import { Task } from '@webjsdev/core/task';
 ```
 
-See the full framework docs at https://github.com/vivek7405/webjs.
+See the full framework docs at https://github.com/webjsdev/webjs.
 
 ## License
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,11 +30,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vivek7405/webjs.git",
+    "url": "git+https://github.com/webjsdev/webjs.git",
     "directory": "packages/core"
   },
-  "homepage": "https://github.com/vivek7405/webjs#readme",
-  "bugs": "https://github.com/vivek7405/webjs/issues",
+  "homepage": "https://github.com/webjsdev/webjs#readme",
+  "bugs": "https://github.com/webjsdev/webjs/issues",
   "license": "MIT",
   "keywords": [
     "webjs",

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,6 +1,6 @@
 # @webjsdev/server
 
-Dev + production server for [webjs](https://github.com/vivek7405/webjs):
+Dev + production server for [webjs](https://github.com/webjsdev/webjs):
 file-based routing, streaming SSR, server actions, WebSocket upgrades, and
 live reload.
 
@@ -44,7 +44,7 @@ import { startServer } from '@webjsdev/server';
 await startServer({ port: 3000, appDir: process.cwd(), dev: true });
 ```
 
-See the full framework docs at https://github.com/vivek7405/webjs.
+See the full framework docs at https://github.com/webjsdev/webjs.
 
 ## License
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -24,11 +24,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vivek7405/webjs.git",
+    "url": "git+https://github.com/webjsdev/webjs.git",
     "directory": "packages/server"
   },
-  "homepage": "https://github.com/vivek7405/webjs#readme",
-  "bugs": "https://github.com/vivek7405/webjs/issues",
+  "homepage": "https://github.com/webjsdev/webjs#readme",
+  "bugs": "https://github.com/webjsdev/webjs/issues",
   "license": "MIT",
   "keywords": [
     "webjs",

--- a/packages/ts-plugin/package.json
+++ b/packages/ts-plugin/package.json
@@ -19,11 +19,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vivek7405/webjs.git",
+    "url": "git+https://github.com/webjsdev/webjs.git",
     "directory": "packages/ts-plugin"
   },
-  "homepage": "https://github.com/vivek7405/webjs#readme",
-  "bugs": "https://github.com/vivek7405/webjs/issues",
+  "homepage": "https://github.com/webjsdev/webjs#readme",
+  "bugs": "https://github.com/webjsdev/webjs/issues",
   "license": "MIT",
   "keywords": [
     "webjs",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -31,11 +31,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vivek7405/webjs.git",
+    "url": "git+https://github.com/webjsdev/webjs.git",
     "directory": "packages/ui"
   },
   "homepage": "https://ui.webjs.dev",
-  "bugs": "https://github.com/vivek7405/webjs/issues",
+  "bugs": "https://github.com/webjsdev/webjs/issues",
   "license": "MIT",
   "keywords": [
     "shadcn",

--- a/packages/ui/packages/website/app/layout.ts
+++ b/packages/ui/packages/website/app/layout.ts
@@ -340,7 +340,7 @@ export default function Layout({ children }: { children: any }) {
         <a class="text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href="/docs/components/accordion">Components</a>
         <a class="text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href="/docs">Docs</a>
         <a class="text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href=${WEBSITE_URL} target="_blank">Webjs</a>
-        <a class="text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href="https://github.com/vivek7405/webjs" target="_blank">GitHub</a>
+        <a class="text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href="https://github.com/webjsdev/webjs" target="_blank">GitHub</a>
         <theme-toggle></theme-toggle>
       </nav>
 
@@ -360,7 +360,7 @@ export default function Layout({ children }: { children: any }) {
             <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="/docs/components/accordion">Components</a>
             <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="/docs">Docs</a>
             <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href=${WEBSITE_URL} target="_blank">Webjs</a>
-            <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="https://github.com/vivek7405/webjs" target="_blank">GitHub</a>
+            <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="https://github.com/webjsdev/webjs" target="_blank">GitHub</a>
           </nav>
         </details>
         <theme-toggle></theme-toggle>
@@ -373,7 +373,7 @@ export default function Layout({ children }: { children: any }) {
       <div class="max-w-5xl mx-auto px-6">
         <a class="text-brand no-underline hover:underline" href=${WEBSITE_URL} target="_blank">Webjs</a> ·
         <a class="text-brand no-underline hover:underline" href=${DOCS_URL} target="_blank">Docs</a> ·
-        <a class="text-brand no-underline hover:underline" href="https://github.com/vivek7405/webjs" target="_blank">GitHub</a>
+        <a class="text-brand no-underline hover:underline" href="https://github.com/webjsdev/webjs" target="_blank">GitHub</a>
       </div>
     </footer>
   `;

--- a/packages/ui/packages/website/app/page.ts
+++ b/packages/ui/packages/website/app/page.ts
@@ -51,7 +51,7 @@ export default async function Home() {
           </svg>
         </a>
         <a
-          href="https://github.com/vivek7405/webjs"
+          href="https://github.com/webjsdev/webjs"
           class="inline-flex items-center rounded-full border border-border-strong bg-transparent px-5 py-3 text-sm font-semibold text-fg-muted transition-colors hover:text-fg hover:border-fg-muted"
         >
           View on GitHub

--- a/scripts/backfill-changelog.js
+++ b/scripts/backfill-changelog.js
@@ -190,8 +190,8 @@ function renderEntry(pkg, version, date, commits) {
   for (const t of order) {
     sections.push(`## ${TYPE_LABEL[t]}\n`);
     for (const c of grouped.get(t)) {
-      const prRef = c.pr ? ` ([#${c.pr}](https://github.com/vivek7405/webjs/pull/${c.pr}))` : '';
-      const sha = `[\`${c.sha}\`](https://github.com/vivek7405/webjs/commit/${c.sha})`;
+      const prRef = c.pr ? ` ([#${c.pr}](https://github.com/webjsdev/webjs/pull/${c.pr}))` : '';
+      const sha = `[\`${c.sha}\`](https://github.com/webjsdev/webjs/commit/${c.sha})`;
       sections.push(`- **${c.title}**${prRef} ${sha}`);
       if (c.body) {
         const summary = c.body.split('\n').slice(0, 4).map((l) => `  ${l}`).join('\n').trimEnd();

--- a/scripts/generate-og.mjs
+++ b/scripts/generate-og.mjs
@@ -136,7 +136,7 @@ const html = (a) => `<!DOCTYPE html>
   </div>
   <div class="footer">
     <span><span class="dot">●</span>&nbsp;&nbsp;ai-first · web-components-first · no build</span>
-    <span>github.com/vivek7405/webjs</span>
+    <span>github.com/webjsdev/webjs</span>
   </div>
 </body>
 </html>`;

--- a/website/app/layout.ts
+++ b/website/app/layout.ts
@@ -254,7 +254,7 @@ export default function RootLayout({ children }: { children: unknown }) {
         <a class="text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href=${UI_URL} target="_blank">UI</a>
         <a class="text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href="/changelog">Changelog</a>
         <a class="text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href=${BLOG_URL} target="_blank">Blog Demo</a>
-        <a class="text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href="https://github.com/vivek7405/webjs" target="_blank">GitHub</a>
+        <a class="text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href="https://github.com/webjsdev/webjs" target="_blank">GitHub</a>
         <theme-toggle></theme-toggle>
       </nav>
 
@@ -276,7 +276,7 @@ export default function RootLayout({ children }: { children: unknown }) {
             <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href=${UI_URL} target="_blank">UI</a>
             <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="/changelog">Changelog</a>
             <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href=${BLOG_URL} target="_blank">Blog Demo</a>
-            <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="https://github.com/vivek7405/webjs" target="_blank">GitHub</a>
+            <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="https://github.com/webjsdev/webjs" target="_blank">GitHub</a>
           </nav>
         </details>
         <theme-toggle></theme-toggle>

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -251,7 +251,7 @@ export default function LandingPage() {
       </p>
       <div class="hero-actions">
         <a class="primary" href=${DOCS_URL + '/docs/getting-started'} target="_blank">Get Started</a>
-        <a class="secondary" href="https://github.com/vivek7405/webjs" target="_blank">GitHub</a>
+        <a class="secondary" href="https://github.com/webjsdev/webjs" target="_blank">GitHub</a>
         <a class="secondary" href=${BLOG_URL} target="_blank">Example Blog</a>
       </div>
     </section>
@@ -361,7 +361,7 @@ middleware.ts              → global auth</pre>
 
     <footer>
       <p>
-        <a href="https://github.com/vivek7405/webjs" target="_blank">GitHub</a> ·
+        <a href="https://github.com/webjsdev/webjs" target="_blank">GitHub</a> ·
         <a href=${DOCS_URL + '/docs/getting-started'} target="_blank">Docs</a> ·
         <a href=${UI_URL} target="_blank">UI</a> ·
         <a href=${DOCS_URL + '/docs/ai-first'} target="_blank">AI-First</a> ·


### PR DESCRIPTION
## Summary

Companion to the GitHub repo transfer to the `@webjsdev` org. Renames every `vivek7405/webjs` URL reference across 53 files: package.json `repository.url` fields, AGENTS.md, agent-docs/, CLAUDE.md, README.md, changelog/, website, docs, scaffold templates, workflow files.

GitHub auto-redirects the old URL so existing links keep working; this is the canonical-URL pass for clarity and future-proofing.

## Follow-ups (separate PR)

- Add a GitHub Packages publish step to `.github/workflows/release.yml` so `@webjsdev/*` shows up in the new org's Packages sidebar.
- Re-link Railway services if they show "repo not found" (the transfer may break the GitHub App connection).

## Test plan

- [x] `git grep 'vivek7405/webjs'` returns 0 hits.
- [x] All 53 files modified are URL replacements only; no logic changes.
- [ ] After merge, verify website/docs/blog Railway services don't crash on the next deploy (transfer may need GitHub App reauth).