### PR TITLE
chore(website): push install section below the fold on mobile

### DIFF
--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -234,7 +234,7 @@ export default function LandingPage() {
       footer a:hover { text-decoration: underline; }
     </style>
 
-    <section class="hero">
+    <section class="hero min-h-[calc(100dvh-5.5rem)] md:min-h-0">
       <div class="rubric">
         <span class="name">webjs</span>
         <span class="sep">·</span>


### PR DESCRIPTION
## Summary

On mobile (`< 768px`), the install section now starts below the visible viewport. Scrolling reveals it.

The hero section itself is untouched (same padding, same content position, same button layout). Only the section's `min-height` is set so it occupies the available viewport space.

## Implementation

One-class change to the hero `<section>`:

```
min-h-[calc(100dvh-5.5rem)] md:min-h-0
```

- `5.5rem` (88px) is the chrome height above the hero (announce banner + nav).
- `min-h-[calc(100dvh - 5.5rem)]` makes the hero exactly tall enough to fill the remaining viewport.
- `md:min-h-0` resets on tablet+ so desktop layout is unchanged.
- `100dvh` (dynamic) over `100vh` (largest) so iOS/Android browser-chrome resizing does not leak the install section into view.

No custom CSS added. Tailwind utilities only.

## Test plan

- [x] Mobile (`< 768px`): hero fills the viewport, install section requires a scroll
- [x] Desktop (`>= 768px`): unchanged from today
- [x] Hero content position not affected (no translate, no flex changes)