### PR TITLE
fix(check): suppress 9 false positives via per-file webjs-disable-file directive

### DIFF
--- a/docs/app/docs/components/page.ts
+++ b/docs/app/docs/components/page.ts
@@ -1,3 +1,9 @@
+// webjs-disable-file tag-name-has-hyphen
+// This is the components-feature docs page. It renders example
+// custom-element tag strings like `<tag>` and `<my-card>` inside
+// prose code blocks; those are NOT real `Class.register(...)` calls
+// the scanner should flag. Real components in this app live in
+// `components/` and are checked normally.
 import { html } from '@webjsdev/core';
 
 export const metadata = { title: 'Components | webjs' };

--- a/docs/app/docs/typescript/page.ts
+++ b/docs/app/docs/typescript/page.ts
@@ -1,3 +1,9 @@
+// webjs-disable-file no-non-erasable-typescript
+// This is the TypeScript-feature-support docs page. It renders
+// `enum`, `namespace`, and parameter-property syntax inside prose
+// code blocks specifically to teach users which constructs the
+// runtime stripper rejects. The scanner reads those examples as
+// real TS source; disable the rule for this file only.
 import { html } from '@webjsdev/core';
 
 export const metadata = { title: 'TypeScript | webjs' };

--- a/packages/server/src/check.js
+++ b/packages/server/src/check.js
@@ -193,6 +193,57 @@ async function loadOverrides(appDir) {
  * @param {Record<string, boolean>} overrides
  * @returns {boolean}
  */
+/**
+ * Parse `// webjs-disable-file [rules]` directives out of a source file.
+ * Returns the set of rule names disabled for the entire file, or the
+ * literal string `'*'` if the directive is unqualified (all rules
+ * disabled). An empty Set means no directives in the file.
+ *
+ * Two valid shapes (line comment only, no block-comment form yet):
+ *   // webjs-disable-file
+ *   // webjs-disable-file tag-name-has-hyphen, no-non-erasable-typescript
+ *
+ * Use case: a docs page that renders code-block examples (tag-name
+ * strings, `enum` syntax) gets falsely flagged by the source scanners.
+ * Adding a single comment at the top suppresses the rule for that
+ * page without disabling it project-wide.
+ *
+ * Per-line `webjs-disable-next-line` is intentionally deferred:
+ * file-level granularity is enough for the documented use cases (a
+ * docs page or test fixture is "all examples"); finer control can
+ * land later if requests come in.
+ *
+ * @param {string} content
+ * @returns {Set<string> | '*'}
+ */
+function parseFileDisables(content) {
+  /** @type {Set<string>} */
+  const disabled = new Set();
+  // Anchor to start-of-line OR start-of-file so a string that
+  // happens to contain `// webjs-disable-file` inside a code-example
+  // template literal doesn't accidentally disable the rule for the
+  // very file the example is illustrating. Multi-line mode.
+  const fileDisableRe = /^\s*\/\/\s*webjs-disable-file(?:\s+([\w,\s-]+))?\s*$/gm;
+  let m;
+  while ((m = fileDisableRe.exec(content)) !== null) {
+    if (!m[1]) return '*';
+    for (const r of m[1].split(/[\s,]+/).filter(Boolean)) disabled.add(r);
+  }
+  return disabled;
+}
+
+/**
+ * Returns true when the given rule should NOT be reported for the
+ * file based on the file's `webjs-disable-file` directives.
+ *
+ * @param {Set<string> | '*'} disabled  result of parseFileDisables
+ * @param {string} rule
+ */
+function isDisabledForFile(disabled, rule) {
+  if (disabled === '*') return true;
+  return disabled.has(rule);
+}
+
 function isRuleEnabled(ruleName, overrides) {
   if (ruleName in overrides) return overrides[ruleName] !== false;
   return true;
@@ -514,6 +565,18 @@ export async function checkConventions(appDir, opts) {
       continue;
     }
     files.push({ abs, rel, content });
+  }
+
+  // Per-file `webjs-disable-file <rule>` directives. Built once
+  // upfront so rule loops can stay simple (they all push violations
+  // unconditionally; we filter at the end). Empty Set is fine; we
+  // store an entry only when at least one rule is disabled to keep
+  // the map small.
+  /** @type {Map<string, Set<string> | '*'>} */
+  const fileDisables = new Map();
+  for (const { rel, content } of files) {
+    const d = parseFileDisables(content);
+    if (d === '*' || d.size > 0) fileDisables.set(rel, d);
   }
 
   // --- Rule: actions-in-modules ---
@@ -1021,6 +1084,19 @@ export async function checkConventions(appDir, opts) {
       }
     }
     }
+  }
+
+  // Filter out violations suppressed by per-file
+  // `webjs-disable-file <rule>` directives. Done at the end so the
+  // rule implementations stay unchanged and so we cleanly handle
+  // rules that push multiple violations per file (e.g. four
+  // different unhyphenated tags in one docs page).
+  if (fileDisables.size > 0) {
+    return violations.filter((v) => {
+      const d = fileDisables.get(v.file);
+      if (!d) return true;
+      return !isDisabledForFile(d, v.rule);
+    });
   }
 
   return violations;

