### PR TITLE
refactor(server): drop chokidar + align session/Buffer with web standards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -731,7 +731,7 @@ Not in v1. Do not implement as part of other tasks:
 
 - **Bundling.** webjs is a **no-build framework**. Same model as Rails 7+ (Hotwire + importmap-rails). Production perf comes from HTTP/2 multiplex + `<link rel="modulepreload">` hints at SSR time, not concatenation. **Do not propose a bundler or `webjs build` command.**
 - **Per-route code splitting.** Downstream of no-build. Browser fetches each module lazily; modulepreload hints emit per-route at SSR.
-- **Vite-grade HMR with state preservation.** Custom elements only `define` once, so full reload is necessary. Data reloads are near-instant via chokidar → SSE.
+- **Vite-grade HMR with state preservation.** Custom elements only `define` once, so full reload is necessary. Data reloads are near-instant via `fs.watch` → SSE.
 - **React Server Components Flight.** Server actions cover "call a server function from the client". Use `Suspense` + streaming.
 - **Edge-runtime bundling / full portability.** See `agent-docs/deployment.md`.
 - **i18n, image optimization.** Layer libraries on top.

--- a/docs/app/docs/configuration/page.ts
+++ b/docs/app/docs/configuration/page.ts
@@ -12,7 +12,7 @@ export default function Configuration() {
     <pre>webjs dev [--port 8080]</pre>
     <ul>
       <li><code>--port</code>: dev server port (default: <code>8080</code>, or <code>PORT</code> env var)</li>
-      <li>File watching via chokidar (automatic)</li>
+      <li>File watching via Node's built-in <code>fs.watch</code> (automatic)</li>
       <li>Live reload via SSE (<code>/__webjs/events</code>)</li>
       <li>TypeScript files transformed on the fly</li>
       <li>No cache-busting needed, since module loads are busted per request</li>

--- a/docs/app/docs/deployment/page.ts
+++ b/docs/app/docs/deployment/page.ts
@@ -16,7 +16,7 @@ npm run dev -- --port 8080
 npm run start -- --port 8080</pre>
     <p>Key differences:</p>
     <ul>
-      <li><strong>Dev:</strong> chokidar watches your source tree and triggers live reload via SSE. TypeScript files are served with <code>Cache-Control: no-cache</code>. Errors include full stack traces. No compression.</li>
+      <li><strong>Dev:</strong> Node's built-in <code>fs.watch</code> watches your source tree and triggers live reload via SSE. TypeScript files are served with <code>Cache-Control: no-cache</code>. Errors include full stack traces. No compression.</li>
       <li><strong>Prod:</strong> no file watcher, no SSE endpoint. Static files get ETags and <code>Cache-Control: public, max-age=3600</code>. Auto-vendored npm packages get <code>max-age=31536000, immutable</code>. Gzip and Brotli compression are enabled. Error responses omit stack traces.</li>
     </ul>
 

--- a/docs/app/docs/no-build/page.ts
+++ b/docs/app/docs/no-build/page.ts
@@ -161,7 +161,7 @@ $ webjs vendor update</pre>
       </thead>
       <tbody>
         <tr><td>TS stripping</td><td>Same: <code>module.stripTypeScriptTypes</code></td><td>Same</td></tr>
-        <tr><td>Mtime cache</td><td>Cleared on file change via chokidar</td><td>Persists for process lifetime</td></tr>
+        <tr><td>Mtime cache</td><td>Cleared on file change via <code>fs.watch</code></td><td>Persists for process lifetime</td></tr>
         <tr><td>Vendor resolution</td><td>Reads <code>.webjs/vendor/importmap.json</code> if present; else calls <code>api.jspm.io/generate</code> on boot and on rebuild</td><td>Reads <code>.webjs/vendor/importmap.json</code> if present; else calls <code>api.jspm.io/generate</code> at boot once</td></tr>
         <tr><td>Cache-Control</td><td><code>no-cache</code></td><td><code>max-age=3600</code> (source), <code>immutable</code> (<code>--download</code> bundles); jspm.io controls headers for direct CDN fetches</td></tr>
         <tr><td>103 Early Hints</td><td>Disabled (stale URL risk)</td><td>Enabled</td></tr>

--- a/packages/core/test/registry/lazy-loading.test.js
+++ b/packages/core/test/registry/lazy-loading.test.js
@@ -27,28 +27,28 @@ test('registry: unknown tag returns false for isLazy', () => {
 
 // --- Dynamic import map entries ---
 
-test('setVendorEntries: adds entries to import map', () => {
-  setVendorEntries({ 'dayjs': '/__webjs/vendor/dayjs.js' });
+test('setVendorEntries: adds entries to import map', async () => {
+  await setVendorEntries({ 'dayjs': '/__webjs/vendor/dayjs.js' });
   const map = buildImportMap();
   assert.equal(map.imports['dayjs'], '/__webjs/vendor/dayjs.js');
   // Built-ins should still be there
   assert.equal(map.imports['@webjsdev/core'], '/__webjs/core/index.js');
   // Clean up
-  setVendorEntries({});
+  await setVendorEntries({});
 });
 
-test('setVendorEntries: overwrite replaces previous entries', () => {
-  setVendorEntries({ 'pkg-a': '/a.js', 'pkg-b': '/b.js' });
+test('setVendorEntries: overwrite replaces previous entries', async () => {
+  await setVendorEntries({ 'pkg-a': '/a.js', 'pkg-b': '/b.js' });
   let map = buildImportMap();
   assert.ok('pkg-a' in map.imports);
   assert.ok('pkg-b' in map.imports);
 
-  setVendorEntries({ 'pkg-c': '/c.js' });
+  await setVendorEntries({ 'pkg-c': '/c.js' });
   map = buildImportMap();
   assert.ok(!('pkg-a' in map.imports), 'old entries should be gone');
   assert.ok('pkg-c' in map.imports);
   // Clean up
-  setVendorEntries({});
+  await setVendorEntries({});
 });
 
 test('import map always includes lazy-loader entry', () => {

--- a/packages/server/AGENTS.md
+++ b/packages/server/AGENTS.md
@@ -76,7 +76,7 @@ can load it without booting the full server.
    serves as plain source. Regression tests live at
    `test/server-file-guardrail.test.js`.
 2. **File router has no manifest.** `buildRouteTable()` walks `app/`
-   at boot; route invalidation in dev is via chokidar → SSE.
+   at boot; route invalidation in dev is via `fs.watch` (Node 24+ built-in, recursive) → SSE.
 3. **One pluggable cache store, four built-in consumers.** `cache.js`
    is shared by `cache-fn.js`, `session.js` (store-backed), and
    `rate-limit.js`. A single `setStore(redisStore({…}))` call at

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -15,7 +15,6 @@
   ],
   "dependencies": {
     "@webjsdev/core": "^0.7.1",
-    "chokidar": "^3.6.0",
     "ws": "^8.20.0"
   },
   "publishConfig": {

--- a/packages/server/src/actions.js
+++ b/packages/server/src/actions.js
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { digestHex } from './crypto-utils.js';
 import { pathToFileURL } from 'node:url';
 import { readFile } from 'node:fs/promises';
 import { join, relative, sep } from 'node:path';
@@ -103,7 +103,7 @@ export async function buildActionIndex(appDir, dev) {
     // throw-at-load stub via `serveServerOnlyStub` instead.
     if (!(await hasUseServerDirective(file))) continue;
 
-    const h = hashFile(file);
+    const h = await hashFile(file);
     hashToFile.set(h, file);
     fileToHash.set(file, h);
     // Load module once at scan time to pick up any expose() tags.
@@ -132,9 +132,9 @@ export async function buildActionIndex(appDir, dev) {
   return { hashToFile, fileToHash, httpRoutes, appDir, dev };
 }
 
-/** @param {string} file */
-export function hashFile(file) {
-  return createHash('sha256').update(file).digest('hex').slice(0, 10);
+/** @param {string} file @returns {Promise<string>} */
+export async function hashFile(file) {
+  return (await digestHex('SHA-256', file)).slice(0, 10);
 }
 
 /**
@@ -222,7 +222,7 @@ throw new Error(${JSON.stringify(msg)});
  */
 export async function serveActionStub(idx, absFile) {
   const mod = await loadModule(absFile, idx.dev);
-  const hash = idx.fileToHash.get(absFile) || hashFile(absFile);
+  const hash = idx.fileToHash.get(absFile) || await hashFile(absFile);
   const fnNames = Object.keys(mod).filter((k) => typeof mod[k] === 'function');
   if (typeof mod.default === 'function' && !fnNames.includes('default')) {
     fnNames.push('default');

--- a/packages/server/src/crypto-utils.js
+++ b/packages/server/src/crypto-utils.js
@@ -1,0 +1,65 @@
+/**
+ * Web-Crypto-based hash helpers. Shared by the SSR / vendor / actions
+ * paths that previously used `node:crypto.createHash`. The Web Crypto
+ * API replaces the synchronous Node-only API with a Promise-returning
+ * one; the trade-off is portability across Node, Deno, Bun, and edge
+ * runtimes.
+ *
+ * @module crypto-utils
+ */
+
+const enc = new TextEncoder();
+
+/**
+ * @param {ArrayBuffer | Uint8Array} buf
+ * @returns {string}
+ */
+function bufToHex(buf) {
+  const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+  let hex = '';
+  for (const b of bytes) hex += b.toString(16).padStart(2, '0');
+  return hex;
+}
+
+/**
+ * @param {ArrayBuffer | Uint8Array} buf
+ * @returns {string}
+ */
+function bufToBase64(buf) {
+  const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+  let s = '';
+  for (const b of bytes) s += String.fromCharCode(b);
+  return btoa(s);
+}
+
+/**
+ * @param {string | ArrayBufferView | ArrayBuffer} data
+ * @returns {Uint8Array}
+ */
+function toBytes(data) {
+  if (typeof data === 'string') return enc.encode(data);
+  if (data instanceof ArrayBuffer) return new Uint8Array(data);
+  return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+}
+
+/**
+ * Compute a hex-encoded digest of `data` under `algo`.
+ *
+ * @param {'SHA-1' | 'SHA-256' | 'SHA-384' | 'SHA-512'} algo
+ * @param {string | ArrayBufferView | ArrayBuffer} data
+ * @returns {Promise<string>}  full hex string (no truncation)
+ */
+export async function digestHex(algo, data) {
+  return bufToHex(await crypto.subtle.digest(algo, toBytes(data)));
+}
+
+/**
+ * Compute a base64-encoded digest of `data` under `algo`.
+ *
+ * @param {'SHA-1' | 'SHA-256' | 'SHA-384' | 'SHA-512'} algo
+ * @param {string | ArrayBufferView | ArrayBuffer} data
+ * @returns {Promise<string>}
+ */
+export async function digestBase64(algo, data) {
+  return bufToBase64(await crypto.subtle.digest(algo, toBytes(data)));
+}

--- a/packages/server/src/dev.js
+++ b/packages/server/src/dev.js
@@ -337,22 +337,24 @@ export async function startServer(opts) {
     },
   });
 
+  /** @type {AbortController | null} */
+  let watcherAbort = null;
   if (dev) {
     // Watch the app root recursively via Node's built-in
     // `fs.promises.watch`. Stable on macOS, Windows, and Linux as of
     // Node 24. No external dep needed.
     //
-    // fs.watch returns relative paths (POSIX separators in the
-    // event payload on all platforms). We apply the same ignore
-    // filter chokidar used before: skip node_modules, .git, and
-    // prisma's dev artefacts (dev.db, migrations/) which the dev
-    // server writes during db:migrate and would otherwise loop.
+    // fs.watch returns relative paths in event.filename. We apply
+    // the same ignore filter chokidar used before: skip
+    // node_modules, .git, and prisma's dev artefacts (dev.db,
+    // migrations/) which the dev server writes during db:migrate
+    // and would otherwise loop.
     const IGNORE = /(^|[\\/])(?:node_modules|\.git)(?:[\\/]|$)|(?:^|[\\/])prisma[\\/](?:dev|migrations)(?:[\\/]|$)/;
     const rebuild = debounce(() => app.rebuild(), 80);
-    const ac = new AbortController();
+    watcherAbort = new AbortController();
     (async () => {
       try {
-        const events = fsWatch(app.appDir, { recursive: true, signal: ac.signal });
+        const events = fsWatch(app.appDir, { recursive: true, signal: watcherAbort.signal });
         for await (const event of events) {
           const filename = event.filename || '';
           if (IGNORE.test(filename)) continue;
@@ -364,9 +366,6 @@ export async function startServer(opts) {
         }
       }
     })();
-    // Stop watching on graceful shutdown.
-    process.once('SIGTERM', () => ac.abort());
-    process.once('SIGINT', () => ac.abort());
   }
 
   // SSE keepalive: send a comment frame every 25s to defeat proxy idle timeouts.
@@ -444,7 +443,13 @@ export async function startServer(opts) {
   // corrupted, so log + start an orderly shutdown rather than continuing.
   installProcessHandlers(logger, () => shutdown('uncaughtException'));
 
-  return { server, close: () => new Promise((r) => server.close(() => r())) };
+  return {
+    server,
+    close: () => new Promise((r) => {
+      if (watcherAbort) watcherAbort.abort();
+      server.close(() => r());
+    }),
+  };
 }
 
 /**

--- a/packages/server/src/dev.js
+++ b/packages/server/src/dev.js
@@ -1,6 +1,6 @@
 import { createServer as createHttp1Server } from 'node:http';
 import { stat, readFile, watch as fsWatch } from 'node:fs/promises';
-import { createHash } from 'node:crypto';
+import { digestHex } from './crypto-utils.js';
 import { createGzip, createBrotliCompress, constants as zlibConstants } from 'node:zlib';
 import { join, extname, resolve, dirname, relative, sep } from 'node:path';
 import { createRequire, stripTypeScriptTypes } from 'node:module';
@@ -175,7 +175,7 @@ export async function createRequestHandler(opts) {
   // Scan for bare npm imports and register vendor import map entries.
   const bareImports = await scanBareImports(appDir);
   const initialVendor = await resolveVendorImports(bareImports, appDir);
-  setVendorEntries(initialVendor.imports, initialVendor.integrity);
+  await setVendorEntries(initialVendor.imports, initialVendor.integrity);
 
   // Build module dependency graph for transitive preload hints.
   const moduleGraph = await buildModuleGraph(appDir);
@@ -240,7 +240,7 @@ export async function createRequestHandler(opts) {
     // will overwrite anyway, but checking the token here avoids a
     // brief window of stale entries.
     if (token === latestRebuildToken) {
-      setVendorEntries(v.imports, v.integrity);
+      await setVendorEntries(v.imports, v.integrity);
     }
     state.moduleGraph = await buildModuleGraph(appDir);
     // Re-scan components in case a new file was added or a tag renamed.
@@ -611,7 +611,7 @@ async function handleCore(req, ctx) {
           // Lazily ensure the index knows about this file so serveActionStub
           // can mint a stable hash and function list.
           if (!state.actionIndex.fileToHash.has(abs)) {
-            const h = hashFile(abs);
+            const h = await hashFile(abs);
             state.actionIndex.fileToHash.set(abs, h);
             state.actionIndex.hashToFile.set(h, abs);
           }
@@ -927,7 +927,7 @@ async function fileResponse(abs, opts) {
     if (opts.dev) {
       headers['cache-control'] = 'no-cache';
     } else {
-      const etag = `"${createHash('sha1').update(data).digest('hex').slice(0, 16)}"`;
+      const etag = `"${(await digestHex('SHA-1', data)).slice(0, 16)}"`;
       headers['etag'] = etag;
       headers['cache-control'] = opts.immutable
         ? 'public, max-age=31536000, immutable'

--- a/packages/server/src/dev.js
+++ b/packages/server/src/dev.js
@@ -1,5 +1,5 @@
 import { createServer as createHttp1Server } from 'node:http';
-import { stat, readFile } from 'node:fs/promises';
+import { stat, readFile, watch as fsWatch } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import { createGzip, createBrotliCompress, constants as zlibConstants } from 'node:zlib';
 import { join, extname, resolve, dirname, relative, sep } from 'node:path';
@@ -212,7 +212,7 @@ export async function createRequestHandler(opts) {
   // Rebuilds are serialized so a slow rebuild #1 (e.g. waiting on a
   // jspm.io fetch) cannot overwrite a fresher rebuild #2's
   // setVendorEntries / route table when it finally finishes. Without
-  // this, two file edits inside one chokidar debounce window could
+  // this, two file edits inside one fs.watch debounce window could
   // produce a permanently-stale importmap until the next rebuild.
   // Each rebuild also gets a monotonic token; setVendorEntries is only
   // applied if its token still matches the latest scheduled rebuild.
@@ -338,15 +338,35 @@ export async function startServer(opts) {
   });
 
   if (dev) {
-    const { watch } = await import('chokidar').catch(() => ({ watch: null }));
-    if (watch) {
-      const watcher = watch(app.appDir, {
-        ignored: [/node_modules/, /\.git/, /prisma\/(dev|migrations)/],
-        ignoreInitial: true,
-      });
-      const rebuild = debounce(() => app.rebuild(), 80);
-      watcher.on('all', rebuild);
-    }
+    // Watch the app root recursively via Node's built-in
+    // `fs.promises.watch`. Stable on macOS, Windows, and Linux as of
+    // Node 24. No external dep needed.
+    //
+    // fs.watch returns relative paths (POSIX separators in the
+    // event payload on all platforms). We apply the same ignore
+    // filter chokidar used before: skip node_modules, .git, and
+    // prisma's dev artefacts (dev.db, migrations/) which the dev
+    // server writes during db:migrate and would otherwise loop.
+    const IGNORE = /(^|[\\/])(?:node_modules|\.git)(?:[\\/]|$)|(?:^|[\\/])prisma[\\/](?:dev|migrations)(?:[\\/]|$)/;
+    const rebuild = debounce(() => app.rebuild(), 80);
+    const ac = new AbortController();
+    (async () => {
+      try {
+        const events = fsWatch(app.appDir, { recursive: true, signal: ac.signal });
+        for await (const event of events) {
+          const filename = event.filename || '';
+          if (IGNORE.test(filename)) continue;
+          rebuild();
+        }
+      } catch (err) {
+        if (err && /** @type any */(err).name !== 'AbortError') {
+          logger.warn({ err }, 'file watcher exited');
+        }
+      }
+    })();
+    // Stop watching on graceful shutdown.
+    process.once('SIGTERM', () => ac.abort());
+    process.once('SIGINT', () => ac.abort());
   }
 
   // SSE keepalive: send a comment frame every 25s to defeat proxy idle timeouts.

--- a/packages/server/src/dev.js
+++ b/packages/server/src/dev.js
@@ -347,9 +347,15 @@ export async function startServer(opts) {
     // fs.watch returns relative paths in event.filename. We apply
     // the same ignore filter chokidar used before: skip
     // node_modules, .git, and prisma's dev artefacts (dev.db,
-    // migrations/) which the dev server writes during db:migrate
-    // and would otherwise loop.
-    const IGNORE = /(^|[\\/])(?:node_modules|\.git)(?:[\\/]|$)|(?:^|[\\/])prisma[\\/](?:dev|migrations)(?:[\\/]|$)/;
+    // dev.db-journal, migrations/) which the dev server writes
+    // during db:migrate and would otherwise loop.
+    //
+    // The prisma branch uses prefix-only matching (no required
+    // trailing separator) so the SQLite sidecar files like
+    // `prisma/dev.db` and `prisma/dev.db-journal` are ignored too.
+    // node_modules / .git stay separator-anchored so unrelated
+    // names like `node_modules.bak/foo` don't get caught.
+    const IGNORE = /(?:^|[\\/])(?:node_modules|\.git)(?:[\\/]|$)|(?:^|[\\/])prisma[\\/](?:dev|migrations)/;
     const rebuild = debounce(() => app.rebuild(), 80);
     watcherAbort = new AbortController();
     (async () => {

--- a/packages/server/src/importmap.js
+++ b/packages/server/src/importmap.js
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { digestHex } from './crypto-utils.js';
 import { jsonForScriptTag } from './script-tag-json.js';
 
 // Local attribute escaper. Matches ssr.js's escapeAttr (the source
@@ -32,17 +32,19 @@ let _extraEntries = {};
 let _vendorIntegrity = {};
 
 /**
- * Merge additional vendor entries into the import map.
- * Called by the server after scanning for bare imports.
+ * Merge additional vendor entries into the import map and precompute
+ * the importmap-hash so `importMapHash()` can stay synchronous on the
+ * per-request SSR hot path. Called by the dev server at boot and on
+ * every vendor rebuild.
+ *
  * @param {Record<string, string>} entries
  * @param {Record<string, string>} [integrity]  SRI hashes keyed by URL
+ * @returns {Promise<void>}
  */
-export function setVendorEntries(entries, integrity) {
+export async function setVendorEntries(entries, integrity) {
   _extraEntries = entries;
   _vendorIntegrity = integrity || {};
-  // Bust the importmap-hash cache. Next call to importMapHash()
-  // recomputes against the new entries.
-  _importMapHash = '';
+  _importMapHash = await digestHex('SHA-256', JSON.stringify(buildImportMap()));
 }
 
 /**
@@ -59,18 +61,20 @@ export function setVendorEntries(entries, integrity) {
  * vendor URLs would never load. The header lets applySwap detect
  * the change and hard-reload before applying the swap.
  *
- * Cached because buildImportMap + JSON.stringify per request would
- * be wasteful; setVendorEntries invalidates the cache.
+ * Synchronous accessor. The hash is precomputed eagerly inside
+ * `setVendorEntries` (which the dev server `await`s during boot and
+ * on every rebuild) so the per-request SSR hot path can return the
+ * cached string without crossing a Promise boundary.
+ *
+ * Returns an empty string if `setVendorEntries` has never run; the
+ * client router treats an empty `X-Webjs-Build` as "version unknown"
+ * and skips the importmap drift check, which is the right behaviour
+ * for tests / embedding contexts that never set vendor entries.
  *
  * @returns {string}  e.g. `abc123…` (hex, 64 chars)
  */
 let _importMapHash = '';
 export function importMapHash() {
-  if (!_importMapHash) {
-    _importMapHash = createHash('sha256')
-      .update(JSON.stringify(buildImportMap()))
-      .digest('hex');
-  }
   return _importMapHash;
 }
 

--- a/packages/server/src/session.js
+++ b/packages/server/src/session.js
@@ -21,7 +21,41 @@
  */
 
 import { getStore } from './cache.js';
-import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+
+// -- Web Crypto helpers ------------------------------------------------------
+// Same shape as auth.js. We duplicate here rather than share a module
+// because the helpers are small and the two consumers want different
+// import surfaces.
+
+const enc = new TextEncoder();
+
+/** @param {string} secret @returns {Promise<CryptoKey>} */
+async function hmacKey(secret) {
+  return crypto.subtle.importKey('raw', enc.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign', 'verify']);
+}
+
+/** @param {ArrayBuffer | ArrayBufferView} buf @returns {string} */
+function b64url(buf) {
+  const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf instanceof ArrayBuffer ? buf : buf.buffer);
+  let s = '';
+  for (const b of bytes) s += String.fromCharCode(b);
+  return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/** @param {string} str @returns {Uint8Array} */
+function unb64url(str) {
+  const bin = atob(str.replace(/-/g, '+').replace(/_/g, '/'));
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+/** Generate a fresh base64url-encoded random 24-byte ID. Sync via Web Crypto. */
+function randomId() {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  return b64url(bytes);
+}
 
 // ---------------------------------------------------------------------------
 // Session class
@@ -46,7 +80,7 @@ export class Session {
    * @param {{ data?: Record<string, unknown>, flash?: Record<string, unknown> }} [initial]
    */
   constructor(id, initial) {
-    this.#id = id || randomBytes(24).toString('base64url');
+    this.#id = id || randomId();
     this.#data = new Map(Object.entries(initial?.data || {}));
     this.#flash = new Map(Object.entries(initial?.flash || {}));
     if (this.#flash.size > 0) this.#dirty = true;
@@ -117,7 +151,7 @@ export class Session {
   regenerateId(deleteOld = false) {
     if (this.#destroyed) throw new Error('Session has been destroyed');
     if (deleteOld) this.#deleteId = this.#id;
-    this.#id = randomBytes(24).toString('base64url');
+    this.#id = randomId();
     this.#dirty = true;
   }
 }
@@ -204,20 +238,29 @@ export const storeSession = storeSessionStorage;
 // Cookie helpers
 // ---------------------------------------------------------------------------
 
-function sign(value, secret) {
-  return `${value}.${createHmac('sha256', secret).update(value).digest('base64url')}`;
+async function sign(value, secret) {
+  const sig = await crypto.subtle.sign('HMAC', await hmacKey(secret), enc.encode(value));
+  return `${value}.${b64url(sig)}`;
 }
 
-function unsign(input, secret) {
+async function unsign(input, secret) {
   const idx = input.lastIndexOf('.');
   if (idx < 1) return null;
   const value = input.slice(0, idx);
-  const expected = createHmac('sha256', secret).update(value).digest('base64url');
-  const sigBuf = Buffer.from(input.slice(idx + 1));
-  const expBuf = Buffer.from(expected);
-  if (sigBuf.length !== expBuf.length) return null;
-  if (!timingSafeEqual(sigBuf, expBuf)) return null;
-  return value;
+  // crypto.subtle.verify is constant-time; replaces node:crypto's
+  // explicit timingSafeEqual. Wrap in try/catch because malformed
+  // base64 throws inside unb64url.
+  try {
+    const ok = await crypto.subtle.verify(
+      'HMAC',
+      await hmacKey(secret),
+      unb64url(input.slice(idx + 1)),
+      enc.encode(value),
+    );
+    return ok ? value : null;
+  } catch {
+    return null;
+  }
 }
 
 function parseCookies(header) {
@@ -284,7 +327,7 @@ export function session(opts = {}) {
   return async function sessionMiddleware(req, next) {
     const cookies = parseCookies(req.headers.get('cookie') || '');
     const rawCookie = cookies[cookieName] || '';
-    const unsigned = rawCookie ? unsign(rawCookie, secret) : null;
+    const unsigned = rawCookie ? await unsign(rawCookie, secret) : null;
 
     // Storage creates the Session
     const s = await storage.read(unsigned);
@@ -303,7 +346,7 @@ export function session(opts = {}) {
     } else if (cookieValue !== null) {
       // Changed: sign and set
       try {
-        resp.headers.append('set-cookie', serializeCookie(cookieName, sign(cookieValue, secret), cookieOpts));
+        resp.headers.append('set-cookie', serializeCookie(cookieName, await sign(cookieValue, secret), cookieOpts));
       } catch {}
     }
     // null = no change

--- a/packages/server/src/session.js
+++ b/packages/server/src/session.js
@@ -36,7 +36,10 @@ async function hmacKey(secret) {
 
 /** @param {ArrayBuffer | ArrayBufferView} buf @returns {string} */
 function b64url(buf) {
-  const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf instanceof ArrayBuffer ? buf : buf.buffer);
+  let bytes;
+  if (buf instanceof Uint8Array) bytes = buf;
+  else if (buf instanceof ArrayBuffer) bytes = new Uint8Array(buf);
+  else bytes = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
   let s = '';
   for (const b of bytes) s += String.fromCharCode(b);
   return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');

--- a/packages/server/src/vendor.js
+++ b/packages/server/src/vendor.js
@@ -43,7 +43,7 @@ import { readFile, readdir, writeFile, mkdir, unlink, stat, rename } from 'node:
 import { readFileSync, existsSync, realpathSync } from 'node:fs';
 import { join, dirname, basename, sep } from 'node:path';
 import { createRequire } from 'node:module';
-import { createHash } from 'node:crypto';
+import { digestBase64, digestHex } from './crypto-utils.js';
 
 /**
  * Set of package names known to be framework-internal (served per-file
@@ -466,15 +466,13 @@ function bundleFilenameWithSubpath(pkgName, version, subpath) {
  * Compute the SHA-384 SRI hash for a bundle body. Matches the format
  * the browser's importmap `integrity` field and the `integrity`
  * attribute on `<link rel="modulepreload">` expect. Accepts a string
- * or any ArrayBufferView (Uint8Array / Buffer / DataView): createHash
- * normalizes all of them to bytes.
+ * or any ArrayBufferView / ArrayBuffer.
  *
- * @param {string | ArrayBufferView} body
- * @returns {string}  e.g. `sha384-<base64>`
+ * @param {string | ArrayBufferView | ArrayBuffer} body
+ * @returns {Promise<string>}  e.g. `sha384-<base64>`
  */
-export function sha384Integrity(body) {
-  const digest = createHash('sha384').update(body).digest('base64');
-  return `sha384-${digest}`;
+export async function sha384Integrity(body) {
+  return `sha384-${await digestBase64('SHA-384', body)}`;
 }
 
 /**
@@ -627,7 +625,7 @@ async function downloadBundle(url, appDir, filename) {
     const buf = new Uint8Array(await response.arrayBuffer());
     await mkdir(pinDir(appDir), { recursive: true });
     await writeFile(join(pinDir(appDir), filename), buf);
-    return { bytes: buf.byteLength, integrity: sha384Integrity(buf) };
+    return { bytes: buf.byteLength, integrity: await sha384Integrity(buf) };
   } catch (e) {
     console.error(`[webjs] download ${url} failed: ${e && e.message}`);
     return null;
@@ -654,7 +652,7 @@ async function fetchIntegrity(url) {
     // browser computes when fetching the same URL. See the
     // matching comment in downloadBundle.
     const buf = new Uint8Array(await response.arrayBuffer());
-    return sha384Integrity(buf);
+    return await sha384Integrity(buf);
   } catch (e) {
     console.error(`[webjs] hash ${url} failed: ${e && e.message}`);
     return null;
@@ -1303,7 +1301,7 @@ export async function serveDownloadedBundle(filename, appDir, dev) {
     // ETag for downstream caches that strip the `immutable` directive.
     // Bundle filenames already carry the version, so content + ETag
     // round-trip is deterministic per filename.
-    const etag = `"${createHash('sha1').update(body).digest('hex').slice(0, 16)}"`;
+    const etag = `"${(await digestHex('SHA-1', body)).slice(0, 16)}"`;
     return new Response(body, {
       headers: {
         'content-type': 'application/javascript; charset=utf-8',

--- a/packages/server/src/vendor.js
+++ b/packages/server/src/vendor.js
@@ -465,9 +465,11 @@ function bundleFilenameWithSubpath(pkgName, version, subpath) {
 /**
  * Compute the SHA-384 SRI hash for a bundle body. Matches the format
  * the browser's importmap `integrity` field and the `integrity`
- * attribute on `<link rel="modulepreload">` expect.
+ * attribute on `<link rel="modulepreload">` expect. Accepts a string
+ * or any ArrayBufferView (Uint8Array / Buffer / DataView): createHash
+ * normalizes all of them to bytes.
  *
- * @param {string | Buffer} body
+ * @param {string | ArrayBufferView} body
  * @returns {string}  e.g. `sha384-<base64>`
  */
 export function sha384Integrity(body) {
@@ -620,9 +622,9 @@ async function downloadBundle(url, appDir, filename) {
     // browser's SRI implementation hashes the raw body bytes; if we
     // hashed `.text()` here we'd risk encoding round-trip drift on
     // any byte sequence the decode-then-re-encode pipeline doesn't
-    // round-trip exactly. arrayBuffer + Buffer.from gives us the
+    // round-trip exactly. arrayBuffer + Uint8Array gives us the
     // same primitive the browser uses.
-    const buf = Buffer.from(await response.arrayBuffer());
+    const buf = new Uint8Array(await response.arrayBuffer());
     await mkdir(pinDir(appDir), { recursive: true });
     await writeFile(join(pinDir(appDir), filename), buf);
     return { bytes: buf.byteLength, integrity: sha384Integrity(buf) };
@@ -651,7 +653,7 @@ async function fetchIntegrity(url) {
     // Hash raw response bytes so the integrity matches what the
     // browser computes when fetching the same URL. See the
     // matching comment in downloadBundle.
-    const buf = Buffer.from(await response.arrayBuffer());
+    const buf = new Uint8Array(await response.arrayBuffer());
     return sha384Integrity(buf);
   } catch (e) {
     console.error(`[webjs] hash ${url} failed: ${e && e.message}`);

--- a/packages/server/src/websocket.js
+++ b/packages/server/src/websocket.js
@@ -87,7 +87,7 @@ function reject(socket, status, message) {
   socket.write(
     `HTTP/1.1 ${status} ${message}\r\n` +
     `Content-Type: text/plain\r\n` +
-    `Content-Length: ${Buffer.byteLength(message)}\r\n` +
+    `Content-Length: ${new TextEncoder().encode(message).byteLength}\r\n` +
     `Connection: close\r\n\r\n` +
     message
   );

--- a/packages/server/test/actions/actions.test.js
+++ b/packages/server/test/actions/actions.test.js
@@ -137,3 +137,17 @@ test('stubs server module and invokes action by hash/fn', async () => {
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test('hashFile: returns a 10-char hex string, stable per input', async () => {
+  // Regression coverage for the createHash → crypto.subtle.digest
+  // migration. hashFile is the RPC-route key derivation: every
+  // server action's URL embeds this hash, so any drift in shape or
+  // determinism would break action routing across deploys.
+  const { hashFile } = await import('../../src/actions.js');
+  const a1 = await hashFile('/abs/path/to/some-action.server.ts');
+  const a2 = await hashFile('/abs/path/to/some-action.server.ts');
+  const b1 = await hashFile('/abs/path/to/other.server.ts');
+  assert.match(a1, /^[0-9a-f]{10}$/, `hashFile must produce 10 hex chars; got ${a1}`);
+  assert.equal(a1, a2, 'hashFile must be deterministic for the same input');
+  assert.notEqual(a1, b1, 'hashFile must differ for different inputs');
+});

--- a/packages/server/test/dev/dev-handler.test.js
+++ b/packages/server/test/dev/dev-handler.test.js
@@ -1141,3 +1141,56 @@ test('createRequestHandler: missing .env file is silent (no error, server boots)
   const app = await createRequestHandler({ appDir, dev: false });
   assert.equal(typeof app.handle, 'function', 'handle() must exist even without a .env file');
 });
+
+/* ------------ dev mode: fs.watch drives SSE reload ------------ */
+
+test('startServer dev=true: fs.watch fires reload event on file change', async () => {
+  // End-to-end test for the chokidar → fs.watch migration. Boots the
+  // dev server, opens an SSE stream to /__webjs/events, edits a file
+  // inside the appDir, and asserts that a reload event reaches the
+  // client. fs.watch should pick up the change and the debounced
+  // rebuild() should push a reload frame.
+  const appDir = makeApp({
+    'app/page.js':
+      `import { html } from ${JSON.stringify(HTML_URL)};\n` +
+      `export default function P() { return html\`<p>v1</p>\`; }\n`,
+  });
+  const logger = { info: () => {}, warn: () => {}, error: () => {} };
+  const { server, close } = await startServer({ appDir, dev: true, port: 0, logger, compress: false });
+  try {
+    const addr = server.address();
+    const baseUrl = `http://127.0.0.1:${addr.port}`;
+    const ac = new AbortController();
+    const resp = await fetch(`${baseUrl}/__webjs/events`, {
+      headers: { accept: 'text/event-stream' },
+      signal: ac.signal,
+    });
+    assert.equal(resp.status, 200);
+    assert.ok(resp.headers.get('content-type').includes('text/event-stream'));
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    const sawReload = (async () => {
+      const deadline = Date.now() + 5_000;
+      let buf = '';
+      while (Date.now() < deadline) {
+        const { value, done } = await reader.read();
+        if (done) return false;
+        buf += decoder.decode(value, { stream: true });
+        if (buf.includes('event: reload')) return true;
+      }
+      return false;
+    })();
+    // Trigger a change after a tick so the SSE response head is flushed.
+    await new Promise((r) => setTimeout(r, 50));
+    writeFileSync(
+      join(appDir, 'app/page.js'),
+      `import { html } from ${JSON.stringify(HTML_URL)};\n` +
+      `export default function P() { return html\`<p>v2</p>\`; }\n`,
+    );
+    const ok = await sawReload;
+    ac.abort();
+    assert.equal(ok, true, 'fs.watch should drive an SSE reload event within 5s of a file write');
+  } finally {
+    await close();
+  }
+});

--- a/packages/server/test/dev/dev-handler.test.js
+++ b/packages/server/test/dev/dev-handler.test.js
@@ -1194,3 +1194,24 @@ test('startServer dev=true: fs.watch fires reload event on file change', async (
     await close();
   }
 });
+
+test('fileResponse prod: ETag is 16-char SHA-1 hex digest in quotes', async () => {
+  // Regression coverage for the createHash → crypto.subtle.digest
+  // migration. The Web Crypto path must produce the same shape as
+  // the old createHash('sha1') ETag: a 16-character hex slice in
+  // double quotes. (Browser/proxy ETag matching is byte-exact, so
+  // any shape drift would break revalidation.)
+  const appDir = makeApp({
+    'app/page.ts': `export default () => 'ok';`,
+    'public/static.txt': 'fixed body for etag check',
+  });
+  const app = await createRequestHandler({ appDir, dev: false });
+  const resp = await app.handle(new Request('http://x/public/static.txt'));
+  assert.equal(resp.status, 200);
+  const etag = resp.headers.get('etag');
+  assert.match(etag, /^"[0-9a-f]{16}"$/,
+    `ETag must be a 16-char hex slice in quotes; got ${etag}`);
+  // Second request must produce identical ETag (stable hash).
+  const resp2 = await app.handle(new Request('http://x/public/static.txt'));
+  assert.equal(resp2.headers.get('etag'), etag, 'ETag must be stable across requests');
+});

--- a/packages/server/test/dev/dev-handler.test.js
+++ b/packages/server/test/dev/dev-handler.test.js
@@ -1215,3 +1215,49 @@ test('fileResponse prod: ETag is 16-char SHA-1 hex digest in quotes', async () =
   const resp2 = await app.handle(new Request('http://x/public/static.txt'));
   assert.equal(resp2.headers.get('etag'), etag, 'ETag must be stable across requests');
 });
+
+test('startServer dev=true: fs.watch does NOT fire reload for prisma/dev.db writes', async () => {
+  // Regression coverage for the IGNORE-regex bug surfaced during
+  // PR #110 review: the chokidar substring-style ignore on
+  // /prisma\/(dev|migrations)/ caught `prisma/dev.db`, but the
+  // first cut of the fs.watch replacement required a trailing
+  // separator and missed the SQLite sidecar file, causing a
+  // rebuild loop on every db:migrate.
+  const appDir = makeApp({
+    'app/page.js':
+      `import { html } from ${JSON.stringify(HTML_URL)};\n` +
+      `export default function P() { return html\`<p>v1</p>\`; }\n`,
+    'prisma/dev.db': 'placeholder',
+  });
+  const logger = { info: () => {}, warn: () => {}, error: () => {} };
+  const { server, close } = await startServer({ appDir, dev: true, port: 0, logger, compress: false });
+  try {
+    const addr = server.address();
+    const ac = new AbortController();
+    const resp = await fetch(`http://127.0.0.1:${addr.port}/__webjs/events`, {
+      headers: { accept: 'text/event-stream' },
+      signal: ac.signal,
+    });
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let buf = '';
+    // Drain the head of the SSE stream so we know the connection is open.
+    await reader.read();
+    // Touch prisma/dev.db plus the journal sidecar. Both are written
+    // during db:migrate and must NOT trigger a reload.
+    writeFileSync(join(appDir, 'prisma/dev.db'), 'updated');
+    writeFileSync(join(appDir, 'prisma/dev.db-journal'), 'wal');
+    // Wait longer than the 80ms debounce window so any rebuild would
+    // have fired by now.
+    await new Promise((r) => setTimeout(r, 250));
+    // Non-blocking read: collect whatever's been buffered.
+    const racer = new Promise((r) => setTimeout(() => r({ done: true, value: null }), 50));
+    const { value } = await Promise.race([reader.read(), racer]);
+    if (value) buf += decoder.decode(value, { stream: true });
+    ac.abort();
+    assert.ok(!buf.includes('event: reload'),
+      `prisma/dev.db writes must NOT fire a reload; got SSE buffer: ${JSON.stringify(buf)}`);
+  } finally {
+    await close();
+  }
+});

--- a/packages/server/test/importmap/importmap.test.js
+++ b/packages/server/test/importmap/importmap.test.js
@@ -148,3 +148,28 @@ test('importMapTag: escapes `<!--` to defeat HTML script-data-escaped state tran
   assert.ok(tag.includes('--\\>'), '--> must be escape-encoded');
   await setVendorEntries({});
 });
+
+test('importMapHash: empty string before any setVendorEntries call', async () => {
+  // Documents the embed/test edge case. Module-fresh imports start
+  // with an empty hash; the client router treats an empty
+  // X-Webjs-Build as "version unknown" and skips the drift check.
+  // We can't reset the singleton; the existing tests have already
+  // called setVendorEntries earlier, so reimport via a fresh URL.
+  const url = new URL('../../src/importmap.js', import.meta.url).href +
+    `?fresh=${Date.now()}-${Math.random()}`;
+  const fresh = await import(url);
+  assert.equal(fresh.importMapHash(), '',
+    'importMapHash() must return empty string until setVendorEntries runs');
+});
+
+test('importMapHash: hash available synchronously after await setVendorEntries', async () => {
+  // The precompute design contract: setVendorEntries computes the
+  // hash inside its body before returning, so the SSR hot path can
+  // read it synchronously without ever crossing a Promise boundary.
+  const { setVendorEntries, importMapHash } = await import('../../src/importmap.js');
+  await setVendorEntries({ 'lib-x': 'https://cdn/lib-x.js' });
+  const h = importMapHash();
+  assert.match(h, /^[0-9a-f]{64}$/,
+    'hash must be a 64-char SHA-256 hex string immediately after await');
+  await setVendorEntries({});
+});

--- a/packages/server/test/importmap/importmap.test.js
+++ b/packages/server/test/importmap/importmap.test.js
@@ -3,48 +3,48 @@ import assert from 'node:assert/strict';
 
 import { importMapTag, setVendorEntries, buildImportMap } from '../../src/importmap.js';
 
-test('importMapTag: emits a bare script tag when no nonce is provided', () => {
-  setVendorEntries({});
+test('importMapTag: emits a bare script tag when no nonce is provided', async () => {
+  await setVendorEntries({});
   const tag = importMapTag();
   assert.match(tag, /^<script type="importmap" data-webjs-build="[0-9a-f]{64}">/);
   assert.ok(!tag.includes('nonce='));
 });
 
-test('importMapTag: emits nonce attribute when provided', () => {
-  setVendorEntries({});
+test('importMapTag: emits nonce attribute when provided', async () => {
+  await setVendorEntries({});
   const tag = importMapTag({ nonce: 'abc123' });
   assert.match(tag, /^<script type="importmap" nonce="abc123" data-webjs-build="[0-9a-f]{64}">/);
 });
 
-test('importMapTag: HTML-escapes embedded quotes in nonce', () => {
+test('importMapTag: HTML-escapes embedded quotes in nonce', async () => {
   // Defensive: a malformed nonce shouldn't break tag structure even
   // though CSP-generated nonces are base64 and never contain quotes.
-  setVendorEntries({});
+  await setVendorEntries({});
   const tag = importMapTag({ nonce: 'a"b' });
   assert.ok(tag.includes('nonce="a&quot;b"'));
 });
 
-test('buildImportMap: framework entries always present', () => {
-  setVendorEntries({});
+test('buildImportMap: framework entries always present', async () => {
+  await setVendorEntries({});
   const map = buildImportMap();
   assert.equal(map.imports['@webjsdev/core'], '/__webjs/core/index.js');
   assert.equal(map.imports['@webjsdev/core/directives'], '/__webjs/core/src/directives.js');
 });
 
-test('buildImportMap: vendor entries merge alongside framework entries', () => {
-  setVendorEntries({ 'dayjs': 'https://ga.jspm.io/npm:dayjs@1.11.20/dayjs.min.js' });
+test('buildImportMap: vendor entries merge alongside framework entries', async () => {
+  await setVendorEntries({ 'dayjs': 'https://ga.jspm.io/npm:dayjs@1.11.20/dayjs.min.js' });
   const map = buildImportMap();
   assert.equal(map.imports['dayjs'], 'https://ga.jspm.io/npm:dayjs@1.11.20/dayjs.min.js');
   assert.equal(map.imports['@webjsdev/core'], '/__webjs/core/index.js');
-  setVendorEntries({}); // reset for other tests
+  await setVendorEntries({}); // reset for other tests
 });
 
-test('importMapTag: escapes `</script>` in vendor URL (defense-in-depth XSS guard)', () => {
+test('importMapTag: escapes `</script>` in vendor URL (defense-in-depth XSS guard)', async () => {
   // Pathological vendor entry: a URL containing a script-close
   // sequence. Without defensive escaping, JSON.stringify emits
   // </script> literally and closes the importmap tag, letting
   // injected content after it execute as fresh HTML / scripts.
-  setVendorEntries({
+  await setVendorEntries({
     'evil': 'https://attacker.example/x.js?</script><img onerror=alert(1) src=x>',
   });
   const tag = importMapTag();
@@ -54,17 +54,17 @@ test('importMapTag: escapes `</script>` in vendor URL (defense-in-depth XSS guar
   assert.ok(!/<\/script>\s*<(?:img|script)/i.test(tag),
     `unescaped </script> in tag: ${tag}`);
   assert.match(tag, /<\\\/script/, 'closing tag sequence escaped to <\\/script');
-  setVendorEntries({});
+  await setVendorEntries({});
 });
 
-test('buildImportMap: emits keys in sorted order (stable across boots/renames)', () => {
+test('buildImportMap: emits keys in sorted order (stable across boots/renames)', async () => {
   // Regression: the client router's importmap-mismatch hard-reload
   // compares textContent. Filesystem-iteration order (which drives
   // scanner output) can change between deploys (e.g. after a file
   // rename), so logically-identical importmaps must serialize
   // identically. Otherwise the user gets a spurious full reload on
   // every nav until the order stabilizes.
-  setVendorEntries(
+  await setVendorEntries(
     { 'z-pkg': 'https://x/z.js', 'a-pkg': 'https://x/a.js', 'm-pkg': 'https://x/m.js' },
     { 'https://x/z.js': 'sha384-zzz', 'https://x/a.js': 'sha384-aaa' },
   );
@@ -76,21 +76,21 @@ test('buildImportMap: emits keys in sorted order (stable across boots/renames)',
   assert.deepEqual(intKeys, [...intKeys].sort(),
     `integrity keys must be sorted; got: ${intKeys.join(',')}`);
   // Verifying byte-identical output across two different insertion orders:
-  setVendorEntries({ 'b': 'https://x/b.js', 'a': 'https://x/a.js' });
+  await setVendorEntries({ 'b': 'https://x/b.js', 'a': 'https://x/a.js' });
   const json1 = JSON.stringify(buildImportMap());
-  setVendorEntries({ 'a': 'https://x/a.js', 'b': 'https://x/b.js' });
+  await setVendorEntries({ 'a': 'https://x/a.js', 'b': 'https://x/b.js' });
   const json2 = JSON.stringify(buildImportMap());
   assert.equal(json1, json2,
     'same content in different insertion order must produce byte-identical JSON');
-  setVendorEntries({}); // reset
+  await setVendorEntries({}); // reset
 });
 
-test('importMapTag: escapes U+2028 / U+2029 line separators in URLs', () => {
+test('importMapTag: escapes U+2028 / U+2029 line separators in URLs', async () => {
   // U+2028 / U+2029 are legal in JSON strings but historically
   // terminated JS strings, which would break the importmap parser.
   const u2028 = String.fromCharCode(0x2028);
   const u2029 = String.fromCharCode(0x2029);
-  setVendorEntries({
+  await setVendorEntries({
     'a': `https://cdn.example/a${u2028}.js`,
     'b': `https://cdn.example/b${u2029}.js`,
   });
@@ -99,38 +99,38 @@ test('importMapTag: escapes U+2028 / U+2029 line separators in URLs', () => {
   assert.ok(!tag.includes(u2029), 'raw U+2029 must not survive');
   assert.ok(tag.includes('\\u2028'), 'U+2028 must be escape-encoded');
   assert.ok(tag.includes('\\u2029'), 'U+2029 must be escape-encoded');
-  setVendorEntries({});
+  await setVendorEntries({});
 });
 
 test('importMapHash: changes when vendor entries change, stable when they do not', async () => {
   const { importMapHash } = await import('../../src/importmap.js');
-  setVendorEntries({});
+  await setVendorEntries({});
   const h1 = importMapHash();
   // Same input → same hash (cache returns identical value).
   assert.equal(importMapHash(), h1);
-  setVendorEntries({ a: 'https://cdn.example/a.js' });
+  await setVendorEntries({ a: 'https://cdn.example/a.js' });
   const h2 = importMapHash();
   assert.notEqual(h2, h1, 'adding a vendor entry must change the hash');
   // Resetting to the prior state recomputes back to the same hash
   // (deterministic, no hidden state).
-  setVendorEntries({});
+  await setVendorEntries({});
   assert.equal(importMapHash(), h1, 'reverting must restore the original hash');
 });
 
 test('importMapHash: integrity change alone changes the hash', async () => {
   const { importMapHash } = await import('../../src/importmap.js');
-  setVendorEntries({ a: 'https://cdn.example/a.js' });
+  await setVendorEntries({ a: 'https://cdn.example/a.js' });
   const without = importMapHash();
-  setVendorEntries(
+  await setVendorEntries(
     { a: 'https://cdn.example/a.js' },
     { 'https://cdn.example/a.js': 'sha384-abcd' },
   );
   const withInt = importMapHash();
   assert.notEqual(withInt, without, 'adding integrity must invalidate the hash');
-  setVendorEntries({});
+  await setVendorEntries({});
 });
 
-test('importMapTag: escapes `<!--` to defeat HTML script-data-escaped state transition', () => {
+test('importMapTag: escapes `<!--` to defeat HTML script-data-escaped state transition', async () => {
   // The HTML5 tokenizer transitions to "script-data-escaped" when it
   // sees `<!--` inside a <script> body. From there a subsequent
   // `<script>` (any casing) hits "script-data-double-escaped" where
@@ -138,7 +138,7 @@ test('importMapTag: escapes `<!--` to defeat HTML script-data-escaped state tran
   // a matching `-->` arrives. Without escaping, a vendor URL
   // carrying `<!--<script>...</script>` could survive the `</` escape
   // and still break out.
-  setVendorEntries({
+  await setVendorEntries({
     'evil': 'https://cdn.example/<!--<script>alert(1)</script>--><img src=x>.js',
   });
   const tag = importMapTag();
@@ -146,5 +146,5 @@ test('importMapTag: escapes `<!--` to defeat HTML script-data-escaped state tran
   assert.ok(!tag.includes('-->'), 'raw --> must not survive');
   assert.ok(tag.includes('<\\!--'), '<!-- must be escape-encoded');
   assert.ok(tag.includes('--\\>'), '--> must be escape-encoded');
-  setVendorEntries({});
+  await setVendorEntries({});
 });

--- a/packages/server/test/vendor/vendor.test.js
+++ b/packages/server/test/vendor/vendor.test.js
@@ -937,12 +937,12 @@ test('readPinFile: returns no integrity field on old pin format (backwards-compa
 
 test('sha384Integrity: returns a sha384-<base64> string', async () => {
   const { sha384Integrity } = await import('../../src/vendor.js');
-  const h = sha384Integrity('hello world');
+  const h = await sha384Integrity('hello world');
   assert.match(h, /^sha384-[A-Za-z0-9+/=]+$/);
   // Deterministic: same input always produces same output.
-  assert.equal(h, sha384Integrity('hello world'));
+  assert.equal(h, await sha384Integrity('hello world'));
   // Different input produces different output.
-  assert.notEqual(h, sha384Integrity('hello worl'));
+  assert.notEqual(h, await sha384Integrity('hello worl'));
 });
 
 test('readPinFile + resolveVendorImports: integrity keyed by FINAL URL (post-rewrite)', async () => {
@@ -1151,11 +1151,11 @@ test('readPinFile: tolerates extra fields in pin JSON (forward-compat)', async (
 test('importMapTag: integrity field omitted when empty, present when populated', async () => {
   const { setVendorEntries, importMapTag } = await import('../../src/importmap.js');
   // Empty integrity → no integrity field in JSON.
-  setVendorEntries({ 'a': 'https://cdn/a.js' }, {});
+  await setVendorEntries({ 'a': 'https://cdn/a.js' }, {});
   let tag = importMapTag();
   assert.ok(!tag.includes('"integrity"'), 'integrity omitted when empty');
   // Populated → integrity field present.
-  setVendorEntries(
+  await setVendorEntries(
     { 'a': 'https://cdn/a.js' },
     { 'https://cdn/a.js': 'sha384-xxxx' },
   );
@@ -1163,7 +1163,7 @@ test('importMapTag: integrity field omitted when empty, present when populated',
   assert.ok(tag.includes('"integrity"'), 'integrity present when populated');
   assert.ok(tag.includes('"sha384-xxxx"'), 'integrity value emitted');
   // Reset.
-  setVendorEntries({}, {});
+  await setVendorEntries({}, {});
 });
 
 test('pinAll default mode: writes integrity field alongside imports', { skip: !NETWORK_OK }, async () => {
@@ -1199,7 +1199,7 @@ test('pinAll --download: writes integrity matching the on-disk bytes', { skip: !
     const { sha384Integrity } = await import('../../src/vendor.js');
     const filename = localUrl.slice('/__webjs/vendor/'.length);
     const onDisk = await readFileFs(join(dir, '.webjs', 'vendor', filename), 'utf8');
-    assert.equal(file.integrity[localUrl], sha384Integrity(onDisk));
+    assert.equal(file.integrity[localUrl], await sha384Integrity(onDisk));
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/test/ssr/ssr.test.js
+++ b/test/ssr/ssr.test.js
@@ -1455,7 +1455,7 @@ test('ssrPage: WEBJS_PUBLIC_* env vars are injected into window.process.env', as
 /* ------------ bundle mode skips per-file preloads ------------ */
 
 
-test('vendor: pin file changes update served importmap (chokidar drives clearVendorCache)', async () => {
+test('vendor: pin file changes update served importmap (fs.watch drives clearVendorCache)', async () => {
   // The pin file is at .webjs/vendor/importmap.json under the app
   // directory. When the dev-server file watcher fires for that path
   // it calls clearVendorCache so the next SSR rereads the new
@@ -1470,7 +1470,7 @@ test('vendor: pin file changes update served importmap (chokidar drives clearVen
   let map = buildImportMap();
   assert.equal(map.imports.a, 'https://cdn.example/a.js');
   // Hand-edit equivalent: a new pin file would update the in-memory
-  // entries on the next chokidar fire. Simulate by re-setting.
+  // entries on the next fs.watch fire. Simulate by re-setting.
   setVendorEntries({ 'a': 'https://cdn.example/a-v2.js', 'b': 'https://cdn.example/b.js' });
   map = buildImportMap();
   assert.equal(map.imports.a, 'https://cdn.example/a-v2.js', 'updated URL replaces old');

--- a/test/ssr/ssr.test.js
+++ b/test/ssr/ssr.test.js
@@ -1466,16 +1466,16 @@ test('vendor: pin file changes update served importmap (fs.watch drives clearVen
   const { setVendorEntries, buildImportMap } = await import(
     new URL('../../packages/server/src/importmap.js', import.meta.url).href
   );
-  setVendorEntries({ 'a': 'https://cdn.example/a.js' });
+  await setVendorEntries({ 'a': 'https://cdn.example/a.js' });
   let map = buildImportMap();
   assert.equal(map.imports.a, 'https://cdn.example/a.js');
   // Hand-edit equivalent: a new pin file would update the in-memory
   // entries on the next fs.watch fire. Simulate by re-setting.
-  setVendorEntries({ 'a': 'https://cdn.example/a-v2.js', 'b': 'https://cdn.example/b.js' });
+  await setVendorEntries({ 'a': 'https://cdn.example/a-v2.js', 'b': 'https://cdn.example/b.js' });
   map = buildImportMap();
   assert.equal(map.imports.a, 'https://cdn.example/a-v2.js', 'updated URL replaces old');
   assert.equal(map.imports.b, 'https://cdn.example/b.js', 'new entry appears');
-  setVendorEntries({});
+  await setVendorEntries({});
 });
 
 test('integrityAttr: emits integrity attribute for vendor URLs with known SRI hash', async () => {
@@ -1489,7 +1489,7 @@ test('integrityAttr: emits integrity attribute for vendor URLs with known SRI ha
   const { integrityAttr } = await import(
     new URL('../../packages/server/src/ssr.js', import.meta.url).href
   );
-  setVendorEntries(
+  await setVendorEntries(
     { 'fake-vendor': '/__webjs/vendor/fake-vendor@1.0.0.js' },
     { '/__webjs/vendor/fake-vendor@1.0.0.js': 'sha384-validHashValueHere==' },
   );
@@ -1504,6 +1504,6 @@ test('integrityAttr: emits integrity attribute for vendor URLs with known SRI ha
     assert.equal(integrityAttr('/components/foo.ts'), '');
     assert.equal(integrityAttr('/__webjs/core/index.js'), '');
   } finally {
-    setVendorEntries({});
+    await setVendorEntries({});
   }
 });


### PR DESCRIPTION
## Summary

Tracker [#22](follow-up to the jspm-direct-vendor PR) plus full alignment with Remix's web-standards philosophy: `Web Streams instead of node:stream, Uint8Array instead of Buffer, Web Crypto instead of node:crypto, Blob/File instead of bespoke APIs`.

After this PR `@webjsdev/server` carries one less runtime dependency (chokidar removed) and **zero `from 'node:crypto'` imports**. The remaining Node-only modules are `node:http` (server boot), `node:fs` (file I/O), `node:path` / `node:url` / `node:zlib` (structural); each genuinely lacks a web-standard equivalent.

## Changes

### chokidar → `fs.promises.watch`
- Node 24+ supports recursive `fs.watch` on every platform. Async-iterator shape maps onto the existing debounce + rebuild flow; the chokidar ignore array shrinks to one regex predicate over `event.filename`. Dependency dropped from `@webjsdev/server`.
- `AbortController` tied to `startServer.close()` so multiple boots in the same process do not pile up SIGINT/SIGTERM listeners.
- End-to-end watcher SSE test: boots the dev server, opens `/__webjs/events`, writes a file, asserts the `reload` event arrives within 5 seconds.

### Buffer / TextEncoder
- `Buffer.from(await response.arrayBuffer())` → `new Uint8Array(...)` in `vendor.js` (2 call sites). `sha384Integrity` accepts any `ArrayBufferView` / `ArrayBuffer`.
- `Buffer.byteLength(message)` → `new TextEncoder().encode(message).byteLength` in `websocket.js` reject path.

### `session.js` `node:crypto` → Web Crypto
- Mirrors `auth.js`. `randomBytes(24).toString('base64url')` → `crypto.getRandomValues` + `b64url` helper (sync). `createHmac` + `timingSafeEqual` → `crypto.subtle.sign` + `crypto.subtle.verify` (constant-time by spec, async). Two callers in `sessionMiddleware` are already async.

### `node:crypto.createHash` → `crypto.subtle.digest`
- New `crypto-utils.js` with `digestHex` and `digestBase64` wrappers; accept string / ArrayBufferView / ArrayBuffer.
- Five call sites migrated:
  - `actions.js` `hashFile`: action ID derivation.
  - `dev.js` `fileResponse`: prod ETag.
  - `vendor.js` `sha384Integrity`: SRI for vendor bundles.
  - `vendor.js` bundle-response: ETag on `/__webjs/vendor/`.
  - `importmap.js` `importMapHash`: per-SSR `data-webjs-build` / `X-Webjs-Build`.
- The SSR hot path stays sync. `setVendorEntries` precomputes the importmap hash inside its body (now async; the dev server already awaits it at boot and on every rebuild). `importMapHash()` returns the cached string synchronously, so `wrapHead` / `buildDocumentParts` / `wrapInDocument` and every SSR caller stay unchanged.

### Tests + docs
- Test callbacks calling `setVendorEntries` / `sha384Integrity` updated to `async` with `await`. Covers `lazy-loading.test.js`, `importmap.test.js`, `vendor.test.js`, `ssr.test.js`.
- Doc + markdown sweep: `AGENTS.md`, `packages/server/AGENTS.md`, `docs/app/docs/{configuration,deployment,no-build}/page.ts`, and the stale chokidar mention in the existing pin-file test.

## Result

- `@webjsdev/server` runtime deps: `{ @webjsdev/core, ws }` (was `{ @webjsdev/core, chokidar, ws }`).
- Zero `node:crypto` imports across the server package.
- Web-standards alignment: complete for the Remix shortlist (Web Streams, Uint8Array, Web Crypto, Blob/File).
- 1313/1313 tests pass.

## Test plan

- [x] `npm test` from repo root, 1313 / 1313
- [x] `startServer dev=true: fs.watch fires reload event on file change` end-to-end test passes
- [x] `webjs check` clean on framework repo and `docs/`
- [x] Session + websocket + vendor + importmap sub-suites all green
- [x] `grep -rn "node:crypto" packages/server/src/` returns only comment hits