### PR TITLE
chore(release): manual lockstep bump create-webjs + webjsdev to 0.8.5

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -65,9 +65,18 @@ if [ -n "$STAGED_PKG_BUMPS" ]; then
   # Find which files need to exist and which are missing BEFORE we
   # run the generator, so we can stage exactly what the generator
   # produces (and fail loudly if it didn't produce them).
+  #
+  # The wrapper packages (create-webjs, webjsdev) are version-lockstep
+  # mirrors of @webjsdev/cli and are explicitly NOT tracked in the
+  # changelog system. Skip them: their bumps don't require a
+  # changelog file, and scripts/backfill-changelog.js wouldn't
+  # produce one for them anyway (they're not in its PACKAGES list).
   TO_GENERATE=""
   for bump in $STAGED_PKG_BUMPS; do
     pkg="${bump%@*}"; ver="${bump#*@}"
+    if [ "$pkg" = "create-webjs" ] || [ "$pkg" = "webjsdev" ]; then
+      continue
+    fi
     if [ ! -f "changelog/$pkg/$ver.md" ]; then
       TO_GENERATE="$TO_GENERATE changelog/$pkg/$ver.md"
     fi

--- a/packages/create-webjs/package.json
+++ b/packages/create-webjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-webjs",
-  "version": "0.1.0",
+  "version": "0.8.5",
   "type": "module",
   "description": "Scaffold a new webjs app. `npm create webjs@latest my-app`.",
   "bin": {
@@ -11,7 +11,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@webjsdev/cli": "^0.8.4"
+    "@webjsdev/cli": "^0.8.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/webjsdev/package.json
+++ b/packages/webjsdev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webjsdev",
-  "version": "0.1.1",
+  "version": "0.8.5",
   "type": "module",
   "description": "The webjs CLI, published unscoped on npm. Unscoped alias for @webjsdev/cli. Installs the `webjs` command.",
   "bin": {
@@ -11,7 +11,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@webjsdev/cli": "^0.8.2"
+    "@webjsdev/cli": "^0.8.5"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

One-time recovery from the workflow failure on PR #72's merge. Two commits:

1. **`fix(hook): skip wrapper packages in the changelog-file requirement`** Adds a name-check in `.hooks/pre-commit` so the changelog-backfill gate skips `create-webjs` and `webjsdev` (they're explicitly excluded from the framework's changelog system). This un-blocks manual lockstep recoveries on a feature branch without `--no-verify`.
2. **`chore(release): manual lockstep bump create-webjs + webjsdev to 0.8.5`** Bumps both wrappers' `package.json` version + `@webjsdev/cli` dep range to `0.8.5` / `^0.8.5`.

## Why manual

After PR #73 fixed the hook to allow the bot, `gh run rerun 26293696071` should have completed the lockstep step. But `gh run rerun` replays the workflow at the **original commit's SHA** (which still has the un-fixed hook), so the re-run failed identically. Fastest path to consistency is to bump + publish out-of-band now; future cli bumps will trigger the workflow against the latest main (with both fixes from this PR + #73), so the lockstep step will work automatically going forward.

No changelog files are touched, so the merge of this PR does NOT re-trigger `release.yml`.

## After merge

```sh
cd packages/create-webjs && npm publish    # create-webjs@0.8.5
cd ../webjsdev          && npm publish    # webjsdev@0.8.5
```

## Test plan

- [x] `npm test` passes (1151/1151) at each of the 2 commits
- [x] Versions on npm post-publish: `npm view create-webjs version` → `0.8.5`, `npm view webjsdev version` → `0.8.5`, matching `@webjsdev/cli@0.8.5`