### PR TITLE
feat(dev): renumber monorepo dev ports to 5001-5004 + per-service overrides + UI site in dev-all

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ git clone https://github.com/webjsdev/webjs
 cd webjs && npm install
 cd examples/blog && npx prisma migrate dev --name init && cd ..
 npm run dev
-# → Website → http://localhost:5000
-# → Docs    → http://localhost:4000
-# → Blog    → http://localhost:3456
+# → Website → http://localhost:5001
+# → Docs    → http://localhost:5002
+# → Blog    → http://localhost:5004
 #
 # Or run any one individually:
 cd examples/blog && npm run dev      # just the blog

--- a/README.md
+++ b/README.md
@@ -65,20 +65,18 @@ npm create webjs@latest my-saas -- --template saas
 npm i -g webjsdev && webjs create my-app
 cd my-app && npm run dev
 
-# or run everything in the monorepo (website + docs + blog together)
+# or run everything in the monorepo (website + docs + blog + UI registry together)
 git clone https://github.com/webjsdev/webjs
 cd webjs && npm install
 cd examples/blog && npx prisma migrate dev --name init && cd ..
 npm run dev
-# → Website → http://localhost:5001
-# → Docs    → http://localhost:5002
-# → Blog    → http://localhost:5004
-#
-# Or run any one individually:
-cd examples/blog && npm run dev      # just the blog
-cd docs           && npm run dev     # just the docs
-cd website        && npm run dev     # just the website
+# → Website     → http://localhost:5001
+# → Docs        → http://localhost:5002
+# → UI registry → http://localhost:5003
+# → Blog        → http://localhost:5004
 ```
+
+See [Local development](#local-development) for running one app at a time and overriding ports.
 
 ## Repo layout
 
@@ -101,6 +99,46 @@ website/            # landing site (built on webjs itself)
 AGENTS.md           # AI-agent contract for the framework
 CLAUDE.md           # Claude Code quick-reference
 ```
