### PR TITLE
feat(release): dual-publish to GitHub Packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,36 +1,45 @@
 name: Auto-release
 
 # Every push to main that lands a new `changelog/<pkg>/<version>.md`
-# file becomes a published npm package AND a GitHub Release for
-# that (package, version) tuple.
+# file becomes:
+#   1. A published npm.com package via scripts/publish-npm.js.
+#   2. A published GitHub Packages copy via scripts/publish-github-packages.js
+#      (so the repo's Packages sidebar lists each version).
+#   3. A GitHub Release via scripts/publish-release.js.
 #
-# Flow per new changelog file:
-#   1. scripts/publish-npm.js     → npm publish @webjsdev/<pkg>@<version>
-#   2. scripts/publish-release.js → gh release create <pkg>@<version>
+# All three scripts are idempotent: they skip when the version is
+# already on the destination registry / a release with the tag
+# already exists. So workflow retries and force-pushes never
+# duplicate or error on previously-published versions.
 #
-# Both scripts are idempotent: they skip when the version is
-# already on the registry / a release with the tag already exists.
-# So workflow retries and force-pushes never duplicate or error on
-# previously-published versions.
-#
-# Order matters: npm runs first. If npm publish fails (auth,
-# network, transient registry error), the GH release step is
-# skipped and the workflow fails. After fixing, re-running picks
-# up where it left off; the npm-side idempotency check makes the
-# completed package a no-op.
+# Order matters: npm.com runs first, then GitHub Packages, then GH
+# Releases. If any step fails (auth, network, transient registry
+# error), later steps are skipped and the workflow fails. A
+# re-run picks up where it left off thanks to the idempotency
+# checks.
 #
 # Triggered only on changelog/** changes so unrelated pushes do
-# not run the job. Cost on public repos: $0 (Actions has unlimited
-# free minutes for public repos on ubuntu-latest).
+# not run the job. workflow_dispatch is also wired so a one-time
+# bootstrap can republish every existing changelog file to GitHub
+# Packages without needing a fresh changelog file. Cost on public
+# repos: $0 (Actions has unlimited free minutes for public repos
+# on ubuntu-latest).
 
 on:
   push:
     branches: [main]
     paths:
       - 'changelog/**'
+  workflow_dispatch:
+    inputs:
+      bootstrap_github_packages:
+        description: 'Republish every existing changelog file to GitHub Packages (one-time bootstrap; npm.com + GH Releases steps are skipped)'
+        type: boolean
+        default: false
 
 permissions:
   contents: write   # gh release create needs write access to the repo
+  packages: write   # npm publish to GitHub Packages
 
 jobs:
   release:
@@ -59,26 +68,45 @@ jobs:
         id: diff
         run: |
           set -euo pipefail
