### PR TITLE
chore(release): lockstep bump create-webjs + webjsdev to match @webjsdev/cli@0.8.6

### DIFF
--- a/packages/create-webjs/package.json
+++ b/packages/create-webjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-webjs",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "type": "module",
   "description": "Scaffold a new webjs app. `npm create webjs@latest my-app`.",
   "bin": {
@@ -11,7 +11,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@webjsdev/cli": "^0.8.5"
+    "@webjsdev/cli": "^0.8.6"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/webjsdev/package.json
+++ b/packages/webjsdev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webjsdev",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "type": "module",
   "description": "The webjs CLI, published unscoped on npm. Unscoped alias for @webjsdev/cli. Installs the `webjs` command.",
   "bin": {
@@ -11,7 +11,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@webjsdev/cli": "^0.8.5"
+    "@webjsdev/cli": "^0.8.6"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

Manually lands the wrapper version bumps that the Auto-release workflow's
"Lockstep-bump wrappers" step couldn't push.

When PR #92 merged, the release workflow ran but its
`github-actions[bot]` direct push to `main` was rejected by branch
protection:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
 ! [remote rejected] HEAD -> main (protected branch hook declined)
```

Failed run: https://github.com/webjsdev/webjs/actions/runs/26368142961

Result: `@webjsdev/ui@0.3.2` and `@webjsdev/cli@0.8.6` published
successfully (those steps ran before the failure), but `create-webjs`
and `webjsdev` stayed at `0.8.5` on the registry. With the wrappers
stranded, npx serves the cached `create-webjs@0.8.5` tarball to every
fresh `npm create webjs@latest`, locking new users into the broken
pre-0.8.6 scaffold (which is exactly the failure mode the wrapper-version
mirroring exists to prevent).

## Changes

* `packages/create-webjs/package.json`: `0.8.5` → `0.8.6`, dep `^0.8.5` → `^0.8.6`
* `packages/webjsdev/package.json`: `0.8.5` → `0.8.6`, dep `^0.8.5` → `^0.8.6`

No `changelog/**` files (wrappers don't get changelog entries, per
`scripts/backfill-changelog.js` `PACKAGES` design).

## After merge

The release workflow won't re-fire because the diff doesn't touch
`changelog/**`. Publish the wrappers manually from a clean `main`:

```
git switch main && git pull
npm publish --workspace=create-webjs --access=public
npm publish --workspace=webjsdev --access=public
```

Verify with:

```
npm view create-webjs version    # → 0.8.6
npm view webjsdev version        # → 0.8.6
```

## Follow-up

Branch protection bypass for `github-actions[bot]` so the lockstep
step can push directly on the next release without manual intervention.
Tracked separately.

## Test plan

- [x] `npm test` via pre-commit hook (1151/1151 pass).
- [ ] After merge + manual publish, `npm view` shows both wrappers at `0.8.6`.
- [ ] Smoke: `rm -rf /tmp/demo && cd /tmp && npm create webjs@latest demo && cd demo && npm run dev` boots cleanly.