### PR TITLE
docs(claude): GitHub Project workflow as Claude Code rule in CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,46 +89,6 @@ The model: always work on a feature branch. Commit + push freely there. The only
    Wait for explicit approval AND the delete/keep preference.
 8. **Run tests before committing.** `webjs test` must pass.
 
-### GitHub Project workflow (mandatory)
-
-The webjs project board at https://github.com/orgs/webjsdev/projects/1 (backed by issues in `webjsdev/webjs`) is the **single source of truth** for outstanding work. AI agents and humans alike track tasks there. Do not maintain a parallel todo list in an agent's private memory, a tracker markdown file, or anywhere else.
-
-The board has three Status columns: **Todo**, **In progress**, **Done**.
-
-1. **Listing pending work.** `gh project item-list 1 --owner webjsdev --format json` is the authoritative answer to "what's open?". Do not consult agent-internal trackers.
-
-2. **Filing new work.** When the user describes a task that needs tracking:
-   ```sh
-   gh issue create --repo webjsdev/webjs --title "..." --body "..." --label enhancement
-   gh project item-add 1 --owner webjsdev --url <issue-url>
-   ```
-   The card lands in Todo by default. Issue bodies follow the same shape as PR descriptions: short problem statement, design rationale, acceptance-criteria checklist.
-
-3. **Starting work on a tracked issue.** When the user says "start work on #N" (or equivalent):
-   1. Create a feature branch: `git checkout -b <type>/<slug>` (e.g. `feat/dist-bundle-core`). Never edit on main.
-   2. Move the project card from Todo to **In progress** (see the snippet below).
-   3. Commit + push as usual.
-   4. Open the PR with `gh pr create` and put `Closes #N` in the body near the top (right after the `## Summary` heading). Multiple linked issues each get their own `Closes #N` line.
-
-4. **Merging.** `Closes #N` in the PR body auto-closes the linked issue on merge. The closed issue auto-moves the project card from In progress to **Done**. No manual move is needed at merge time.
-
-5. **Partial PRs.** A PR that does NOT fully resolve an issue must NOT use `Closes #N` for it. Reference the issue with a plain `#N` mention instead, e.g. "Partial fix toward #112; elision logic still needs ...".
-
-### Moving a card to In progress via gh
-
-`gh project item-edit` needs four IDs (project, item, field, option). Resolve them once at branch creation time:
-
-```sh
-N=<issue-number>
-PROJECT_ID=$(gh project view 1 --owner webjsdev --format json --jq '.id')
-ITEM_ID=$(gh project item-list 1 --owner webjsdev --format json --jq ".items[] | select(.content.number == $N) | .id")
-STATUS_FIELD_ID=$(gh project field-list 1 --owner webjsdev --format json --jq '.fields[] | select(.name == "Status") | .id')
-IN_PROGRESS_OPT_ID=$(gh project field-list 1 --owner webjsdev --format json --jq '.fields[] | select(.name == "Status") | .options[] | select(.name == "In progress") | .id')
-gh project item-edit --project-id "$PROJECT_ID" --id "$ITEM_ID" --field-id "$STATUS_FIELD_ID" --single-select-option-id "$IN_PROGRESS_OPT_ID"
-```
-
-The same shape with the `Done` option's ID moves a card to Done manually if ever needed (rare; the `Closes #N` automation handles the merge path).
-
 ---
 
 ## Working in the webjs framework repo itself

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,46 @@ The model: always work on a feature branch. Commit + push freely there. The only
    Wait for explicit approval AND the delete/keep preference.
 8. **Run tests before committing.** `webjs test` must pass.
 
+### GitHub Project workflow (mandatory)
+
+The webjs project board at https://github.com/orgs/webjsdev/projects/1 (backed by issues in `webjsdev/webjs`) is the **single source of truth** for outstanding work. AI agents and humans alike track tasks there. Do not maintain a parallel todo list in an agent's private memory, a tracker markdown file, or anywhere else.
+
+The board has three Status columns: **Todo**, **In progress**, **Done**.
+
+1. **Listing pending work.** `gh project item-list 1 --owner webjsdev --format json` is the authoritative answer to "what's open?". Do not consult agent-internal trackers.
+
+2. **Filing new work.** When the user describes a task that needs tracking:
+   ```sh
+   gh issue create --repo webjsdev/webjs --title "..." --body "..." --label enhancement
+   gh project item-add 1 --owner webjsdev --url <issue-url>
+   ```
+   The card lands in Todo by default. Issue bodies follow the same shape as PR descriptions: short problem statement, design rationale, acceptance-criteria checklist.
+
+3. **Starting work on a tracked issue.** When the user says "start work on #N" (or equivalent):
+   1. Create a feature branch: `git checkout -b <type>/<slug>` (e.g. `feat/dist-bundle-core`). Never edit on main.
+   2. Move the project card from Todo to **In progress** (see the snippet below).
+   3. Commit + push as usual.
+   4. Open the PR with `gh pr create` and put `Closes #N` in the body near the top (right after the `## Summary` heading). Multiple linked issues each get their own `Closes #N` line.
+
+4. **Merging.** `Closes #N` in the PR body auto-closes the linked issue on merge. The closed issue auto-moves the project card from In progress to **Done**. No manual move is needed at merge time.
+
+5. **Partial PRs.** A PR that does NOT fully resolve an issue must NOT use `Closes #N` for it. Reference the issue with a plain `#N` mention instead, e.g. "Partial fix toward #112; elision logic still needs ...".
+
+### Moving a card to In progress via gh
+
+`gh project item-edit` needs four IDs (project, item, field, option). Resolve them once at branch creation time:
+
+```sh
+N=<issue-number>
+PROJECT_ID=$(gh project view 1 --owner webjsdev --format json --jq '.id')
+ITEM_ID=$(gh project item-list 1 --owner webjsdev --format json --jq ".items[] | select(.content.number == $N) | .id")
+STATUS_FIELD_ID=$(gh project field-list 1 --owner webjsdev --format json --jq '.fields[] | select(.name == "Status") | .id')
+IN_PROGRESS_OPT_ID=$(gh project field-list 1 --owner webjsdev --format json --jq '.fields[] | select(.name == "Status") | .options[] | select(.name == "In progress") | .id')
+gh project item-edit --project-id "$PROJECT_ID" --id "$ITEM_ID" --field-id "$STATUS_FIELD_ID" --single-select-option-id "$IN_PROGRESS_OPT_ID"
+```
+
+The same shape with the `Done` option's ID moves a card to Done manually if ever needed (rare; the `Closes #N` automation handles the merge path).
+
 ---
 
 ## Working in the webjs framework repo itself

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,54 @@
 @AGENTS.md