-          # Sort by the `date:` timestamp inside each file's
-          # frontmatter, ASCending. GitHub Releases lists releases by
-          # created_at DESC, so publishing oldest-first means newest
-          # entries end up at the top of the Releases page.
-          #
-          # Within tied timestamps (multiple packages bumped in one
-          # PR), sort the filename DESC so the alphabetically-first
-          # package publishes LAST, gets the latest created_at, and
-          # ends up at the top of the GH list. The website's
-          # /changelog page iterates package dirs alphabetically
-          # too, so this produces matching order on both surfaces.
-          mapfile -t NEW < <(
-            git diff --name-only --diff-filter=A HEAD~1 HEAD -- 'changelog/**.md' \
-              | while read -r f; do
-                  ts=$(awk '/^date:/ { print $2; exit }' "$f")
-                  printf '%s\t%s\n' "$ts" "$f"
-                done \
-              | sort -k1,1 -k2,2r \
-              | cut -f2-
-          )
+          # Two modes:
+          #   1. push event: diff HEAD~1..HEAD for newly added changelog files.
+          #   2. workflow_dispatch with bootstrap_github_packages=true: list
+          #      every changelog/**.md file currently in the tree. The
+          #      publish-github-packages.js step is idempotent (skips
+          #      already-published versions) so a re-run is safe.
+          BOOTSTRAP='${{ inputs.bootstrap_github_packages }}'
+          if [ "$BOOTSTRAP" = 'true' ]; then
+            mapfile -t NEW < <(
+              find changelog -name '*.md' -not -name 'README.md' \
+                | while read -r f; do
+                    ts=$(awk '/^date:/ { print $2; exit }' "$f")
+                    printf '%s\t%s\n' "$ts" "$f"
+                  done \
+                | sort -k1,1 -k2,2r \
+                | cut -f2-
+            )
+          else
+            # Sort by the `date:` timestamp inside each file's
+            # frontmatter, ASCending. GitHub Releases lists releases by
+            # created_at DESC, so publishing oldest-first means newest
+            # entries end up at the top of the Releases page.
+            #
+            # Within tied timestamps (multiple packages bumped in one
+            # PR), sort the filename DESC so the alphabetically-first
+            # package publishes LAST, gets the latest created_at, and
+            # ends up at the top of the GH list. The website's
+            # /changelog page iterates package dirs alphabetically
+            # too, so this produces matching order on both surfaces.
+            mapfile -t NEW < <(
+              git diff --name-only --diff-filter=A HEAD~1 HEAD -- 'changelog/**.md' \
+                | while read -r f; do
+                    ts=$(awk '/^date:/ { print $2; exit }' "$f")
+                    printf '%s\t%s\n' "$ts" "$f"
+                  done \
+                | sort -k1,1 -k2,2r \
+                | cut -f2-
+            )
+          fi
           if [ ${#NEW[@]} -eq 0 ]; then
             echo "No new changelog files in this push; skipping."
             echo "count=0" >> "$GITHUB_OUTPUT"
@@ -87,9 +115,10 @@ jobs:
           printf '  + %s\n' "${NEW[@]}"
           printf '%s\n' "${NEW[@]}" > .new-changelog-files.txt
           echo "count=${#NEW[@]}" >> "$GITHUB_OUTPUT"
+          echo "bootstrap=$BOOTSTRAP" >> "$GITHUB_OUTPUT"
 
       - name: Publish to npm
-        if: steps.diff.outputs.count != '0'
+        if: steps.diff.outputs.count != '0' && steps.diff.outputs.bootstrap != 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
@@ -99,8 +128,19 @@ jobs:
             node scripts/publish-npm.js "$f"
           done < .new-changelog-files.txt
 
-      - name: Create GitHub Releases
+      - name: Publish to GitHub Packages
         if: steps.diff.outputs.count != '0'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            node scripts/publish-github-packages.js "$f"
+          done < .new-changelog-files.txt
+
+      - name: Create GitHub Releases
+        if: steps.diff.outputs.count != '0' && steps.diff.outputs.bootstrap != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/scripts/publish-github-packages.js
+++ b/scripts/publish-github-packages.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * Publish ONE package version to GitHub Packages, driven by a changelog file.
+ *
+ *   node scripts/publish-github-packages.js changelog/core/0.7.1.md
+ *
+ * Sibling to scripts/publish-npm.js. Same idempotency shape: parse
+ * frontmatter, derive package + version, check whether that version
+ * is already on the registry, skip if yes, publish if no.
+ *
+ * Registry: https://npm.pkg.github.com. GitHub Packages enforces
+ * that the package scope match the GitHub org/user that owns the
+ * repo (webjsdev/webjs in our case, so @webjsdev/* lines up).
+ *
+ * Auth: relies on NODE_AUTH_TOKEN, which the workflow sets to
+ * secrets.GITHUB_TOKEN. The workflow also needs `permissions:
+ * packages: write` for the token to be allowed to publish.
+ *
+ * Locally, set NODE_AUTH_TOKEN to a personal access token with the
+ * `write:packages` scope (gh auth refresh -s write:packages, then
+ * gh auth token), or write your own ~/.npmrc.
+ */
+import { spawnSync } from 'node:child_process';
+import { readFileSync, existsSync, writeFileSync } from 'node:fs';
+import { basename, resolve } from 'node:path';
+import { homedir } from 'node:os';
+
+const REGISTRY = 'https://npm.pkg.github.com';
+
+const file = process.argv[2];
+if (!file) {
+  console.error('usage: node scripts/publish-github-packages.js <changelog/<pkg>/<version>.md>');
+  process.exit(2);
+}
+if (!existsSync(file)) {
+  console.error(`[publish-github-packages] file not found: ${file}`);
+  process.exit(2);
+}
+
+const raw = readFileSync(resolve(file), 'utf8');
+const m = raw.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+if (!m) {
+  console.error(`[publish-github-packages] ${file}: no frontmatter block`);
+  process.exit(2);
+}
+const fm = {};
+for (const line of m[1].split('\n')) {
+  const idx = line.indexOf(':');
+  if (idx < 0) continue;
+  const k = line.slice(0, idx).trim();
+  let v = line.slice(idx + 1).trim();
+  if (v.startsWith('"') && v.endsWith('"')) v = v.slice(1, -1);
+  fm[k] = v;
+}
+
+// Historical changelog files (the @webjskit era) record `package:
+// "@webjskit/<short>"` in their frontmatter; we cannot publish those
+// names to GitHub Packages because the @webjskit scope does not
+// match the webjsdev GitHub org. Skip them with an explicit log so
+// a bootstrap pass over the full changelog/ tree is safe to run.
+const pkgName = fm.package;
+const version = fm.version;
+if (!pkgName || !version) {
+  console.error(`[publish-github-packages] ${file}: missing package or version in frontmatter`);
+  process.exit(2);
+}
+if (!pkgName.startsWith('@webjsdev/')) {
+  console.log(`[publish-github-packages] skip ${pkgName}@${version}: scope is not @webjsdev (legacy entry)`);
+  process.exit(0);
+}
+
+// Make sure the .npmrc routes @webjsdev to GitHub Packages. The
+// workflow's setup-node step targets registry.npmjs.org by default
+// for the unscoped lookup, so we install our own scope override.
+const npmrcPath = `${homedir()}/.npmrc`;
+const existing = existsSync(npmrcPath) ? readFileSync(npmrcPath, 'utf8') : '';
+const scopeLine = '@webjsdev:registry=https://npm.pkg.github.com';
+const authLine = '//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}';
+const lines = existing.split('\n').filter(Boolean);
+if (!lines.includes(scopeLine)) lines.push(scopeLine);
+if (!lines.some((l) => l.startsWith('//npm.pkg.github.com/:_authToken='))) lines.push(authLine);
+writeFileSync(npmrcPath, lines.join('\n') + '\n');
+
+// Idempotency: already published to GitHub Packages?
+const view = spawnSync(
+  'npm', ['view', `${pkgName}@${version}`, 'version', `--registry=${REGISTRY}`],
+  { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+);
+if (view.status === 0 && view.stdout.trim() === version) {
+  console.log(`[publish-github-packages] skip ${pkgName}@${version}: already on GitHub Packages`);
+  process.exit(0);
+}
+
+// Publish. `--registry` forces the target; the per-package
+// publishConfig stays on npmjs.org as the canonical registry.
+const pub = spawnSync(
+  'npm',
+  ['publish', `--workspace=${pkgName}`, `--registry=${REGISTRY}`, '--access=public', '--ignore-scripts=false'],
+  { stdio: 'inherit' },
+);
+if (pub.status !== 0) {
+  console.error(`[publish-github-packages] npm publish failed for ${pkgName}@${version}`);
+  process.exit(pub.status || 1);
+}
+console.log(`[publish-github-packages] published ${pkgName}@${version} to GitHub Packages (${basename(file)})`);


### PR DESCRIPTION
## Summary

Adds a parallel publish step so every release lands on both `npm.com` (canonical) and `npm.pkg.github.com` (GitHub Packages). Once the bootstrap workflow_dispatch run completes, the repo's Packages sidebar will list all 5 `@webjsdev/*` versions.

- New script: `scripts/publish-github-packages.js`. Same idempotency shape as `publish-npm.js` (parse frontmatter, check `npm view <pkg>@<ver> --registry=https://npm.pkg.github.com`, skip if present, publish otherwise). Writes a scope override to `~/.npmrc` so `@webjsdev:*` routes to GitHub Packages. Auth via `NODE_AUTH_TOKEN`, which the workflow sets from `secrets.GITHUB_TOKEN`.
- Workflow changes:
  - `permissions: packages: write` added so `GITHUB_TOKEN` can publish.
  - New step "Publish to GitHub Packages" wired between the npm.com publish and GH Releases steps.
  - `workflow_dispatch` trigger with `bootstrap_github_packages` input: when set to `true`, lists every existing `changelog/**.md` and runs only the GitHub Packages step (the npm.com + GH Releases steps are skipped via the `bootstrap != 'true'` condition). Idempotent so re-runs are safe.
- Legacy `@webjskit/*` changelog entries (the 24 historical ones) are skipped by the script because GitHub Packages enforces scope matches the GitHub org (`webjsdev`).

## After merge

Trigger the bootstrap once via Actions → Auto-release → Run workflow with `bootstrap_github_packages: true`. That populates GitHub Packages with the current 5 `@webjsdev/*` versions (`core@0.7.1`, `server@0.7.2`, `cli@0.8.1`, `ts-plugin@0.4.1`, `ui@0.3.1`). Verify the Packages sidebar lists them.

## Test plan

- [x] `npm test` passes (1151 tests).
- [ ] After merge: trigger bootstrap workflow_dispatch and confirm 5 packages appear in the org's Packages sidebar.
- [ ] Next changelog file added (organic release) dual-publishes to both registries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)