### PR TITLE
fix(rate-limit): add trustProxy option; default to socket-stamped IP

### DIFF
--- a/agent-docs/advanced.md
+++ b/agent-docs/advanced.md
@@ -154,15 +154,29 @@ from the trusted socket address, otherwise a malicious client forges
 the header and the framework trusts it. Call the exported helper:
 
 ```js
+// express adapter sketch
+import express from 'express';
 import { createRequestHandler, stampRemoteIp } from '@webjsdev/server';
+
+const app = express();
 const handler = await createRequestHandler({ appDir });
 
 app.use(async (req, res) => {
-  const webReq = new Request(buildUrl(req), { method: req.method, headers: req.headers, body: ... });
+  const url = `${req.protocol}://${req.get('host')}${req.originalUrl}`;
+  const body = req.method === 'GET' || req.method === 'HEAD' ? undefined : req;
+  const webReq = new Request(url, {
+    method: req.method,
+    headers: new Headers(req.headers),
+    body,
+    duplex: 'half',
+  });
   // Strips any forged x-webjs-remote-ip, stamps the real socket address.
   const safe = stampRemoteIp(webReq, req.socket.remoteAddress);
   const webRes = await handler.handle(safe);
-  // write webRes back to res
+  res.status(webRes.status);
+  webRes.headers.forEach((v, k) => res.setHeader(k, v));
+  if (webRes.body) webRes.body.pipeTo(new WritableStream({ write: (c) => res.write(c) })).then(() => res.end());
+  else res.end();
 });
 ```
 

--- a/agent-docs/advanced.md
+++ b/agent-docs/advanced.md
@@ -108,8 +108,51 @@ export default rateLimit({
 ```
 
 **Options:** `window` (`'10s'`, `'1m'`, `'1h'`, ms), `max` (default 60),
-`key` (string prefix or `(req) => string`, defaulting to client IP from
-`x-forwarded-for`/`cf-connecting-ip`/`x-real-ip`), `message`, `store`.
+`key` (string prefix or `(req) => string`, defaulting to the
+framework-stamped client IP from the TCP socket), `message`, `store`,
+`trustProxy` (default `false`).
+
+**`trustProxy`** controls how the default key is derived:
+
+- **`false` (default, safe):** key on the framework-stamped
+  `x-webjs-remote-ip` header, which `startServer` sets from the
+  underlying TCP socket on every request (and strips any inbound
+  copy of, so clients cannot spoof it). Forwarded-IP headers like
+  `x-forwarded-for`, `cf-connecting-ip`, `x-real-ip` are ignored.
+  Correct for direct deployments (bare Node, no proxy in front).
+- **`true`:** honour forwarded-IP headers, preferring the leftmost
+  entry of `x-forwarded-for`, then `cf-connecting-ip`, then
+  `x-real-ip`. Production deploys MUST run behind a reverse proxy
+  (nginx, Caddy, Cloudflare, Fly, Railway, Render edge) that STRIPS
+  inbound `x-forwarded-for` before adding its own. If the proxy
+  doesn't strip, the option reintroduces the per-request bucket
+  rotation it exists to defend against.
+
+```js
+// Direct deploy (default): safe, ignores spoofable forwarded headers.
+export default rateLimit({ window: '10s', max: 5 });
+
+// Behind a trusted reverse proxy: opt in, MUST strip inbound XFF.
+export default rateLimit({ window: '10s', max: 5, trustProxy: true });
+```
+
+The `clientIp(req, { trustProxy })` helper is exported separately so
+custom `key` functions can reuse the same resolution:
+
+```js
+import { rateLimit, clientIp } from '@webjsdev/server';
+export default rateLimit({
+  window: '1m', max: 30,
+  key: (req) => `${req.headers.get('x-tenant') || 'global'}:${clientIp(req, { trustProxy: true })}`,
+});
+```
+
+**Embedded use:** in `createRequestHandler` setups (Express / Bun /
+Deno / edge adapters), the host adapter is responsible for stamping
+`x-webjs-remote-ip` from its own socket abstraction, or the rate
+limit collapses to a single `_anon_` bucket. Alternatively, pass a
+custom `key` function that reads whatever client identifier the host
+exposes.
 
 **Exceeded:** returns `429 Too Many Requests` with JSON `{ error: "Too Many Requests" }` and headers `x-ratelimit-limit`, `x-ratelimit-remaining`, `x-ratelimit-reset`, `retry-after`.
 

