### PR TITLE
fix(docker): COPY scripts/ before the dist build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,10 @@ COPY packages  ./packages
 COPY examples  ./examples
 COPY website   ./website
 COPY docs      ./docs
+# scripts/build-framework-dist.js is invoked by the step-3
+# `npm run build:dist --workspace=@webjsdev/core` line, so the
+# scripts tree has to be in the image before that step runs.
+COPY scripts   ./scripts
 # website/app/changelog/page.ts reads ../../../changelog/<pkg>/*.md at
 # SSR time. Without copying the changelog tree into the image, the
 # deployed page renders "No entries yet."


### PR DESCRIPTION
## Summary

Second half of the Railway hotfix. #124 made the `prepare` lifecycle hook safe so step 1 (`RUN npm install`) no longer fails on the manifests-only layer. But the explicit `RUN npm run build:dist --workspace=@webjsdev/core` line I added in step 3 needs `scripts/build-framework-dist.js` to exist in the image, and the Dockerfile's source-COPY list (`packages`, `examples`, `website`, `docs`, `changelog`, `blog`) never included `scripts/`. So the explicit build step died with `MODULE_NOT_FOUND` and all four Railway services kept failing on commit a12d373.

- Add `COPY scripts ./scripts` alongside the other source COPY lines in step 2.

Reproduced locally with `docker build --no-cache`: pre-fix failed at step 3 with the missing-module error; post-fix the full build runs to completion and the image exports cleanly.

## Definition of done

- Tests: full suite stays green (no source change, just a build-context COPY).
- Markdown files: walked `git ls-files '*.md'`; none describe the Dockerfile COPY ordering, so N/A across the board. The `packages/core/AGENTS.md` dual-layout invariant talks about `prepare` and `dist/` in generic terms; the COPY ordering is build-infra, not surface.
- `website/` / scaffold: N/A, no public-facing change.

## Test plan

- [x] `docker build --no-cache -t webjs-test .` succeeds locally end-to-end.
- [ ] Railway re-deploys all four services successfully after merge.