### PR TITLE
chore(release): bump @webjsdev/ui to 0.3.2 and @webjsdev/cli to 0.8.6

### DIFF
--- a/changelog/cli/0.8.6.md
+++ b/changelog/cli/0.8.6.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/cli"
+version: 0.8.6
+date: 2026-05-24T14:55:07.650Z
+commit_count: 1
+---
+## Fixes
+
+- **fail loudly when @webjsdev/ui registry is missing at scaffold time** [`6ac4a0d`](https://github.com/webjsdev/webjs/commit/6ac4a0d)
+  The scaffold reads UI component sources directly from the installed
+  @webjsdev/ui's `packages/registry/` directory, then generates an
+  `app/page.ts` that imports the copied files. Until the previous commit,
+  if the registry wasn't on disk, the copy helpers silently no-op'd and

--- a/changelog/ui/0.3.2.md
+++ b/changelog/ui/0.3.2.md
@@ -1,0 +1,9 @@
+---
+package: "@webjsdev/ui"
+version: 0.3.2
+date: 2026-05-24T14:55:07.739Z
+commit_count: 1
+---
+## Fixes
+
+- **include packages/registry in npm package files** [`a23b43e`](https://github.com/webjsdev/webjs/commit/a23b43e)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/ui",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "description": "An AI-first component library - class-helper functions for visuals, custom elements only where state matters. Source-copied into your repo, you own it. Works with any Tailwind v4 project.",
   "bin": {


### PR DESCRIPTION
## Summary

Patch bumps to ship the scaffold registry fix from #90 to end-users of
`npm create webjs@latest`.

* `@webjsdev/ui` **0.3.1 → 0.3.2** republishes the tarball with
  `packages/registry/` included. This is the load-bearing fix.
  Without this bump the broken 0.3.1 tarball keeps being served and
  every `npm create webjs@latest` continues to crash with
  `ERR_MODULE_NOT_FOUND` on `components/ui/button.ts`.
* `@webjsdev/cli` **0.8.5 → 0.8.6** ships the scaffold-time
  `assertUiRegistryAvailable()` guard. With this in users' hands, any
  future regression in the published `@webjsdev/ui` tarball surfaces
  immediately at create time rather than producing a half-broken app.

`create-webjs` and `webjsdev` will be lockstep-bumped to 0.8.6 by the
release workflow's wrapper step automatically (no manual edit needed).

## What ships when this merges

Squash-merging this PR lands two new files under `changelog/**`, which
triggers `.github/workflows/release.yml` to publish four packages:

| Package | Version | Source |
|---|---|---|
| `@webjsdev/ui` | 0.3.2 | from `changelog/ui/0.3.2.md` |
| `@webjsdev/cli` | 0.8.6 | from `changelog/cli/0.8.6.md` |
| `create-webjs` | 0.8.6 | auto-lockstep to cli |
| `webjsdev` | 0.8.6 | auto-lockstep to cli |

Two GitHub Releases (`ui@0.3.2`, `cli@0.8.6`) are created from the same
files. Wrappers don't get changelog files or releases (by design).

## Test plan

- [x] Pre-commit hook auto-generated `changelog/ui/0.3.2.md` and
  `changelog/cli/0.8.6.md` from the staged bumps.
- [x] Repo-wide `npm test` via pre-commit hook (1146/1146).
- [x] `npm pack --dry-run --workspace=@webjsdev/ui` confirms the
  tarball now includes 32 component sources, `lib/utils.ts`, themes,
  and the registry manifest.
- [ ] After merge: confirm `release.yml` publishes all four packages
  and creates the two GitHub Releases.
- [ ] After publish: `npm create webjs@latest demo` from a clean
  cache, then `cd demo && npm run dev`, then `curl http://localhost:3000`
  returns the example page.