### PR TITLE
fix(core): guard prepare so it's a no-op without scripts/src in scope

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,15 @@ COPY changelog ./changelog
 COPY blog ./blog
 
 # --- 3. Build-time work --------------------------------------------------
+# Core: build the dist/ bundles. The package.json `prepare` hook is a
+# self-guarded no-op during step 1 (manifests-only npm install, before
+# scripts/ and packages/core/src/ are copied in), so the bundle has to
+# be built explicitly here, after sources land. Without this step,
+# production images serve per-file from src/ via the workspace-dev
+# fallback, which is functional but waterfalls the browser through ~15
+# requests per page instead of one chunk per subpath.
+RUN npm run build:dist --workspace=@webjsdev/core
+
 # Blog: generate Prisma client (needs schema.prisma in context).
 RUN cd examples/blog && npx prisma generate
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
   ],
   "scripts": {
     "build:dist": "node ../../scripts/build-framework-dist.js",
-    "prepare": "npm run build:dist"
+    "prepare": "node -e \"require('fs').existsSync('../../scripts/build-framework-dist.js') && require('fs').existsSync('./src/html.js') && require('child_process').execSync('npm run build:dist', {stdio:'inherit'})\""
   },
   "devDependencies": {
     "esbuild": "^0.24.0"


### PR DESCRIPTION
## Summary

Hotfix for the Railway deploy outage observed after #117 merged. All four services fail to build because the `prepare` lifecycle hook on `@webjsdev/core` runs `node ../../scripts/build-framework-dist.js` during the Dockerfile's `npm install` step, but at that point `scripts/` and `packages/core/src/` are not yet in the image (the manifests-only install pattern). `npm install` exits non-zero, the image build fails.

- `packages/core/package.json`: change `prepare` from `npm run build:dist` to a Node one-liner that runs `build:dist` only when both `../../scripts/build-framework-dist.js` AND `./src/html.js` exist. Silent no-op when either is missing.
- `Dockerfile`: add explicit `RUN npm run build:dist --workspace=@webjsdev/core` after source COPY in step 3, so production images still ship the `dist/` bundle (the guard makes `prepare` a no-op during step 1).

## Why this shape

The `prepare` lifecycle has to handle three install contexts: maintainer dev install (full tree, build runs), git-dep install (full tree, build runs), npm-tarball consumer (no src/scripts but tarball already contains dist/, no build needed). The guard correctly skips the maintainer-tooling-context where intermediate state is incomplete (manifests-only Docker layer), while still running the build where it should.

The `packages/core/package.json` `files` array is unchanged, so published tarballs still ship both `src/` and `dist/`. Browsers fetch the bundle for performance; AI agents grep `src/` for the readable runtime source per the dual-layout invariant.

## Definition of done

- Tests: `node scripts/run-node-tests.js` 1345/1345.
- AGENTS.md (root): N/A because no API or invariant changed.
- AGENTS.md (packages/core): N/A because invariant 1 already documents the dual-layout including the workspace-dev fallback path the guard now also takes when scripts/ is missing.
- AGENTS.md (packages/server): N/A.
- README.md (packages/core): N/A because the "Layout in the tarball" section already describes the prepare lifecycle in generic terms (no mention of the exact npm script invocation).
- docs/: N/A because the user-facing no-build page documents the dual-layout, not the build mechanics.
- website/: N/A.
- Scaffold templates: N/A.
- Changelog: N/A because no version bump.

## Test plan

- [x] Local: simulated manifests-only Dockerfile step 1, prepare exits 0 silently.
- [x] Local: ran prepare in a real packages/core/ tree, dist/ rebuilt (196.4 KB, 26 files).
- [x] Local: full test suite 1345/1345.
- [ ] Railway: rebuild + redeploy all four services after merge; confirm green build logs.