### PR TITLE
docs: refer to the production server as `npm run start`, not `webjs start`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -538,7 +538,7 @@ Form submissions (`<form action method>`) ride the same pipeline. GET forms prom
 
 Wire-byte optimization is automatic: the router sends `X-Webjs-Have` listing marker paths it has; the server short-circuits at the deepest match and returns only the divergent fragment. Rapid clicks are safe (prior fetches abort, nav-tokens prevent stale reverts). Scroll position is captured + restored on back/forward.
 
-**Production benefits from HTTP/2 at the edge.** Per-file ESM rides HTTP/2 multiplex to be competitive with bundling. PaaS edges (Railway, Fly, Render, Vercel, Cloudflare, Heroku) serve HTTP/2 automatically; bare-VM self-hosters put nginx / Caddy / Traefik in front. `webjs start` itself speaks plain HTTP/1.1.
+**Production benefits from HTTP/2 at the edge.** Per-file ESM rides HTTP/2 multiplex to be competitive with bundling. PaaS edges (Railway, Fly, Render, Vercel, Cloudflare, Heroku) serve HTTP/2 automatically. Bare-VM self-hosters put nginx / Caddy / Traefik in front. The production server (`npm run start`) speaks plain HTTP/1.1.
 
 For partial-swap NOT tied to a folder layout, wrap in `<webjs-frame id="...">`. See `agent-docs/advanced.md` for the full mechanism.
 

--- a/agent-docs/advanced.md
+++ b/agent-docs/advanced.md
@@ -26,7 +26,7 @@ Five stacked zero-build optimizations:
    The SSR pass knows every custom element in the final HTML. A startup
    module-graph scan adds their transitive import dependencies too. All
    preload hints are deduplicated and emitted in `<head>`.
-2. **HTTP/2 multiplex at the edge.** `webjs start` itself speaks plain
+2. **HTTP/2 multiplex at the edge.** The production server (`npm run start`) speaks plain
    HTTP/1.1. PaaS edges (Railway, Fly, Render, Vercel, Cloudflare Pages,
    Heroku) and reverse proxies (nginx, Caddy, Traefik) speak
    HTTP/2 to the browser and proxy 1.1 to the container, fetching many module
@@ -64,8 +64,8 @@ production. The Rails 7+ / Hotwire pattern:
   imports. This is what eliminates the perceived gap vs a bundle.
 - **HTTP/2 multiplex** is what makes per-file serving competitive: one
   TCP+TLS handshake, many module fetches in parallel over the same
-  connection. `webjs start` itself speaks plain HTTP/1.1. TLS + HTTP/2
-  is the proxy's job. PaaS edges (Railway, Fly, Render, Vercel,
+  connection. The production server (`npm run start`) speaks plain HTTP/1.1.
+  TLS + HTTP/2 is the proxy's job. PaaS edges (Railway, Fly, Render, Vercel,
   Cloudflare Pages, Heroku) do this automatically. For bare-VM
   deploys, put nginx, Caddy, or Traefik in front.
 


### PR DESCRIPTION
## Summary

Three prose lines (one in `AGENTS.md`, two in `agent-docs/advanced.md`) still said "`webjs start` itself speaks plain HTTP/1.1" when describing the production-deployment topology. Per the existing convention, user-facing prose should refer to the npm wrapper that users actually invoke. Reserve the raw `webjs <subcommand>` form for the CLI reference table in `AGENTS.md` (left unchanged here).

The same pattern was already fixed in `README.md`, `docs/deployment`, and elsewhere in #68 / #69 / #70. This PR closes the gap on the three remaining occurrences I missed in #70.

Also folds the now-orphaned `automatically; bare-VM self-hosters...` semicolon-pause in `AGENTS.md` into two sentences. Invariant 11 bans semicolons surrounded by spaces between word characters as pause punctuation.

## Test plan

- [x] `npm test` passes (1151/1151, run by the universal pre-commit hook)
- [x] CLI reference tables and "never use `webjs dev` / `webjs start` directly" warnings in AGENTS.md left intact, since those intentionally name the raw CLI surface