--- a/agent-docs/advanced.md
+++ b/agent-docs/advanced.md
@@ -154,31 +154,20 @@ from the trusted socket address, otherwise a malicious client forges
 the header and the framework trusts it. Call the exported helper:
 
 ```js
-// express adapter sketch
-import express from 'express';
 import { createRequestHandler, stampRemoteIp } from '@webjsdev/server';
-
-const app = express();
 const handler = await createRequestHandler({ appDir });
 
-app.use(async (req, res) => {
-  const url = `${req.protocol}://${req.get('host')}${req.originalUrl}`;
-  const body = req.method === 'GET' || req.method === 'HEAD' ? undefined : req;
-  const webReq = new Request(url, {
-    method: req.method,
-    headers: new Headers(req.headers),
-    body,
-    duplex: 'half',
-  });
-  // Strips any forged x-webjs-remote-ip, stamps the real socket address.
-  const safe = stampRemoteIp(webReq, req.socket.remoteAddress);
-  const webRes = await handler.handle(safe);
-  res.status(webRes.status);
-  webRes.headers.forEach((v, k) => res.setHeader(k, v));
-  if (webRes.body) webRes.body.pipeTo(new WritableStream({ write: (c) => res.write(c) })).then(() => res.end());
-  else res.end();
-});
+// Inside the host adapter's per-request callback. `nodeReq` is the
+// host's request object (Express req, Node IncomingMessage, etc.).
+// `webReq` is whatever Request you constructed from the wire (URL,
+// method, headers, body); building that is host-specific. The
+// security-relevant line is the one that wraps it in stampRemoteIp:
+const safe = stampRemoteIp(webReq, nodeReq.socket.remoteAddress);
+const webRes = await handler.handle(safe);
+// Pipe webRes back through the host's response API.
 ```
+
+The host-specific Request construction has its own gotchas (Node `Readable` to WHATWG `ReadableStream` for bodies; coalescing array-valued raw headers into comma-joined strings; URL synthesis from host + path). The `stampRemoteIp` line is what makes the result safe to hand off to webjs's rate limit; it MUST come after the inbound headers land in `webReq` and before `handler.handle(safe)` is called.
 
 If the adapter cannot expose a trusted socket address, pass a custom
 `key` function to `rateLimit()` that reads whatever client identifier

--- a/agent-docs/advanced.md
+++ b/agent-docs/advanced.md
@@ -147,12 +147,29 @@ export default rateLimit({
 });
 ```
 
-**Embedded use:** in `createRequestHandler` setups (Express / Bun /
-Deno / edge adapters), the host adapter is responsible for stamping
-`x-webjs-remote-ip` from its own socket abstraction, or the rate
-limit collapses to a single `_anon_` bucket. Alternatively, pass a
-custom `key` function that reads whatever client identifier the host
-exposes.
+**Embedded use** (`createRequestHandler` running under Express / Bun /
+Deno / edge adapters): the host adapter is responsible for stripping
+any inbound `x-webjs-remote-ip` from the wire AND stamping its own
+from the trusted socket address, otherwise a malicious client forges
+the header and the framework trusts it. Call the exported helper:
+
+```js
+import { createRequestHandler, stampRemoteIp } from '@webjsdev/server';
+const handler = await createRequestHandler({ appDir });
+
+app.use(async (req, res) => {
+  const webReq = new Request(buildUrl(req), { method: req.method, headers: req.headers, body: ... });
+  // Strips any forged x-webjs-remote-ip, stamps the real socket address.
+  const safe = stampRemoteIp(webReq, req.socket.remoteAddress);
+  const webRes = await handler.handle(safe);
+  // write webRes back to res
+});
+```
+
+If the adapter cannot expose a trusted socket address, pass a custom
+`key` function to `rateLimit()` that reads whatever client identifier
+the host actually provides. The default rate-limit collapsing to
+`_anon_` is preferable to silently trusting wire-set headers.
 
 **Exceeded:** returns `429 Too Many Requests` with JSON `{ error: "Too Many Requests" }` and headers `x-ratelimit-limit`, `x-ratelimit-remaining`, `x-ratelimit-reset`, `retry-after`.
 

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -34,7 +34,7 @@ export { buildModuleGraph, transitiveDeps } from './src/module-graph.js';
 export { scanComponents, primeComponentRegistry, extractComponents, findOrphanComponents } from './src/component-scanner.js';
 export { headers, cookies, getRequest, withRequest, cspNonce } from './src/context.js';
 export { defaultLogger } from './src/logger.js';
-export { rateLimit, parseWindow } from './src/rate-limit.js';
+export { rateLimit, parseWindow, clientIp } from './src/rate-limit.js';
 export { memoryStore, redisStore, getStore, setStore } from './src/cache.js';
 export { cache } from './src/cache-fn.js';
 export { Session, session, cookieSessionStorage, storeSessionStorage, cookieSession, storeSession, getSession } from './src/session.js';

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -34,7 +34,7 @@ export { buildModuleGraph, transitiveDeps } from './src/module-graph.js';
 export { scanComponents, primeComponentRegistry, extractComponents, findOrphanComponents } from './src/component-scanner.js';
 export { headers, cookies, getRequest, withRequest, cspNonce } from './src/context.js';
 export { defaultLogger } from './src/logger.js';
-export { rateLimit, parseWindow, clientIp } from './src/rate-limit.js';
+export { rateLimit, parseWindow, clientIp, stampRemoteIp } from './src/rate-limit.js';
 export { memoryStore, redisStore, getStore, setStore } from './src/cache.js';
 export { cache } from './src/cache-fn.js';
 export { Session, session, cookieSessionStorage, storeSessionStorage, cookieSession, storeSession, getSession } from './src/session.js';

