### PR TITLE
chore(website): tighten install section comments + section-level scroll on mobile

### DIFF
--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -123,7 +123,7 @@ export default function LandingPage() {
         text-align: left;
         overflow-x: auto;
       }
-      .install .comment { color: var(--fg-subtle); }
+      .install .comment { color: var(--fg-subtle); white-space: nowrap; }
       .install .cmd { color: var(--fg); }
       /* On narrow viewports the box would stretch full-width and its
          left/right border + rounded corners would visibly clip the
@@ -258,16 +258,16 @@ export default function LandingPage() {
     </section>
 
     <div class="install">
-      <div class="comment"># get started in one command, no global install</div>
+      <div class="comment"># create a full-stack app</div>
       <copy-cmd>npm create webjs@latest my-app</copy-cmd>
       <div class="h-3"></div>
-      <div class="comment"># backend-only API</div>
+      <div class="comment"># create an API-only app</div>
       <copy-cmd>npm create webjs@latest my-api -- --template api</copy-cmd>
       <div class="h-3"></div>
-      <div class="comment"># SaaS starter (auth + dashboard + Prisma)</div>
+      <div class="comment"># create a SaaS app with auth</div>
       <copy-cmd>npm create webjs@latest my-saas -- --template saas</copy-cmd>
       <div class="h-3"></div>
-      <div class="comment"># or install the CLI globally for repeated use</div>
+      <div class="comment"># install the CLI globally</div>
       <copy-cmd>npm i -g webjsdev && webjs create my-app</copy-cmd>
     </div>
 

--- a/website/components/copy-cmd.ts
+++ b/website/components/copy-cmd.ts
@@ -61,7 +61,7 @@ export class CopyCmd extends WebComponent {
         @click=${this._copy}
         @keydown=${this._onKey}
       >
-        <span data-copy-text class="flex-1 min-w-0 overflow-x-auto whitespace-nowrap">
+        <span data-copy-text class="whitespace-nowrap">
           <slot></slot>
         </span>
         <button


### PR DESCRIPTION
## Summary

Two related fixes for the `.install` block on the landing page, both visible mainly on narrow viewports.

## 1. Comments shortened to fit a single mobile line

Same parallel structure across the four entries:

```
# create a full-stack app
# create an API-only app
# create a SaaS app with auth
# install the CLI globally
```

All under 30 characters, comfortably fits ~320px-wide screens at the existing 14px monospace size. Added `white-space: nowrap` to `.install .comment` so a future longer comment cannot wrap to a second line; it triggers section-level scroll instead.

## 2. Section-level scroll instead of per-command scroll

Removed `flex-1 min-w-0 overflow-x-auto` from `<copy-cmd>`'s text span. With those classes the inner span shrank to fit and provided its OWN horizontal scrollbar per command, so long commands scrolled inside their pill while the section box stayed put.

Now `copy-cmd`'s text takes its natural width with `whitespace-nowrap`. When a command is wider than the container, the parent `.install` (which already has `overflow-x: auto`) scrolls the whole row including the copy button. One scroll surface per section, not one per command.

`copy-cmd` is used only on this landing page (4 instances), so the removal is scoped to this surface.

## Test plan

- [x] Mobile: comments fit on a single line, no wrap
- [x] Mobile: long commands trigger horizontal scroll of the whole install box, not per-command
- [x] Desktop: unchanged