+
+## GitHub Project workflow (Claude Code rule)
+
+The webjs project board at https://github.com/orgs/webjsdev/projects/1 (backed by issues in `webjsdev/webjs`) is the **single source of truth** for outstanding work. Do NOT maintain a parallel todo list in Claude Code's internal task tracker, agent memory, or anywhere else.
+
+The board has three Status columns: **Todo**, **In progress**, **Done**.
+
+### Listing pending work
+
+`gh project item-list 1 --owner webjsdev --format json` is the authoritative answer to "what's open?". Do not consult internal task lists or memory for this question.
+
+### Filing new work
+
+When the user describes a task that needs tracking:
+
+```sh
+gh issue create --repo webjsdev/webjs --title "..." --body "..." --label enhancement
+gh project item-add 1 --owner webjsdev --url <issue-url>
+```
+
+The card lands in Todo by default. Issue bodies follow the same shape as PR descriptions: short problem statement, design rationale, acceptance-criteria checklist.
+
+### Starting work on a tracked issue
+
+When the user says "start work on #N" (or equivalent):
+
+1. Create a feature branch: `git checkout -b <type>/<slug>` (e.g. `feat/dist-bundle-core`). Never edit on main.
+2. Move the project card from Todo to **In progress** (see the snippet below).
+3. Commit + push as usual.
+4. Open the PR with `gh pr create` and put `Closes #N` in the body near the top (right after the `## Summary` heading). Multiple linked issues each get their own `Closes #N` line.
+
+### Merging
+
+`Closes #N` in the PR body auto-closes the linked issue on merge. The closed issue auto-moves the project card from In progress to **Done**. No manual move is needed at merge time.
+
+### Partial PRs
+
+A PR that does NOT fully resolve an issue MUST NOT use `Closes #N` for it. Reference the issue with a plain `#N` mention instead, e.g. "Partial fix toward #112; elision logic still needs ...".
+
+### Moving a card to In progress via gh
+
+`gh project item-edit` needs four IDs (project, item, field, option). Resolve them once at branch creation time:
+
+```sh
+N=<issue-number>
+PROJECT_ID=$(gh project view 1 --owner webjsdev --format json --jq '.id')
+ITEM_ID=$(gh project item-list 1 --owner webjsdev --format json --jq ".items[] | select(.content.number == $N) | .id")
+STATUS_FIELD_ID=$(gh project field-list 1 --owner webjsdev --format json --jq '.fields[] | select(.name == "Status") | .id')
+IN_PROGRESS_OPT_ID=$(gh project field-list 1 --owner webjsdev --format json --jq '.fields[] | select(.name == "Status") | .options[] | select(.name == "In progress") | .id')
+gh project item-edit --project-id "$PROJECT_ID" --id "$ITEM_ID" --field-id "$STATUS_FIELD_ID" --single-select-option-id "$IN_PROGRESS_OPT_ID"
+```
+
+The same shape with the `Done` option's ID moves a card to Done manually if ever needed (rare; the `Closes #N` automation handles the merge path).


### PR DESCRIPTION
## Summary

Note: this PR establishes the workflow, so it does NOT itself carry a `Closes #N`. Future PRs follow the rule it introduces.

Codifies the GitHub Project workflow we just adopted, but in **`CLAUDE.md`** (not `AGENTS.md`). The rule is specifically how a Claude Code session collaborates with the project tracker, not framework convention or runtime contract.

`CLAUDE.md` previously contained only `@AGENTS.md` (a single-line include). It now @-includes AGENTS.md AND carries the rule directly. AGENTS.md is unchanged.

### Rule contents

- **Single source of truth:** https://github.com/orgs/webjsdev/projects/1, backed by issues in `webjsdev/webjs`. No parallel Claude Code internal task list or memory todos.
- **Three Status columns:** Todo, In progress, Done.
- **Lifecycle:**
  - List pending: `gh project item-list 1 --owner webjsdev ...`.
  - File new: `gh issue create` + `gh project item-add` (lands in Todo).
  - Start work: branch out, move card to In progress, open PR with `Closes #N` near the top of the body.
  - Merge: `Closes #N` auto-closes the issue, project card auto-moves to Done.
- **Partial PRs:** no `Closes #N`; reference with plain `#N` mention.

Includes the 4-ID `gh project item-edit` recipe inline so the "move to In progress" step is one paste away.

## Test plan

- [x] `webjs check` clean
- [x] AGENTS.md untouched (verified via `git diff` against pre-PR state)
- [x] Markdown renders cleanly