--- a/packages/server/test/check/check.test.js
+++ b/packages/server/test/check/check.test.js
@@ -1,3 +1,10 @@
+// webjs-disable-file reactive-props-use-declare
+// This test file contains class-field initializer fixtures used to
+// assert that the `reactive-props-use-declare` rule catches them.
+// The fixture strings are inside template literals or contained
+// classes that the file-walking source scanner reads as real source.
+// Disable the rule for this file so `webjs check` on the framework
+// repo itself stays clean.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
@@ -1235,6 +1242,156 @@ test('gitignore-vendor-not-ignored: skipped when no .gitignore exists', async ()
     const violations = await checkConventions(appDir);
     const v = violations.find((v) => v.rule === 'gitignore-vendor-not-ignored');
     assert.equal(v, undefined, 'rule must skip when .gitignore is absent');
+  } finally {
+    await rm(appDir, { recursive: true, force: true });
+  }
+});
+
+test('webjs-disable-file: suppresses a single rule for the whole file', async () => {
+  // The directive: `// webjs-disable-file <rule>` at the top of a
+  // file tells `webjs check` to ignore the named rule's violations
+  // in that file. Use case: a docs page rendering example code
+  // strings that the scanner reads as real source. Verify with the
+  // `reactive-props-use-declare` rule + a real violation that
+  // would normally fire.
+  const appDir = await makeTempApp();
+  try {
+    await mkdir(join(appDir, 'components'), { recursive: true });
+    await writeFile(
+      join(appDir, 'components', 'fixture.ts'),
+      '// webjs-disable-file reactive-props-use-declare\n' +
+      "import { WebComponent } from '@webjsdev/core';\n" +
+      'class Bad extends WebComponent {\n' +
+      '  static properties = { x: { type: Number } };\n' +
+      '  x = 0;\n' +  // class-field initializer: would normally violate
+      '}\n',
+    );
+    const violations = await checkConventions(appDir);
+    const v = violations.find((v) => v.rule === 'reactive-props-use-declare');
+    assert.equal(v, undefined,
+      'directive must suppress the named rule for this file');
+  } finally {
+    await rm(appDir, { recursive: true, force: true });
+  }
+});
+
+test('webjs-disable-file: bare directive (no rule) suppresses all rules', async () => {
+  // `// webjs-disable-file` with no rule list disables every rule
+  // for the file. Useful for test fixtures or docs pages that
+  // violate many rules at once.
+  const appDir = await makeTempApp();
+  try {
+    await mkdir(join(appDir, 'components'), { recursive: true });
+    await writeFile(
+      join(appDir, 'components', 'fixture.ts'),
+      '// webjs-disable-file\n' +
+      "import { WebComponent } from '@webjsdev/core';\n" +
+      'class Bad extends WebComponent {\n' +
+      '  static properties = { x: { type: Number } };\n' +
+      '  x = 0;\n' +
+      '}\n' +
+      // also triggers no-non-erasable-typescript:
+      'enum E { A, B }\n',
+    );
+    const violations = await checkConventions(appDir);
+    // Filter to violations in our fixture file; other rules on
+    // other files are out of scope for this assertion.
+    const ours = violations.filter((v) => v.file.endsWith('fixture.ts'));
+    assert.deepEqual(ours, [],
+      'bare webjs-disable-file must suppress every rule for the file');
+  } finally {
+    await rm(appDir, { recursive: true, force: true });
+  }
+});
+
+test('webjs-disable-file: comma-separated rule list suppresses each named rule', async () => {
+  const appDir = await makeTempApp();
+  try {
+    await mkdir(join(appDir, 'components'), { recursive: true });
+    await writeFile(
+      join(appDir, 'components', 'fixture.ts'),
+      '// webjs-disable-file reactive-props-use-declare, no-non-erasable-typescript\n' +
+      "import { WebComponent } from '@webjsdev/core';\n" +
+      'class Bad extends WebComponent {\n' +
+      '  static properties = { x: { type: Number } };\n' +
+      '  x = 0;\n' +
+      '}\n' +
+      "Bad.register('bad-tag');\n" + // keep components-have-register happy
+      'enum E { A, B }\n',
+    );
+    const violations = await checkConventions(appDir);
+    const ours = violations.filter((v) => v.file.endsWith('fixture.ts'));
+    // Both named rules suppressed. Any OTHER rules that fire on this
+    // fixture are fine to assert against here (none expected with
+    // the register() call in place).
+    const named = ours.filter((v) => v.rule === 'reactive-props-use-declare' || v.rule === 'no-non-erasable-typescript');
+    assert.deepEqual(named, [], 'both named rules must be suppressed');
+  } finally {
+    await rm(appDir, { recursive: true, force: true });
+  }
+});
+
+test('webjs-disable-file: only the named rule is suppressed (other rules still fire)', async () => {
+  // Defensive: a single-rule directive must NOT silence unrelated
+  // rules. If it did, users would lose lint coverage by mistake.
+  const appDir = await makeTempApp();
+  try {
+    await mkdir(join(appDir, 'components'), { recursive: true });
+    await writeFile(
+      join(appDir, 'components', 'fixture.ts'),
+      '// webjs-disable-file reactive-props-use-declare\n' +
+      "import { WebComponent } from '@webjsdev/core';\n" +
+      'class Bad extends WebComponent {\n' +
+      '  static properties = { x: { type: Number } };\n' +
+      '  x = 0;\n' +
+      '}\n' +
+      // Also triggers no-non-erasable-typescript, but that rule is
+      // NOT in the disable list, so it must still fire.
+      'enum E { A, B }\n',
+    );
+    const violations = await checkConventions(appDir);
+    const reactive = violations.find((v) => v.rule === 'reactive-props-use-declare' && v.file.endsWith('fixture.ts'));
+    const tsRule = violations.find((v) => v.rule === 'no-non-erasable-typescript' && v.file.endsWith('fixture.ts'));
+    assert.equal(reactive, undefined, 'named rule must be suppressed');
+    assert.ok(tsRule, 'unrelated rule must still fire');
+  } finally {
+    await rm(appDir, { recursive: true, force: true });
+  }
+});
+
+test('webjs-disable-file: directive inside a template-literal string does NOT disable the rule', async () => {
+  // Anti-bypass: the directive must be a real top-of-file comment.
+  // If a string value inside source code happens to contain
+  // "// webjs-disable-file ...", that should not silently disable
+  // lint coverage. Implementation anchors the regex with `^\s*//`
+  // (multi-line mode), which still matches if the directive begins
+  // a line, but does not match characters strictly embedded inside
+  // an expression. The realistic threat is documentation prose
+  // containing the literal directive; we accept that as a "looks
+  // like a real comment" indistinguishable case and rely on
+  // authoring discipline (the directive is opt-in, anyone reading
+  // the file sees it).
+  //
+  // What we DO guard against: a directive that's clearly inside a
+  // string concatenation expression (no `//` line-start). Verified
+  // by ensuring the rule still fires when the directive is part of
+  // a string literal returned by a function rather than a real
+  // line comment.
+  const appDir = await makeTempApp();
+  try {
+    await mkdir(join(appDir, 'components'), { recursive: true });
+    await writeFile(
+      join(appDir, 'components', 'fixture.ts'),
+      "import { WebComponent } from '@webjsdev/core';\n" +
+      'const fake = `// webjs-disable-file reactive-props-use-declare`;\n' +
+      'class Bad extends WebComponent {\n' +
+      '  static properties = { x: { type: Number } };\n' +
+      '  x = 0;\n' +
+      '}\n',
+    );
+    const violations = await checkConventions(appDir);
+    const v = violations.find((v) => v.rule === 'reactive-props-use-declare' && v.file.endsWith('fixture.ts'));
+    assert.ok(v, 'directive in a string literal must NOT disable the rule');
   } finally {
     await rm(appDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Closes tracker #63. `webjs check` reported 9 false positives on the framework repo itself, all from the source scanner reading docs-page code-block examples and intentional test-fixture violations as real source.

**New mechanism:** `webjs check` now honors a per-file disable directive at the top of any source file:

```js
// webjs-disable-file tag-name-has-hyphen
// webjs-disable-file reactive-props-use-declare, no-non-erasable-typescript
// webjs-disable-file                                  (all rules)
```

Anchored to a line-start `//` comment (multi-line regex), so a string literal containing the directive text does NOT silently bypass lint coverage. Comma-separated rule lists; bare directive disables everything.

**Applied to the 3 offending files:**

- `docs/app/docs/components/page.ts` disables `tag-name-has-hyphen` (4 example `<tag>` strings in prose code blocks).
- `docs/app/docs/typescript/page.ts` disables `no-non-erasable-typescript` (3 `enum` / `namespace` / parameter-property examples teaching users what NOT to write).
- `packages/server/test/check/check.test.js` disables `reactive-props-use-declare` (intentional class-field-initializer fixtures used to assert the rule catches them).

The proper template-literal-aware scanner fix (#42) remains a separate AST-rewrite project. This PR is the minimal change to get `webjs check` clean on the framework repo today, while giving every other webjs user the same opt-in escape hatch for their own docs / fixture files.

## Test plan

- [x] `node packages/cli/bin/webjs.js check` reports 0 violations on the framework repo (was 9).
- [x] 1300 unit / integration tests green (+5 new directive regression tests).
- [x] Directive tests cover: single rule, comma list, bare (all rules), unrelated rules still fire, in-string-literal does NOT bypass.
- [x] No external behavior change for projects that don't use the directive.