### PR TITLE
feat(vendor): multi-CDN pin (--from), audit/outdated/update, data-webjs-track reload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -603,7 +603,16 @@ webjs db <prisma-subcommand> [...]                    # passthrough to prisma
 webjs ui init                                         # @webjsdev/ui CLI
 webjs ui add <names...>                               # copy components into your project
 webjs ui list / view <name>                           # browse the registry
+
+webjs vendor pin [--from PROVIDER] [--download]       # pin npm packages to .webjs/vendor/importmap.json
+webjs vendor unpin <pkg>                              # remove a package from the pin file
+webjs vendor list                                     # show pinned packages
+webjs vendor audit                                    # npm security advisories against pinned versions
+webjs vendor outdated                                 # list pinned packages with newer versions
+webjs vendor update [--from PROVIDER]                 # re-pin every outdated package to latest
 ```
+
+`--from PROVIDER` accepts `jspm` (default), `jsdelivr`, `unpkg`, `skypack`. The chosen provider is persisted in `.webjs/vendor/importmap.json` so subsequent `pin` / `update` runs stay on the same CDN until you switch back with another `--from`. Same posture as Rails 7's `bin/importmap pin foo --from jsdelivr`.
 
 `PORT` env is honoured by `dev` and `start` when `--port` is absent.
 

--- a/agent-docs/advanced.md
+++ b/agent-docs/advanced.md
@@ -156,6 +156,34 @@ inner tree is wrapped in that layout's marker pair and returned. Outer
 layouts are not loaded, not rendered, not re-serialized. Real savings
 on every same-shell navigation.
 
+### Cross-deploy hard-reload signals
+
+Two complementary mechanisms tell the client when a partial swap is
+unsafe and a hard reload is required:
+
+1. **Importmap drift** (the common case after a vendor pin change).
+   Server stamps a SHA-256 of the importmap on `<script type="importmap"
+   data-webjs-build="…">` AND emits the same hash as `X-Webjs-Build`
+   on every response, including X-Webjs-Have partial responses with no
+   head. Client compares the response header against the live
+   document's `data-webjs-build`; mismatch triggers `location.href =
+   target` instead of partial swap. Works for every nav, including
+   partial-response navs.
+
+2. **Generic `data-webjs-track="reload"`** (for non-importmap concerns,
+   e.g. a CSS bundle hash, a build-id meta tag). Any head element with
+   the attribute joins a signature computed from concatenated outerHTML.
+   On nav, mismatched signatures trigger reload. Mirrors hotwired/turbo's
+   `data-turbo-track="reload"`.
+
+```html
+<link rel="stylesheet" href="/build/main-abc123.css" data-webjs-track="reload">
+<meta name="build-id" content="rev-42" data-webjs-track="reload">
+```
+
+Both paths share a one-shot `sessionStorage` reload guard so a
+genuinely-churning resource doesn't loop reloads.
+
 ### Snapshot cache + revalidation
 
 URL-keyed `Map<url, snapshot>` (LRU, cap 16). Back/forward via

--- a/docs/app/docs/no-build/page.ts
+++ b/docs/app/docs/no-build/page.ts
@@ -111,6 +111,19 @@ Pinned 2 packages, wrote .webjs/vendor/importmap.json + 2 bundles.</pre>
     <p>Pin is intentionally manual (no <code>predev</code>/<code>prestart</code> auto-run). Auto-pin would cause silent churn in the committed importmap.json as jspm.io resolves URLs or transitive deps drift. Rails takes the same posture: <code>bin/importmap pin</code> is always developer-invoked.</p>
     <p>The pin command computes a <code>sha384</code> integrity hash for every vendor URL and writes them alongside the imports in <code>importmap.json</code> under an <code>integrity</code> key. The SSR pipeline stamps the matching hash on each <code>&lt;link rel="modulepreload"&gt;</code> and on the importmap entry itself, so the browser refuses to execute a bundle whose bytes don't match (CDN compromise defense). Both <code>webjs vendor pin</code> and <code>webjs vendor pin --download</code> populate <code>integrity</code>. The hashes only update when <code>webjs vendor pin</code> is rerun; routine cache-busting cannot drop them.</p>
 
+    <h2>Switch CDN with <code>--from</code></h2>
+    <p>If jspm.io has an incident, or you want jsdelivr-served packages, pass a different resolver:</p>
+    <pre>$ webjs vendor pin --from jsdelivr
+Pinning vendor packages from /home/me/my-app via jsdelivr...</pre>
+    <p>Accepts <code>jspm</code> (default), <code>jsdelivr</code>, <code>unpkg</code>, or <code>skypack</code>. Same shape as Rails's <code>bin/importmap pin foo --from jsdelivr</code>. The chosen resolver is persisted in <code>importmap.json</code> as a <code>provider</code> sibling field so <code>webjs vendor update</code> targets the same CDN.</p>
+
+    <h2>Maintenance commands</h2>
+    <p>For pinned packages, three commands stand in for <code>npm audit</code> / <code>npm outdated</code> / <code>npm update</code>:</p>
+    <pre>$ webjs vendor audit
+$ webjs vendor outdated
+$ webjs vendor update</pre>
+    <p><code>audit</code> POSTs your pinned versions to the same <code>registry.npmjs.org/-/npm/v1/security/advisories/bulk</code> endpoint <code>npm audit</code> uses, prints any CVEs, and exits non-zero on findings so CI can gate. <code>outdated</code> queries each pinned package's <code>dist-tags.latest</code> and lists what trails. <code>update</code> re-pins every outdated package to its latest, recomputes SRI, and writes the new pin file (you still run <code>npm install &lt;pkg&gt;@&lt;latest&gt;</code> afterward to sync your <code>node_modules</code>).</p>
+
     <h2>Why jspm.io and not local bundling?</h2>
     <p>A stricter "browser-native ESM only" interpretation of no-build would refuse to run any bundler anywhere on the user's machine, including for npm packages. Rails 7+ with <code>importmap-rails</code> is the canonical example, and webjs adopts the same posture exactly. The webjs server never invokes a bundler for vendor packages; jspm.io pre-bundled them on their CDN.</p>
     <p>Why jspm.io specifically: institutional sponsors (37signals, CacheFly, Socket, Framer), years of uptime, status page at <code>status.jspm.io</code>, standards-first maintenance by Guy Bedford (TC39 ESM + import maps + HTML spec). Same CDN Rails uses.</p>

--- a/packages/cli/bin/webjs.js
+++ b/packages/cli/bin/webjs.js
@@ -275,7 +275,7 @@ Full docs: https://docs.webjs.com`);
       const sub = rest[0];
       const args = rest.slice(1);
       const appDir = process.cwd();
-      const { pinAll, unpinPackage, listPinned, auditPinned, findOutdated, updatePinned, SUPPORTED_PROVIDERS } = await import('@webjsdev/server');
+      const { pinAll, unpinPackage, listPinned, auditPinned, findOutdated, updatePinned, readPinFile, SUPPORTED_PROVIDERS } = await import('@webjsdev/server');
 
       // Parse `--from <provider>` once at the top so subcommands share it.
       // Mirrors importmap-rails's `bin/importmap pin foo --from jsdelivr`.
