### PR TITLE
chore(release): @webjsdev/cli 0.9.1

### DIFF
--- a/changelog/cli/0.9.1.md
+++ b/changelog/cli/0.9.1.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/cli"
+version: 0.9.1
+date: 2026-05-25T11:56:39.876Z
+commit_count: 1
+---
+## Fixes
+
+- **sync scaffold dark mode so ui-* components follow the theme** ([#101](https://github.com/webjsdev/webjs/pull/101)) [`f0a1fa1`](https://github.com/webjsdev/webjs/commit/f0a1fa1)
+  * fix(cli): sync scaffold dark mode so ui-* components follow the theme
+  
+  The default scaffold shipped two unsynced theme systems: the editorial
+  chrome tokens (--fg/--bg) toggled via a `data-theme` attribute, while

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {


### PR DESCRIPTION
## Summary

Patch release to ship the scaffold dark-mode fix (#101) to end users.

| Package | Bump | Ships |
|---|---|---|
| `@webjsdev/cli` | 0.9.0 to 0.9.1 | #101: scaffold syncs the shadcn `.dark` class with the theme, so `components/ui/*` render correctly in dark mode |

## On merge

`.github/workflows/release.yml` publishes `@webjsdev/cli@0.9.1` (npm + GitHub Packages + GitHub Release), then the no-git lockstep step (from #100) publishes `create-webjs@0.9.1` and `webjsdev@0.9.1` to npm.

## Test plan

- [x] Pre-commit hook generated `changelog/cli/0.9.1.md` and ran the full suite green (1151/1151).
- [ ] After merge: confirm cli + both wrappers report 0.9.1 on npm, then `npm create webjs@latest demo` scaffolds an app whose dark mode renders correctly.