+
+## Local development
+
+Contributing to the framework itself? Run the monorepo's apps with
+`npm run dev` (never `webjs dev` directly: each app's `npm run dev`
+also spawns its Tailwind watcher, and the blog and UI site run extra
+prep steps via `predev` hooks).
+
+```sh
+npm install                          # once, from the repo root (installs every workspace)
+npm run dev                          # all four apps at once
+```
+
+Default ports (a contiguous 5001-5004 block; port 5000 is skipped
+because macOS reserves it for the AirPlay Receiver / Control Center):
+
+| App | Dir | Port | Env override |
+|---|---|---|---|
+| Landing site | `website/` | 5001 | `WEBSITE_PORT` |
+| Docs | `docs/` | 5002 | `DOCS_PORT` |
+| UI registry site | `packages/ui/packages/website/` | 5003 | `UI_PORT` |
+| Example blog | `examples/blog/` | 5004 | `BLOG_PORT` |
+
+**Run a single app** (from its directory). Each honors a `PORT` env var:
+
+```sh
+cd docs && npm run dev               # docs on 5002
+PORT=8080 npm run dev                # ...or on 8080
+```
+
+**Override ports when running all four** via the per-app env vars:
+
+```sh
+WEBSITE_PORT=8001 DOCS_PORT=8002 UI_PORT=8003 BLOG_PORT=8004 npm run dev
+```
+
+The apps cross-link by URL (the landing site links to docs/blog/UI,
+the UI site links back). Those default to the localhost ports above and
+are overridable via `DOCS_URL` / `BLOG_URL` / `UI_URL` / `WEBSITE_URL`
+(this is also how deploys point them at real domains).
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,13 @@ PORT=8080 npm run dev                # ...or on 8080
 WEBSITE_PORT=8001 DOCS_PORT=8002 UI_PORT=8003 BLOG_PORT=8004 npm run dev
 ```
 
+> Use the `PORT` / `*_PORT` env vars, **not** a `--port` flag. `npm run dev
+> --port 5678` does not work: npm parses `--port` as its own (deprecated)
+> config, and the `dev` script runs each app through `concurrently`, which
+> would intercept any passthrough args before they reached `webjs dev`. The
+> env var is the supported interface (and the conventional one: Railway,
+> Heroku, Fly, etc. all drive port via `PORT`).
+
 The apps cross-link by URL (the landing site links to docs/blog/UI,
 the UI site links back). Those default to the localhost ports above and
 are overridable via `DOCS_URL` / `BLOG_URL` / `UI_URL` / `WEBSITE_URL`

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,10 +2,10 @@
 # from a single image. Local parity with Railway deployment (same Dockerfile).
 #
 #   docker compose up --build
-#     website    → http://localhost:15000
-#     docs       → http://localhost:14000
-#     blog       → http://localhost:13000
-#     ui-website → http://localhost:15001  (registry host + @webjsdev/ui docs)
+#     website    → http://localhost:15001
+#     docs       → http://localhost:15002
+#     blog       → http://localhost:15004
+#     ui-website → http://localhost:15003  (registry host + @webjsdev/ui docs)
 services:
   website:
     image: webjs
@@ -13,21 +13,21 @@ services:
     working_dir: /app/website
     # @webjsdev/cli installed in the root node_modules/.bin by npm workspaces;
     # invoke its binary directly rather than via `webjs`.
-    command: ["node", "/app/node_modules/@webjsdev/cli/bin/webjs.js", "start", "--port", "5000"]
+    command: ["node", "/app/node_modules/@webjsdev/cli/bin/webjs.js", "start", "--port", "5001"]
     ports:
-      - "15000:5000"
+      - "15001:5001"
     environment:
-      DOCS_URL: ${DOCS_URL:-http://localhost:14000}
-      BLOG_URL: ${BLOG_URL:-http://localhost:13000}
-      UI_URL:   ${UI_URL:-http://localhost:15001}
+      DOCS_URL: ${DOCS_URL:-http://localhost:15002}
+      BLOG_URL: ${BLOG_URL:-http://localhost:15004}
+      UI_URL:   ${UI_URL:-http://localhost:15003}
 
   docs:
     image: webjs
     build: .
     working_dir: /app/docs
-    command: ["node", "/app/node_modules/@webjsdev/cli/bin/webjs.js", "start", "--port", "4000"]
+    command: ["node", "/app/node_modules/@webjsdev/cli/bin/webjs.js", "start", "--port", "5002"]
     ports:
-      - "14000:4000"
+      - "15002:5002"
 
   blog:
     image: webjs
@@ -40,9 +40,9 @@ services:
       - -c
       - |
         node /app/node_modules/prisma/build/index.js migrate deploy && \
-        node /app/node_modules/@webjsdev/cli/bin/webjs.js start --port 3000
+        node /app/node_modules/@webjsdev/cli/bin/webjs.js start --port 5004
     ports:
-      - "13000:3000"
+      - "15004:5004"
     environment:
       DATABASE_URL: file:/data/dev.db
       AUTH_SECRET:    ${AUTH_SECRET:-change-me-at-least-32-characters-long!}
@@ -59,9 +59,9 @@ services:
     #   GET /r/index.json    - flat list of all items
     #   GET /docs/components/<name> - per-component docs page
     # The registry JSON is built at image time (see Dockerfile RUN step).
-    command: ["node", "/app/node_modules/@webjsdev/cli/bin/webjs.js", "start", "--port", "5001"]
+    command: ["node", "/app/node_modules/@webjsdev/cli/bin/webjs.js", "start", "--port", "5003"]
     ports:
-      - "15001:5001"
+      - "15003:5003"
 
 volumes:
   blog-data:

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -52,7 +52,7 @@ That's it. No separate manifest, no rebuild.
 ## Run
 
 ```sh
-cd docs && npm run dev          # http://localhost:4000
+cd docs && npm run dev          # http://localhost:5002
 ```
 
 **Use `npm run dev`, not `webjs dev` directly.** `webjs dev` only runs

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
     "prestart": "npm run css:build",
     "dev": "concurrently --names css,web --prefix-colors magenta,cyan --kill-others-on-fail \"npm:css:watch\" \"npm:webjs:dev\"",
     "start": "webjs start",
-    "webjs:dev": "webjs dev --port 4000",
+    "webjs:dev": "webjs dev --port ${PORT:-5002}",
     "css:watch": "tailwindcss -i ./public/input.css -o ./public/tailwind.css --watch",
     "css:build": "tailwindcss -i ./public/input.css -o ./public/tailwind.css --minify"
   },

--- a/examples/blog/.env.example
+++ b/examples/blog/.env.example
@@ -1,7 +1,7 @@
 # webjs blog example - environment variables
 # Copy to .env: cp .env.example .env
 
-PORT=3000
+PORT=5004
 AUTH_SECRET=change-me-to-a-random-string-at-least-32-chars
 DATABASE_URL=file:./dev.db
 

--- a/examples/blog/AGENTS.md
+++ b/examples/blog/AGENTS.md
@@ -149,7 +149,7 @@ their custom element on import.
 ```sh
 cp .env.example .env          # AUTH_SECRET, SESSION_SECRET, DATABASE_URL
 npm run db:migrate            # creates prisma/dev.db + applies migrations
