### PR TITLE
chore(release): lockstep bump create-webjs + webjsdev to 0.9.0

### DIFF
--- a/packages/create-webjs/package.json
+++ b/packages/create-webjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-webjs",
-  "version": "0.8.6",
+  "version": "0.9.0",
   "type": "module",
   "description": "Scaffold a new webjs app. `npm create webjs@latest my-app`.",
   "bin": {
@@ -11,7 +11,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@webjsdev/cli": "^0.8.6"
+    "@webjsdev/cli": "^0.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/webjsdev/package.json
+++ b/packages/webjsdev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webjsdev",
-  "version": "0.8.6",
+  "version": "0.9.0",
   "type": "module",
   "description": "The webjs CLI, published unscoped on npm. Unscoped alias for @webjsdev/cli. Installs the `webjs` command.",
   "bin": {
@@ -11,7 +11,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@webjsdev/cli": "^0.8.6"
+    "@webjsdev/cli": "^0.9.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Lands the wrapper version bumps the Auto-release workflow pushed but couldn't merge.

The lockstep step pushed this branch, then `gh pr create` failed with "GitHub Actions is not permitted to create or approve pull requests" (the repo's `can_approve_pull_request_reviews` setting is off). cli@0.9.0 and server@0.7.3 published fine; only the wrappers (create-webjs, webjsdev) stayed at 0.8.6.

Merging this lands the bumps on main. Wrappers are then published manually (workflow won't re-fire: no `changelog/**` change). A follow-up enables the Actions PR-create setting so future releases self-complete.