### PR TITLE
fix(cli): sync scaffold dark mode so ui-* components follow the theme

### DIFF
--- a/agent-docs/styling.md
+++ b/agent-docs/styling.md
@@ -63,6 +63,34 @@ the definition site and compose naturally with other props (conditional
 classes, active states, etc.). They run at SSR time. Output HTML is
 identical to inline classes, no client-side runtime.
 
+## Dark mode: two signals, keep them in sync
+
+The default scaffold runs **two** theming systems, and a theme switch must
+drive **both** or one half goes stale (this is the single most common
+dark-mode bug in a scaffolded app):
+
+1. **Editorial chrome tokens** (`--fg`, `--bg`, `--accent`, ...) declared in
+   the root layout. They react to a **`data-theme` attribute** on `<html>`
+   (`data-theme="light"` vs absent) and default to dark.
+2. **Webjs UI (shadcn) component tokens** (`--background`, `--foreground`,
+   `--primary`, ...) used by everything under `components/ui/`. They react
+   to a **`.dark` class** on an ancestor (`@custom-variant dark (&:is(.dark *))`)
+   and default to light.
+
+The scaffold's head init script and `theme-toggle` set **both** signals on
+`<html>`: they write `data-theme` AND `classList.toggle('dark', isDark)`. If
+you wire your own theme switch or replace the toggle, you MUST set both.
+Setting only `data-theme` leaves the ui-* components rendering light tokens
+on a dark page (white buttons, white cards, invisible text) while the chrome
+looks correct.
+
+**Verify dark mode in a real browser, not just light.** Light mode passing
+proves nothing about dark mode: with neither signal set, both systems sit at
+a coincidentally matching default, so the divergence only appears once
+`.dark` / `data-theme` are applied. Emulate dark (`colorScheme: 'dark'` or
+flip the toggle) and check a shadcn component's computed `background-color`,
+not just the page chrome.
+
 ## Vanilla CSS for the whole app (opt-out of Tailwind)
 
 Tailwind isn't required. To hand-write CSS everywhere, you need a

--- a/agent-docs/testing.md
+++ b/agent-docs/testing.md
@@ -184,3 +184,26 @@ a feature, the test is probably testing too many things at once.
 - **Don't add `.unit` / `.integration` filename suffixes.** The
   folder tells you the kind; the filename should match what it
   tests.
+
+---
+
+## Verifying UI and theming changes
+
+For anything visual (layout, components, themes), a passing unit test or a
+clean-looking code diff is not enough. Render it in a real browser and look.
+
+- **Test both light AND dark mode.** Light mode passing proves nothing about
+  dark mode. The scaffold drives dark mode through two signals (a `data-theme`
+  attribute for the editorial chrome and a `.dark` class for the ui-* kit, see
+  `agent-docs/styling.md`), and when neither is set both default to a
+  coincidentally matching light, so a desync only shows once dark is active.
+  Emulate dark (Playwright `newContext({ colorScheme: 'dark' })` or flip the
+  theme toggle) and inspect a component's **computed** `background-color` /
+  `color`, not just the page chrome.
+- **Read the screenshot.** Capture `page.screenshot({ fullPage: true })` and
+  open the PNG; white-on-white or a stray light box is obvious visually and
+  invisible in the markup.
+- **Guard the wiring in a fast test where you can.** A runtime cascade bug
+  needs a browser, but the mechanism that triggers it (e.g. the theme toggle
+  setting `.dark`) can be asserted cheaply. See the dark-mode assertions in
+  `test/scaffolds/scaffold-integration.test.js`.

