### PR TITLE
scaffold: enforce documentation-as-part-of-task in end-user apps

### DIFF
--- a/packages/cli/templates/.cursorrules
+++ b/packages/cli/templates/.cursorrules
@@ -52,8 +52,12 @@ Quality bar stays the same - just no blocking on questions.
    test/<feature>/browser/ (WTR + Playwright, real Chromium). Run `webjs test`
    after every change. Never deliver code without passing tests.
 
-2. DOCS: Update AGENTS.md for API changes. Update docs/ and website/ if
-   they exist. The user should never have to ask for tests or docs.
+2. DOCS: Documentation lands on the same PR as the code, never as a
+   follow-up. Walk every surface in the **Definition of done** section
+   of CONVENTIONS.md (AGENTS.md, CONVENTIONS.md, README.md, docs/,
+   website/, scaffold scripts) and either update it or write
+   "N/A because <reason>" in the PR body. The user should never have to
+   ask for tests or docs.
 
 3. CONVENTIONS: Run `webjs check` and fix violations before committing.
 

--- a/packages/cli/templates/.github/copilot-instructions.md
+++ b/packages/cli/templates/.github/copilot-instructions.md
@@ -51,7 +51,11 @@ Every code change must include:
    Claude users; Copilot users should self-enforce the same rule. Automatic.
 2. Server tests in test/<feature>/*.test.ts (node:test for actions, queries, utilities)
 3. Browser tests in test/<feature>/browser/*.test.js (WTR + Playwright, real Chromium)
-4. Documentation updates (AGENTS.md for API, docs/ for user guides)
+4. Documentation updates. Walk every surface in the **Definition of
+   done** section of CONVENTIONS.md (AGENTS.md, CONVENTIONS.md,
+   README.md, docs/, website/, scaffold scripts) and either update or
+   write "N/A because <reason>" in the PR body. Docs land on the same
+   PR as the code.
 5. Convention validation: `webjs check` must pass
 
 ## Git rules

--- a/packages/cli/templates/.github/pull_request_template.md
+++ b/packages/cli/templates/.github/pull_request_template.md
@@ -8,7 +8,30 @@
 - [ ] E2E tests added/updated for user-facing changes (`webjs test --e2e` passes)
 - [ ] `webjs check` passes (no convention violations)
 
-## Documentation
+## Definition of done
 
-- [ ] AGENTS.md updated (if API surface changed)
-- [ ] Docs updated (if docs/ exists and feature is documented)
+Documentation MUST land on the same PR as the code change. Drift is how a
+codebase rots. For each surface below, write `Updated <path>` or
+`N/A because <reason>`. If you find yourself writing `N/A` for every
+surface except tests, that is a smell. Reviewers should reject the PR if
+this section is left as the template default.
+
+- [ ] **Tests.** Unit coverage for logic. Real-browser coverage for
+      user-facing behaviour.
+- [ ] **`AGENTS.md`.** Updated if any API surface, invariant, or
+      file-routing rule changed.
+- [ ] **`CONVENTIONS.md`.** Updated if a project-level convention
+      changed (e.g. a new architectural rule, a new agent workflow
+      step). Conventions go in CONVENTIONS.md; lint rules go in
+      `package.json` under `"webjs": { "conventions": { … } }`.
+- [ ] **`README.md`.** Updated if install / use / public surface
+      changed.
+- [ ] **`docs/`** (if the project has one). Updated for every
+      user-visible change.
+- [ ] **`website/`** (if the project has one). Updated when landing
+      copy or pricing-page claims touch the change.
+- [ ] **Scaffold scripts / templates** (if the project ships any).
+      Updated when the change affects what new instances generate.
+
+See the **Definition of done** section in
+[`CONVENTIONS.md`](../CONVENTIONS.md) for the full per-surface guidance.

--- a/packages/cli/templates/.github/pull_request_template.md
+++ b/packages/cli/templates/.github/pull_request_template.md
@@ -10,28 +10,25 @@
 
 ## Definition of done
 
-Documentation MUST land on the same PR as the code change. Drift is how a
-codebase rots. For each surface below, write `Updated <path>` or
-`N/A because <reason>`. If you find yourself writing `N/A` for every
-surface except tests, that is a smell. Reviewers should reject the PR if
-this section is left as the template default.
+Documentation MUST land on the same PR as the code change. Drift is how
+a codebase rots. Walk every markdown file in the project (`git ls-files
+'*.md'`) and ask whether this PR changed behaviour, surface, or
+invariants it describes. For each row below, write `Updated <path>` or
+`N/A because <reason>`. Reviewers should reject the PR if this section
+is left as the template default. See the **Definition of done** section
+in [`CONVENTIONS.md`](../CONVENTIONS.md) for the full guidance.
 
 - [ ] **Tests.** Unit coverage for logic. Real-browser coverage for
       user-facing behaviour.
-- [ ] **`AGENTS.md`.** Updated if any API surface, invariant, or
-      file-routing rule changed.
-- [ ] **`CONVENTIONS.md`.** Updated if a project-level convention
-      changed (e.g. a new architectural rule, a new agent workflow
-      step). Conventions go in CONVENTIONS.md; lint rules go in
-      `package.json` under `"webjs": { "conventions": { … } }`.
-- [ ] **`README.md`.** Updated if install / use / public surface
-      changed.
-- [ ] **`docs/`** (if the project has one). Updated for every
-      user-visible change.
-- [ ] **`website/`** (if the project has one). Updated when landing
-      copy or pricing-page claims touch the change.
-- [ ] **Scaffold scripts / templates** (if the project ships any).
-      Updated when the change affects what new instances generate.
-
-See the **Definition of done** section in
-[`CONVENTIONS.md`](../CONVENTIONS.md) for the full per-surface guidance.
+- [ ] **Every markdown file in the project** that describes the
+      changed surface. Common cases (non-exhaustive): `AGENTS.md` (root
+      + nested), `CONVENTIONS.md`, `README.md` (root + nested),
+      `CHANGELOG.md`, `docs/**/*.md`, `agent-docs/**/*.md`,
+      `.github/*.md`. The rule is generative: if a markdown file in
+      this project mentions a thing this PR changed, it gets touched
+      on this PR.
+- [ ] **`website/`** (if the project has one). Marketing copy on the
+      landing or pricing page when the change touches a claim made
+      there.
+- [ ] **Scaffold scripts / codegen** (if the project has any). Updated
+      when the change affects what new instances generate.

--- a/packages/cli/templates/.windsurfrules
+++ b/packages/cli/templates/.windsurfrules
@@ -46,7 +46,11 @@ Quality bar stays the same - no blocking on questions.
 Every code change must include:
 1. Server tests in test/<feature>/*.test.ts (node:test)
 2. Browser tests in test/<feature>/browser/*.test.js (WTR + Playwright, real Chromium)
-3. Documentation updates (AGENTS.md, docs/, website/ if they exist)
+3. Documentation updates. Walk every surface in the **Definition of
+   done** section of CONVENTIONS.md (AGENTS.md, CONVENTIONS.md,
+   README.md, docs/, website/, scaffold scripts) and either update it
+   or write "N/A because <reason>" in the PR body. Docs land on the
+   same PR as the code, never as a follow-up.
 4. Convention check: `webjs check` must pass
 
 The user should never have to ask for tests or documentation.

--- a/packages/cli/templates/CONVENTIONS.md
+++ b/packages/cli/templates/CONVENTIONS.md
@@ -118,29 +118,32 @@ checklist mirrors this list.
    user-facing behaviour. `webjs test` must pass; `webjs test --browser`
    for any DOM-touching change. See the "Testing" section below for the
    per-change matrix.
-2. **`AGENTS.md`.** The project contract for AI agents. Update when:
-   - A new API surface is exposed (a new server action / query module,
-     a new exposed REST endpoint, a new component tag in the public
-     catalogue).
-   - An invariant changes (file routing, persistence rules, security
-     posture).
-   - A new project-wide agent workflow rule applies.
-3. **`CONVENTIONS.md`** (this file). Update when:
-   - A new architectural convention is introduced (a new module split,
-     a new testing layout, a new git rule).
-   - An existing convention shifts. Do NOT enumerate lint rules in
-     prose; those live in `package.json` under
+2. **Every markdown file in the project.** Walk the whole tree, not a
+   closed list. Run `git ls-files '*.md'` (or `git ls-files '*.md'
+   '*.mdx'` if the project ships MDX) and for each path ask: does this
+   file describe behaviour, surface, or invariants that this PR changed?
+   If yes, update it on this PR. Common surfaces (non-exhaustive):
+   - `AGENTS.md` (root and every nested one) for API surface, invariants,
+     file-routing rules, project-wide agent workflow.
+   - `CONVENTIONS.md` (this file) for architectural conventions. Do NOT
+     enumerate lint rules in prose; those live in `package.json` under
      `"webjs": { "conventions": { … } }`.
-4. **`README.md`.** Update when install steps, the homepage example,
-   or the public surface description changes.
-5. **`docs/`** (if the project has one). Every user-visible change. Add
-   a new page if the surface is new and there's no obvious home.
-6. **`website/`** (if the project has one). Marketing copy on the
+   - `README.md` (root and any nested ones) for install / use / public
+     surface descriptions.
+   - `CHANGELOG.md` for any user-visible change, including the SHA / PR
+     reference. Keep it in chronological order; don't backdate.
+   - `docs/` (if the project has one). Every user-visible change. Add a
+     new page if the surface is new and there's no obvious home.
+   - Any `*.md` under `agent-docs/`, `docs-internal/`, `decisions/`, or
+     similar reference trees.
+   - `.github/*.md` (issue templates, PR templates, contributing) when
+     a workflow rule shifts.
+3. **`website/`** (if the project has one). Marketing copy on the
    landing page or pricing page when the change touches a claim made
    there.
-7. **Scaffold or codegen scripts** (if the project has any). Update
+4. **Scaffold or codegen scripts** (if the project has any). Update
    when the change affects what new instances generate.
-8. **PR body.** Summary, test plan checklist, and a per-row answer to
+5. **PR body.** Summary, test plan checklist, and a per-row answer to
    the Definition-of-done checklist (`Updated <path>` or `N/A because
    <reason>`).
 
@@ -150,26 +153,31 @@ one of:
 - **Updated**, with the file path in the commit and PR body.
 - **N/A because**, with a one-sentence reason.
 
+The "every markdown file" rule is generative, not enumerative. New
+markdown files appear over a project's lifetime, and this checklist
+must not silently exclude them. The git query above is the source of
+truth; the named files are just common cases.
+
 If you find yourself writing `N/A` for every surface except tests, that
-is a smell. Most user-visible code changes touch at least one doc page
-and either `AGENTS.md` or `CONVENTIONS.md`.
+is a smell. Most user-visible code changes touch at least one markdown
+file and either `AGENTS.md` or `CONVENTIONS.md`.
 
 **Worked examples:**
 
 - Add a new server action `modules/posts/actions/create-post.server.ts`.
-  Updated: test (`test/posts/posts.test.ts`), AGENTS.md (action listed
-  in the module map if the project keeps one), docs
-  (`/docs/server-actions` if the page lists shipped actions). N/A on
-  README / website / scaffold.
+  Updated: test (`test/posts/posts.test.ts`), `AGENTS.md` (action listed
+  in the module map if the project keeps one), `CHANGELOG.md` (one-line
+  entry), `docs/` (the page listing shipped actions if one exists). N/A
+  on website / scaffold scripts.
 - Rename a directory convention (e.g. `modules/` to `features/`).
-  Updated: existing tests still pass after renames, AGENTS.md (whole
-  modules section), CONVENTIONS.md (architecture section), scaffold
-  scripts (so new generations follow the new name), README if the
-  layout is documented there. N/A on website unless the layout appears
-  in a landing-page screenshot.
+  Updated: existing tests still pass after renames, every markdown file
+  that mentions the old name (run `git grep -l 'modules/' '*.md'`),
+  scaffold scripts, `CHANGELOG.md`. N/A on website unless the layout
+  appears in a landing-page screenshot.
 - Fix a bug in `rateLimit()` that doesn't change the surface. Updated:
-  test (regression). N/A on everything else (the public contract did
-  not change).
+  test (regression), `CHANGELOG.md` (one-line entry under fixes). N/A
+  on every other markdown file because the public contract did not
+  change.
 
 ### Autonomous mode (sandbox / bypass permissions)
 

--- a/packages/cli/templates/CONVENTIONS.md
+++ b/packages/cli/templates/CONVENTIONS.md
@@ -95,15 +95,81 @@ even if the user doesn't explicitly ask.**
    Run `webjs test` after every change. Never mark work as done with
    failing tests.
 
-3. **Documentation updates.** When adding or modifying features:
-   - Update `AGENTS.md` if the change affects the framework API surface.
-   - Update `CONVENTIONS.md` only if the change introduces a new convention.
-   - If a `docs/` directory exists, add or update the relevant doc page.
-   - If a `website/` directory exists, update the landing page for
-     user-facing features.
+3. **Documentation updates.** See the **Definition of done** section
+   below for the per-surface checklist. The short version: docs land on
+   the same PR as the code, never as a follow-up. Drift is how a
+   codebase rots; the user should never have to ask "did you update the
+   docs?"
 
-3. **Convention check.** Run `webjs check` after changes and fix
+4. **Convention check.** Run `webjs check` after changes and fix
    any violations before reporting the task as done.
+
+### Definition of done (MUST be addressed BEFORE opening the PR)
+
+This is the per-PR contract. Before running `gh pr create`, walk through
+every surface below and either update it OR write `N/A because <reason>`
+in the PR body so the omission is visible. The
+[`.github/pull_request_template.md`](./.github/pull_request_template.md)
+checklist mirrors this list.
+
+**Surfaces to consider on EVERY PR:**
+
+1. **Tests.** Unit coverage for new logic. Real-browser coverage for
+   user-facing behaviour. `webjs test` must pass; `webjs test --browser`
+   for any DOM-touching change. See the "Testing" section below for the
+   per-change matrix.
+2. **`AGENTS.md`.** The project contract for AI agents. Update when:
+   - A new API surface is exposed (a new server action / query module,
+     a new exposed REST endpoint, a new component tag in the public
+     catalogue).
+   - An invariant changes (file routing, persistence rules, security
+     posture).
+   - A new project-wide agent workflow rule applies.
+3. **`CONVENTIONS.md`** (this file). Update when:
+   - A new architectural convention is introduced (a new module split,
+     a new testing layout, a new git rule).
+   - An existing convention shifts. Do NOT enumerate lint rules in
+     prose; those live in `package.json` under
+     `"webjs": { "conventions": { … } }`.
+4. **`README.md`.** Update when install steps, the homepage example,
+   or the public surface description changes.
+5. **`docs/`** (if the project has one). Every user-visible change. Add
+   a new page if the surface is new and there's no obvious home.
+6. **`website/`** (if the project has one). Marketing copy on the
+   landing page or pricing page when the change touches a claim made
+   there.
+7. **Scaffold or codegen scripts** (if the project has any). Update
+   when the change affects what new instances generate.
+8. **PR body.** Summary, test plan checklist, and a per-row answer to
+   the Definition-of-done checklist (`Updated <path>` or `N/A because
+   <reason>`).
+
+**How to use the checklist.** For each surface above, explicitly answer
+one of:
+
+- **Updated**, with the file path in the commit and PR body.
+- **N/A because**, with a one-sentence reason.
+
+If you find yourself writing `N/A` for every surface except tests, that
+is a smell. Most user-visible code changes touch at least one doc page
+and either `AGENTS.md` or `CONVENTIONS.md`.
+
+**Worked examples:**
+
+- Add a new server action `modules/posts/actions/create-post.server.ts`.
+  Updated: test (`test/posts/posts.test.ts`), AGENTS.md (action listed
+  in the module map if the project keeps one), docs
+  (`/docs/server-actions` if the page lists shipped actions). N/A on
+  README / website / scaffold.
+- Rename a directory convention (e.g. `modules/` to `features/`).
+  Updated: existing tests still pass after renames, AGENTS.md (whole
+  modules section), CONVENTIONS.md (architecture section), scaffold
+  scripts (so new generations follow the new name), README if the
+  layout is documented there. N/A on website unless the layout appears
+  in a landing-page screenshot.
+- Fix a bug in `rateLimit()` that doesn't change the surface. Updated:
+  test (regression). N/A on everything else (the public contract did
+  not change).
 
 ### Autonomous mode (sandbox / bypass permissions)
 


### PR DESCRIPTION
## Summary

Closes #122.

- Rewrite scaffolded `.github/pull_request_template.md` so the doc rule is generative ("walk every markdown file in the project via `git ls-files '*.md'`") rather than enumerative. CHANGELOG.md, nested READMEs, `agent-docs/`, `.github/*.md`, future markdown files we haven't named: all covered automatically by the git query. Common cases still listed, but only as examples, not as the closed contract.
- Expand scaffolded `CONVENTIONS.md` "Every code change must include" with a full **Definition of done** section enumerating tests + the generative markdown rule + website + scaffold scripts, plus three worked examples (server action, directory rename, fix-with-changelog-entry).
- Replace per-agent doc reminders in `.cursorrules`, `.windsurfrules`, `.github/copilot-instructions.md` with pointers to the CONVENTIONS.md section so the rule lives in one place across four agents.

Mirrors the framework-side `webjs-start-work` Claude skill, which was updated in the same direction (generative rule, all markdown files, CHANGELOG.md explicit) so framework PRs and scaffolded-app PRs share the same contract.

## Definition of done

- Tests: `node scripts/run-node-tests.js` 1345/1345 (scaffold tests under `test/scaffolds/` cover the templates).
- Markdown sweep (`git ls-files '*.md'` filtered to relevant): N/A on framework-root `AGENTS.md` / `CONVENTIONS.md` / `agent-docs/*.md` / per-package `AGENTS.md` / `README.md` / `CHANGELOG.md` because this PR changes scaffolded-app template content, not the framework's own contract or surface. The framework already follows the same Definition of done (now reinforced in the start-work skill).
- docs/: N/A because no user-visible framework feature changed.
- website/: N/A.
- Scaffold templates: Updated (the five files listed in Summary).

## Test plan

- [x] `node scripts/run-node-tests.js` passes locally (1345/1345).
- [ ] `webjs create demo` produces a scaffolded app whose `CONVENTIONS.md` carries the generative Definition-of-done section.
- [ ] The new PR template renders correctly when a user opens a PR in a freshly-scaffolded app.

## Out of scope (separate issue if we want it)

A `webjs check` lint rule that flags new actions/pages/components without a doc touch on the same commit. It needs git state and produces false positives on refactors/renames. Not blocking this PR.