### PR TITLE
fix(hook): allow github-actions bot to commit on main for lockstep bumps

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -3,11 +3,27 @@
 # Framework-repo pre-commit hook.
 #
 # Mirrors what scaffolded webjs apps get via webjs create, adapted
-# for the framework's own test runner. Two gates:
+# for the framework's own test runner. Three gates:
 #   1. Block direct commits to main/master. Use a feature branch.
 #   2. Run `npm test` to refuse commits that break the suite.
+#   3. Auto-generate matching changelog/<pkg>/<version>.md files
+#      when a packages/<pkg>/package.json version bumped in the
+#      staged diff.
 #
-# To bypass in emergencies: git commit --no-verify
+# Exception: the release workflow's `github-actions[bot]` commits
+# the lockstep wrapper bumps directly to main (.github/workflows/
+# release.yml step "Lockstep-bump wrappers"). That's intentional
+# automation, not a human bypass, so we detect $GITHUB_ACTIONS=true
+# and skip the entire hook for the bot. The bot's commit is a
+# mechanical version-field write; there's nothing to validate.
+# Human commits still hit every gate as designed.
+#
+# To bypass in emergencies (humans only): git commit --no-verify
+
+if [ "$GITHUB_ACTIONS" = "true" ]; then
+  echo "[pre-commit] github-actions runner detected; skipping all gates."
+  exit 0
+fi
 
 BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null)
 


### PR DESCRIPTION
## Summary

The release workflow's "Lockstep-bump wrappers" step (added in #72) commits the create-webjs + webjsdev version bumps directly to main as `github-actions[bot]`. The pre-commit hook's gate 1 (block commits to main) fires on those bot commits and fails the workflow.

Add an early short-circuit at the top of the hook. When `$GITHUB_ACTIONS=true`, skip every gate. The bot's commit is a mechanical version-field write to two package.json files; there is nothing to validate.

Human commits still hit every gate as designed.

## Caught by

Failed workflow run [26293696071](https://github.com/webjsdev/webjs/actions/runs/26293696071). cli@0.8.5 published cleanly, but the lockstep step errored on `git commit -m ...` with "Cannot commit directly to 'main'".

## Recovery plan after merge

1. Merge this PR. The merge push triggers nothing because no changelog files are touched, so release.yml stays idle.
2. Re-run the failed release workflow run 26293696071 via `gh run rerun 26293696071`. The earlier "Publish to npm" / "Publish to GitHub Packages" / "Create GitHub Releases" steps are idempotent and will skip already-published cli@0.8.5. The Lockstep-bump step will now succeed, bump create-webjs + webjsdev to 0.8.5, commit + push, and publish both to npm.

## Test plan

- [x] `npm test` passes (1151/1151)
- [x] No invariant-11 punctuation violations