### PR TITLE
chore(release): @webjsdev/cli 0.9.0 + @webjsdev/server 0.7.3

### DIFF
--- a/changelog/cli/0.9.0.md
+++ b/changelog/cli/0.9.0.md
@@ -1,0 +1,29 @@
+---
+package: "@webjsdev/cli"
+version: 0.9.0
+date: 2026-05-25T08:47:54.016Z
+commit_count: 2
+---
+## Breaking
+
+- **Default `webjs dev` / `webjs start` port is now 8080 (was 3000)** ([#97](https://github.com/webjsdev/webjs/pull/97)) [`7c44e6e`](https://github.com/webjsdev/webjs/commit/7c44e6e)
+
+  3000 is heavily contested locally (Next.js, CRA, Express, Flask all
+  default there), so newly scaffolded apps now serve on 8080.
+  `process.env.PORT` still wins, so deploys that inject `PORT` (Railway,
+  Fly, Heroku, etc.) are unaffected.
+
+  **Migration:** to keep the old port, set `PORT=3000` (or pass
+  `--port 3000`) when running `webjs dev` / `webjs start`. Scaffolded
+  apps need no change.
+
+## Fixes
+
+- **Resolve the @webjsdev/ui registry via the module resolver, not path math** ([#95](https://github.com/webjsdev/webjs/pull/95)) [`f01059b`](https://github.com/webjsdev/webjs/commit/f01059b)
+
+  `webjs create` located the UI registry with `__dirname/../../ui/packages/registry`,
+  which assumed @webjsdev/ui was hoisted as a sibling of @webjsdev/cli. That
+  broke on non-hoisted layouts (pnpm's isolated linker, `npm install
+  --install-strategy=nested`, some CI setups), failing the scaffold. It now
+  resolves the registry through `require.resolve`, so `webjs create` works
+  regardless of install layout.

--- a/changelog/server/0.7.3.md
+++ b/changelog/server/0.7.3.md
@@ -1,0 +1,16 @@
+---
+package: "@webjsdev/server"
+version: 0.7.3
+date: 2026-05-25T08:47:53.970Z
+commit_count: 1
+---
+## Changes
+
+- **`startServer` default port and OAuth fallback origin moved to 8080** ([#97](https://github.com/webjsdev/webjs/pull/97)) [`7c44e6e`](https://github.com/webjsdev/webjs/commit/7c44e6e)
+
+  `startServer({ appDir })` without an explicit `port` now defaults to 8080
+  (was 3000), matching the new `@webjsdev/cli` default, and the OAuth
+  no-request fallback origin moved from `localhost:3000` to `localhost:8080`.
+  `process.env.PORT` and an explicit `port` option still win. The recommended
+  `createRequestHandler` embedding path is unaffected (the host server owns
+  the port there).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.8.6",
+  "version": "0.9.0",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
## Summary

Release PR. Bumps two framework packages; merging fires the Auto-release workflow to publish them.

| Package | Bump | Ships |
|---|---|---|
| `@webjsdev/cli` | 0.8.6 to 0.9.0 | #97 (breaking: default port 8080) plus #95 (registry-resolution fix) |
| `@webjsdev/server` | 0.7.2 to 0.7.3 | #97 (startServer default plus OAuth origin to 8080) |

`@webjsdev/cli`'s `@webjsdev/server` dep is `^0.7.2`, which includes 0.7.3, so cli@0.9.0 resolves the new server automatically (no dep-range edit needed).

## Changelogs

Auto-generated by the pre-commit hook, then hand-curated:
- `changelog/cli/0.9.0.md`: breaking port note with migration steps (`PORT=3000` to keep old behavior), plus the #95 fix.
- `changelog/server/0.7.3.md`: reframed as a non-breaking change. The shared squash commit carried `feat(cli)!`, but the server-side impact is a minor default tweak, and `createRequestHandler` embedders are unaffected.

## On merge

`.github/workflows/release.yml` will:
1. Publish `@webjsdev/cli@0.9.0` and `@webjsdev/server@0.7.3` to npm plus GitHub Packages.
2. Create GitHub Releases `cli@0.9.0` and `server@0.7.3`.
3. Lockstep-bump plus publish `create-webjs@0.9.0` and `webjsdev@0.9.0` via the PR-merge flow landed in #94 (first real exercise of that fixed lockstep path).

## Test plan

- [x] `npm test` green via pre-commit hook (1151/1151).
- [ ] After merge: confirm all four packages report new versions on npm and the two GitHub Releases are created.