-npm run dev                   # http://localhost:3456
+npm run dev                   # http://localhost:5004
 ```
 
 **Always `npm run dev` / `npm start`, never `webjs dev` / `webjs start`

--- a/examples/blog/package.json
+++ b/examples/blog/package.json
@@ -8,7 +8,7 @@
     "prestart": "prisma migrate deploy",
     "dev": "concurrently --names css,web --prefix-colors magenta,cyan --kill-others-on-fail \"npm:css:watch\" \"npm:webjs:dev\"",
     "start": "webjs start",
-    "webjs:dev": "webjs dev",
+    "webjs:dev": "webjs dev --port ${PORT:-5004}",
     "css:watch": "tailwindcss -i ./public/input.css -o ./public/tailwind.css --watch",
     "css:build": "tailwindcss -i ./public/input.css -o ./public/tailwind.css --minify",
     "db:generate": "webjs db generate",

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -300,7 +300,7 @@ the overall layout.
 ## Building / running
 
 ```sh
-npm run ui:dev                       # serve the registry website on :5001
+npm run ui:dev                       # serve the registry website on :5003
 ```
 
 **No registry build step.** Registry JSON is composed on demand by the

--- a/packages/ui/packages/website/.env.example
+++ b/packages/ui/packages/website/.env.example
@@ -3,5 +3,5 @@
 # Canonical localhost dev ports (one source of truth alongside the
 # matching fallbacks in app/layout.ts). Deployments override these
 # with real public URLs (e.g. via Railway's service env vars).
-WEBSITE_URL=http://localhost:5000
-DOCS_URL=http://localhost:4000
+WEBSITE_URL=http://localhost:5001
+DOCS_URL=http://localhost:5002

--- a/packages/ui/packages/website/AGENTS.md
+++ b/packages/ui/packages/website/AGENTS.md
@@ -86,7 +86,7 @@ which composes JSON on demand from `../registry/` (no build step).
 ## Dev
 
 ```sh
-npm run dev    # http://localhost:5001
+npm run dev    # http://localhost:5003
 ```
 
 **Use `npm run dev`, not `webjs dev` directly.** `webjs dev` only runs
@@ -112,8 +112,8 @@ by overriding via the service env (e.g. Railway's variables):
 
 | Env var | Local fallback | Production value |
 |---|---|---|
-| `WEBSITE_URL` | `http://localhost:5000` | `https://webjs.dev` |
-| `DOCS_URL` | `http://localhost:4000` | `https://docs.webjs.dev` |
+| `WEBSITE_URL` | `http://localhost:5001` | `https://webjs.dev` |
+| `DOCS_URL` | `http://localhost:5002` | `https://docs.webjs.dev` |
 
 `.env.example` in this directory documents the same defaults. Copy it to
 `.env` only if you need to override locally; the fallbacks already match.

--- a/packages/ui/packages/website/README.md
+++ b/packages/ui/packages/website/README.md
@@ -22,7 +22,7 @@ generated output to commit.
 ## Dev
 
 ```sh
-npm run dev      # http://localhost:5001
+npm run dev      # http://localhost:5003
 ```
 
 A `predev` hook runs `scripts/copy-registry.js`, which mirrors the

--- a/packages/ui/packages/website/app/layout.ts
+++ b/packages/ui/packages/website/app/layout.ts
@@ -13,8 +13,8 @@ import './_components/theme-toggle.ts';
  * on the client during hydration.
  */
 const env = (globalThis as any).process?.env ?? {};
-const WEBSITE_URL = env.WEBSITE_URL || 'http://localhost:5000';
-const DOCS_URL = env.DOCS_URL || 'http://localhost:4000';
+const WEBSITE_URL = env.WEBSITE_URL || 'http://localhost:5001';
+const DOCS_URL = env.DOCS_URL || 'http://localhost:5002';
 
 const TITLE = 'Webjs UI: AI-first component library';
 const DESCRIPTION =

--- a/packages/ui/packages/website/package.json
+++ b/packages/ui/packages/website/package.json
@@ -9,7 +9,7 @@
     "prestart": "node scripts/copy-registry.js && npm run css:build",
     "dev": "concurrently --names css,web --prefix-colors magenta,cyan --kill-others-on-fail \"npm:css:watch\" \"npm:webjs:dev\"",
     "start": "webjs start",
