### PR TITLE
chore(website): stack hero CTAs in two rows

### DIFF
--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -85,18 +85,6 @@ export default function LandingPage() {
         max-width: 60ch;
         margin: 0 auto var(--sp-6);
       }
-      .hero-actions {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: var(--sp-3);
-      }
-      .hero-actions-row {
-        display: flex;
-        gap: var(--sp-3);
-        justify-content: center;
-        flex-wrap: wrap;
-      }
       .hero-actions a {
         display: inline-block;
         padding: var(--sp-3) var(--sp-5);
@@ -256,11 +244,11 @@ export default function LandingPage() {
         You get native web components, server actions, streaming SSR.
         Built on web standards. No bundler, no config, no magic.
       </p>
-      <div class="hero-actions">
-        <div class="hero-actions-row">
+      <div class="hero-actions flex flex-col items-center gap-3">
+        <div class="flex gap-3 justify-center flex-wrap">
           <a class="primary" href=${DOCS_URL + '/docs/getting-started'} target="_blank">Get Started</a>
         </div>
-        <div class="hero-actions-row">
+        <div class="flex gap-3 justify-center flex-wrap">
           <a class="secondary" href="https://github.com/webjsdev/webjs" target="_blank">GitHub</a>
           <a class="secondary" href=${BLOG_URL} target="_blank">Demo</a>
         </div>

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -244,11 +244,11 @@ export default function LandingPage() {
         You get native web components, server actions, streaming SSR.
         Built on web standards. No bundler, no config, no magic.
       </p>
-      <div class="hero-actions flex flex-col items-center gap-3">
-        <div class="flex gap-3 justify-center flex-wrap">
+      <div class="hero-actions flex flex-col items-center gap-3 md:flex-row md:justify-center md:flex-wrap">
+        <div class="flex gap-3 justify-center flex-wrap md:contents">
           <a class="primary" href=${DOCS_URL + '/docs/getting-started'} target="_blank">Get Started</a>
         </div>
-        <div class="flex gap-3 justify-center flex-wrap">
+        <div class="flex gap-3 justify-center flex-wrap md:contents">
           <a class="secondary" href="https://github.com/webjsdev/webjs" target="_blank">GitHub</a>
           <a class="secondary" href=${BLOG_URL} target="_blank">Demo</a>
         </div>

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -87,6 +87,12 @@ export default function LandingPage() {
       }
       .hero-actions {
         display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: var(--sp-3);
+      }
+      .hero-actions-row {
+        display: flex;
         gap: var(--sp-3);
         justify-content: center;
         flex-wrap: wrap;
@@ -251,9 +257,13 @@ export default function LandingPage() {
         Built on web standards. No bundler, no config, no magic.
       </p>
       <div class="hero-actions">
-        <a class="primary" href=${DOCS_URL + '/docs/getting-started'} target="_blank">Get Started</a>
-        <a class="secondary" href="https://github.com/webjsdev/webjs" target="_blank">GitHub</a>
-        <a class="secondary" href=${BLOG_URL} target="_blank">Demo</a>
+        <div class="hero-actions-row">
+          <a class="primary" href=${DOCS_URL + '/docs/getting-started'} target="_blank">Get Started</a>
+        </div>
+        <div class="hero-actions-row">
+          <a class="secondary" href="https://github.com/webjsdev/webjs" target="_blank">GitHub</a>
+          <a class="secondary" href=${BLOG_URL} target="_blank">Demo</a>
+        </div>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary

The hero had three buttons on one row: **Get Started** (primary), **GitHub** (secondary), **Demo** (secondary). Restructured so the primary CTA sits on its own row, with the two secondary actions on the row below.

```
Before:        [ Get Started ] [ GitHub ] [ Demo ]

After:         [    Get Started    ]
               [ GitHub ] [ Demo ]
```

## Implementation

- `.hero-actions` becomes a flex column with two `.hero-actions-row` children.
- Each row keeps the existing horizontal flex gap and wrap behavior, so on narrow viewports the two secondary buttons still wrap independently if they cannot fit side by side.

## Test plan

- [x] Visual check: Get Started alone in row 1, GitHub + Demo together in row 2
- [x] Responsive: secondary buttons wrap to two rows on narrow viewports
- [x] All three links still go to the correct targets