### PR TITLE
feat(dev): auto-load <appDir>/.env at server boot

### DIFF
--- a/packages/server/src/dev.js
+++ b/packages/server/src/dev.js
@@ -109,6 +109,43 @@ const TS_CACHE_MAX = 500;
 const TS_CACHE = new Map();
 
 /**
+ * Auto-load `<appDir>/.env` into `process.env` once at boot. Mirrors
+ * what Rails / Next / Astro do out of the box: a scaffolded app with
+ * a committed `.env.example` and a developer-copied `.env` should
+ * "just work" without the user having to add a dotenv import or set
+ * the file path on the CLI.
+ *
+ * Uses Node 24+'s built-in `process.loadEnvFile`, which is dotenv-
+ * compatible and DOES NOT override pre-existing `process.env` values.
+ * Calls that hit a missing file or parse error are silenced; the
+ * server should still come up cleanly when there's no `.env`.
+ *
+ * Idempotent: re-running is a no-op for any env var the user already
+ * exported (e.g. via the host shell or a process manager). That
+ * keeps the "shell-set wins over file" precedence Rails users
+ * expect.
+ *
+ * Must run before any server-only module is loaded by
+ * buildActionIndex, since module-init code in `lib/*.server.ts`
+ * (e.g. `createAuth({ secret: process.env.AUTH_SECRET })`) reads
+ * process.env at import time. createRequestHandler is the
+ * single entry point where this is guaranteed.
+ *
+ * @param {string} appDir
+ */
+function loadAppEnv(appDir) {
+  try {
+    if (typeof process.loadEnvFile === 'function') {
+      process.loadEnvFile(join(appDir, '.env'));
+    }
+  } catch {
+    // No .env file, malformed file, or Node version without
+    // loadEnvFile. Either way, fall through silently: the user
+    // may not need any env vars, or they may set them via shell.
+  }
+}
+
+/**
  * Create a reusable, framework-agnostic request handler for a webjs app.
  * The returned `handle(req)` takes a standard `Request` and resolves to a
  * standard `Response`: suitable for Node http, Deno, Bun, Cloudflare Workers,
@@ -123,6 +160,14 @@ const TS_CACHE = new Map();
  */
 export async function createRequestHandler(opts) {
   const appDir = resolve(opts.appDir);
+  // Load <appDir>/.env into process.env BEFORE anything else.
+  // buildActionIndex below imports server-only files (lib/*.server.ts,
+  // modules/**/*.server.ts), some of which read process.env at module
+  // init (e.g. createAuth reads AUTH_SECRET). Without this call,
+  // scaffolded apps with a committed .env.example + .env would fail
+  // to boot until the user discovered the missing env-load. See
+  // tracker #37.
+  loadAppEnv(appDir);
   const dev = !!opts.dev;
   const logger = opts.logger || defaultLogger({ dev });
   const coreDir = locateCoreDir(appDir);

--- a/packages/server/test/dev/dev-handler.test.js
+++ b/packages/server/test/dev/dev-handler.test.js
@@ -1087,3 +1087,57 @@ test('handle: /__webjs/vendor/ sets ETag for downstream cache revalidation', asy
   const resp2 = await app.handle(new Request('http://x/__webjs/vendor/fake@1.0.0.js'));
   assert.equal(resp2.headers.get('etag'), etag);
 });
+
+test('createRequestHandler: auto-loads <appDir>/.env into process.env', async () => {
+  // Scaffolded apps ship .env.example. A user who copies it to .env
+  // and runs `npm run dev` expects the framework to read it without
+  // any extra import (Rails / Next / Astro all do this). Without
+  // this, `lib/auth.server.ts` calling `createAuth({ secret:
+  // process.env.AUTH_SECRET })` at module init fails to boot the
+  // SaaS scaffold. See tracker #37.
+  const appDir = makeApp({
+    'app/page.ts': `export default () => 'ok';`,
+    '.env': 'WEBJS_TEST_ENV_FOO=loaded-from-env-file\n',
+  });
+  // Pre-condition: var must not already be in process.env.
+  delete process.env.WEBJS_TEST_ENV_FOO;
+  try {
+    await createRequestHandler({ appDir, dev: false });
+    assert.equal(
+      process.env.WEBJS_TEST_ENV_FOO, 'loaded-from-env-file',
+      '.env file in appDir should auto-load into process.env',
+    );
+  } finally {
+    delete process.env.WEBJS_TEST_ENV_FOO;
+  }
+});
+
+test('createRequestHandler: shell-set env var wins over .env (does not override)', async () => {
+  // Standard dotenv precedence: shell / process-manager / parent
+  // process beats the file. Allows production deploys to override
+  // any value without editing the .env file.
+  const appDir = makeApp({
+    'app/page.ts': `export default () => 'ok';`,
+    '.env': 'WEBJS_TEST_ENV_PRECEDENCE=from-file\n',
+  });
+  process.env.WEBJS_TEST_ENV_PRECEDENCE = 'from-shell';
+  try {
+    await createRequestHandler({ appDir, dev: false });
+    assert.equal(
+      process.env.WEBJS_TEST_ENV_PRECEDENCE, 'from-shell',
+      'pre-set process.env value must win over .env file content',
+    );
+  } finally {
+    delete process.env.WEBJS_TEST_ENV_PRECEDENCE;
+  }
+});
+
+test('createRequestHandler: missing .env file is silent (no error, server boots)', async () => {
+  // The common case: dev project with no .env, no shell-set vars.
+  // The boot path must NOT throw or log an error.
+  const appDir = makeApp({ 'app/page.ts': `export default () => 'ok';` });
+  // No .env file created. createRequestHandler should still return
+  // a working handler.
+  const app = await createRequestHandler({ appDir, dev: false });
+  assert.equal(typeof app.handle, 'function', 'handle() must exist even without a .env file');
+});


### PR DESCRIPTION
## Summary

Adds dotenv-style auto-loading to webjs's dev / start path. Closes tracker #37.

Scaffolded apps (especially SaaS, which calls `createAuth({ secret: process.env.AUTH_SECRET })` at module init) failed to boot because the framework never read the `.env` file the scaffold ships an `.env.example` for. Users had to discover that they needed to `export AUTH_SECRET=...` in their shell.

The fix calls Node 24+'s built-in `process.loadEnvFile(<appDir>/.env)` at the top of `createRequestHandler`, before `buildActionIndex` triggers any module loads. `process.loadEnvFile` is dotenv-compatible and does NOT override pre-existing `process.env` values, so the standard precedence (shell, process-manager, parent process beats file) holds.

Missing `.env` and parse errors are swallowed silently. The server still boots cleanly for apps that don't need env vars.

## Test plan

- [x] 1295 unit / integration tests green (added 3 for auto-load, shell-precedence, missing-file).
- [x] `.env` in appDir auto-loads into `process.env.WEBJS_TEST_ENV_FOO` after `createRequestHandler` returns.
- [x] Pre-set `process.env.X` wins over `.env` file content.
- [x] Missing `.env` is a silent no-op; server still boots.
- [x] Embedded users who already loaded their own `.env` via dotenv or `node --env-file` see no regression (loadEnvFile does not clobber).