### PR TITLE
fix(changelog): rewrite cli 0.8.5 entry with accurate per-feature scope

### DIFF
--- a/changelog/cli/0.8.5.md
+++ b/changelog/cli/0.8.5.md
@@ -1,13 +1,31 @@
 ---
 package: "@webjsdev/cli"
 version: 0.8.5
-date: 2026-05-22T19:59:14+05:30
-commit_count: 1
+date: 2026-05-22T19:02:29+05:30
+commit_count: 4
 ---
 ## Features
 
-- **npx-first scaffold UX (create-webjs-app, wjs alias, auto-install)** ([#72](https://github.com/webjsdev/webjs/pull/72)) [`4f13870`](https://github.com/webjsdev/webjs/commit/4f13870)
-  * feat(cli): auto-install dependencies after webjs create
-  
-  `webjs create <name>` now runs `<pm> install` inside the new directory
-  by default. Pass `--no-install` to opt out and get the prior behaviour
+- **auto-install dependencies after `webjs create`** ([#72](https://github.com/webjsdev/webjs/pull/72))
+  `webjs create <name>` runs `<pm> install` inside the new directory by default. Pass `--no-install` to opt out. The package manager is detected from `npm_config_user_agent`, so pnpm / yarn / bun users get their own. The library-level `scaffoldApp(...)` default stays opt-in (`install: true` required) so tests and programmatic callers remain side-effect-free.
+
+- **scaffold's next-steps banner reordered so the run command lands last** ([#72](https://github.com/webjsdev/webjs/pull/72))
+  Previously the "Next steps:" block printed BEFORE the long AI-agent guidance, pushing the actionable `cd <name> && <pm> run dev` line off the visible terminal. New order: AI guidance prints first (long reading material), install runs, then the run command lands as the final output. Single copy-paste line.
+
+## Fixes
+
+- **scaffold's next-steps banner points at `npx webjsdev ui ...` instead of the broken `npx webjs ui ...`** ([#72](https://github.com/webjsdev/webjs/pull/72))
+  The bare `webjs` npm name is owned by an unrelated package, so `npx webjs <cmd>` would fetch THAT package outside a scaffolded project. Switched both banner lines to the unscoped CLI alias `webjsdev`, which resolves to the same `webjs` binary via npx's single-bin fallback.
+
+## Breaking
+
+- **0.8.2's `wjs` bin alias was reverted in 0.8.3+** ([#72](https://github.com/webjsdev/webjs/pull/72))
+  cli@0.8.2 briefly shipped with both `webjs` and `wjs` bin entries. cli@0.8.3 and later ship only `webjs`. Anyone who installed cli@0.8.2 and started typing `wjs <cmd>` should switch to `webjs <cmd>`. Behaviour is identical, only the command name differs. The unscoped `webjsdev` package now provides the no-scope global install path; the `wjs` namespace was blocked by npm's name-similarity filter.
+
+## See also
+
+`@webjsdev/cli@0.8.5` ships in lockstep with two new npm packages introduced in PR #72:
+- [`create-webjs`](https://www.npmjs.com/package/create-webjs) for `npm create webjs@latest my-app` scaffolding
+- [`webjsdev`](https://www.npmjs.com/package/webjsdev) as the unscoped CLI mirror for `npm i -g webjsdev`
+
+Both auto-version-bump in lockstep with cli via `.github/workflows/release.yml`'s lockstep step.


### PR DESCRIPTION
## Why

The auto-generated `cli@0.8.5.md` from PR #76 was technically correct per the script's rules but content-wrong for readers:

1. **Title referenced names that didn't ship.** `create-webjs-app` was renamed to `create-webjs`, and `wjs` was dropped (npm's similarity filter; we settled on `webjsdev`).
2. **Body misrepresented what cli@0.8.5 contains.** The script picked the first 4 lines of PR #72's squash commit body, which happens to describe the cli@0.8.2 auto-install work. The actual 0.8.5 work (`npx webjsdev` banner fix) wasn't visible.
3. **Single bullet under "Features"** miscategorised a mix of feat + fix + breaking work.

## What this PR does

Rewrites `changelog/cli/0.8.5.md` as a multi-section entry covering everything the cli has gained since 0.8.1:

- **Features**: auto-install + next-steps banner reorder
- **Fixes**: scaffold banner uses `npx webjsdev` not `npx webjs`
- **Breaking**: 0.8.2's `wjs` bin alias reverted in 0.8.3 (with migration note)
- **See also**: links to the new `create-webjs` and `webjsdev` companion packages

## Companion change (already landed)

PR #72's title on GitHub is now `feat: npx-first scaffold UX (create-webjs + webjsdev + auto-install)`, matching the actual deliverables. That edit affects the PR page only; the squash commit's subject on `main` is unchanged because editing it would require force-pushing main.

## Why this isn't a recurring issue

PR #72 bundled four cli version bumps (0.8.2-0.8.5) into one squash-merge commit. Future releases under the "one-bump-per-PR" cadence will produce one accurate auto-generated bullet per release without this kind of hand-edit.