-    "webjs:dev": "webjs dev --port 5001",
+    "webjs:dev": "webjs dev --port ${PORT:-5003}",
     "css:watch": "tailwindcss -i ./public/input.css -o ./public/tailwind.css --watch",
     "css:build": "tailwindcss -i ./public/input.css -o ./public/tailwind.css --minify",
     "preview:build": "node scripts/copy-registry.js"

--- a/scripts/dev-all.js
+++ b/scripts/dev-all.js
@@ -1,12 +1,20 @@
 #!/usr/bin/env node
 /**
- * Starts the website, docs, and example blog together.
- * One command, three servers:
- *   - Website (landing)  → http://localhost:5000
- *   - Docs               → http://localhost:4000
- *   - Example blog       → http://localhost:3456
+ * Starts the website, docs, example blog, and UI registry site together.
+ * One command, four servers (defaults):
+ *   - Website (landing)  → http://localhost:5001
+ *   - Docs               → http://localhost:5002
+ *   - UI registry site   → http://localhost:5003
+ *   - Example blog       → http://localhost:5004
  *
- * All three are webjs apps running in dev mode with file watching.
+ * Ports sit in the 5001-5004 block on purpose: macOS reserves 5000 for
+ * the AirPlay Receiver / Control Center, so a dev server there silently
+ * fails to bind on Macs.
+ *
+ * Override any port via its env var:
+ *   WEBSITE_PORT=8080 DOCS_PORT=8081 npm run dev
+ *
+ * All four are webjs apps running in dev mode with file watching.
  * Ctrl-C stops all.
  */
 import { spawn } from 'node:child_process';
@@ -42,12 +50,23 @@ function start(name, cwd, cmd, args, extraEnv = {}) {
   return child;
 }
 
+// Per-service ports, each overridable via its own env var. Each app's
+// `webjs:dev` script reads PORT (with a matching default baked in), so
+// setting PORT here is what actually drives the bind.
+const ports = {
+  website: process.env.WEBSITE_PORT || '5001',
+  docs:    process.env.DOCS_PORT    || '5002',
+  ui:      process.env.UI_PORT      || '5003',
+  blog:    process.env.BLOG_PORT    || '5004',
+};
+
 // Use each workspace's `npm run dev` so the concurrently-spawned
