### PR TITLE
chore(ts-plugin): replace stale @webjskit identifiers with @webjsdev

### DIFF
--- a/packages/ts-plugin/package.json
+++ b/packages/ts-plugin/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "keywords": [
     "webjs",
-    "webjskit",
+    "webjsdev",
     "typescript",
     "language-service",
     "tsserver-plugin",

--- a/packages/ts-plugin/src/index.js
+++ b/packages/ts-plugin/src/index.js
@@ -956,7 +956,7 @@ function init(modules) {
             `attribute '${ctx.attr}' of type '${checker.typeToString(propType)}' on <${ctx.tag}>.`,
           category: ts.DiagnosticCategory.Error,
           code: 9001,
-          source: 'webjskit-ts-plugin',
+          source: 'webjsdev-ts-plugin',
         });
       }
     }

--- a/packages/ts-plugin/test/plugin/ts-plugin.test.mjs
+++ b/packages/ts-plugin/test/plugin/ts-plugin.test.mjs
@@ -545,7 +545,7 @@ test('flags number passed where string is declared', () => {
       `}\n`,
   });
   const diags = svc.getSemanticDiagnostics('/page.ts');
-  const ours = diags.filter((d) => d.source === 'webjskit-ts-plugin');
+  const ours = diags.filter((d) => d.source === 'webjsdev-ts-plugin');
   assert.equal(ours.length, 1, `expected one webjs diagnostic, got ${ours.length}`);
   const m = ours[0].messageText;
   assert.ok(/'number'/.test(m) && /'mode'/.test(m) && /'string'/.test(m),
@@ -570,7 +570,7 @@ test('passes when interpolated value is assignable to declared string type', () 
       `}\n`,
   });
   const diags = svc.getSemanticDiagnostics('/page.ts');
-  const ours = diags.filter((d) => d.source === 'webjskit-ts-plugin');
+  const ours = diags.filter((d) => d.source === 'webjsdev-ts-plugin');
   assert.equal(ours.length, 0, `unexpected diagnostics: ${ours.map((d) => d.messageText).join('; ')}`);
 });
 
@@ -593,7 +593,7 @@ test('flags string-or-number against a string-literal-union type', () => {
       `}\n`,
   });
   const diags = svc.getSemanticDiagnostics('/page.ts');
-  const ours = diags.filter((d) => d.source === 'webjskit-ts-plugin');
+  const ours = diags.filter((d) => d.source === 'webjsdev-ts-plugin');
   assert.equal(ours.length, 1, `expected one diagnostic for string|number against Mode`);
 });
 
@@ -616,7 +616,7 @@ test('does not type-check static (non-interpolated) attribute values', () => {
       `}\n`,
   });
   const diags = svc.getSemanticDiagnostics('/page.ts');
-  const ours = diags.filter((d) => d.source === 'webjskit-ts-plugin');
+  const ours = diags.filter((d) => d.source === 'webjsdev-ts-plugin');
   assert.equal(ours.length, 0, 'static attribute value should not produce a webjs diagnostic');
 });
 
@@ -639,7 +639,7 @@ test('skips check when component is reachable but the prop has no `declare` anno
       `}\n`,
   });
   const diags = svc.getSemanticDiagnostics('/page.ts');
-  const ours = diags.filter((d) => d.source === 'webjskit-ts-plugin');
+  const ours = diags.filter((d) => d.source === 'webjsdev-ts-plugin');
   assert.equal(ours.length, 0, 'no declare → no check, no diagnostic');
 });
 
@@ -665,7 +665,7 @@ test('does not check tags that are not reachable through imports', () => {
       `}\n`,
   });
   const diags = svc.getSemanticDiagnostics('/page.ts');
-  const ours = diags.filter((d) => d.source === 'webjskit-ts-plugin');
+  const ours = diags.filter((d) => d.source === 'webjsdev-ts-plugin');
   assert.equal(ours.length, 0, 'unreachable tag → no value-check (lit-plugin keeps its own "unknown tag" warning)');
 });
 


### PR DESCRIPTION
## Summary

Sweep two live-code `@webjskit` references left over from the late-2024 npm rescope. Tracker #25.

- `packages/ts-plugin/package.json` keyword: `"webjskit"` → `"webjsdev"`.
- `packages/ts-plugin/src/index.js` diagnostic source: `'webjskit-ts-plugin'` → `'webjsdev-ts-plugin'`. Visible to users in the editor Problems panel next to webjs-specific attribute-type errors. Updated the 6 test call sites that filter by this string.

The third reference the original memo cited (`@webjskit/core` import in `packages/ui/packages/website/components/site/theme-toggle.ts`) turned out to be a gitignored on-disk leftover, not tracked. The canonical website-chrome theme-toggle at `packages/ui/packages/website/app/_components/theme-toggle.ts` already uses `@webjsdev/core`.

Backward-compat shims in `scripts/publish-release.js` and `scripts/publish-github-packages.js` that read historical changelog frontmatter (where `@webjskit/*` versions WERE published) stay as-is intentionally.

## Test plan

- [x] `grep -rn webjskit packages/` returns zero hits in tracked files.
- [x] 1292 unit + integration tests green, including the ts-plugin suite which now filters by `'webjsdev-ts-plugin'`.
- [x] No external surface change for users (keyword is npm-search metadata; diagnostic source updates editor Problems-panel text).