--- a/packages/server/src/dev.js
+++ b/packages/server/src/dev.js
@@ -860,8 +860,9 @@ function toWebRequest(req, url) {
     // Strip any inbound `x-webjs-remote-ip` header so clients cannot
     // spoof the framework-stamped client IP that rate-limit's
     // `clientIp(req, { trustProxy: false })` reads. We rewrite it
-    // below from the actual TCP socket.
-    if (k.toLowerCase() === 'x-webjs-remote-ip') continue;
+    // below from the actual TCP socket. Node's IncomingMessage
+    // always lowercases header keys, so a literal compare is enough.
+    if (k === 'x-webjs-remote-ip') continue;
     headers[k] = Array.isArray(v) ? v.join(',') : String(v ?? '');
   }
   // Stamp the framework-trusted remote IP from the socket. Read by

--- a/packages/server/src/dev.js
+++ b/packages/server/src/dev.js
@@ -853,12 +853,22 @@ function toWebRequest(req, url) {
   /** @type {Record<string,string>} */
   const headers = {};
   for (const [k, v] of Object.entries(req.headers)) {
-    // Drop HTTP/2 pseudo-headers (`:method`, `:path`, `:scheme`, `:authority`) -
-    // they're parsed separately into req.method / req.url and are rejected
+    // Drop HTTP/2 pseudo-headers (`:method`, `:path`, `:scheme`, `:authority`).
+    // They're parsed separately into req.method / req.url and are rejected
     // by the standard Headers class if we pass them through verbatim.
     if (k.startsWith(':')) continue;
+    // Strip any inbound `x-webjs-remote-ip` header so clients cannot
+    // spoof the framework-stamped client IP that rate-limit's
+    // `clientIp(req, { trustProxy: false })` reads. We rewrite it
+    // below from the actual TCP socket.
+    if (k.toLowerCase() === 'x-webjs-remote-ip') continue;
     headers[k] = Array.isArray(v) ? v.join(',') : String(v ?? '');
   }
+  // Stamp the framework-trusted remote IP from the socket. Read by
+  // `clientIp(req)` (rate-limit.js) as the bucket key when
+  // `trustProxy: false` (the safe default).
+  const remoteIp = req.socket?.remoteAddress;
+  if (remoteIp) headers['x-webjs-remote-ip'] = remoteIp;
   let body;
   if (method !== 'GET' && method !== 'HEAD') {
     body = new ReadableStream({

--- a/packages/server/src/rate-limit.js
+++ b/packages/server/src/rate-limit.js
@@ -125,6 +125,47 @@ export function clientIp(req, opts = {}) {
   return req.headers.get(REMOTE_IP_HEADER) || '_anon_';
 }
 
+/**
+ * Return a Request equivalent to `req` but with `x-webjs-remote-ip`
+ * stripped from inbound headers and re-set to `remoteAddress`.
+ *
+ * `startServer`'s built-in HTTP path does this internally via
+ * `toWebRequest`. Embedded adapters (`createRequestHandler` running
+ * under Express / Bun / Deno / edge runtimes) MUST call this helper
+ * before invoking `app.handle(req)`, otherwise a malicious client
+ * can include `x-webjs-remote-ip: <fake>` on the wire and webjs's
+ * rate-limit `clientIp(req)` will trust it.
+ *
+ * Body and method are preserved verbatim. The new Request consumes
+ * the original's body stream, so do not reuse the original afterwards.
+ *
+ * ```js
+ * // express adapter
+ * app.use(async (req, res) => {
+ *   const webReq = new Request(..., { headers: req.headers, ... });
+ *   const safe = stampRemoteIp(webReq, req.socket.remoteAddress);
+ *   const webRes = await handler.handle(safe);
+ *   // write webRes back to res
+ * });
+ * ```
+ *
+ * @param {Request} req
+ * @param {string | null | undefined} remoteAddress  trusted socket IP
+ * @returns {Request}
+ */
+export function stampRemoteIp(req, remoteAddress) {
+  const headers = new Headers(req.headers);
+  headers.delete(REMOTE_IP_HEADER);
+  if (remoteAddress) headers.set(REMOTE_IP_HEADER, remoteAddress);
+  /** @type {RequestInit & { duplex?: string }} */
+  const init = { method: req.method, headers };
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    init.body = req.body;
+    init.duplex = 'half';
+  }
+  return new Request(req.url, init);
+}
+
 /** @param {number | string} w @returns {number} milliseconds */
 export function parseWindow(w) {
   if (typeof w === 'number') return w;

--- a/packages/server/src/rate-limit.js
+++ b/packages/server/src/rate-limit.js
@@ -31,22 +31,24 @@ import { getStore } from './cache.js';
  *   key?: string | ((req: Request) => string | Promise<string>),
  *   message?: string,
  *   store?: import('./cache.js').CacheStore,
+ *   trustProxy?: boolean,
  * }} opts
  * @returns {(req: Request, next: () => Promise<Response>) => Promise<Response>}
  */
 export function rateLimit(opts = {}) {
   const windowMs = parseWindow(opts.window ?? '1m');
   const max = opts.max ?? 60;
-  const keyFn = typeof opts.key === 'function' ? opts.key : defaultKey;
+  const keyFn = typeof opts.key === 'function' ? opts.key : null;
   const keyPrefix = typeof opts.key === 'string' ? opts.key : '';
   const message = opts.message ?? 'Too Many Requests';
-  // Use the provided store, or fall back to the global cache store -
-  // whatever was set via `setStore()` at app startup (in-memory by default).
+  const trustProxy = opts.trustProxy === true;
+  // Use the provided store, or fall back to the global cache store.
+  // Whatever was set via `setStore()` at app startup (in-memory by default).
   const store = opts.store || null;
 
   return async function rateLimitMiddleware(req, next) {
     const s = store || getStore();
-    const raw = typeof opts.key === 'function' ? await keyFn(req) : defaultKey(req);
+    const raw = keyFn ? await keyFn(req) : clientIp(req, { trustProxy });
     const key = `rl:${keyPrefix}${raw}`;
 
     const count = await s.increment(key, windowMs);
@@ -77,14 +79,50 @@ export function rateLimit(opts = {}) {
   };
 }
 
-/** @param {Request} req */
-function defaultKey(req) {
-  return (
-    req.headers.get('x-forwarded-for')?.split(',')[0].trim() ||
-    req.headers.get('cf-connecting-ip') ||
-    req.headers.get('x-real-ip') ||
-    '_anon_'
-  );
+/**
+ * Header name the framework stamps onto every incoming request with
+ * the TCP socket's remote address. Surfaces the socket IP through the
+ * Web `Request` boundary (which has no `.socket` property of its own).
+ *
+ * `dev.js`'s `toWebRequest` strips any inbound copy of this header
+ * BEFORE adding its own, so clients cannot spoof it from the wire.
+ */
+const REMOTE_IP_HEADER = 'x-webjs-remote-ip';
+
+/**
+ * Resolve the client IP for rate-limit bucket keying.
+ *
+ * `trustProxy: false` (default, safe everywhere): read ONLY the
+ * framework-stamped `x-webjs-remote-ip` header, which `dev.js`
+ * derives from the actual TCP socket and which clients cannot
+ * spoof. Forwarded-IP headers (`x-forwarded-for`, `cf-connecting-ip`,
+ * `x-real-ip`) are IGNORED. Fallback `_anon_` covers embedded use
+ * (`createRequestHandler`) where the host adapter never stamped a
+ * remote IP.
+ *
+ * `trustProxy: true`: honour forwarded-IP headers, preferring the
+ * leftmost entry of `X-Forwarded-For`, then `CF-Connecting-IP`,
+ * then `X-Real-IP`, then the framework-stamped remote IP, then
+ * `_anon_`. Production deploys MUST run behind a reverse proxy that
+ * STRIPS inbound `X-Forwarded-For` before adding its own, otherwise
+ * trust-proxy reintroduces the spoofability this option exists to
+ * defend against.
+ *
+ * @param {Request} req
+ * @param {{ trustProxy?: boolean }} [opts]
+ * @returns {string}
+ */
+export function clientIp(req, opts = {}) {
+  if (opts.trustProxy === true) {
+    return (
+      req.headers.get('x-forwarded-for')?.split(',')[0].trim() ||
+      req.headers.get('cf-connecting-ip') ||
+      req.headers.get('x-real-ip') ||
+      req.headers.get(REMOTE_IP_HEADER) ||
+      '_anon_'
+    );
+  }
+  return req.headers.get(REMOTE_IP_HEADER) || '_anon_';
 }
 
 /** @param {number | string} w @returns {number} milliseconds */

--- a/packages/server/src/rate-limit.js
+++ b/packages/server/src/rate-limit.js
@@ -93,12 +93,16 @@ const REMOTE_IP_HEADER = 'x-webjs-remote-ip';
  * Resolve the client IP for rate-limit bucket keying.
  *
  * `trustProxy: false` (default, safe everywhere): read ONLY the
- * framework-stamped `x-webjs-remote-ip` header, which `dev.js`
- * derives from the actual TCP socket and which clients cannot
- * spoof. Forwarded-IP headers (`x-forwarded-for`, `cf-connecting-ip`,
- * `x-real-ip`) are IGNORED. Fallback `_anon_` covers embedded use
- * (`createRequestHandler`) where the host adapter never stamped a
- * remote IP.
+ * framework-stamped `x-webjs-remote-ip` header. Under `startServer`
+ * the framework derives it from the actual TCP socket and strips
+ * any inbound copy via `toWebRequest`, so clients cannot spoof it.
+ * Under `createRequestHandler` (embedded use) the host adapter MUST
+ * call `stampRemoteIp(req, remoteAddress)` first, otherwise the
+ * adapter may pass forged inbound headers straight through and the
+ * "cannot spoof" guarantee no longer holds. Forwarded-IP headers
+ * (`x-forwarded-for`, `cf-connecting-ip`, `x-real-ip`) are IGNORED
+ * regardless. Fallback `_anon_` covers requests that arrive without
+ * a stamped IP.
  *
  * `trustProxy: true`: honour forwarded-IP headers, preferring the
  * leftmost entry of `X-Forwarded-For`, then `CF-Connecting-IP`,
@@ -159,6 +163,11 @@ export function stampRemoteIp(req, remoteAddress) {
   if (remoteAddress) headers.set(REMOTE_IP_HEADER, remoteAddress);
   /** @type {RequestInit & { duplex?: string }} */
   const init = { method: req.method, headers };
+  // Preserve AbortSignal so host-side cancellation propagates
+  // (e.g. client disconnects mid-request). The framework's body
+  // stream has its own teardown, but downstream consumers may
+  // listen on the signal directly.
+  if (req.signal) init.signal = req.signal;
   if (req.method !== 'GET' && req.method !== 'HEAD') {
     init.body = req.body;
     init.duplex = 'half';

--- a/packages/server/test/dev/dev-handler.test.js
+++ b/packages/server/test/dev/dev-handler.test.js
@@ -1545,3 +1545,40 @@ test('gate: page imports from app/_components/ stay servable', async () => {
     assert.equal(resp.status, 200, `${url} should be reachable through _components imports`);
   }
 });
+
+/* ------------ x-webjs-remote-ip stamping + spoof-strip (rate-limit #114) ------------ */
+
+test('toWebRequest: x-webjs-remote-ip is set from the socket and inbound copies are dropped', async () => {
+  // Regression for #114. The wire is presumed hostile: any client can
+  // send `X-Webjs-Remote-IP: <fake>` to escape per-IP rate buckets if
+  // rate-limit's defaultKey (trustProxy:false) trusts it as-is. The
+  // dev server's IncomingMessage → Request wrapper must strip the
+  // inbound copy and replace it with `req.socket.remoteAddress`.
+  const appDir = makeApp({
+    'app/page.js':
+      `import { html } from ${JSON.stringify(HTML_URL)};\n` +
+      `export default function P() { return html\`<p>ok</p>\`; }\n`,
+    'app/api/echo/route.js':
+      `export async function GET(req) {\n` +
+      `  return Response.json({ stamped: req.headers.get('x-webjs-remote-ip') });\n` +
+      `}\n`,
+  });
+  const logger = { info: () => {}, warn: () => {}, error: () => {} };
+  const { server, close } = await startServer({ appDir, dev: false, port: 0, logger, compress: false });
+  try {
+    const addr = server.address();
+    // Client tries to spoof the header. Expect the framework to ignore it
+    // and emit the actual socket address (127.0.0.1 over localhost loopback).
+    const resp = await fetch(`http://127.0.0.1:${addr.port}/api/echo`, {
+      headers: { 'x-webjs-remote-ip': '6.6.6.6' },
+    });
+    assert.equal(resp.status, 200);
+    const { stamped } = await resp.json();
+    assert.notEqual(stamped, '6.6.6.6',
+      'inbound x-webjs-remote-ip must be stripped (spoof attempt rejected)');
+    assert.ok(/^(127\.0\.0\.1|::1|::ffff:127\.0\.0\.1)$/.test(stamped),
+      `framework must stamp the real socket address; got: ${stamped}`);
+  } finally {
+    await close();
+  }
+});

--- a/packages/server/test/rate-limit/rate-limit.test.js
+++ b/packages/server/test/rate-limit/rate-limit.test.js
@@ -179,3 +179,50 @@ test('clientIp(req, {trustProxy:false}) ignores x-forwarded-for entirely', async
   assert.equal(clientIp(reqNoStamp), '_anon_',
     'default trustProxy:false must NOT fall back to XFF when stamped IP is missing');
 });
+
+test('stampRemoteIp: strips any inbound x-webjs-remote-ip and sets the new value', async () => {
+  const { stampRemoteIp } = await import('../../src/rate-limit.js');
+  const inbound = new Request('http://x/api', {
+    method: 'POST',
+    headers: {
+      'x-webjs-remote-ip': '6.6.6.6',   // forged on the wire
+      'x-other': 'kept',
+    },
+    body: 'payload',
+    duplex: 'half',
+  });
+  const safe = stampRemoteIp(inbound, '127.0.0.1');
+  assert.equal(safe.headers.get('x-webjs-remote-ip'), '127.0.0.1',
+    'forged header must be replaced by the trusted socket address');
+  assert.equal(safe.headers.get('x-other'), 'kept',
+    'other headers must survive the rewrite');
+  assert.equal(safe.method, 'POST');
+  assert.equal(await safe.text(), 'payload',
+    'body must round-trip through the new Request');
+});
+
+test('stampRemoteIp: missing remoteAddress just strips the inbound header (collapses to _anon_)', async () => {
+  const { stampRemoteIp } = await import('../../src/rate-limit.js');
+  const inbound = new Request('http://x/', { headers: { 'x-webjs-remote-ip': '6.6.6.6' } });
+  const safe = stampRemoteIp(inbound, undefined);
+  assert.equal(safe.headers.get('x-webjs-remote-ip'), null,
+    'no trusted address means the header must NOT be present');
+  // clientIp should fall back to _anon_, NOT the forged value.
+  const { clientIp } = await import('../../src/rate-limit.js');
+  assert.equal(clientIp(safe), '_anon_');
+});
+
+test('createRequestHandler WITHOUT stampRemoteIp trusts wire headers (documented boundary)', async () => {
+  // Counterfactual covering the embedded-use threat boundary: the
+  // built-in startServer path strips/stamps in toWebRequest, but
+  // createRequestHandler hands the user back a `handle(req)` that
+  // consumes whatever Request they construct. If the adapter copies
+  // wire headers verbatim, x-webjs-remote-ip is trusted. This test
+  // pins that boundary so a future refactor doesn't accidentally
+  // make embedded use "magically safe" without going through
+  // stampRemoteIp.
+  const { clientIp } = await import('../../src/rate-limit.js');
+  const forged = new Request('http://x/', { headers: { 'x-webjs-remote-ip': '6.6.6.6' } });
+  assert.equal(clientIp(forged), '6.6.6.6',
+    'without stampRemoteIp, forged header IS read; adapters MUST call the helper');
+});

--- a/packages/server/test/rate-limit/rate-limit.test.js
+++ b/packages/server/test/rate-limit/rate-limit.test.js
@@ -226,3 +226,14 @@ test('createRequestHandler WITHOUT stampRemoteIp trusts wire headers (documented
   assert.equal(clientIp(forged), '6.6.6.6',
     'without stampRemoteIp, forged header IS read; adapters MUST call the helper');
 });
+
+test('stampRemoteIp: preserves AbortSignal for host-side cancellation', async () => {
+  const { stampRemoteIp } = await import('../../src/rate-limit.js');
+  const ac = new AbortController();
+  const inbound = new Request('http://x/', { headers: {}, signal: ac.signal });
+  const safe = stampRemoteIp(inbound, '127.0.0.1');
+  assert.equal(safe.signal.aborted, false, 'signal must not be pre-aborted');
+  ac.abort();
+  assert.equal(safe.signal.aborted, true,
+    'aborting the source controller must propagate to the safe Request');
+});

--- a/packages/server/test/rate-limit/rate-limit.test.js
+++ b/packages/server/test/rate-limit/rate-limit.test.js
@@ -1,9 +1,13 @@
 import { test, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { rateLimit, parseWindow, _resetRateLimits } from '../../src/rate-limit.js';
+import { rateLimit, parseWindow } from '../../src/rate-limit.js';
+import { memoryStore, setStore } from '../../src/cache.js';
 
-beforeEach(() => _resetRateLimits());
+// Swap in a fresh in-memory store before every test. Tests that bucket
+// under shared keys (`_anon_`, no-stamp default) would otherwise leak
+// state across the suite and 429 each other.
+beforeEach(() => setStore(memoryStore()));
 
 test('parseWindow handles ms/s/m/h suffixes', () => {
   assert.equal(parseWindow(500), 500);
@@ -16,7 +20,7 @@ test('parseWindow handles ms/s/m/h suffixes', () => {
 
 test('rateLimit allows up to max then 429s with Retry-After', async () => {
   const mw = rateLimit({ window: '1s', max: 2 });
-  const req = new Request('http://x/', { headers: { 'x-forwarded-for': '9.9.9.9' } });
+  const req = new Request('http://x/', { headers: { 'x-webjs-remote-ip': '9.9.9.9' } });
   const ok1 = await mw(req, async () => new Response('ok'));
   const ok2 = await mw(req, async () => new Response('ok'));
   const no3 = await mw(req, async () => new Response('ok'));
@@ -29,8 +33,8 @@ test('rateLimit allows up to max then 429s with Retry-After', async () => {
 
 test('separate keys get separate buckets', async () => {
   const mw = rateLimit({ window: '1s', max: 1 });
-  const reqA = new Request('http://x/', { headers: { 'x-forwarded-for': '1.1.1.1' } });
-  const reqB = new Request('http://x/', { headers: { 'x-forwarded-for': '2.2.2.2' } });
+  const reqA = new Request('http://x/', { headers: { 'x-webjs-remote-ip': '1.1.1.1' } });
+  const reqB = new Request('http://x/', { headers: { 'x-webjs-remote-ip': '2.2.2.2' } });
   assert.equal((await mw(reqA, async () => new Response())).status, 200);
   assert.equal((await mw(reqB, async () => new Response())).status, 200);
   assert.equal((await mw(reqA, async () => new Response())).status, 429);
@@ -52,15 +56,18 @@ test('custom key function is honoured', async () => {
 
 test('passes through x-ratelimit-* headers on the success path', async () => {
   const mw = rateLimit({ window: '1s', max: 5 });
-  const req = new Request('http://x/', { headers: { 'x-forwarded-for': '3.3.3.3' } });
+  const req = new Request('http://x/', { headers: { 'x-webjs-remote-ip': '3.3.3.3' } });
   const r = await mw(req, async () => new Response('ok'));
   assert.equal(r.headers.get('x-ratelimit-limit'), '5');
   assert.equal(r.headers.get('x-ratelimit-remaining'), '4');
   assert.ok(r.headers.get('x-ratelimit-reset'));
 });
 
-test('defaultKey falls back through cf-connecting-ip, x-real-ip, then `_anon_`', async () => {
-  const mw = rateLimit({ window: '1s', max: 1 });
+test('trustProxy:true falls back through cf-connecting-ip, x-real-ip, then `_anon_`', async () => {
+  // Behaviour only available when the deploy opts into trustProxy.
+  // Default trustProxy:false would bucket all three under `_anon_`
+  // (no `x-webjs-remote-ip` stamped on these synthetic requests).
+  const mw = rateLimit({ window: '1s', max: 1, trustProxy: true });
   const cf = new Request('http://x/', { headers: { 'cf-connecting-ip': '4.4.4.4' } });
   const real = new Request('http://x/', { headers: { 'x-real-ip': '5.5.5.5' } });
   const anon = new Request('http://x/');
@@ -77,7 +84,7 @@ test('immutable response headers do not throw (catch branch)', async () => {
   // A cross-realm Response can expose immutable headers. Simulate that
   // by returning a Response whose `headers.set` throws.
   const mw = rateLimit({ window: '1s', max: 5 });
-  const req = new Request('http://x/', { headers: { 'x-forwarded-for': '8.8.8.8' } });
+  const req = new Request('http://x/', { headers: { 'x-webjs-remote-ip': '8.8.8.8' } });
   const frozenHeaders = new Headers({ 'content-type': 'text/plain' });
   frozenHeaders.set = () => { throw new TypeError('immutable'); };
   const resp = new Response('ok', { headers: {} });
@@ -92,7 +99,7 @@ test('static string key acts as a bucket prefix (namespaces IP buckets)', async 
   // collapse all callers into one bucket.
   const mwA = rateLimit({ window: '1s', max: 1, key: 'group-a:' });
   const mwB = rateLimit({ window: '1s', max: 1, key: 'group-b:' });
-  const req = new Request('http://x/', { headers: { 'x-forwarded-for': '7.7.7.7' } });
+  const req = new Request('http://x/', { headers: { 'x-webjs-remote-ip': '7.7.7.7' } });
   // Same IP, different prefix → independent buckets.
   assert.equal((await mwA(req, async () => new Response())).status, 200);
   assert.equal((await mwB(req, async () => new Response())).status, 200);
@@ -102,8 +109,73 @@ test('static string key acts as a bucket prefix (namespaces IP buckets)', async 
 
 test('custom message is surfaced in the 429 body', async () => {
   const mw = rateLimit({ window: '1s', max: 0, message: 'chill out' });
-  const req = new Request('http://x/', { headers: { 'x-forwarded-for': '10.10.10.10' } });
+  const req = new Request('http://x/', { headers: { 'x-webjs-remote-ip': '10.10.10.10' } });
   const resp = await mw(req, async () => new Response());
   assert.equal(resp.status, 429);
   assert.deepEqual(await resp.json(), { error: 'chill out' });
+});
+
+/* ------------------ trustProxy + clientIp security surface ------------------ */
+
+test('trustProxy:false (default): spoofed X-Forwarded-For does NOT escape the bucket', async () => {
+  // Regression coverage for #114. The vulnerability the trustProxy
+  // option closes: without it, an attacker rotates X-Forwarded-For
+  // per request and stays under the rate limit forever.
+  const mw = rateLimit({ window: '1s', max: 1 });
+  const ip = 'x-webjs-remote-ip'; // the framework-stamped client IP
+  // All three requests come from the same real client (same stamped
+  // IP) but rotate XFF. Under trustProxy:false, XFF is IGNORED;
+  // all three bucket together and the second + third return 429.
+  const r1 = new Request('http://x/', { headers: { [ip]: '1.2.3.4', 'x-forwarded-for': '10.0.0.1' } });
+  const r2 = new Request('http://x/', { headers: { [ip]: '1.2.3.4', 'x-forwarded-for': '10.0.0.2' } });
+  const r3 = new Request('http://x/', { headers: { [ip]: '1.2.3.4', 'x-forwarded-for': '10.0.0.3' } });
+  assert.equal((await mw(r1, async () => new Response())).status, 200);
+  assert.equal((await mw(r2, async () => new Response())).status, 429,
+    'second request from the same stamped IP must 429 even with rotated XFF');
+  assert.equal((await mw(r3, async () => new Response())).status, 429);
+});
+
+test('trustProxy:true: rotated X-Forwarded-For DOES escape the bucket (caller opted in)', async () => {
+  // Counterfactual: with trustProxy:true the deploy contract is
+  // "you have a trusted reverse proxy in front, and it strips
+  // inbound XFF before adding its own". If the contract is met,
+  // rotating XFF can only come from a misconfigured proxy, not
+  // from clients. This test verifies the trustProxy:true semantic
+  // is faithfully different from the default.
+  const mw = rateLimit({ window: '1s', max: 1, trustProxy: true });
+  const r1 = new Request('http://x/', { headers: { 'x-forwarded-for': '10.0.0.1' } });
+  const r2 = new Request('http://x/', { headers: { 'x-forwarded-for': '10.0.0.2' } });
+  assert.equal((await mw(r1, async () => new Response())).status, 200);
+  assert.equal((await mw(r2, async () => new Response())).status, 200,
+    'different XFFs map to different buckets under trustProxy:true');
+});
+
+test('trustProxy:false: no stamped IP → all requests collapse to `_anon_` and share a bucket', async () => {
+  // Embedded use (createRequestHandler under Express/Bun/Deno where
+  // the adapter does not stamp x-webjs-remote-ip). Requests share
+  // a bucket. Users wanting per-client buckets in that setup must
+  // either stamp the IP themselves or pass a custom `key` function.
+  const mw = rateLimit({ window: '1s', max: 1 });
+  const r1 = new Request('http://x/');
+  const r2 = new Request('http://x/', { headers: { 'x-forwarded-for': '1.1.1.1' } });
+  assert.equal((await mw(r1, async () => new Response())).status, 200);
+  assert.equal((await mw(r2, async () => new Response())).status, 429,
+    'both requests collapse to `_anon_` even with different XFF values');
+});
+
+test('clientIp(req, {trustProxy:true}) prefers x-forwarded-for leftmost entry', async () => {
+  const { clientIp } = await import('../../src/rate-limit.js');
+  const req = new Request('http://x/', { headers: { 'x-forwarded-for': '1.1.1.1, 2.2.2.2, 3.3.3.3', 'x-webjs-remote-ip': '9.9.9.9' } });
+  assert.equal(clientIp(req, { trustProxy: true }), '1.1.1.1',
+    'trustProxy:true must return the leftmost XFF entry, NOT the stamped remote IP');
+});
+
+test('clientIp(req, {trustProxy:false}) ignores x-forwarded-for entirely', async () => {
+  const { clientIp } = await import('../../src/rate-limit.js');
+  const req = new Request('http://x/', { headers: { 'x-forwarded-for': '1.1.1.1', 'x-webjs-remote-ip': '9.9.9.9' } });
+  assert.equal(clientIp(req), '9.9.9.9',
+    'default trustProxy:false must return the stamped IP, ignoring XFF');
+  const reqNoStamp = new Request('http://x/', { headers: { 'x-forwarded-for': '1.1.1.1' } });
+  assert.equal(clientIp(reqNoStamp), '_anon_',
+    'default trustProxy:false must NOT fall back to XFF when stamped IP is missing');
 });


### PR DESCRIPTION
## Summary

Closes #114.

`rateLimit()` previously read `X-Forwarded-For` / `CF-Connecting-IP` / `X-Real-IP` unconditionally for its per-client bucket key. On a deployment without a trusted reverse proxy (bare Node, or a proxy that doesn't strip inbound forwarded headers), an attacker rotates those headers per request and stays under the rate limit forever.

## Design

- **`trustProxy: false`** (new default, safe everywhere) keys on `x-webjs-remote-ip`, a framework-stamped header set from the TCP socket on every request. Forwarded-IP headers are ignored.
- **`trustProxy: true`** keeps the prior behaviour (XFF / CF / X-Real-IP chain). Deploys MUST run behind a reverse proxy that strips inbound `X-Forwarded-For` before adding its own.
- **`toWebRequest` in `dev.js`** strips any inbound `x-webjs-remote-ip` before adding its own from `req.socket.remoteAddress`. Clients cannot forge the framework-stamped header from the wire.
- **`clientIp(req, opts)`** exported from `@webjsdev/server` so custom `key` functions can reuse the same resolution logic instead of reimplementing it.

## Migration note (0.x SemVer breaking)

Existing apps that relied on the implicit forwarded-IP behaviour must now opt in: `rateLimit({ ..., trustProxy: true })`. The agent-docs update spells out both deploy postures and the proxy contract.

## Test plan

- [x] `npm test` 1338 / 1338 (1332 baseline + 6 new)
- [x] `webjs check` clean on framework repo
- [x] Existing rate-limit tests migrated from `x-forwarded-for` to `x-webjs-remote-ip` (matching the new safe default)
- [x] One existing test renamed and pinned to `trustProxy: true` since it covered the proxy-trust fallback chain explicitly
- [x] 5 new rate-limit tests: spoofed XFF does not escape the bucket under `trustProxy: false`; rotated XFF DOES escape under `trustProxy: true` (counterfactual); no stamped IP collapses to `_anon_`; `clientIp` honours / ignores XFF per option
- [x] 1 new integration test in `dev-handler.test.js`: inbound `x-webjs-remote-ip: <fake>` is stripped and replaced by the real socket address (127.0.0.1 over loopback)
- [x] Fixed pre-existing test-isolation bug: `_resetRateLimits()` was a no-op (cache store leaked state); `beforeEach` now swaps in a fresh `memoryStore()`
- [x] `agent-docs/advanced.md` rate-limit section updated with `trustProxy` semantics, both deploy postures, the `clientIp` helper, and the embedded-use contract