-// tailwind CLI watcher (and, for the blog, prisma generate) runs too.
-// The PORT env var is honoured by webjs dev's default-port fallback.
-start('website', resolve(root, 'website'), 'npm', ['run', 'dev'], { PORT: '5000' });
-start('docs',    resolve(root, 'docs'),    'npm', ['run', 'dev'], { PORT: '4000' });
-start('blog',    resolve(root, 'examples', 'blog'), 'npm', ['run', 'dev'], { PORT: '3456' });
+// tailwind CLI watcher (and, for the blog, prisma generate; for the UI
+// site, the predev copy-registry step) runs too.
+start('website', resolve(root, 'website'), 'npm', ['run', 'dev'], { PORT: ports.website });
+start('docs',    resolve(root, 'docs'),    'npm', ['run', 'dev'], { PORT: ports.docs });
+start('ui',      resolve(root, 'packages', 'ui', 'packages', 'website'), 'npm', ['run', 'dev'], { PORT: ports.ui });
+start('blog',    resolve(root, 'examples', 'blog'), 'npm', ['run', 'dev'], { PORT: ports.blog });
 
 function cleanup() {
   console.log('\n▲ shutting down...');
@@ -61,9 +80,11 @@ process.on('SIGTERM', cleanup);
 
 console.log(`
 ▲ webjs development servers:
-  Website   → http://localhost:5000
-  Docs      → http://localhost:4000
-  Demo      → http://localhost:3456
+  Website     → http://localhost:${ports.website}
+  Docs        → http://localhost:${ports.docs}
+  UI registry → http://localhost:${ports.ui}
+  Demo        → http://localhost:${ports.blog}
 
+  Override any port: WEBSITE_PORT / DOCS_PORT / UI_PORT / BLOG_PORT
   Ctrl-C to stop all.
 `);

--- a/website/.env.example
+++ b/website/.env.example
@@ -3,6 +3,6 @@
 # Canonical localhost dev ports (one source of truth alongside the
 # matching fallbacks in app/layout.ts and app/page.ts). Deployments
 # override these with real public URLs (e.g. via Railway service env).
-DOCS_URL=http://localhost:4000
-BLOG_URL=http://localhost:3456
-UI_URL=http://localhost:5001
+DOCS_URL=http://localhost:5002
+BLOG_URL=http://localhost:5004
+UI_URL=http://localhost:5003

--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -68,7 +68,7 @@ function. Edit the inline `<h1>` / `<p>` text.
 ## Run
 
 ```sh
-cd website && npm run dev       # http://localhost:5000
+cd website && npm run dev       # http://localhost:5001
 ```
 
 **Use `npm run dev`, not `webjs dev` directly.** `webjs dev` only runs

--- a/website/app/layout.ts
+++ b/website/app/layout.ts
@@ -16,9 +16,9 @@ import '../components/theme-toggle.ts';
 // Guarded against `process` being undefined because this file also
 // loads on the client during hydration.
 const env = (globalThis as any).process?.env ?? {};
-const DOCS_URL = env.DOCS_URL || 'http://localhost:4000';
-const BLOG_URL = env.BLOG_URL || 'http://localhost:3456';
-const UI_URL = env.UI_URL || 'http://localhost:5001';
+const DOCS_URL = env.DOCS_URL || 'http://localhost:5002';
+const BLOG_URL = env.BLOG_URL || 'http://localhost:5004';
+const UI_URL = env.UI_URL || 'http://localhost:5003';
 
 // Site-wide Open Graph + Twitter card metadata. `generateMetadata`
 // receives the request context so we can derive an absolute og:image

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -17,9 +17,9 @@ export const metadata = {
 // the module and prevents custom elements (e.g. <theme-toggle>) from
 // upgrading.
 const env = (globalThis as any).process?.env ?? {};
-const DOCS_URL = env.DOCS_URL || 'http://localhost:4000';
-const BLOG_URL = env.BLOG_URL || 'http://localhost:3456';
-const UI_URL   = env.UI_URL   || 'http://localhost:5001';
+const DOCS_URL = env.DOCS_URL || 'http://localhost:5002';
+const BLOG_URL = env.BLOG_URL || 'http://localhost:5004';
+const UI_URL   = env.UI_URL   || 'http://localhost:5003';
 const STORY_URL = 'https://heyvivek.com/i-built-a-tiny-in-size-not-in-power-full-stack-framework-for-the-ai-era-i-call-it-webjs';
 
 const FEATURES = [

--- a/website/package.json
+++ b/website/package.json
@@ -7,7 +7,7 @@
     "prestart": "npm run css:build",
     "dev": "concurrently --names css,web --prefix-colors magenta,cyan --kill-others-on-fail \"npm:css:watch\" \"npm:webjs:dev\"",
     "start": "webjs start",
-    "webjs:dev": "webjs dev --port 5000",
+    "webjs:dev": "webjs dev --port ${PORT:-5001}",
     "css:watch": "tailwindcss -i ./public/input.css -o ./public/tailwind.css --watch",
     "css:build": "tailwindcss -i ./public/input.css -o ./public/tailwind.css --minify"
   },


### PR DESCRIPTION
## Summary

Monorepo contributor dev-experience changes (no published-package impact; all four apps here are private).

- **Renumber dev ports to a contiguous 5001-5004 block**: website 5001, docs 5002, UI registry 5003, blog 5004. Port 5000 is avoided because macOS reserves it for the AirPlay Receiver / Control Center (a dev server there silently fails to bind on Macs).
- **Add the UI registry site to `npm run dev`** (`dev-all.js` now starts four apps, not three).
- **Per-service port overrides**: `WEBSITE_PORT` / `DOCS_PORT` / `UI_PORT` / `BLOG_PORT` at the root, plain `PORT` for a single app. Each app's `webjs:dev` now reads `--port ${PORT:-<default>}` instead of hardcoding a port (which previously ignored the `PORT` dev-all was setting).
- **Inter-app link fallbacks + `.env.example` + docker compose + all docs** updated to the new scheme.
- **README**: new "Local development" section (port table, override docs, and a note that `--port` isn't supported via `npm run dev`; use `PORT=`).

## Notes

- Prod/deploy unaffected: apps deploy via `npm start` → `webjs start` → injected `$PORT`; only dev defaults and localhost fallbacks changed.
- The blog e2e harness keeps its own isolated port (3456), deliberately distinct from the dev ports to avoid collisions during test runs.

## Test plan

- [x] `npm test` green via pre-commit hook on every commit (1151/1151).
- [x] Booted `dev-all` with `WEBSITE_PORT=15001 …` overrides; all four apps came up on the override ports.
- [x] Repo-wide sweep: no stale 5000/4000/3456 references outside timeouts/fixtures/intentional-explanations.