### PR TITLE
chore(website): bump version to trigger Railway redeploy

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/website",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Why

PRs #73-#77 each pushed to main but Railway marked every deploy SKIPPED for the website service (verified via \`railway deployment list\`). The website service's dashboard-set Watch Paths only match \`website/**\`, so changelog edits, hook fixes, and empty commits never trigger a rebuild. The live \`/changelog\` page is still rendering from PR #72's deploy.

This PR bumps \`website/package.json\` from \`0.1.0\` to \`0.1.1\`, which is a real change inside the watch path. The next Railway deploy will pick up the latest main HEAD, which includes:

- PR #75: corrected dates on cli 0.8.2-0.8.5 changelogs
- PR #76: regenerated cli 0.8.5 from git history with proper PR + SHA links (and removal of the intermediate 0.8.2-0.8.4 entries)
- PR #77: empty commit (no-op for files)

After this, the live \`/changelog\` page should show \`cli@0.8.5\` at the top with the canonical auto-generated body.

## Long-term fix

The dashboard Watch Paths should be cleared (or set to \`**/*\`) per the original intent in #53, so any changelog / cli / hook / scripts change automatically rebuilds the website. As long as those filters stay, every cross-service infra commit will need a manual website-touch like this one to actually deploy.