### PR TITLE
fix(ui,cli): ship registry sources in @webjsdev/ui tarball and fail loudly when missing

### DIFF
--- a/packages/cli/lib/create.js
+++ b/packages/cli/lib/create.js
@@ -72,11 +72,10 @@ const UI_REGISTRY_ROOT = resolve(
  * utils/ folder: `../../lib/utils/cn.ts`.
  *
  * @param {string} name  component name without `.ts` (e.g. 'button')
- * @returns {Promise<string|null>} source or null if not found
+ * @returns {Promise<string>} source with import rewritten
  */
 async function readUiComponent(name) {
   const src = join(UI_REGISTRY_ROOT, 'components', `${name}.ts`);
-  if (!existsSync(src)) return null;
   const raw = await readFile(src, 'utf8');
   return raw
     .replaceAll("'../lib/utils.ts'", "'../../lib/utils/cn.ts'")
@@ -85,7 +84,10 @@ async function readUiComponent(name) {
 
 /**
  * Copy a list of @webjsdev/ui registry components into the scaffolded app
- * under `components/ui/`. Silently skips any name that isn't in the registry.
+ * under `components/ui/`. Throws if any name is missing from the registry,
+ * since the scaffold's generated pages import these by name and a missing
+ * file would produce ERR_MODULE_NOT_FOUND at first request. Caller must
+ * have already invoked assertUiRegistryAvailable().
  *
  * @param {string} appDir  destination app root
  * @param {string[]} names list of component file basenames (without `.ts`)
@@ -94,9 +96,16 @@ async function copyUiComponents(appDir, names) {
   const uiDir = join(appDir, 'components', 'ui');
   await mkdir(uiDir, { recursive: true });
   for (const n of names) {
-    const content = await readUiComponent(n);
-    if (content == null) continue;
-    await writeFile(join(uiDir, `${n}.ts`), content);
+    const src = join(UI_REGISTRY_ROOT, 'components', `${n}.ts`);
+    if (!existsSync(src)) {
+      throw new Error(
+        `@webjsdev/ui registry is missing component '${n}.ts' at ${src}. ` +
+        `The scaffold's example pages import this component by name. ` +
+        `Either the registry was published incompletely or the scaffold's ` +
+        `component list is out of sync with the registry.`,
+      );
+    }
+    await writeFile(join(uiDir, `${n}.ts`), await readUiComponent(n));
   }
 }
 
@@ -110,13 +119,15 @@ async function copyUiComponents(appDir, names) {
  * @param {string} appDir
  */
 async function writeUiBootstrap(appDir) {
+  // Caller (scaffoldApp) has already invoked assertUiRegistryAvailable(),
+  // so the source files below are guaranteed to exist.
+
   // 1) lib/utils/cn.ts: the cn() helper
-  const utilsSrc = join(UI_REGISTRY_ROOT, 'lib', 'utils.ts');
-  if (existsSync(utilsSrc)) {
-    const content = await readFile(utilsSrc, 'utf8');
-    await mkdir(join(appDir, 'lib', 'utils'), { recursive: true });
-    await writeFile(join(appDir, 'lib', 'utils', 'cn.ts'), content);
-  }
+  const utilsContent = await readFile(
+    join(UI_REGISTRY_ROOT, 'lib', 'utils.ts'), 'utf8',
+  );
+  await mkdir(join(appDir, 'lib', 'utils'), { recursive: true });
+  await writeFile(join(appDir, 'lib', 'utils', 'cn.ts'), utilsContent);
 
   // 2) components.json: the same shape `webjsui init` writes for webjs
   // projects (see packages/ui/src/utils/detect-project.js). The utils alias
@@ -144,12 +155,11 @@ async function writeUiBootstrap(appDir) {
 
   // 3) app/globals.css: copy the neutral theme verbatim. components.json
   // references this path, and future `webjs ui add` calls append to it.
-  const themeSrc = join(UI_REGISTRY_ROOT, 'themes', 'index.css');
-  if (existsSync(themeSrc)) {
-    const css = await readFile(themeSrc, 'utf8');
-    await mkdir(join(appDir, 'app'), { recursive: true });
-    await writeFile(join(appDir, 'app', 'globals.css'), css);
-  }
+  const css = await readFile(
+    join(UI_REGISTRY_ROOT, 'themes', 'index.css'), 'utf8',
+  );
+  await mkdir(join(appDir, 'app'), { recursive: true });
+  await writeFile(join(appDir, 'app', 'globals.css'), css);
 }
 
 /**
@@ -159,12 +169,43 @@ async function writeUiBootstrap(appDir) {
  * tokens (`--color-primary`, `--color-card`, …) the registry components
  * consume are available at runtime without a build step.
  *
- * @returns {Promise<string>} theme CSS source, or '' if registry missing
+ * @returns {Promise<string>} theme CSS source
  */
 async function readThemeCss() {
   const src = join(UI_REGISTRY_ROOT, 'themes', 'index.css');
-  if (!existsSync(src)) return '';
   return await readFile(src, 'utf8');
+}
+
+/**
+ * Fail loudly when the @webjsdev/ui registry is not on disk. The scaffold
+ * reads component sources, the cn() helper, and the shadcn theme from
+ * UI_REGISTRY_ROOT and weaves them into a generated app/page.ts that
+ * imports `components/ui/button.ts`. If the registry is missing, the
+ * generated app boots to ERR_MODULE_NOT_FOUND on first request, which is
+ * a confusing failure for end-users to debug.
+ *
+ * The check guards against an @webjsdev/ui published tarball that forgets
+ * to ship `packages/registry/` in its `files` array (the bug fixed in
+ * the same commit), and against a corrupted node_modules install.
+ */
+function assertUiRegistryAvailable() {
+  const required = [
+    join(UI_REGISTRY_ROOT, 'components'),
+    join(UI_REGISTRY_ROOT, 'lib', 'utils.ts'),
+    join(UI_REGISTRY_ROOT, 'themes', 'index.css'),
+  ];
+  const missing = required.filter((p) => !existsSync(p));
+  if (missing.length === 0) return;
+  throw new Error(
+    `@webjsdev/ui registry sources not found at ${UI_REGISTRY_ROOT}.\n` +
+    `Missing:\n${missing.map((p) => `  - ${p}`).join('\n')}\n\n` +
+    `The scaffold reads component sources from the installed @webjsdev/ui ` +
+    `package. If you see this from a fresh \`npm create webjs\`, the ` +
+    `published @webjsdev/ui tarball is missing \`packages/registry/\` ` +
+    `(check its package.json \`files\` array). Please file an issue at ` +
+    `https://github.com/webjsdev/webjs/issues with your @webjsdev/ui ` +
+    `version (\`npm ls @webjsdev/ui\`).`,
+  );
 }
 
 /**
@@ -512,6 +553,13 @@ export type ActionResult<T> =
     if (existsSync(uiSrc)) {
       await cp(uiSrc, join(utilsDir, 'ui.ts'));
     }
+
+    // Fail loudly if the @webjsdev/ui registry sources aren't on disk.
+    // Without this, downstream copy helpers would silently skip and the
+    // generated app would boot to ERR_MODULE_NOT_FOUND on the first page
+    // render (the import in app/page.ts below points at a file we didn't
+    // write).
+    assertUiRegistryAvailable();
 
     // Pre-initialise @webjsdev/ui so the scaffold boots ready for
     // `webjs ui add <name>`: writes components.json + lib/utils/cn.ts +

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -15,6 +15,7 @@
   "files": [
     "bin",
     "src",
+    "packages/registry",
     "README.md"
   ],
   "scripts": {


### PR DESCRIPTION
## Summary

Fixes a broken `npm create webjs@latest <app>` experience. The scaffolded
app's first request crashed with `ERR_MODULE_NOT_FOUND` on
`components/ui/button.ts`.

## Root cause

The scaffold in `@webjsdev/cli` reads UI component sources directly from
`@webjsdev/ui`'s `packages/registry/` directory at create time (see
`packages/cli/lib/create.js:62`), then emits an `app/page.ts` that
imports the copied files. But `@webjsdev/ui`'s `package.json` `files`
array only shipped `bin`, `src`, and `README.md`, so `packages/registry/`
was missing from the published tarball. The downstream copy helpers had
defensive `existsSync` checks that silently skipped, so the scaffold
appeared to succeed and the failure only surfaced on first dev request.

Reported user error:

```
[webjs] unhandled render error: Error [ERR_MODULE_NOT_FOUND]:
Cannot find module '.../my-app/components/ui/button.ts'
imported from '.../my-app/app/page.ts'
```

## Changes

**`a23b43e` fix(ui): include `packages/registry` in npm package files**

One-line addition to `packages/ui/package.json`'s `files` array.
Verified via `npm pack --dry-run --workspace=@webjsdev/ui`. The tarball
now includes 32 component sources, `lib/utils.ts`, themes, and the
registry manifest.

**`6ac4a0d` fix(cli): fail loudly when @webjsdev/ui registry is missing at scaffold time**

Adds `assertUiRegistryAvailable()` (called once before any registry
read) and tightens the per-component copy to throw on missing files
instead of silently skipping. A future regression in the published
`files` array (or a corrupted install) will now fail the scaffold
immediately with an error that names the missing path and points the
user at filing an issue, rather than producing a half-broken app.

## Test plan

- [x] `npm pack --dry-run --workspace=@webjsdev/ui` lists every
  `packages/registry/components/*.ts`, `lib/utils.ts`, and
  `themes/index.css`.
- [x] `node --test test/scaffolds/scaffold-template-validation.test.js` (2/2)
- [x] `node --test test/scaffolds/scaffold-integration.test.js` (5/5)
- [x] `node --test test/scaffolds/scaffold-ui-integration.test.js` (5/5)
- [x] Repo-wide `npm test` via pre-commit hook (1146/1146)
- [ ] Manual smoke after npm publish: from a clean machine,
  `npm create webjs@latest demo`, then `cd demo && npm run dev`, then
  `curl http://localhost:3000` returns the example page.