--- a/packages/cli/lib/create.js
+++ b/packages/cli/lib/create.js
@@ -642,10 +642,21 @@ export default function RootLayout({ children }: { children: unknown }) {
     <script>
       (function(){
         try {
-          var t = localStorage.getItem('webjs_theme');
-          if (t === 'light' || t === 'dark') {
-            document.documentElement.dataset.theme = t;
+          var mq = window.matchMedia('(prefers-color-scheme: light)');
+          function apply(){
+            var t = null;
+            try { t = localStorage.getItem('webjs_theme'); } catch (_) {}
+            var el = document.documentElement;
+            if (t === 'light' || t === 'dark') el.dataset.theme = t;
+            else delete el.dataset.theme;
+            // Keep shadcn's .dark class in sync with the effective theme so the
+            // copied ui-* components (button, card, etc.) follow light/dark too.
+            // Dark is the default unless the OS prefers light or 'light' is set.
+            var dark = t === 'dark' || (t !== 'light' && !mq.matches);
+            el.classList.toggle('dark', dark);
           }
+          apply();
+          mq.addEventListener('change', apply);
         } catch (_) {}
       })();
     </script>
@@ -874,8 +885,13 @@ export class ThemeToggle extends WebComponent {
       if (next === 'system') localStorage.removeItem('webjs_theme');
       else localStorage.setItem('webjs_theme', next);
     } catch {}
-    if (next === 'system') delete document.documentElement.dataset.theme;
-    else document.documentElement.dataset.theme = next;
+    const el = document.documentElement;
+    if (next === 'system') delete el.dataset.theme;
+    else el.dataset.theme = next;
+    // Keep shadcn's .dark class in sync so the ui-* components follow the theme.
+    const dark = next === 'dark'
+      || (next === 'system' && !window.matchMedia('(prefers-color-scheme: light)').matches);
+    el.classList.toggle('dark', dark);
   }
 
   render() {

--- a/packages/cli/templates/CONVENTIONS.md
+++ b/packages/cli/templates/CONVENTIONS.md
@@ -568,6 +568,17 @@ or a build-step pipeline. The framework has no hard dependency on Tailwind.
 If you mix custom CSS into a light-DOM component, apply the class-prefix
 rule (see Components section above).
 
+**Dark mode uses two signals; a theme switch must set both.** The editorial
+chrome tokens (`--fg`, `--bg`, `--accent`) follow a `data-theme` attribute on
+`<html>`; the Webjs UI kit under `components/ui/` follows a `.dark` class
+(`@custom-variant dark (&:is(.dark *))`). The scaffold's head init script and
+`theme-toggle` set **both** (`data-theme` AND
+`classList.toggle('dark', isDark)`). If you replace the toggle or build your
+own theme switch, set both, or the `components/ui/*` render light tokens on a
+dark page (white buttons and cards, invisible text) while the chrome looks
+correct. Light mode hides this (both systems default to light), so **verify
+dark mode in a browser, not just light.**
+
 ---
 
 ## Styling alternative: vanilla CSS end-to-end

--- a/test/scaffolds/scaffold-integration.test.js
+++ b/test/scaffolds/scaffold-integration.test.js
@@ -63,6 +63,18 @@ test('scaffoldApp full-stack: writes the canonical full-stack app layout', async
     assert.ok(existsSync(join(appDir, 'app', 'page.ts')), 'page.ts written');
     assert.ok(existsSync(join(appDir, 'components', 'theme-toggle.ts')), 'theme-toggle written');
 
+    // Dark-mode wiring: the head init script (in layout) AND the theme-toggle
+    // must toggle the shadcn `.dark` class, not only the `data-theme`
+    // attribute. Without `.dark`, the copied components/ui/* render light
+    // tokens on the dark chrome (white buttons/cards, invisible text). Light
+    // mode hides this, so guard it here. See agent-docs/styling.md "Dark mode".
+    const layoutSrc = readFileSync(join(appDir, 'app', 'layout.ts'), 'utf8');
+    const toggleSrc = readFileSync(join(appDir, 'components', 'theme-toggle.ts'), 'utf8');
+    assert.match(layoutSrc, /classList\.toggle\(['"]dark['"]/,
+      'layout head script must toggle the .dark class (shadcn dark-mode signal)');
+    assert.match(toggleSrc, /classList\.toggle\(['"]dark['"]/,
+      'theme-toggle must toggle the .dark class (shadcn dark-mode signal)');
+
     // Prisma + lib singleton wired up
     assert.ok(existsSync(join(appDir, 'prisma', 'schema.prisma')), 'prisma schema written');
     assert.ok(existsSync(join(appDir, 'lib', 'prisma.server.ts')), 'lib/prisma.server.ts written');


### PR DESCRIPTION
## Bug

In a default-scaffolded app, the dark theme is broken for every copied `components/ui/*` component. The reported symptom: the **"View docs" (outline) button** renders white-on-light (invisible text) in dark mode; light mode is fine.

## Root cause

The scaffold ships **two unsynced theme systems**:
- **Editorial chrome** (`--fg`/`--bg`, dark-by-default) toggled via a `data-theme` attribute on `<html>`.
- **shadcn ui-* components** (`--background`/`--foreground`/etc.) whose dark tokens key off a `.dark` **class** (`@custom-variant dark (&:is(.dark *))`).

Neither the head init script nor the theme-toggle ever set a `.dark` class, so the shadcn tokens were **permanently stuck in light mode**. On the dark chrome that means `bg-background` = white, etc. Reproduced in a browser (emulated dark):

| element | before (dark) | after |
|---|---|---|
| View docs (outline) | bg `oklch(1 0 0)` white, light text → invisible | `input/30` tint + light text → readable |
| card | bg white, dark text → white box | bg `0.205` dark, light text |

Light mode only "worked" because both systems happened to be light.

## Fix

The head init script and `theme-toggle.cycle()` now toggle a `.dark` class in sync with the effective theme (dark by default unless the OS prefers light or `light` is chosen), and the head script re-applies on OS theme changes. The `data-theme` chrome mechanism is unchanged; `.dark` just drives the shadcn tokens alongside it.

## Verification

Browser-tested against a live scaffolded app (`/usr/bin/chromium`, emulated dark + light):
- Dark: `.dark` now present; outline button + card + alert + badge render dark-correct (screenshot reviewed).
- Light: unchanged, all correct.
- `npm test` green via pre-commit hook (1151/1151).

## Follow-up note (not in this PR)

Minor secondary gap: the scaffold chrome's `--accent` (brand orange) and shadcn's `--accent` collide by name, so ui-* hover states (`hover:bg-accent`) use the orange instead of shadcn's accent. Hover-only and arguably acceptable as a brand accent; flagging for a separate decision.