### PR TITLE
fix(deploy): include blog/ in the production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,11 @@ COPY docs      ./docs
 # SSR time. Without copying the changelog tree into the image, the
 # deployed page renders "No entries yet."
 COPY changelog ./changelog
+# website/app/blog/[slug]/page.ts reads ../../../../blog/<slug>.md at
+# SSR time (via modules/blog/queries/list-posts.server.ts). Same
+# reason as changelog: without the tree in the image, /blog renders
+# "No posts yet."
+COPY blog ./blog
 
 # --- 3. Build-time work --------------------------------------------------
 # Blog: generate Prisma client (needs schema.prisma in context).


### PR DESCRIPTION
## Summary

`webjs.dev/blog` rendered **"No posts yet."** because the production Docker image was not shipping the `blog/` tree.

The website's `modules/blog/queries/list-posts.server.ts` and `get-post.server.ts` resolve `REPO_ROOT/blog/` at SSR time. That directory exists in dev (it lives at the repo root) but the Dockerfile was not copying it into the image.

## Fix

Added `COPY blog ./blog` to the Dockerfile, mirroring the existing `COPY changelog ./changelog` line that solved the identical problem for `/changelog` in PR #51.

## Test plan

- [x] Local dev still works (no path change in queries)
- [x] Railway watchPattern `/blog/**` already in the service config (added in PR #80), so this push triggers a redeploy
- [ ] After deploy, webjs.dev/blog shows all 11 posts
- [ ] After deploy, webjs.dev/blog/why-webjs renders the full post