### PR TITLE
fix(cli): resolve @webjsdev/ui registry via module resolver, not path math

### DIFF
--- a/packages/cli/lib/create.js
+++ b/packages/cli/lib/create.js
@@ -15,6 +15,7 @@ import { mkdir, writeFile, readFile, cp } from 'node:fs/promises';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { spawnSync } from 'node:child_process';
 
 /**
@@ -54,14 +55,33 @@ const TEMPLATES = resolve(__dirname, '..', 'templates');
 // directly from disk at create time so the scaffolded app boots ready for
 // `webjs ui add` without an HTTP round-trip during scaffolding.
 //
-// Layout in the monorepo:
-//   packages/cli/lib/create.js                       ← __dirname
-//   packages/ui/packages/registry/components/*.ts
-//   packages/ui/packages/registry/lib/utils.ts
-//   packages/ui/packages/registry/themes/index.css
-const UI_REGISTRY_ROOT = resolve(
-  __dirname, '..', '..', 'ui', 'packages', 'registry',
-);
+//   <ui-pkg-root>/packages/registry/components/*.ts
+//   <ui-pkg-root>/packages/registry/lib/utils.ts
+//   <ui-pkg-root>/packages/registry/themes/index.css
+//
+// Locate <ui-pkg-root> via Node's module resolver rather than path
+// arithmetic off __dirname. The old `__dirname/../../ui/packages/registry`
+// form assumed @webjsdev/ui was a hoisted sibling of @webjsdev/cli under
+// node_modules/@webjsdev/. That holds for npm/yarn's default hoisting, but
+// breaks on nested layouts (pnpm's isolated linker, `npm install
+// --install-strategy=nested`, some CI setups), where @webjsdev/ui lives at
+// node_modules/@webjsdev/cli/node_modules/@webjsdev/ui and the arithmetic
+// resolves to a path that doesn't exist, failing `webjs create`.
+//
+// @webjsdev/ui's package.json isn't reachable via require.resolve (its
+// `exports` map doesn't expose `./package.json`), so resolve the package
+// entry and walk up to the directory that owns its package.json.
+function resolveUiRegistryRoot() {
+  const require = createRequire(import.meta.url);
+  let dir = dirname(require.resolve('@webjsdev/ui'));
+  while (!existsSync(join(dir, 'package.json'))) {
+    const parent = dirname(dir);
+    if (parent === dir) break; // reached filesystem root; give up
+    dir = parent;
+  }
+  return resolve(dir, 'packages', 'registry');
+}
+const UI_REGISTRY_ROOT = resolveUiRegistryRoot();
 
 /**
  * Read a single @webjsdev/ui registry component, rewrite its relative import


### PR DESCRIPTION
## Summary

`webjs create` (the globally-installed CLI path) fails to locate the UI
component registry on **non-hoisted** dependency layouts. Replaces the
brittle path arithmetic with Node's module resolver so it works
regardless of install layout.

## The bug

`packages/cli/lib/create.js` located the registry with:

```js
const UI_REGISTRY_ROOT = resolve(__dirname, '..', '..', 'ui', 'packages', 'registry');
```

That assumes `@webjsdev/ui` is hoisted as a sibling of `@webjsdev/cli`
under `node_modules/@webjsdev/`. True for npm/yarn default hoisting and
the `npm create webjs@latest` npx path, but false for:

- pnpm's isolated linker
- `npm install --install-strategy=nested`
- some CI / monorepo setups

In those, `@webjsdev/ui` lands at
`node_modules/@webjsdev/cli/node_modules/@webjsdev/ui`. The arithmetic
then points at a path that doesn't exist, and scaffolding aborts.

## Reproduction (verified, not theoretical)

```
mkdir t && cd t && npm init -y
npm install @webjsdev/cli --install-strategy=nested
node node_modules/@webjsdev/cli/bin/webjs.js create demo --no-install
# Error: @webjsdev/ui registry sources not found at
#   .../node_modules/@webjsdev/ui/packages/registry
```

The PR #90 `assertUiRegistryAvailable` guard surfaces it as a clear
error. Before #90 it was a silent `ERR_MODULE_NOT_FOUND` at first render.

## The fix

Resolve the registry root through `require.resolve` instead of path math.
`@webjsdev/ui`'s `exports` map doesn't expose `./package.json` (so
`require.resolve('@webjsdev/ui/package.json')` throws
`ERR_PACKAGE_PATH_NOT_EXPORTED`), so resolve the package *entry* and walk
up to the directory owning its `package.json`:

```js
function resolveUiRegistryRoot() {
  const require = createRequire(import.meta.url);
  let dir = dirname(require.resolve('@webjsdev/ui'));
  while (!existsSync(join(dir, 'package.json'))) {
    const parent = dirname(dir);
    if (parent === dir) break;
    dir = parent;
  }
  return resolve(dir, 'packages', 'registry');
}
```

Works for hoisted, nested, and symlinked (monorepo workspace) layouts.

## Test plan

- [x] Repro the failure with `--install-strategy=nested`.
- [x] Patch + re-run `webjs create` in the nested layout: scaffolds
  cleanly, all 7 `components/ui/*.ts` created.
- [x] Monorepo scaffold tests pass (10/10), confirming the symlinked
  workspace layout still resolves.
- [x] Full suite green via pre-commit hook (1151/1151).
- [x] `npm create webjs@latest` (hoisted/npx path) verified working
  before and after (`require.resolve` finds the hoisted ui too).

## Note

CLI-only change. Takes effect once `@webjsdev/cli` is republished (next
release). No `@webjsdev/ui` change needed: the fix works against the
already-published `@webjsdev/ui@0.3.2`.