@@ -296,12 +296,21 @@ Full docs: https://docs.webjs.com`);
 
       if (sub === 'pin') {
         const download = args.includes('--download');
+        // Same precedence rule as `vendor update`: explicit --from
+        // wins; otherwise pinAll reads the pin file's persisted
+        // provider so a user who pinned via jsdelivr stays on it.
+        // Pass undefined (not the parsed 'jspm' default) when no
+        // --from to engage the pin-file fallback. Peek at the pin
+        // file here to compute the log line before pinAll runs.
+        const explicitFrom = fromIdx !== -1 ? from : undefined;
+        const existing = await readPinFile(appDir);
+        const usedFrom = explicitFrom || existing?.provider || 'jspm';
         console.log(
           `Pinning vendor packages from ${appDir}` +
-          (from !== 'jspm' ? ` via ${from}` : '') +
+          (usedFrom !== 'jspm' ? ` via ${usedFrom}` : '') +
           (download ? ' (downloading bundles)' : '') + '...',
         );
-        const result = await pinAll(appDir, { download, from });
+        const result = await pinAll(appDir, { download, from: explicitFrom });
         if (result.noBareImports) {
           // Scanner found zero bare-specifier imports in client-
           // reachable source. Without this branch pinAll would write
@@ -460,9 +469,10 @@ Full docs: https://docs.webjs.com`);
         // default) when no --from was given so updatePinned's
         // pin-file fallback engages.
         const explicitFrom = fromIdx !== -1 ? from : undefined;
-        const result = await updatePinned(appDir, { from: explicitFrom });
-        const usedFrom = result.provider || 'jspm';
+        const existing = await readPinFile(appDir);
+        const usedFrom = explicitFrom || existing?.provider || 'jspm';
         console.log(`Updating outdated vendor pins in ${appDir}${usedFrom !== 'jspm' ? ` via ${usedFrom}` : ''}...`);
+        const result = await updatePinned(appDir, { from: explicitFrom });
         if (result.noOutdated) {
           console.log('No outdated packages found.');
           break;

--- a/packages/cli/bin/webjs.js
+++ b/packages/cli/bin/webjs.js
@@ -325,20 +325,22 @@ Full docs: https://docs.webjs.com`);
         }
         if (result.failed) {
           // pinAll refused to write the pin file because every install
-          // failed to resolve via jspm.io (e.g. brand-new published
-          // version not yet on the CDN, network outage, jspm.io 5xx).
-          // Surface the failure so the user fixes the cause before
-          // shipping; the per-package failures already logged via
-          // jspmResolveOne above tell the user which packages broke.
+          // failed to resolve via the chosen resolver (jspm.io's
+          // Generator API powers all providers; the failure mode is
+          // typically a brand-new published version not yet on the
+          // CDN, a network outage, or a provider-side 5xx). Surface
+          // the failure with the actual provider in the message so
+          // the user can fix the cause before shipping.
+          const provider = result.provider || 'jspm.io';
           console.error(
-            `Pin FAILED: every package failed to resolve via jspm.io. No pin file written ` +
+            `Pin FAILED: every package failed to resolve via ${provider}. No pin file written ` +
             `(would shadow the live-API fallback with an empty importmap and break the browser).`,
           );
           console.error(`Attempted installs:`);
           for (const i of result.attemptedInstalls) console.error(`  ${i}`);
           console.error(
-            `Possible causes: the package version is too new for jspm.io's CDN to have indexed yet; ` +
-            `network outage; jspm.io is down. Try again in a few minutes, or pin an older version.`,
+            `Possible causes: the package version is too new for ${provider}'s CDN to have indexed yet; ` +
+            `network outage; ${provider} is down. Try again in a few minutes, or pin an older version.`,
           );
           process.exit(1);
         }

--- a/packages/cli/bin/webjs.js
+++ b/packages/cli/bin/webjs.js
@@ -392,10 +392,17 @@ Full docs: https://docs.webjs.com`);
         // npm bulk-advisories check against pinned versions. Mirrors
         // bin/importmap audit. Exits non-zero when any vulnerability
         // is found so CI can gate on it.
-        const { vulnerable, totalChecked } = await auditPinned(appDir);
+        const { vulnerable, totalChecked, errored } = await auditPinned(appDir);
         if (totalChecked === 0) {
           console.log('No pinned packages to audit. Run "webjs vendor pin" first.');
           break;
+        }
+        if (errored) {
+          console.error(
+            `Could not reach registry.npmjs.org for security advisories ` +
+            `(network failure, timeout, or 5xx). Retry when connectivity is back.`,
+          );
+          process.exit(1);
         }
         if (vulnerable.length === 0) {
           console.log(`No vulnerable packages found (${totalChecked} checked).`);
@@ -445,8 +452,17 @@ Full docs: https://docs.webjs.com`);
         // update. Does NOT modify package.json or node_modules; the
         // user should run `npm install <pkg>@<latest>` afterward to
         // keep the local install in sync.
-        console.log(`Updating outdated vendor pins in ${appDir}${from !== 'jspm' ? ` via ${from}` : ''}...`);
-        const result = await updatePinned(appDir, { from });
+        //
+        // Provider precedence: explicit --from CLI flag wins. Without
+        // it, updatePinned reads the pin file's persisted provider so
+        // a user who pinned via jsdelivr stays on jsdelivr after
+        // update. Pass `undefined` (not the parsed `from = 'jspm'`
+        // default) when no --from was given so updatePinned's
+        // pin-file fallback engages.
+        const explicitFrom = fromIdx !== -1 ? from : undefined;
+        const result = await updatePinned(appDir, { from: explicitFrom });
+        const usedFrom = result.provider || 'jspm';
+        console.log(`Updating outdated vendor pins in ${appDir}${usedFrom !== 'jspm' ? ` via ${usedFrom}` : ''}...`);
         if (result.noOutdated) {
           console.log('No outdated packages found.');
           break;

--- a/packages/cli/bin/webjs.js
+++ b/packages/cli/bin/webjs.js
@@ -275,15 +275,33 @@ Full docs: https://docs.webjs.com`);
       const sub = rest[0];
       const args = rest.slice(1);
       const appDir = process.cwd();
-      const { pinAll, unpinPackage, listPinned } = await import('@webjsdev/server');
+      const { pinAll, unpinPackage, listPinned, auditPinned, findOutdated, updatePinned, SUPPORTED_PROVIDERS } = await import('@webjsdev/server');
+
+      // Parse `--from <provider>` once at the top so subcommands share it.
+      // Mirrors importmap-rails's `bin/importmap pin foo --from jsdelivr`.
+      let from = 'jspm';
+      const fromIdx = args.indexOf('--from');
+      if (fromIdx !== -1) {
+        from = args[fromIdx + 1];
+        if (!from || !SUPPORTED_PROVIDERS.has(from)) {
+          console.error(
+            `Unknown --from provider '${from || ''}'. Supported: ${[...SUPPORTED_PROVIDERS].join(', ')}.`,
+          );
+          process.exit(1);
+        }
+        // Strip --from + its argument so downstream flag checks like
+        // `args.includes('--download')` aren't confused.
+        args.splice(fromIdx, 2);
+      }
 
       if (sub === 'pin') {
         const download = args.includes('--download');
         console.log(
           `Pinning vendor packages from ${appDir}` +
+          (from !== 'jspm' ? ` via ${from}` : '') +
           (download ? ' (downloading bundles)' : '') + '...',
         );
-        const result = await pinAll(appDir, { download });
+        const result = await pinAll(appDir, { download, from });
         if (result.noBareImports) {
           // Scanner found zero bare-specifier imports in client-
           // reachable source. Without this branch pinAll would write
@@ -370,11 +388,94 @@ Full docs: https://docs.webjs.com`);
         break;
       }
 
+      if (sub === 'audit') {
+        // npm bulk-advisories check against pinned versions. Mirrors
+        // bin/importmap audit. Exits non-zero when any vulnerability
+        // is found so CI can gate on it.
+        const { vulnerable, totalChecked } = await auditPinned(appDir);
+        if (totalChecked === 0) {
+          console.log('No pinned packages to audit. Run "webjs vendor pin" first.');
+          break;
+        }
+        if (vulnerable.length === 0) {
+          console.log(`No vulnerable packages found (${totalChecked} checked).`);
+          break;
+        }
+        console.log(`Package                                  Severity   Vulnerable versions       Title`);
+        for (const v of vulnerable) {
+          console.log(
+            `  ${v.name.padEnd(38)} ${v.severity.padEnd(10)} ${v.vulnerableVersions.padEnd(25)} ${v.title}`,
+          );
+        }
+        const bySeverity = vulnerable.reduce((acc, v) => {
+          acc[v.severity] = (acc[v.severity] || 0) + 1;
+          return acc;
+        }, /** @type {Record<string,number>} */ ({}));
+        const summary = Object.entries(bySeverity)
+          .sort((a, b) => b[1] - a[1])
+          .map(([sev, n]) => `${n} ${sev}`).join(', ');
+        console.error(
+          `  ${vulnerable.length} vulnerabilit${vulnerable.length === 1 ? 'y' : 'ies'} found: ${summary}`,
+        );
+        process.exit(1);
+      }
+
+      if (sub === 'outdated') {
+        // npm registry latest-version check against pinned versions.
+        // Mirrors bin/importmap outdated. Exits non-zero when any
+        // package is outdated so CI / Renovate-style automation can
+        // detect it.
+        const outdated = await findOutdated(appDir);
+        if (outdated.length === 0) {
+          console.log('No outdated packages found.');
+          break;
+        }
+        console.log(`Package                                  Current               Latest`);
+        for (const o of outdated) {
+          console.log(`  ${o.pkg.padEnd(38)} ${o.current.padEnd(21)} ${o.latest}`);
+        }
+        console.error(
+          `  ${outdated.length} outdated package${outdated.length === 1 ? '' : 's'} found.`,
+        );
+        process.exit(1);
+      }
+
+      if (sub === 'update') {
+        // Re-pin outdated packages to latest. Mirrors bin/importmap
+        // update. Does NOT modify package.json or node_modules; the
+        // user should run `npm install <pkg>@<latest>` afterward to
+        // keep the local install in sync.
+        console.log(`Updating outdated vendor pins in ${appDir}${from !== 'jspm' ? ` via ${from}` : ''}...`);
+        const result = await updatePinned(appDir, { from });
+        if (result.noOutdated) {
+          console.log('No outdated packages found.');
+          break;
+        }
+        if (result.updated.length === 0) {
+          console.error('No packages were updated (jspm.io may have failed to resolve any of the new versions).');
+          process.exit(1);
+        }
+        for (const u of result.updated) {
+          console.log(`  ${u.pkg.padEnd(38)} ${u.from} → ${u.to}`);
+        }
+        console.log(
+          `Updated ${result.updated.length} package${result.updated.length === 1 ? '' : 's'}. ` +
+          `Run \`npm install ${result.updated.map(u => `${u.pkg}@${u.to}`).join(' ')}\` to ` +
+          `sync your node_modules.`,
+        );
+        break;
+      }
+
       console.error(`Unknown vendor subcommand: ${sub || '(none)'}\n` +
         `Usage:\n` +
-        `  webjs vendor pin [--download]    Pin packages to .webjs/vendor/importmap.json\n` +
-        `  webjs vendor unpin <pkg>         Remove a package from the pin file\n` +
-        `  webjs vendor list                Show pinned packages with versions and URLs`);
+        `  webjs vendor pin [--from PROVIDER] [--download]   Pin packages to .webjs/vendor/importmap.json\n` +
+        `  webjs vendor unpin <pkg>                          Remove a package from the pin file\n` +
+        `  webjs vendor list                                 Show pinned packages with versions and URLs\n` +
+        `  webjs vendor audit                                Run a security audit against pinned versions\n` +
+        `  webjs vendor outdated                             Check pinned packages for newer versions\n` +
+        `  webjs vendor update [--from PROVIDER]             Re-pin outdated packages to latest\n` +
+        `\n` +
+        `  --from PROVIDER     CDN to resolve through. One of: ${[...SUPPORTED_PROVIDERS].join(', ')}. Default: jspm.`);
       process.exit(1);
     }
     case 'help':

--- a/packages/cli/templates/AGENTS.md
+++ b/packages/cli/templates/AGENTS.md
@@ -367,10 +367,20 @@ or compliance environments. See [docs.webjs.com Deployment → CSP](https://docs
 ```sh
 webjs vendor list                 # show pinned packages with versions
 webjs vendor unpin <pkg>          # remove one entry from pin file
+webjs vendor audit                # npm security advisories against pinned versions
+webjs vendor outdated             # list pinned packages with newer versions on npm
+webjs vendor update               # re-pin every outdated package to its latest
+
+# Switch CDN at pin time (default: jspm.io). Resolver options:
+# jspm, jsdelivr, unpkg, skypack. Useful for jspm.io incident response.
+webjs vendor pin --from jsdelivr
+webjs vendor update --from jsdelivr
 ```
 
 Same posture as Rails 7 + importmap-rails: explicit pin command,
-committed manifest, optional `--download` for full offline capability.
+committed manifest, optional `--download` for full offline capability,
+and a `--from` knob to swap the resolver CDN if jspm.io has an
+incident.
 
 **Don't auto-run `webjs vendor pin` in `predev` / `prestart`.** Auto-pin
 would silently churn the committed importmap.json as jspm.io resolves

--- a/packages/core/src/router-client.js
+++ b/packages/core/src/router-client.js
@@ -886,8 +886,14 @@ function trackedReloadSignature(root) {
   if (!root || !root.head) return '';
   const tracked = root.head.querySelectorAll('[data-webjs-track="reload"]');
   if (!tracked.length) return '';
+  // Use outerHTMLForDiff so the CSP nonce (which rotates per
+  // request) is stripped before signature comparison. Without this,
+  // a nonced tracked script like `<script nonce="${cspNonce()}"
+  // data-webjs-track="reload" src="/build.js?v=42">` would mismatch
+  // every navigation and infinite-reload. Matches Turbo's
+  // head_snapshot.js elementWithoutNonce posture.
   let sig = '';
-  for (const el of tracked) sig += el.outerHTML;
+  for (const el of tracked) sig += outerHTMLForDiff(el);
   return sig;
 }
 
@@ -939,13 +945,19 @@ function applySwap(doc, frameId, revalidating, href, incomingBuild) {
     // primary mechanism because they ALSO work on partial responses
     // (no head in the body). data-webjs-track is for elements that
     // can't ride the build hash.
-    if (!mismatch) {
-      const incomingDoc = doc;
+    //
+    // Skip the check when the incoming response has no head content
+    // (X-Webjs-Have partial-fragment response). Without this guard
+    // a partial response would always mismatch any current tracked
+    // signature and falsely reload. With the guard, a partial
+    // response means "trust the build hash; don't decide based on
+    // missing head info." Comparing on full responses also catches
+    // added/removed track markers because empty `incomingSig`
+    // would correctly differ from a non-empty `currentSig`.
+    if (!mismatch && doc.head && doc.head.children.length > 0) {
       const currentSig = trackedReloadSignature(document);
-      const incomingSig = trackedReloadSignature(incomingDoc);
-      if (currentSig && incomingSig && currentSig !== incomingSig) {
-        mismatch = true;
-      }
+      const incomingSig = trackedReloadSignature(doc);
+      if (currentSig !== incomingSig) mismatch = true;
     }
     if (mismatch && typeof location !== 'undefined') {
       // Infinite-reload guard: if the importmap appears to genuinely

--- a/packages/core/src/router-client.js
+++ b/packages/core/src/router-client.js
@@ -865,6 +865,32 @@ async function fetchAndApply(href, frameId, recordHistory, optimisticState, meth
  * @param {string | null} [href]  Target URL for hard-reload fallback on importmap mismatch.
  * @param {string | null} [incomingBuild]  X-Webjs-Build header from the response, or null.
  */
+/**
+ * Compute the signature of all `data-webjs-track="reload"` elements
+ * in the head of `root`. Returns the concatenation of each element's
+ * `outerHTML`, in document order. Two documents with identical
+ * tracked-element sets produce identical signatures; any change in
+ * attributes, content, or set membership produces a different one.
+ *
+ * Mirrors hotwired/turbo's `head_snapshot.js` `trackedElementSignature`
+ * (the data-turbo-track="reload" mechanism). Used by applySwap as a
+ * generic opt-in next to the importmap-specific build hash.
+ *
+ * Returns the empty string when `root` has no head (e.g. an
+ * X-Webjs-Have partial response) or when no elements opt in.
+ *
+ * @param {Document | undefined} root
+ * @returns {string}
+ */
+function trackedReloadSignature(root) {
+  if (!root || !root.head) return '';
+  const tracked = root.head.querySelectorAll('[data-webjs-track="reload"]');
+  if (!tracked.length) return '';
+  let sig = '';
+  for (const el of tracked) sig += el.outerHTML;
+  return sig;
+}
+
 function applySwap(doc, frameId, revalidating, href, incomingBuild) {
   // Any clean swap (no importmap mismatch, including cache restores
   // and frame swaps where we don't even run the mismatch check) is a
@@ -899,6 +925,27 @@ function applySwap(doc, frameId, revalidating, href, incomingBuild) {
         incoming && currentTag &&
         (incoming.textContent || '').trim() !== (currentTag.textContent || '').trim()
       );
+    }
+    // Generic `data-webjs-track="reload"` opt-in. ANY element in the
+    // head that the user marks gets included in the tracked-element
+    // signature. If the signature differs between current and incoming
+    // documents, hard-reload. Mirrors hotwired/turbo's
+    // data-turbo-track="reload" semantics (head_snapshot.js
+    // trackedElementSignature). Lets app authors tag arbitrary
+    // version-sensitive elements (CSS bundle <link>, deploy meta tag)
+    // for cross-deploy reload, not just the importmap.
+    //
+    // Importmap-specific data-webjs-build / X-Webjs-Build remain the
+    // primary mechanism because they ALSO work on partial responses
+    // (no head in the body). data-webjs-track is for elements that
+    // can't ride the build hash.
+    if (!mismatch) {
+      const incomingDoc = doc;
+      const currentSig = trackedReloadSignature(document);
+      const incomingSig = trackedReloadSignature(incomingDoc);
+      if (currentSig && incomingSig && currentSig !== incomingSig) {
+        mismatch = true;
+      }
     }
     if (mismatch && typeof location !== 'undefined') {
       // Infinite-reload guard: if the importmap appears to genuinely

--- a/packages/core/test/routing/router-client.test.js
+++ b/packages/core/test/routing/router-client.test.js
@@ -800,6 +800,123 @@ test('navigate: data-webjs-track="reload" signature change triggers hard reload'
   }
 });
 
+test('navigate: data-webjs-track="reload" added between deploys triggers reload', async () => {
+  // Deploy A had no tracker. Deploy B added one. Currently-loaded
+  // page came from A (no tracker); incoming from B (with tracker).
+  // currentSig is empty, incomingSig is non-empty. Different.
+  // Must reload.
+  document.head.innerHTML = '<meta charset="utf-8">';
+  document.body.innerHTML = '<p>current</p>';
+  sessionStorage.removeItem('webjs:importmap-reload');
+  const newBody =
+    '<!doctype html><html><head>' +
+    '<meta charset="utf-8">' +
+    '<meta data-webjs-track="reload" name="build-id" content="rev-2">' +
+    '</head><body><p>after</p></body></html>';
+  const { redirect, restore } = installNavigationMocks({
+    contentType: 'text/html',
+    body: newBody,
+  });
+  try {
+    await navigate('http://localhost/added');
+    assert.equal(redirect.href, 'http://localhost/added',
+      'tracked element added in incoming response must reload');
+  } finally {
+    restore();
+    sessionStorage.removeItem('webjs:importmap-reload');
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+  }
+});
+
+test('navigate: data-webjs-track="reload" removed between deploys triggers reload', async () => {
+  // Inverse: deploy A had tracker, deploy B removed it.
+  document.head.innerHTML =
+    '<meta charset="utf-8">' +
+    '<meta data-webjs-track="reload" name="build-id" content="rev-1">';
+  document.body.innerHTML = '<p>current</p>';
+  sessionStorage.removeItem('webjs:importmap-reload');
+  const newBody =
+    '<!doctype html><html><head>' +
+    '<meta charset="utf-8">' +
+    '</head><body><p>after</p></body></html>';
+  const { redirect, restore } = installNavigationMocks({
+    contentType: 'text/html',
+    body: newBody,
+  });
+  try {
+    await navigate('http://localhost/removed');
+    assert.equal(redirect.href, 'http://localhost/removed',
+      'tracked element removed in incoming response must reload');
+  } finally {
+    restore();
+    sessionStorage.removeItem('webjs:importmap-reload');
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+  }
+});
+
+test('navigate: X-Webjs-Have partial response (no head) does NOT reload due to track signature', async () => {
+  // Partial responses (X-Webjs-Have short-circuit) carry only the
+  // inner body, no head. The current page has tracked elements;
+  // incoming has nothing to compare against. Without the guard,
+  // every partial nav would reload-loop because incomingSig is
+  // empty. The presence-of-head check makes the comparison
+  // selective.
+  document.head.innerHTML =
+    '<meta charset="utf-8">' +
+    '<meta data-webjs-track="reload" name="build-id" content="rev-1">';
+  document.body.innerHTML = '<p>current</p>';
+  sessionStorage.removeItem('webjs:importmap-reload');
+  // Partial fragment: no <head>, no <html>, just inner content.
+  const partialBody = '<p>partial</p>';
+  const { redirect, restore } = installNavigationMocks({
+    contentType: 'text/html',
+    body: partialBody,
+  });
+  try {
+    await navigate('http://localhost/partial');
+    assert.ok(!redirect.assigns.includes('http://localhost/partial'),
+      'partial response (no head) must NOT trigger track-signature reload');
+  } finally {
+    restore();
+    sessionStorage.removeItem('webjs:importmap-reload');
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+  }
+});
+
+test('navigate: data-webjs-track="reload" strips nonce from signature (per-request nonce churn must not infinite-reload)', async () => {
+  // A user marking a nonced script with data-webjs-track="reload"
+  // would see infinite reloads if the signature included the nonce
+  // (every request rotates the nonce, so every nav would mismatch).
+  // outerHTMLForDiff strips the nonce attr before signature
+  // comparison so only content changes count.
+  document.head.innerHTML = '<script nonce="abc" data-webjs-track="reload" src="/build-42.js"></script>';
+  document.body.innerHTML = '<p>current</p>';
+  sessionStorage.removeItem('webjs:importmap-reload');
+  // Incoming has the SAME script but a DIFFERENT per-request nonce
+  // (the build hash and src are unchanged). Must NOT reload.
+  const newBody =
+    '<!doctype html><html><head>' +
+    '<script nonce="xyz" data-webjs-track="reload" src="/build-42.js"></script>' +
+    '</head><body><p>after</p></body></html>';
+  const { redirect, restore } = installNavigationMocks({
+    contentType: 'text/html',
+    body: newBody,
+  });
+  try {
+    await navigate('http://localhost/same-build');
+    assert.ok(!redirect.assigns.includes('http://localhost/same-build'),
+      'nonce-only change must NOT trigger reload');
+  } finally {
+    restore();
+    sessionStorage.removeItem('webjs:importmap-reload');
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+  }
+});
+
 test('navigate: matching data-webjs-track="reload" elements proceed with partial swap', async () => {
   document.head.innerHTML = '<meta data-webjs-track="reload" name="build-id" content="rev-1">';
   document.body.innerHTML = '<p>current</p>';

--- a/packages/core/test/routing/router-client.test.js
+++ b/packages/core/test/routing/router-client.test.js
@@ -771,6 +771,59 @@ test('navigate: response-header lookup is case-insensitive (mock contract)', asy
   }
 });
 
+test('navigate: data-webjs-track="reload" signature change triggers hard reload', async () => {
+  // Generic Turbo-style tracked-element opt-in: any element in the
+  // head marked data-webjs-track="reload" gets included in a signature.
+  // Mismatch between current and incoming signature triggers reload.
+  document.head.innerHTML = '<meta data-webjs-track="reload" name="build-id" content="rev-1">';
+  document.body.innerHTML = '<p>current</p>';
+  sessionStorage.removeItem('webjs:importmap-reload');
+  const newBody =
+    '<!doctype html><html><head>' +
+    '<meta data-webjs-track="reload" name="build-id" content="rev-2">' +
+    '</head><body><p>after deploy</p></body></html>';
+  const { redirect, restore } = installNavigationMocks({
+    contentType: 'text/html',
+    body: newBody,
+  });
+  try {
+    await navigate('http://localhost/path');
+    assert.equal(redirect.href, 'http://localhost/path',
+      'data-webjs-track="reload" signature change must trigger reload');
+    assert.equal(document.body.querySelector('p')?.textContent, 'current',
+      'partial swap must have been aborted');
+  } finally {
+    restore();
+    sessionStorage.removeItem('webjs:importmap-reload');
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+  }
+});
+
+test('navigate: matching data-webjs-track="reload" elements proceed with partial swap', async () => {
+  document.head.innerHTML = '<meta data-webjs-track="reload" name="build-id" content="rev-1">';
+  document.body.innerHTML = '<p>current</p>';
+  sessionStorage.removeItem('webjs:importmap-reload');
+  const newBody =
+    '<!doctype html><html><head>' +
+    '<meta data-webjs-track="reload" name="build-id" content="rev-1">' +
+    '</head><body><p>after</p></body></html>';
+  const { redirect, restore } = installNavigationMocks({
+    contentType: 'text/html',
+    body: newBody,
+  });
+  try {
+    await navigate('http://localhost/other');
+    assert.ok(!redirect.assigns.includes('http://localhost/other'),
+      'identical tracked-element signature must NOT trigger reload');
+  } finally {
+    restore();
+    sessionStorage.removeItem('webjs:importmap-reload');
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+  }
+});
+
 test('navigate: importmap drift detected via X-Webjs-Build header on partial response', async () => {
   // Partial-response navs (the X-Webjs-Have optimization) carry only
   // the inner body, no head. Without the X-Webjs-Build header the

--- a/packages/server/AGENTS.md
+++ b/packages/server/AGENTS.md
@@ -47,7 +47,7 @@ with metadata, Suspense, streaming) for HTML, or `api.js` /
 | `serializer.js` | Default serializer + `setSerializer` / `getSerializer` for the RPC wire format |
 | `json.js` | `json()` + `readBody()` content-negotiation helpers |
 | `check.js` | Convention validator backing `webjs check`. Rules include `no-json-data-files`, `no-non-erasable-typescript` |
-| `vendor.js` | Resolve bare-specifier npm deps via jspm.io. Reads `.webjs/vendor/importmap.json` if present (committed pin file), else calls `api.jspm.io/generate` at boot. `--download` mode also serves cached bundle files from `.webjs/vendor/` |
+| `vendor.js` | Resolve bare-specifier npm deps via jspm.io. Reads `.webjs/vendor/importmap.json` if present (committed pin file), else calls `api.jspm.io/generate` at boot. Backs the `webjs vendor pin / unpin / list / audit / outdated / update` CLI surface plus the `--from <provider>` (jspm, jsdelivr, unpkg, skypack) and `--download` modes. `--download` mode also serves cached bundle files from `.webjs/vendor/`. |
 | `module-graph.js` | Dependency graph for transitive preload hints |
 | `importmap.js` | Browser import-map builder |
 | `component-scanner.js` | Maps every webjs component class to its browser-visible URL |

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -22,8 +22,13 @@ export {
   pinAll,
   unpinPackage,
   listPinned,
+  auditPinned,
+  findOutdated,
+  updatePinned,
   readPinFile,
   serveDownloadedBundle,
+  SUPPORTED_PROVIDERS,
+  normalizeProvider,
 } from './src/vendor.js';
 export { buildModuleGraph, transitiveDeps } from './src/module-graph.js';
 export { scanComponents, primeComponentRegistry, extractComponents, findOrphanComponents } from './src/component-scanner.js';

--- a/packages/server/src/vendor.js
+++ b/packages/server/src/vendor.js
@@ -963,9 +963,15 @@ export async function listPinned(appDir) {
       // exactly and just need to find the `<bare>@<version>`
       // substring. Stop at the first `/` after the version so we
       // don't include the entry-point path.
+      //
+      // Anchor the match against a non-pkg-name char (or string
+      // start) so a short package name like `ms` doesn't false-
+      // match inside another package's URL like `npm/terms@1.0.0/`.
+      // npm package names use `[a-zA-Z0-9._-]` (plus `@` and `/`
+      // for scoped names), so anything else is a safe boundary.
       const bare = extractPackageName(pkg) || pkg;
       const escapedBare = bare.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      const bareMatch = new RegExp(`${escapedBare}@([^/]+)`).exec(url);
+      const bareMatch = new RegExp(`(?:^|[^a-zA-Z0-9_.-])${escapedBare}@([^/]+)`).exec(url);
       if (bareMatch) version = bareMatch[1];
     }
     entries.push({ pkg, version, url, bytes });

--- a/packages/server/src/vendor.js
+++ b/packages/server/src/vendor.js
@@ -826,7 +826,7 @@ export async function pinAll(appDir, opts = {}) {
   // user knows pin didn't take, and let the next boot fall back to
   // live API resolution (which may have recovered by then).
   if (installs.length > 0 && pins.length === 0) {
-    return { pins, pruned: [], downloaded, failed: true, attemptedInstalls: installs };
+    return { pins, pruned: [], downloaded, failed: true, attemptedInstalls: installs, provider: from };
   }
 
   // Partial-failure surface. Some installs were attempted but not
@@ -867,7 +867,7 @@ export async function pinAll(appDir, opts = {}) {
   // -imports filter, so the file exists but does nothing. The CLI
   // surfaces this as a clearer "no bare imports found" message.
   if (installs.length === 0) {
-    return { pins, pruned: [], downloaded, noBareImports: true };
+    return { pins, pruned: [], downloaded, noBareImports: true, provider: from };
   }
 
   await writePinFile(appDir, importmap, integrity, from);

--- a/packages/server/src/vendor.js
+++ b/packages/server/src/vendor.js
@@ -255,6 +255,32 @@ const JSPM_GENERATE_ENDPOINT = 'https://api.jspm.io/generate';
 const JSPM_GENERATE_TIMEOUT_MS = 10_000;
 
 /**
+ * Provider names accepted by `webjs vendor pin --from <provider>`.
+ * Default `jspm` resolves to jspm.io. Same set Rails's importmap-rails
+ * accepts (`packager.rb:normalize_provider`).
+ *
+ * jspm.io's Generator API itself supports multiple providers via the
+ * `provider` field in the request body. We surface the same choice as
+ * a CLI flag.
+ *
+ * @type {Set<string>}
+ */
+export const SUPPORTED_PROVIDERS = new Set(['jspm', 'jsdelivr', 'unpkg', 'skypack']);
+
+/**
+ * Normalize the user-facing provider name to what the jspm.io API
+ * expects in its `provider` field. Mirrors importmap-rails's
+ * `normalize_provider`: `jspm` is shorthand for `jspm.io`; the rest
+ * pass through verbatim.
+ *
+ * @param {string} name
+ * @returns {string}
+ */
+export function normalizeProvider(name) {
+  return name === 'jspm' ? 'jspm.io' : name;
+}
+
+/**
  * Resolve a SINGLE `pkg@version` (or `pkg@version/subpath`) install via
  * api.jspm.io/generate. Returns the imports fragment (typically one or
  * two entries; subpath installs sometimes include the root package).
@@ -265,14 +291,20 @@ const JSPM_GENERATE_TIMEOUT_MS = 10_000;
  * Calling per-package means one bad dep can no longer poison the
  * importmap for legitimate deps.
  *
- * Cached in-process by the install spec. Failures are logged loudly
- * with the package name and the reason jspm.io returned.
+ * Cached in-process by the install spec + provider. Failures are
+ * logged loudly with the package name and the reason jspm.io
+ * returned.
  *
  * @param {string} install  e.g. 'dayjs@1.11.13' or 'dayjs@1.11.13/plugin/utc'
+ * @param {string} [provider]  one of SUPPORTED_PROVIDERS; defaults to 'jspm'
  * @returns {Promise<Record<string, string>>}
  */
-async function jspmResolveOne(install) {
-  const existing = jspmCache.get(install);
+async function jspmResolveOne(install, provider = 'jspm') {
+  // Cache key includes provider since the same install can resolve
+  // to different URLs across CDNs (e.g. `dayjs@1.11.13` returns
+  // ga.jspm.io vs cdn.jsdelivr.net depending on `provider`).
+  const cacheKey = `${provider}::${install}`;
+  const existing = jspmCache.get(cacheKey);
   if (existing) return existing;
 
   const promise = (async () => {
@@ -294,7 +326,7 @@ async function jspmResolveOne(install) {
           // specifier error. Matches importmap-rails's posture.
           flattenScope: true,
           env: ['browser', 'production', 'module'],
-          provider: 'jspm.io',
+          provider: normalizeProvider(provider),
         }),
         signal: controller.signal,
       });
@@ -309,9 +341,9 @@ async function jspmResolveOne(install) {
           if (body && typeof body.error === 'string') detail = `: ${body.error}`;
         } catch { /* non-JSON body */ }
         console.error(
-          `[webjs] could not vendor '${install}' via jspm.io (status ${response.status})${detail}`,
+          `[webjs] could not vendor '${install}' via ${provider} (status ${response.status})${detail}`,
         );
-        jspmCache.delete(install);
+        jspmCache.delete(cacheKey);
         return {};
       }
       const result = await response.json();
@@ -320,15 +352,15 @@ async function jspmResolveOne(install) {
       const msg = e && e.name === 'AbortError'
         ? `timed out after ${JSPM_GENERATE_TIMEOUT_MS}ms`
         : `${e && e.message}`;
-      console.error(`[webjs] could not vendor '${install}' via jspm.io: ${msg}`);
-      jspmCache.delete(install);
+      console.error(`[webjs] could not vendor '${install}' via ${provider}: ${msg}`);
+      jspmCache.delete(cacheKey);
       return {};
     } finally {
       clearTimeout(timer);
     }
   })();
 
-  jspmCache.set(install, promise);
+  jspmCache.set(cacheKey, promise);
   return promise;
 }
 
@@ -344,11 +376,12 @@ async function jspmResolveOne(install) {
  * URL as `dayjs@x.y.z/plugin/foo`'s incidental `dayjs` entry.
  *
  * @param {Array<string>} installs  e.g. ['dayjs@1.11.13', 'clsx@2.1.1']
+ * @param {string} [provider]  one of SUPPORTED_PROVIDERS; defaults to 'jspm'
  * @returns {Promise<Record<string, string>>}
  */
-export async function jspmGenerate(installs) {
+export async function jspmGenerate(installs, provider = 'jspm') {
   if (installs.length === 0) return {};
-  const perPackage = await Promise.all(installs.map(jspmResolveOne));
+  const perPackage = await Promise.all(installs.map(i => jspmResolveOne(i, provider)));
   const merged = {};
   for (const fragment of perPackage) Object.assign(merged, fragment);
   return merged;
@@ -444,13 +477,14 @@ export function sha384Integrity(body) {
 
 /**
  * Read the committed pin importmap if one exists. Returns the parsed
- * `{ imports, integrity? }` shape or null if no pin file. The
- * `integrity` field is optional: pin files written before SRI support
- * lack it; pin files written by `webjs vendor pin` (current version)
- * include it.
+ * `{ imports, integrity?, provider? }` shape or null if no pin file.
+ * The `integrity` and `provider` fields are optional: pin files
+ * written before SRI / multi-CDN support lack them; pin files written
+ * by current `webjs vendor pin` include them (provider only when
+ * non-default).
  *
  * @param {string} appDir
- * @returns {Promise<{ imports: Record<string, string>, integrity?: Record<string, string> } | null>}
+ * @returns {Promise<{ imports: Record<string, string>, integrity?: Record<string, string>, provider?: string } | null>}
  */
 export async function readPinFile(appDir) {
   try {
@@ -507,8 +541,15 @@ export async function readPinFile(appDir) {
         }
       }
     }
+    /** @type {{ imports: Record<string,string>, integrity?: Record<string,string>, provider?: string }} */
     const out = { imports: cleanImports };
     if (Object.keys(cleanIntegrity).length) out.integrity = cleanIntegrity;
+    // Provider is optional in the pin file. Validate against the
+    // supported set so a tampered file can't smuggle an arbitrary
+    // string into downstream code paths.
+    if (typeof parsed.provider === 'string' && SUPPORTED_PROVIDERS.has(parsed.provider)) {
+      out.provider = parsed.provider;
+    }
     return out;
   } catch {
     return null;
@@ -524,15 +565,24 @@ export async function readPinFile(appDir) {
  * spec: a flat `{url: 'sha384-...'}` map). Omitted entirely when empty
  * so older webjs versions read the file as before.
  *
+ * `provider` is persisted alongside imports when non-default. It lets
+ * `webjs vendor update` know which CDN to re-resolve against, and
+ * makes the pin file self-describing for incident response: if jspm.io
+ * has an outage you can read the file and know which alternate CDN
+ * the deploy targets. Omitted for the default jspm provider so the
+ * pin file shape stays stable for the 99% case.
+ *
  * @param {string} appDir
  * @param {Record<string, string>} imports
  * @param {Record<string, string>} [integrity]
+ * @param {string} [provider]
  */
-async function writePinFile(appDir, imports, integrity) {
+async function writePinFile(appDir, imports, integrity, provider) {
   await mkdir(pinDir(appDir), { recursive: true });
-  const payload = integrity && Object.keys(integrity).length
-    ? { imports, integrity }
-    : { imports };
+  /** @type {Record<string, any>} */
+  const payload = { imports };
+  if (integrity && Object.keys(integrity).length) payload.integrity = integrity;
+  if (provider && provider !== 'jspm') payload.provider = provider;
   const body = JSON.stringify(payload, null, 2) + '\n';
   // Atomic write: stage into a sibling tmp file, then rename onto the
   // final path. Rename within the same directory is atomic on POSIX
@@ -652,9 +702,9 @@ async function pruneOrphans(appDir, expected) {
  * and mode switches all leave a clean directory.
  *
  * On success (at least one install resolved), returns
- * `{ pins, pruned, downloaded }`. On total failure (one or more
- * installs were attempted but every jspm.io resolution failed), the
- * pin file is NOT written and the function returns
+ * `{ pins, pruned, downloaded, provider }`. On total failure (one or
+ * more installs were attempted but every jspm.io resolution failed),
+ * the pin file is NOT written and the function returns
  * `{ pins: [], pruned: [], downloaded: 0, failed: true, attemptedInstalls }`
  * instead. When the app has zero bare-specifier imports at all
  * (scanned source produced nothing), returns
@@ -663,12 +713,20 @@ async function pruneOrphans(appDir, expected) {
  * non-zero exit code key off `failed` or `noBareImports`; both
  * are absent on the success path.
  *
+ * The `from` option mirrors importmap-rails's `bin/importmap pin foo
+ * --from jsdelivr`. Default `jspm` resolves to jspm.io; other values
+ * (jsdelivr, unpkg, skypack) are passed through to jspm.io's
+ * Generator API which returns URLs from the chosen CDN. The provider
+ * is persisted in the pin file so `vendor update` and incident
+ * response know which CDN to re-resolve against.
+ *
  * @param {string} appDir
- * @param {{ download?: boolean }} [opts]
+ * @param {{ download?: boolean, from?: string }} [opts]
  * @returns {Promise<{
  *   pins: Array<{ pkg: string, version: string, url: string, bytes?: number, integrity?: string }>,
  *   pruned: string[],
  *   downloaded: number,
+ *   provider?: string,
  *   failed?: boolean,
  *   noBareImports?: boolean,
  *   attemptedInstalls?: string[],
@@ -676,6 +734,12 @@ async function pruneOrphans(appDir, expected) {
  */
 export async function pinAll(appDir, opts = {}) {
   const download = !!opts.download;
+  const from = opts.from || 'jspm';
+  if (!SUPPORTED_PROVIDERS.has(from)) {
+    throw new Error(
+      `[webjs] unknown provider '${from}'. Supported: ${[...SUPPORTED_PROVIDERS].join(', ')}.`,
+    );
+  }
   const bare = await scanBareImports(appDir);
   const installs = [];
   /**
@@ -696,7 +760,7 @@ export async function pinAll(appDir, opts = {}) {
     installs.push(install);
     partsByInstall.set(spec, { pkg, version, subpath });
   }
-  const resolved = await jspmGenerate(installs);
+  const resolved = await jspmGenerate(installs, from);
 
   /** @type {Record<string, string>} */
   const importmap = {};
@@ -798,9 +862,9 @@ export async function pinAll(appDir, opts = {}) {
     return { pins, pruned: [], downloaded, noBareImports: true };
   }
 
-  await writePinFile(appDir, importmap, integrity);
+  await writePinFile(appDir, importmap, integrity, from);
   const pruned = await pruneOrphans(appDir, expected);
-  return { pins, pruned, downloaded };
+  return { pins, pruned, downloaded, provider: from };
 }
 
 /**
@@ -883,6 +947,217 @@ export async function listPinned(appDir) {
     entries.push({ pkg, version, url, bytes });
   }
   return entries;
+}
+
+// ---------------------------------------------------------------------------
+// npm registry queries: audit + outdated + update
+// ---------------------------------------------------------------------------
+
+const NPM_REGISTRY = 'https://registry.npmjs.org';
+const NPM_TIMEOUT_MS = 10_000;
+
+/**
+ * Fetch one URL from registry.npmjs.org with a small timeout. Returns
+ * the parsed JSON body on 2xx, or null on any non-2xx / network /
+ * timeout. Used by audit + outdated.
+ *
+ * @param {string} url
+ * @param {RequestInit} [init]
+ * @returns {Promise<any | null>}
+ */
+async function fetchNpmJson(url, init) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), NPM_TIMEOUT_MS);
+  try {
+    const resp = await fetch(url, { ...init, signal: controller.signal });
+    if (!resp.ok) return null;
+    return await resp.json();
+  } catch { return null; }
+  finally { clearTimeout(timer); }
+}
+
+/**
+ * Group the pin file's entries by package name + the set of versions
+ * actually pinned (a single package can be pinned at multiple versions
+ * via subpath imports). Used by audit (npm advisories want
+ * `{ pkgName: [versions] }`) and outdated (one query per package).
+ *
+ * @param {Array<{ pkg: string, version: string }>} entries
+ * @returns {Map<string, Set<string>>}
+ */
+function groupPinnedByPackage(entries) {
+  const out = new Map();
+  for (const e of entries) {
+    if (!e.version || e.version === '(unknown)') continue;
+    // entries[].pkg can include a subpath (e.g. `dayjs/plugin/utc`).
+    // Extract the bare package name (`dayjs` or `@scope/name`).
+    const bare = extractPackageName(e.pkg) || e.pkg;
+    if (!out.has(bare)) out.set(bare, new Set());
+    out.get(bare).add(e.version);
+  }
+  return out;
+}
+
+/**
+ * Run a security audit against the pinned versions in the committed
+ * pin file. POSTs to npm's bulk-advisory endpoint, the same one
+ * `npm audit` uses internally.
+ *
+ * Mirrors importmap-rails's `bin/importmap audit`.
+ *
+ * @param {string} appDir
+ * @returns {Promise<{
+ *   vulnerable: Array<{ name: string, severity: string, vulnerableVersions: string, title: string }>,
+ *   totalChecked: number,
+ * }>}
+ */
+export async function auditPinned(appDir) {
+  const entries = await listPinned(appDir);
+  if (!entries.length) return { vulnerable: [], totalChecked: 0 };
+  const grouped = groupPinnedByPackage(entries);
+  const body = {};
+  for (const [pkg, versions] of grouped) body[pkg] = [...versions];
+  const result = await fetchNpmJson(`${NPM_REGISTRY}/-/npm/v1/security/advisories/bulk`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const totalChecked = grouped.size;
+  if (!result || typeof result !== 'object') return { vulnerable: [], totalChecked };
+  /** @type {Array<{ name: string, severity: string, vulnerableVersions: string, title: string }>} */
+  const vulnerable = [];
+  for (const [name, advisories] of Object.entries(result)) {
+    if (!Array.isArray(advisories)) continue;
+    for (const a of advisories) {
+      vulnerable.push({
+        name,
+        severity: String(a?.severity || 'unknown'),
+        vulnerableVersions: String(a?.vulnerable_versions || a?.range || ''),
+        title: String(a?.title || a?.overview || ''),
+      });
+    }
+  }
+  return { vulnerable, totalChecked };
+}
+
+/**
+ * Find pinned packages that have a newer version available on npm.
+ * Queries `registry.npmjs.org/<pkg>` per pinned package, compares the
+ * pinned version against `dist-tags.latest` with semver-shaped string
+ * ordering (regex parse, then numeric compare per segment).
+ *
+ * Mirrors importmap-rails's `bin/importmap outdated`.
+ *
+ * @param {string} appDir
+ * @returns {Promise<Array<{ pkg: string, current: string, latest: string }>>}
+ */
+export async function findOutdated(appDir) {
+  const entries = await listPinned(appDir);
+  if (!entries.length) return [];
+  const grouped = groupPinnedByPackage(entries);
+  /** @type {Array<{ pkg: string, current: string, latest: string }>} */
+  const outdated = [];
+  for (const [pkg, versions] of grouped) {
+    const meta = await fetchNpmJson(`${NPM_REGISTRY}/${encodeURIComponent(pkg)}`);
+    const latest = meta?.['dist-tags']?.latest;
+    if (typeof latest !== 'string') continue;
+    // A package can be pinned at multiple versions (subpath imports).
+    // Take the max pinned version as the "current" for the comparison
+    // so we only report it as outdated when EVERY pinned version
+    // trails latest.
+    const current = maxSemverVersion([...versions]);
+    if (compareSemver(current, latest) < 0) {
+      outdated.push({ pkg, current, latest });
+    }
+  }
+  return outdated;
+}
+
+/**
+ * Re-pin every package returned by findOutdated to its latest version.
+ * Calls jspm.io's Generator API with `<pkg>@<latest>` for each
+ * outdated entry, then writes the new pin file.
+ *
+ * Mirrors importmap-rails's `bin/importmap update`, with the same
+ * caveat: this updates the pin file but does NOT update the user's
+ * `package.json` / `node_modules`. The user should run `npm install
+ * <pkg>@<latest>` afterward to keep package.json in sync.
+ *
+ * @param {string} appDir
+ * @param {{ from?: string }} [opts]
+ * @returns {Promise<{ updated: Array<{ pkg: string, from: string, to: string }>, noOutdated?: boolean }>}
+ */
+export async function updatePinned(appDir, opts = {}) {
+  const from = opts.from || 'jspm';
+  if (!SUPPORTED_PROVIDERS.has(from)) {
+    throw new Error(
+      `[webjs] unknown provider '${from}'. Supported: ${[...SUPPORTED_PROVIDERS].join(', ')}.`,
+    );
+  }
+  const outdated = await findOutdated(appDir);
+  if (!outdated.length) return { updated: [], noOutdated: true };
+  const file = await readPinFile(appDir);
+  if (!file) return { updated: [] };
+  const newImports = { ...file.imports };
+  const newIntegrity = { ...(file.integrity || {}) };
+  /** @type {Array<{ pkg: string, from: string, to: string }>} */
+  const updated = [];
+  for (const { pkg, current, latest } of outdated) {
+    // Resolve the new version via jspm.io. The Generator API
+    // returns URLs for `<pkg>@<latest>` (and any subpath we ask
+    // for, but for update we just refresh the bare root pin and
+    // any subpaths that were already pinned).
+    for (const [spec, oldUrl] of Object.entries(file.imports)) {
+      const specPkg = extractPackageName(spec) || spec;
+      if (specPkg !== pkg) continue;
+      const subpath = spec.slice(specPkg.length);
+      const install = `${pkg}@${latest}${subpath}`;
+      const resolved = await jspmGenerate([install], from);
+      const newUrl = resolved[spec];
+      if (!newUrl) continue;
+      newImports[spec] = newUrl;
+      // Recompute integrity for the new URL. Drop the stale entry
+      // even on fetch failure so the new pin doesn't carry the
+      // wrong hash silently.
+      delete newIntegrity[oldUrl];
+      const sri = await fetchIntegrity(newUrl);
+      if (sri) newIntegrity[newUrl] = sri;
+    }
+    updated.push({ pkg, from: current, to: latest });
+  }
+  await writePinFile(appDir, newImports, newIntegrity, from);
+  return { updated };
+}
+
+/**
+ * Lightweight semver-aware comparison (no prerelease tags). Returns
+ * negative if a < b, zero if equal, positive if a > b. Used by
+ * findOutdated to decide if `current` lags `latest`. Non-numeric
+ * segments fall back to string compare so prerelease-ish strings
+ * still sort somewhere.
+ *
+ * @param {string} a
+ * @param {string} b
+ * @returns {number}
+ */
+function compareSemver(a, b) {
+  const aParts = a.split(/[.+-]/).map((p) => /^\d+$/.test(p) ? Number(p) : p);
+  const bParts = b.split(/[.+-]/).map((p) => /^\d+$/.test(p) ? Number(p) : p);
+  for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
+    const ai = aParts[i] ?? 0;
+    const bi = bParts[i] ?? 0;
+    if (typeof ai === 'number' && typeof bi === 'number') {
+      if (ai !== bi) return ai - bi;
+    } else if (ai !== bi) {
+      return String(ai) < String(bi) ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+/** @param {string[]} versions */
+function maxSemverVersion(versions) {
+  return versions.reduce((max, v) => compareSemver(v, max) > 0 ? v : max, versions[0]);
 }
 
 /**

--- a/packages/server/src/vendor.js
+++ b/packages/server/src/vendor.js
@@ -1094,7 +1094,14 @@ export async function findOutdated(appDir) {
   /** @type {Array<{ pkg: string, current: string, latest: string }>} */
   const outdated = [];
   for (const [pkg, versions] of grouped) {
-    const meta = await fetchNpmJson(`${NPM_REGISTRY}/${encodeURIComponent(pkg)}`);
+    // Scoped packages: the `/` between `@scope` and `name` is part of
+    // the URL path, NOT a path separator that should be encoded.
+    // `encodeURIComponent` would emit `%2F`, which the npm registry
+    // accepts but other npm-compatible registries (Verdaccio, JFrog,
+    // GitHub Packages) sometimes reject. The npm-cli uses the literal
+    // form. npm package-name rules disallow URL-unsafe chars so this
+    // is safe.
+    const meta = await fetchNpmJson(`${NPM_REGISTRY}/${pkg}`);
     const latest = meta?.['dist-tags']?.latest;
     if (typeof latest !== 'string') continue;
     // A package can be pinned at multiple versions (subpath imports).

--- a/packages/server/src/vendor.js
+++ b/packages/server/src/vendor.js
@@ -899,7 +899,11 @@ export async function unpinPackage(appDir, pkg) {
     // guard.
     try { await unlink(pinFilePath(appDir)); } catch { /* race or never existed */ }
   } else {
-    await writePinFile(appDir, file.imports, newIntegrity);
+    // Preserve the pin file's persisted provider (jsdelivr, unpkg,
+    // etc.). Without this, `webjs vendor unpin <pkg>` would silently
+    // revert the file to the default jspm provider, defeating
+    // pinAll's stickiness for the remaining packages.
+    await writePinFile(appDir, file.imports, newIntegrity, file.provider);
   }
 
   let deletedFile;
@@ -927,16 +931,14 @@ export async function listPinned(appDir) {
   for (const [pkg, url] of Object.entries(file.imports)) {
     let version = '(unknown)';
     let bytes;
-    // Match `/npm:<pkg>@<version>/...`. The non-capturing `(?:@[^/]+\/)?`
-    // consumes an optional scope prefix (`@scope/`) so the second
-    // `@<version>` is what we capture. Without it, scoped packages
-    // (e.g. `/npm:@scope/name@1.2.3/`) would silently fall through to
-    // "(unknown)" because the original `[^@]+` couldn't accept a
-    // leading `@`.
-    const jspmMatch = /\/npm:(?:@[^/]+\/)?[^@/]+@([^/]+)\//.exec(url);
-    if (jspmMatch) {
-      version = jspmMatch[1];
-    } else if (url.startsWith('/__webjs/vendor/')) {
+    // Order matters: try the local `/__webjs/vendor/` filename
+    // parser first, then the CDN bare-name search. The local
+    // filename embeds the subpath as `__plugin__utc.js`, which the
+    // bare-name regex would match as part of the version (greedy
+    // `[^/]+` swallows the encoded subpath). Handling the local
+    // case explicitly preserves the cleaner version output for
+    // `--download` mode pins.
+    if (url.startsWith('/__webjs/vendor/')) {
       const filename = url.slice('/__webjs/vendor/'.length);
       const atIdx = filename.lastIndexOf('@');
       if (atIdx > 0) {
@@ -951,6 +953,20 @@ export async function listPinned(appDir) {
         const st = await stat(join(pinDir(appDir), filename));
         bytes = st.size;
       } catch { /* file missing; bytes stays undefined */ }
+    } else {
+      // Derive the version from the URL by searching for the spec's
+      // bare package name followed by `@<version>`. Works across
+      // every CDN we support (jspm.io's `npm:dayjs@1.11.13`,
+      // jsdelivr's `npm/dayjs@1.11.13`, unpkg's bare
+      // `dayjs@1.11.13/`, skypack's `dayjs@1.11.13`). The bare name
+      // lives in entries[].pkg (the import-map key), so we know it
+      // exactly and just need to find the `<bare>@<version>`
+      // substring. Stop at the first `/` after the version so we
+      // don't include the entry-point path.
+      const bare = extractPackageName(pkg) || pkg;
+      const escapedBare = bare.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const bareMatch = new RegExp(`${escapedBare}@([^/]+)`).exec(url);
+      if (bareMatch) version = bareMatch[1];
     }
     entries.push({ pkg, version, url, bytes });
   }
@@ -1138,6 +1154,7 @@ export async function updatePinned(appDir, opts = {}) {
     // returns URLs for `<pkg>@<latest>` (and any subpath we ask
     // for, but for update we just refresh the bare root pin and
     // any subpaths that were already pinned).
+    let anySpecUpdated = false;
     for (const [spec, oldUrl] of Object.entries(file.imports)) {
       const specPkg = extractPackageName(spec) || spec;
       if (specPkg !== pkg) continue;
@@ -1153,8 +1170,13 @@ export async function updatePinned(appDir, opts = {}) {
       delete newIntegrity[oldUrl];
       const sri = await fetchIntegrity(newUrl);
       if (sri) newIntegrity[newUrl] = sri;
+      anySpecUpdated = true;
     }
-    updated.push({ pkg, from: current, to: latest });
+    // Only report `pkg` as updated when at least one spec actually
+    // got a new URL. If every subpath failed to resolve via
+    // jspm.io (transient outage, the new version not yet indexed),
+    // the CLI must not lie about having updated it.
+    if (anySpecUpdated) updated.push({ pkg, from: current, to: latest });
   }
   await writePinFile(appDir, newImports, newIntegrity, from);
   return { updated, provider: from };

--- a/packages/server/src/vendor.js
+++ b/packages/server/src/vendor.js
@@ -1003,12 +1003,17 @@ function groupPinnedByPackage(entries) {
  * pin file. POSTs to npm's bulk-advisory endpoint, the same one
  * `npm audit` uses internally.
  *
+ * Returns `{ errored: true }` when the registry call failed (network
+ * down, timeout, 5xx) so the CLI can surface the failure clearly
+ * instead of misleading the user with "no vulnerabilities found".
+ *
  * Mirrors importmap-rails's `bin/importmap audit`.
  *
  * @param {string} appDir
  * @returns {Promise<{
  *   vulnerable: Array<{ name: string, severity: string, vulnerableVersions: string, title: string }>,
  *   totalChecked: number,
+ *   errored?: boolean,
  * }>}
  */
 export async function auditPinned(appDir) {
@@ -1023,7 +1028,14 @@ export async function auditPinned(appDir) {
     body: JSON.stringify(body),
   });
   const totalChecked = grouped.size;
-  if (!result || typeof result !== 'object') return { vulnerable: [], totalChecked };
+  if (result === null) {
+    // Distinguish "registry returned no advisories" (success, empty
+    // object) from "couldn't reach registry" (null). The latter is
+    // user-visible because a silent "no vulnerabilities" on a failed
+    // call would falsely reassure the user.
+    return { vulnerable: [], totalChecked, errored: true };
+  }
+  if (typeof result !== 'object') return { vulnerable: [], totalChecked };
   /** @type {Array<{ name: string, severity: string, vulnerableVersions: string, title: string }>} */
   const vulnerable = [];
   for (const [name, advisories] of Object.entries(result)) {
@@ -1083,21 +1095,32 @@ export async function findOutdated(appDir) {
  * `package.json` / `node_modules`. The user should run `npm install
  * <pkg>@<latest>` afterward to keep package.json in sync.
  *
+ * When `opts.from` is not passed, the existing pin file's `provider`
+ * field is used (so a user who pinned `--from jsdelivr` originally
+ * stays on jsdelivr after update). When the file has no provider
+ * field, defaults to `jspm`.
+ *
  * @param {string} appDir
  * @param {{ from?: string }} [opts]
- * @returns {Promise<{ updated: Array<{ pkg: string, from: string, to: string }>, noOutdated?: boolean }>}
+ * @returns {Promise<{ updated: Array<{ pkg: string, from: string, to: string }>, noOutdated?: boolean, provider?: string }>}
  */
 export async function updatePinned(appDir, opts = {}) {
-  const from = opts.from || 'jspm';
+  const file = await readPinFile(appDir);
+  // Provider precedence:
+  //   1. explicit opts.from (CLI flag wins)
+  //   2. pin file's persisted provider
+  //   3. default 'jspm'
+  // Validate AFTER resolving so a stale pin file with a previously-
+  // valid-but-now-removed provider still errors clearly.
+  const from = opts.from || file?.provider || 'jspm';
   if (!SUPPORTED_PROVIDERS.has(from)) {
     throw new Error(
       `[webjs] unknown provider '${from}'. Supported: ${[...SUPPORTED_PROVIDERS].join(', ')}.`,
     );
   }
   const outdated = await findOutdated(appDir);
-  if (!outdated.length) return { updated: [], noOutdated: true };
-  const file = await readPinFile(appDir);
-  if (!file) return { updated: [] };
+  if (!outdated.length) return { updated: [], noOutdated: true, provider: from };
+  if (!file) return { updated: [], provider: from };
   const newImports = { ...file.imports };
   const newIntegrity = { ...(file.integrity || {}) };
   /** @type {Array<{ pkg: string, from: string, to: string }>} */
@@ -1126,7 +1149,7 @@ export async function updatePinned(appDir, opts = {}) {
     updated.push({ pkg, from: current, to: latest });
   }
   await writePinFile(appDir, newImports, newIntegrity, from);
-  return { updated };
+  return { updated, provider: from };
 }
 
 /**

--- a/packages/server/src/vendor.js
+++ b/packages/server/src/vendor.js
@@ -1091,29 +1091,40 @@ export async function findOutdated(appDir) {
   const entries = await listPinned(appDir);
   if (!entries.length) return [];
   const grouped = groupPinnedByPackage(entries);
-  /** @type {Array<{ pkg: string, current: string, latest: string }>} */
-  const outdated = [];
-  for (const [pkg, versions] of grouped) {
-    // Scoped packages: the `/` between `@scope` and `name` is part of
-    // the URL path, NOT a path separator that should be encoded.
-    // `encodeURIComponent` would emit `%2F`, which the npm registry
-    // accepts but other npm-compatible registries (Verdaccio, JFrog,
-    // GitHub Packages) sometimes reject. The npm-cli uses the literal
-    // form. npm package-name rules disallow URL-unsafe chars so this
-    // is safe.
+  // Fetch in parallel. With sequential awaits a 50-package project
+  // could take 50 × 10s = 500s in the worst case (one npm registry
+  // timeout each). Parallel `Promise.all` collapses this to one
+  // round-trip's wall-clock, while staying well below npm registry's
+  // unauthenticated-client soft rate limit (registry-side concern,
+  // not ours to throttle).
+  //
+  // Scoped packages: the `/` between `@scope` and `name` is part of
+  // the URL path, NOT a path separator that should be encoded.
+  // `encodeURIComponent` would emit `%2F`, which the npm registry
+  // accepts but other npm-compatible registries (Verdaccio, JFrog,
+  // GitHub Packages) sometimes reject. The npm-cli uses the literal
+  // form. npm package-name rules disallow URL-unsafe chars so this
+  // is safe.
+  const queries = [...grouped].map(async ([pkg, versions]) => {
     const meta = await fetchNpmJson(`${NPM_REGISTRY}/${pkg}`);
     const latest = meta?.['dist-tags']?.latest;
-    if (typeof latest !== 'string') continue;
+    if (typeof latest !== 'string') return null;
     // A package can be pinned at multiple versions (subpath imports).
     // Take the max pinned version as the "current" for the comparison
     // so we only report it as outdated when EVERY pinned version
     // trails latest.
     const current = maxSemverVersion([...versions]);
-    if (compareSemver(current, latest) < 0) {
-      outdated.push({ pkg, current, latest });
-    }
-  }
-  return outdated;
+    if (compareSemver(current, latest) >= 0) return null;
+    return { pkg, current, latest };
+  });
+  const results = await Promise.all(queries);
+  // `return` followed by a newline triggers ASI: `return; (expr);`
+  // returns undefined and drops the value. Keep the filter on the
+  // same line as `return` (or pull the result into a variable
+  // first) to avoid the trap.
+  /** @type {Array<{ pkg: string, current: string, latest: string }>} */
+  const out = results.filter((x) => x !== null);
+  return out;
 }
 
 /**

--- a/packages/server/src/vendor.js
+++ b/packages/server/src/vendor.js
@@ -734,7 +734,15 @@ async function pruneOrphans(appDir, expected) {
  */
 export async function pinAll(appDir, opts = {}) {
   const download = !!opts.download;
-  const from = opts.from || 'jspm';
+  // Provider precedence (same as updatePinned for consistency):
+  //   1. explicit opts.from (CLI --from flag wins)
+  //   2. existing pin file's persisted provider (stickiness: user
+  //      who pinned via jsdelivr stays on jsdelivr until they
+  //      explicitly switch back)
+  //   3. default 'jspm'
+  // Pre-read the file once to access its provider.
+  const existing = await readPinFile(appDir);
+  const from = opts.from || existing?.provider || 'jspm';
   if (!SUPPORTED_PROVIDERS.has(from)) {
     throw new Error(
       `[webjs] unknown provider '${from}'. Supported: ${[...SUPPORTED_PROVIDERS].join(', ')}.`,

--- a/packages/server/test/vendor/vendor.test.js
+++ b/packages/server/test/vendor/vendor.test.js
@@ -1597,3 +1597,20 @@ test('unpinPackage: preserves the pin file provider field after removing an entr
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test('findOutdated: returns an Array, not undefined (ASI regression guard)', async () => {
+  // Regression: a `return` followed by a newline + JSDoc-cast parens
+  // triggers automatic semicolon insertion (`return; (expr);`), so
+  // the value gets dropped and findOutdated returns undefined.
+  // Callers like updatePinned then crash with
+  // `Cannot read properties of undefined (reading 'length')`.
+  const dir = join(tmpdir(), `webjs-outdated-arr-${Date.now()}`);
+  await mkdir(dir, { recursive: true });
+  // No pin file → grouped is empty → no fetches → return empty array.
+  // The interesting assertion is that the return value is an
+  // ARRAY (.length accessible), not undefined.
+  const result = await findOutdated(dir);
+  assert.ok(Array.isArray(result), 'findOutdated must always return an Array');
+  assert.equal(result.length, 0);
+  await rm(dir, { recursive: true, force: true });
+});

--- a/packages/server/test/vendor/vendor.test.js
+++ b/packages/server/test/vendor/vendor.test.js
@@ -1441,3 +1441,35 @@ test('auditPinned: surfaces network failure as errored:true', { skip: !NETWORK_O
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test('pinAll: respects existing pin file provider when --from is not passed', async () => {
+  // Regression for the consistency gap: pinAll used to default to
+  // 'jspm' on every run, silently reverting a user's jsdelivr choice
+  // on subsequent re-pins. Now reads the existing pin file's
+  // provider as the default. Explicit opts.from still wins.
+  const dir = join(tmpdir(), `webjs-pin-sticky-${Date.now()}`);
+  await mkdir(join(dir, '.webjs', 'vendor'), { recursive: true });
+  await mkdir(join(dir, 'app'), { recursive: true });
+  await writeFile(join(dir, 'package.json'), '{"name":"tmp"}');
+  await writeFile(join(dir, 'app', 'page.ts'), `export default () => 'no bare imports';`);
+  await writeFile(
+    join(dir, '.webjs', 'vendor', 'importmap.json'),
+    JSON.stringify({
+      imports: { 'a': 'https://cdn.jsdelivr.net/npm/a@1.0.0/+esm' },
+      provider: 'jsdelivr',
+    }),
+  );
+  try {
+    // App has zero bare imports, so pinAll returns noBareImports
+    // without writing. The interesting assertion: it didn't throw
+    // and pinAll read the provider for whatever it would have done.
+    // Verify by checking pin file's provider field unchanged.
+    const result = await pinAll(dir);
+    assert.ok(result.noBareImports);
+    const file = await readPinFile(dir);
+    assert.equal(file.provider, 'jsdelivr',
+      'pinAll must not overwrite a non-default provider field even on noBareImports');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/server/test/vendor/vendor.test.js
+++ b/packages/server/test/vendor/vendor.test.js
@@ -1473,3 +1473,127 @@ test('pinAll: respects existing pin file provider when --from is not passed', as
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test('listPinned: extracts version from jsdelivr CDN URL pattern', async () => {
+  // Bug fix: listPinned only recognized jspm.io URLs (`npm:pkg@ver/`).
+  // jsdelivr/unpkg/skypack pins fell through to '(unknown)', which
+  // broke audit/outdated/update for any non-default provider. New
+  // logic derives version by searching for `<pkg-name>@<version>`
+  // in the URL.
+  const dir = join(tmpdir(), `webjs-list-jsdelivr-${Date.now()}`);
+  await mkdir(join(dir, '.webjs', 'vendor'), { recursive: true });
+  await writeFile(join(dir, '.webjs', 'vendor', 'importmap.json'), JSON.stringify({
+    imports: {
+      'dayjs': 'https://cdn.jsdelivr.net/npm/dayjs@1.11.13/+esm',
+      '@hotwired/turbo': 'https://cdn.jsdelivr.net/npm/@hotwired/turbo@8.0.0/+esm',
+    },
+    provider: 'jsdelivr',
+  }));
+  try {
+    const entries = await listPinned(dir);
+    const dayjs = entries.find(e => e.pkg === 'dayjs');
+    const turbo = entries.find(e => e.pkg === '@hotwired/turbo');
+    assert.equal(dayjs.version, '1.11.13');
+    assert.equal(turbo.version, '8.0.0', 'scoped package version is correctly extracted');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('listPinned: extracts version from unpkg + skypack URL patterns', async () => {
+  const dir = join(tmpdir(), `webjs-list-multi-cdn-${Date.now()}`);
+  await mkdir(join(dir, '.webjs', 'vendor'), { recursive: true });
+  await writeFile(join(dir, '.webjs', 'vendor', 'importmap.json'), JSON.stringify({
+    imports: {
+      'lodash': 'https://www.unpkg.com/lodash@4.17.21/lodash.js',
+      'preact': 'https://cdn.skypack.dev/preact@10.19.3',
+    },
+    provider: 'unpkg',
+  }));
+  try {
+    const entries = await listPinned(dir);
+    assert.equal(entries.find(e => e.pkg === 'lodash').version, '4.17.21');
+    assert.equal(entries.find(e => e.pkg === 'preact').version, '10.19.3');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('updatePinned: only counts a package as updated when at least one spec resolved', async () => {
+  // Regression: previously updatePinned pushed every outdated pkg
+  // to result.updated regardless of whether any subpath actually
+  // got a new URL from jspm.io. A user could see "Updated dayjs
+  // 1.11.13 → 1.11.20" while the pin file was unchanged because
+  // every jspm.io call failed. Now `anySpecUpdated` gates the push.
+  //
+  // We mock the package's latest by stubbing fetch: only the
+  // npm-registry call for dayjs returns a "latest" newer than the
+  // pinned version, but the jspm.io call for the new install
+  // fails. Result: findOutdated reports dayjs as outdated, but
+  // updatePinned tries jspm.io and the resolve returns nothing,
+  // so updated[] stays empty.
+  const dir = join(tmpdir(), `webjs-update-no-resolve-${Date.now()}`);
+  await mkdir(join(dir, '.webjs', 'vendor'), { recursive: true });
+  await writeFile(join(dir, '.webjs', 'vendor', 'importmap.json'), JSON.stringify({
+    imports: { 'dayjs': 'https://ga.jspm.io/npm:dayjs@1.11.13/dayjs.min.js' },
+  }));
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    const u = String(url);
+    if (u.includes('registry.npmjs.org/dayjs')) {
+      // Pretend the latest is newer than the pinned 1.11.13.
+      return /** @type any */ ({
+        ok: true, status: 200,
+        json: async () => ({ 'dist-tags': { latest: '99.99.99' } }),
+      });
+    }
+    if (u.includes('api.jspm.io')) {
+      // Pretend jspm.io fails for the new version. updatePinned's
+      // resolved[spec] will be undefined, so the inner loop hits
+      // `continue` for every spec.
+      return /** @type any */ ({
+        ok: false, status: 401,
+        json: async () => ({ error: 'simulated' }),
+      });
+    }
+    // No other fetches should fire in this test.
+    return /** @type any */ ({ ok: false, status: 404, json: async () => ({}) });
+  };
+  try {
+    const result = await updatePinned(dir);
+    assert.deepEqual(result.updated, [],
+      'no spec resolved, so updated[] must be empty even though findOutdated saw dayjs as outdated');
+  } finally {
+    globalThis.fetch = origFetch;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('unpinPackage: preserves the pin file provider field after removing an entry', async () => {
+  // Regression: unpinPackage rewrote the pin file via
+  // writePinFile(appDir, imports, integrity) without the provider
+  // argument, so a user who pinned with --from jsdelivr would lose
+  // that choice after running `webjs vendor unpin <pkg>` for any
+  // single package. Other pinned packages must keep their CDN.
+  const dir = join(tmpdir(), `webjs-unpin-provider-${Date.now()}`);
+  await mkdir(join(dir, '.webjs', 'vendor'), { recursive: true });
+  await writeFile(join(dir, '.webjs', 'vendor', 'importmap.json'), JSON.stringify({
+    imports: {
+      'dayjs': 'https://cdn.jsdelivr.net/npm/dayjs@1.11.13/+esm',
+      'lodash': 'https://cdn.jsdelivr.net/npm/lodash@4.17.21/+esm',
+    },
+    provider: 'jsdelivr',
+  }));
+  try {
+    const result = await unpinPackage(dir, 'dayjs');
+    assert.ok(result.removed);
+    const after = await readPinFile(dir);
+    assert.ok(after, 'pin file still exists (lodash remains)');
+    assert.equal(after.provider, 'jsdelivr',
+      'provider field must survive a single-package unpin');
+    assert.equal(Object.keys(after.imports).length, 1);
+    assert.equal(after.imports.lodash, 'https://cdn.jsdelivr.net/npm/lodash@4.17.21/+esm');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/server/test/vendor/vendor.test.js
+++ b/packages/server/test/vendor/vendor.test.js
@@ -17,6 +17,11 @@ import {
   readPinFile,
   resolveVendorImports,
   serveDownloadedBundle,
+  SUPPORTED_PROVIDERS,
+  normalizeProvider,
+  auditPinned,
+  findOutdated,
+  updatePinned,
 } from '../../src/vendor.js';
 
 // --- extractPackageName ---
@@ -1234,6 +1239,131 @@ test('serveDownloadedBundle: missing file returns 404', async () => {
   try {
     const resp = await serveDownloadedBundle('not-there@1.0.0.js', dir, false);
     assert.equal(resp.status, 404);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// --- provider (--from) parity tests ---
+
+test('SUPPORTED_PROVIDERS lists the four Rails-importmap-rails CDNs', () => {
+  assert.deepEqual(
+    [...SUPPORTED_PROVIDERS].sort(),
+    ['jsdelivr', 'jspm', 'skypack', 'unpkg'],
+  );
+});
+
+test('normalizeProvider: jspm → jspm.io, others pass through (Rails parity)', () => {
+  assert.equal(normalizeProvider('jspm'), 'jspm.io');
+  assert.equal(normalizeProvider('jsdelivr'), 'jsdelivr');
+  assert.equal(normalizeProvider('unpkg'), 'unpkg');
+  assert.equal(normalizeProvider('skypack'), 'skypack');
+});
+
+test('pinAll: rejects unknown provider with a clear error', async () => {
+  const dir = join(tmpdir(), `webjs-pin-bad-prov-${Date.now()}`);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, 'package.json'), '{"name":"tmp"}');
+  try {
+    await assert.rejects(
+      () => pinAll(dir, { from: 'not-a-real-cdn' }),
+      /unknown provider 'not-a-real-cdn'/,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('writePinFile + readPinFile: provider persists for non-jspm choice', async () => {
+  // Verify the provider round-trips through the pin file when the
+  // user picked something other than the default. For default jspm
+  // the field is omitted to keep the pin file shape stable for the
+  // 99% case (covered by other tests).
+  const dir = join(tmpdir(), `webjs-pin-prov-${Date.now()}`);
+  await mkdir(join(dir, '.webjs', 'vendor'), { recursive: true });
+  await writeFile(
+    join(dir, '.webjs', 'vendor', 'importmap.json'),
+    JSON.stringify({
+      imports: { 'dayjs': 'https://cdn.jsdelivr.net/npm/dayjs@1.11.13/+esm' },
+      provider: 'jsdelivr',
+    }),
+  );
+  try {
+    const file = await readPinFile(dir);
+    assert.ok(file);
+    assert.equal(file.provider, 'jsdelivr');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('readPinFile: rejects unknown provider value (tamper guard)', async () => {
+  const dir = join(tmpdir(), `webjs-pin-prov-bad-${Date.now()}`);
+  await mkdir(join(dir, '.webjs', 'vendor'), { recursive: true });
+  await writeFile(
+    join(dir, '.webjs', 'vendor', 'importmap.json'),
+    JSON.stringify({
+      imports: { 'a': 'https://cdn.example/a.js' },
+      provider: 'malicious-resolver',
+    }),
+  );
+  try {
+    const file = await readPinFile(dir);
+    assert.ok(file);
+    assert.equal(file.provider, undefined,
+      'provider must be dropped when not in SUPPORTED_PROVIDERS');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// --- audit / outdated / update parity tests ---
+
+test('auditPinned: no pin file returns zero-checked', async () => {
+  const dir = join(tmpdir(), `webjs-audit-empty-${Date.now()}`);
+  await mkdir(dir, { recursive: true });
+  try {
+    const { vulnerable, totalChecked } = await auditPinned(dir);
+    assert.equal(totalChecked, 0);
+    assert.deepEqual(vulnerable, []);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('findOutdated: no pin file returns []', async () => {
+  const dir = join(tmpdir(), `webjs-outdated-empty-${Date.now()}`);
+  await mkdir(dir, { recursive: true });
+  try {
+    assert.deepEqual(await findOutdated(dir), []);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('updatePinned: rejects unknown provider', async () => {
+  const dir = join(tmpdir(), `webjs-update-bad-${Date.now()}`);
+  await mkdir(dir, { recursive: true });
+  try {
+    await assert.rejects(
+      () => updatePinned(dir, { from: 'not-real' }),
+      /unknown provider/,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('updatePinned: no outdated returns noOutdated:true without writing', async () => {
+  // Mock listPinned + findOutdated trivially: empty pin file means
+  // both return empty, and updatePinned short-circuits before
+  // any network call.
+  const dir = join(tmpdir(), `webjs-update-clean-${Date.now()}`);
+  await mkdir(dir, { recursive: true });
+  try {
+    const result = await updatePinned(dir);
+    assert.ok(result.noOutdated);
+    assert.deepEqual(result.updated, []);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/packages/server/test/vendor/vendor.test.js
+++ b/packages/server/test/vendor/vendor.test.js
@@ -1614,3 +1614,26 @@ test('findOutdated: returns an Array, not undefined (ASI regression guard)', asy
   assert.equal(result.length, 0);
   await rm(dir, { recursive: true, force: true });
 });
+
+test('listPinned: short package names do not false-match inside other package URLs', async () => {
+  // Regression: a bare-name regex without a boundary check would
+  // find `ms@1.0.0` inside `terms@1.0.0/ms@2.0.0.js`, returning
+  // version 1.0.0 for the `ms` package when the actual version
+  // is 2.0.0. The boundary check ensures the match starts at
+  // a non-pkg-name char (URL separator).
+  const dir = join(tmpdir(), `webjs-list-boundary-${Date.now()}`);
+  await mkdir(join(dir, '.webjs', 'vendor'), { recursive: true });
+  await writeFile(join(dir, '.webjs', 'vendor', 'importmap.json'), JSON.stringify({
+    imports: {
+      'ms': 'https://cdn.example/npm/terms@1.0.0/ms@2.0.0/index.js',
+    },
+  }));
+  try {
+    const entries = await listPinned(dir);
+    const ms = entries.find(e => e.pkg === 'ms');
+    assert.equal(ms.version, '2.0.0',
+      'must extract ms\'s own version, not the embedded "ms" inside "terms"');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/server/test/vendor/vendor.test.js
+++ b/packages/server/test/vendor/vendor.test.js
@@ -1368,3 +1368,76 @@ test('updatePinned: no outdated returns noOutdated:true without writing', async 
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test('updatePinned: respects pin file provider when --from is not passed', async () => {
+  // Regression: a user who pinned `--from jsdelivr` and later runs
+  // `webjs vendor update` (no flag) should stay on jsdelivr, not
+  // silently fall back to jspm.
+  const dir = join(tmpdir(), `webjs-update-provider-${Date.now()}`);
+  await mkdir(join(dir, '.webjs', 'vendor'), { recursive: true });
+  await writeFile(
+    join(dir, '.webjs', 'vendor', 'importmap.json'),
+    JSON.stringify({
+      // No actual outdated packages here; we're checking the
+      // provider read path. updatePinned reaches the
+      // findOutdated network call and returns noOutdated:true OR
+      // updated:[]. Either way, the `provider` field on the
+      // result should reflect what was on the pin file.
+      imports: { 'a': 'https://cdn.jsdelivr.net/npm/a@1.0.0/+esm' },
+      provider: 'jsdelivr',
+    }),
+  );
+  try {
+    const result = await updatePinned(dir);
+    assert.equal(result.provider, 'jsdelivr',
+      'updatePinned must use the pin file provider when no --from passed');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('updatePinned: explicit --from overrides pin file provider', async () => {
+  const dir = join(tmpdir(), `webjs-update-override-${Date.now()}`);
+  await mkdir(join(dir, '.webjs', 'vendor'), { recursive: true });
+  await writeFile(
+    join(dir, '.webjs', 'vendor', 'importmap.json'),
+    JSON.stringify({
+      imports: { 'a': 'https://cdn.jsdelivr.net/npm/a@1.0.0/+esm' },
+      provider: 'jsdelivr',
+    }),
+  );
+  try {
+    const result = await updatePinned(dir, { from: 'unpkg' });
+    assert.equal(result.provider, 'unpkg',
+      'explicit opts.from must override pin file provider');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('auditPinned: surfaces network failure as errored:true', { skip: !NETWORK_OK }, async () => {
+  // The audit command must NOT silently report "no vulnerabilities"
+  // when the registry call failed. Use an obviously-unresolvable
+  // hostname by stubbing the global fetch for the duration of the
+  // test. Fail-closed contract: errored:true means the user must
+  // retry.
+  const dir = join(tmpdir(), `webjs-audit-err-${Date.now()}`);
+  await mkdir(join(dir, '.webjs', 'vendor'), { recursive: true });
+  await writeFile(
+    join(dir, '.webjs', 'vendor', 'importmap.json'),
+    JSON.stringify({
+      imports: { 'dayjs': 'https://ga.jspm.io/npm:dayjs@1.11.13/dayjs.min.js' },
+    }),
+  );
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = async () => { throw new Error('simulated network failure'); };
+  try {
+    const result = await auditPinned(dir);
+    assert.equal(result.errored, true);
+    assert.deepEqual(result.vulnerable, []);
+    assert.equal(result.totalChecked, 1);
+  } finally {
+    globalThis.fetch = origFetch;
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Adds five capabilities to the webjs vendor pipeline and client router.

- **`webjs vendor pin --from <provider>`** picks the resolver CDN. Accepts `jspm` (default), `jsdelivr`, `unpkg`, `skypack`. The chosen provider is persisted in `.webjs/vendor/importmap.json` so subsequent `pin` / `update` runs stay on the same CDN until explicitly switched. Lets users escape a jspm.io incident with one CLI flag instead of hand-editing the pin file.
- **`webjs vendor audit`** runs a security audit against pinned versions via the npm registry's bulk advisories endpoint, tabulates CVEs by severity, exits non-zero on findings. Distinguishes "no vulnerabilities" from "couldn't reach registry" so a network failure doesn't falsely reassure.
- **`webjs vendor outdated`** queries the npm registry for each pinned package's latest version and lists those that trail. Parallel fetches so a 50-package project resolves in one round-trip's wall-clock.
- **`webjs vendor update [--from <provider>]`** re-pins outdated packages to their latest versions, recomputes SRI integrity, and writes the new pin file. Reports only packages whose resolver actually returned a new URL (no false-positive "updated" claims).
- **`data-webjs-track="reload"`** on any head element joins a tracked-element signature; mismatch between current and incoming triggers a hard reload during client-router nav. Complements the importmap-specific `data-webjs-build` + `X-Webjs-Build` mechanism for non-importmap concerns like CSS bundle hashes or build-id meta tags. CSP nonce is stripped before comparison so per-request nonce churn does not infinite-reload.

The CLI surface and the track-reload attribute follow the boring, battle-tested shape Rails 7's `bin/importmap` and hotwired/turbo's `data-turbo-track` already ship. Same trust model. Skipped from the wider Rails CLI: `pristine` and `download <pkg>` since `webjs vendor pin --download` already covers both (idempotent batch download).

## Test plan

- [x] 1292 unit / integration tests green (added ~40 new for this PR's surface, each verified to catch its own bug via fault injection where applicable).
- [x] 265 browser tests green; no regressions in existing framework features.
- [x] 12 scaffold tests + 6 blog real-Chromium e2e tests green; no regressions.
- [x] Provider plumbing: `pinAll` / `updatePinned` / `unpinPackage` all preserve the persisted provider field across operations.
- [x] `listPinned` extracts versions across jspm.io, jsdelivr, unpkg, skypack URL patterns; short package names like `ms` do not false-match inside another package's URL.
- [x] `data-webjs-track`: signature change triggers reload; matching signature does not; added / removed elements between deploys reload; partial responses (X-Webjs-Have short-circuit) do not reload; nonce churn does not reload.
- [x] Docs updated: scaffold `AGENTS.md`, repo-root `AGENTS.md`, `packages/server/AGENTS.md`, `docs/no-build` page, `agent-docs/advanced.md` client-router section.