### PR TITLE
chore(website): rename Example Blog / Blog Demo labels to just "Demo"

### DIFF
--- a/scripts/dev-all.js
+++ b/scripts/dev-all.js
@@ -63,7 +63,7 @@ console.log(`
 ▲ webjs development servers:
   Website   → http://localhost:5000
   Docs      → http://localhost:4000
-  Blog Demo → http://localhost:3456
+  Demo      → http://localhost:3456
 
   Ctrl-C to stop all.
 `);

--- a/website/app/layout.ts
+++ b/website/app/layout.ts
@@ -254,7 +254,7 @@ export default function RootLayout({ children }: { children: unknown }) {
         <a class="text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href=${UI_URL} target="_blank">UI</a>
         <a class="text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href="/blog">Blog</a>
         <a class="text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href="/changelog">Changelog</a>
-        <a class="text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href=${BLOG_URL} target="_blank">Blog Demo</a>
+        <a class="text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href=${BLOG_URL} target="_blank">Demo</a>
         <a class="text-fg-muted no-underline font-medium text-[13px] leading-none transition-colors duration-fast hover:text-fg" href="https://github.com/webjsdev/webjs" target="_blank">GitHub</a>
         <theme-toggle></theme-toggle>
       </nav>
@@ -277,7 +277,7 @@ export default function RootLayout({ children }: { children: unknown }) {
             <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href=${UI_URL} target="_blank">UI</a>
             <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="/blog">Blog</a>
             <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="/changelog">Changelog</a>
-            <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href=${BLOG_URL} target="_blank">Blog Demo</a>
+            <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href=${BLOG_URL} target="_blank">Demo</a>
             <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="https://github.com/webjsdev/webjs" target="_blank">GitHub</a>
           </nav>
         </details>

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -253,7 +253,7 @@ export default function LandingPage() {
       <div class="hero-actions">
         <a class="primary" href=${DOCS_URL + '/docs/getting-started'} target="_blank">Get Started</a>
         <a class="secondary" href="https://github.com/webjsdev/webjs" target="_blank">GitHub</a>
-        <a class="secondary" href=${BLOG_URL} target="_blank">Example Blog</a>
+        <a class="secondary" href=${BLOG_URL} target="_blank">Demo</a>
       </div>
     </section>
 
@@ -364,7 +364,7 @@ middleware.ts              → global auth</pre>
         <a href=${DOCS_URL + '/docs/getting-started'} target="_blank">Docs</a> ·
         <a href=${UI_URL} target="_blank">UI</a> ·
         <a href=${DOCS_URL + '/docs/ai-first'} target="_blank">AI-First</a> ·
-        <a href=${BLOG_URL} target="_blank">Example Blog</a> ·
+        <a href=${BLOG_URL} target="_blank">Demo</a> ·
         <a href=${STORY_URL} target="_blank" rel="noopener noreferrer">Webjs Story</a>
       </p>
     </footer>


### PR DESCRIPTION
## Summary

The `/blog` route now serves actual webjs blog posts. The example-blog app linked from the nav, hero CTA, and footer was labeled **"Example Blog"** (page) and **"Blog Demo"** (nav), which collided with the real blog and confused visitors who clicked expecting webjs content and landed on the demo app instead.

Renamed every reference to just **"Demo"**:

- `layout.ts` desktop nav: `Blog Demo` → `Demo`
- `layout.ts` mobile nav: `Blog Demo` → `Demo`
- `page.ts` hero CTA: `Example Blog` → `Demo`
- `page.ts` footer link: `Example Blog` → `Demo`

The link target (`BLOG_URL` env var, pointing at the example-blog sibling app) is unchanged. Only the visible label updates.

## Test plan

- [x] Visual check on localhost:5000: nav, hero, footer all say "Demo"
- [x] Hover / click still goes to BLOG_URL (the example-blog app)
- [x] No "Blog Demo" or "Example Blog" left anywhere in the website