### PR TITLE
docs: refresh rate-limit and middleware surfaces for trustProxy

### DIFF
--- a/blog/built-ins-auth-session-cookies-cache.md
+++ b/blog/built-ins-auth-session-cookies-cache.md
@@ -117,14 +117,18 @@ The cache is opt-in. We do not auto-memoize all queries. Each function the user 
 ```ts
 import { rateLimit } from '@webjsdev/server';
 
-export default rateLimit({
-  window: '10s',
-  max: 5,
-  key: (req) => req.headers.get('x-forwarded-for') || 'anonymous',
-});
+// Direct deploy (default). Keys on the framework-stamped socket IP.
+// Forwarded-IP headers are ignored, so clients cannot bucket-shift
+// by setting x-forwarded-for on the wire.
+export default rateLimit({ window: '10s', max: 5 });
+
+// Behind a trusted reverse proxy or CDN. Opt in to forwarded-header
+// parsing. Your proxy MUST strip inbound x-forwarded-for before
+// adding its own, or trustProxy reintroduces spoofability.
+export default rateLimit({ window: '10s', max: 5, trustProxy: true });
 ```
 
-Five requests per ten seconds per IP. The `key` function is the user-controlled bucket id.
+Five requests per ten seconds per IP. The default `key` resolves the IP via the framework-stamped `x-webjs-remote-ip` header (`startServer` derives it from the TCP socket and strips any inbound copy). Custom keys are still supported (per-tenant, per-authenticated-user); when you want one that includes the IP, compose with the exported `clientIp(req, { trustProxy })` helper rather than reading `x-forwarded-for` by hand.
 
 Internally it computes the current windowed key (e.g. `ratelimit:<bucket>:<window-start>`), calls `store.increment(...)`, and 429s if the result exceeds `max`. Atomic on Redis. Works in-memory for development. The single-process memory store implements increment atomically too, so the rate limiter works there as well.
 

--- a/docs/app/docs/middleware/page.ts
+++ b/docs/app/docs/middleware/page.ts
@@ -209,7 +209,7 @@ const userAgent = headers().get('user-agent');</pre>
       <li><strong>Keep middleware fast.</strong> It runs on every request in its scope. Defer heavy work to the route handler when possible.</li>
       <li><strong>Avoid mutating the request.</strong> The Web <code>Request</code> API is largely immutable. If you need to pass data downstream (e.g., a resolved user object), store it in a module-scoped <code>AsyncLocalStorage</code> or use a header.</li>
       <li><strong>One default export.</strong> Each <code>middleware.ts</code> must export a single default function. Multiple middleware in one file are not supported. If you need composition, chain them manually inside your export.</li>
-      <li><strong>Use <code>rateLimit()</code> from <code>@webjsdev/server</code></strong> rather than writing your own. It handles cleanup, header injection, and IP extraction from proxy headers.</li>
+      <li><strong>Use <code>rateLimit()</code> from <code>@webjsdev/server</code></strong> rather than writing your own. It handles cleanup, header injection, and per-bucket IP resolution that defaults to the framework-stamped socket address (spoof-safe) and only honours <code>X-Forwarded-For</code> / <code>CF-Connecting-IP</code> / <code>X-Real-IP</code> when you opt in with <code>trustProxy: true</code>. See <a href="/docs/rate-limiting">Rate limiting</a> for the threat model.</li>
     </ul>
   `;
 }

--- a/docs/app/docs/rate-limiting/page.ts
+++ b/docs/app/docs/rate-limiting/page.ts
@@ -34,10 +34,39 @@ export default rateLimit({ window: '1m', max: 10 });</pre>
     <ul>
       <li><code>window</code>: duration string or milliseconds. Supports: <code>'10s'</code>, <code>'1m'</code>, <code>'1h'</code>, <code>60000</code>. Default: <code>'1m'</code>.</li>
       <li><code>max</code>: maximum requests per window. Default: <code>60</code>.</li>
-      <li><code>key</code>: a string prefix or a function <code>(req) => string</code> that returns a unique key per client. Default: IP address from <code>x-forwarded-for</code>, <code>cf-connecting-ip</code>, or <code>x-real-ip</code> headers.</li>
+      <li><code>key</code>: a string prefix or a function <code>(req) => string</code> that returns a unique key per client. Default: the framework-stamped socket IP, see <strong>Behind a proxy</strong> below.</li>
+      <li><code>trustProxy</code>: when <code>true</code>, the default key resolution honours the leftmost <code>X-Forwarded-For</code> entry, then <code>CF-Connecting-IP</code>, then <code>X-Real-IP</code>, before falling back to the socket IP. Default: <code>false</code>. See <strong>Behind a proxy</strong> below for the threat model.</li>
       <li><code>message</code>: error message in the 429 response body. Default: <code>'Too Many Requests'</code>.</li>
       <li><code>store</code>: override the cache store (e.g. a dedicated Redis instance for rate limits).</li>
     </ul>
+
+    <h2>Behind a proxy</h2>
+    <p>The default IP source is the TCP socket address that the framework stamps onto every inbound request via the <code>x-webjs-remote-ip</code> internal header. <code>dev.js</code>'s <code>toWebRequest</code> strips any inbound copy of that header before adding its own, so clients cannot spoof it from the wire. Forwarded-IP headers (<code>X-Forwarded-For</code>, <code>CF-Connecting-IP</code>, <code>X-Real-IP</code>) are ignored. This is the correct default for any server that handles its own TCP connections directly (bare-metal, single-VM, dev mode).</p>
+
+    <p><strong>When you're fronted by a reverse proxy or CDN</strong> (Cloudflare, nginx, Caddy, Railway, Fly, Render, Vercel, Heroku), the socket IP is the proxy, not the user. Every request shares the same IP and the limiter buckets everyone together. Opt in to forwarded-header parsing:</p>
+
+    <pre>// app/api/auth/middleware.ts
+import { rateLimit } from '@webjsdev/server';
+
+export default rateLimit({ window: '1m', max: 10, trustProxy: true });</pre>
+
+    <p>With <code>trustProxy: true</code>, the limiter reads the leftmost <code>X-Forwarded-For</code> entry, then <code>CF-Connecting-IP</code>, then <code>X-Real-IP</code>, then the stamped socket IP, then <code>'_anon_'</code>. Your reverse proxy MUST strip any inbound <code>X-Forwarded-For</code> from the wire before adding its own; otherwise <code>trustProxy</code> re-introduces the spoofability it exists to defend against. Cloudflare, Fly, Railway, Render, and Vercel all strip by default. Nginx and Caddy strip only if explicitly configured (<code>proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for</code> in nginx).</p>
+
+    <p><strong>Embedded adapters</strong> (running webjs via <code>createRequestHandler</code> under Express / Fastify / Bun / Deno / edge runtimes) do NOT get the socket-stamping automatically, the framework's <code>startServer</code> path does it. The adapter MUST call <code>stampRemoteIp(req, remoteAddress)</code> before passing the request to webjs:</p>
+
+    <pre>// express adapter
+import { createRequestHandler, stampRemoteIp } from '@webjsdev/server';
+
+const handler = createRequestHandler({ appDir: './app' });
+
+app.use(async (req, res) => {
+  const webReq = new Request(/* ... */, { method: req.method, headers: req.headers, /* ... */ });
+  const safe = stampRemoteIp(webReq, req.socket.remoteAddress);
+  const webRes = await handler.handle(safe);
+  // write webRes back to res
+});</pre>
+
+    <p>Without <code>stampRemoteIp</code>, the adapter passes inbound headers through unmodified. A malicious client can include <code>x-webjs-remote-ip: &lt;anything&gt;</code> on the wire and <code>clientIp(req)</code> will trust it, defeating the limiter even with <code>trustProxy: false</code>.</p>
 
     <h2>Custom key function</h2>
     <p>Rate limit by authenticated user instead of IP:</p>

--- a/examples/blog/CONVENTIONS.md
+++ b/examples/blog/CONVENTIONS.md
@@ -631,7 +631,15 @@ Use `rateLimit()` as per-segment middleware to protect routes:
 ```ts
 // app/api/auth/middleware.ts: protect auth endpoints
 import { rateLimit } from '@webjsdev/server';
+
+// Direct deploy (default). Keys on the socket-stamped IP, ignoring
+// forwarded-IP headers.
 export default rateLimit({ window: '10s', max: 5 });
+
+// Behind a reverse proxy or CDN (Cloudflare, Railway, Fly, Vercel,
+// nginx, Caddy). Set trustProxy to honour X-Forwarded-For. The proxy
+// MUST strip inbound X-Forwarded-For before adding its own.
+export default rateLimit({ window: '10s', max: 5, trustProxy: true });
 ```
 
 Place `middleware.ts` at any route level. It applies to that subtree only.

--- a/packages/cli/templates/CONVENTIONS.md
+++ b/packages/cli/templates/CONVENTIONS.md
@@ -727,7 +727,15 @@ Use `rateLimit()` as per-segment middleware to protect routes:
 ```ts
 // app/api/auth/middleware.ts: protect auth endpoints
 import { rateLimit } from '@webjsdev/server';
+
+// Direct deploy (default). Keys on the socket-stamped IP, ignoring
+// forwarded-IP headers.
 export default rateLimit({ window: '10s', max: 5 });
+
+// Behind a reverse proxy or CDN (Cloudflare, Railway, Fly, Vercel,
+// nginx, Caddy). Set trustProxy to honour X-Forwarded-For. The proxy
+// MUST strip inbound X-Forwarded-For before adding its own.
+export default rateLimit({ window: '10s', max: 5, trustProxy: true });
 ```
 
 Place `middleware.ts` at any route level. It applies to that subtree only.


### PR DESCRIPTION
## Summary

Closes #120.

Refreshes the user-facing rate-limit and middleware surfaces for PR #116's `trustProxy` work. The defaults changed (socket-stamped IP, forwarded headers ignored unless opted in), and several markdown files plus two doc-site pages still described the pre-#116 behaviour.

## Surfaces touched

- `docs/app/docs/middleware/page.ts`: rewrite the "Use `rateLimit()`" tip so it describes the spoof-safe default and the `trustProxy` opt-in instead of the old "IP extraction from proxy headers" line.
- `docs/app/docs/rate-limiting/page.ts`: fix the Options table's `key` entry (default is socket-stamped, not XFF-based), add a `trustProxy` row, add a new "Behind a proxy" section covering three cases (direct, trusted proxy, embedded adapter via `stampRemoteIp`) with runnable examples and threat-model notes.
- `blog/built-ins-auth-session-cookies-cache.md`: rewrite the rate-limit example. The previous custom-key function read `x-forwarded-for` directly, which is exactly the anti-pattern PR #116 eliminated. Two example blocks now show direct deploy and `trustProxy: true`; the surrounding prose routes custom-key users at the `clientIp(req, { trustProxy })` helper.
- `packages/cli/templates/CONVENTIONS.md` and `examples/blog/CONVENTIONS.md`: extend the scaffolded "Rate limiting & middleware" section with a second example block for the trusted-proxy case (the common deploy shape on Railway / Fly / Render / Cloudflare).

## Definition of done

- Tests: `node scripts/run-node-tests.js` 1345/1345.
- Markdown sweep (`git ls-files '*.md' | xargs grep -l 'rateLimit\\|trustProxy\\|x-forwarded-for'`): touched every file the sweep flagged that had stale content. `agent-docs/advanced.md` already documents the full surface comprehensively (pre-existing). One-line passing mentions in root `AGENTS.md`, root `README.md`, `packages/server/AGENTS.md`, `packages/cli/templates/AGENTS.md`, `examples/blog/AGENTS.md` are surface-accurate; not touched.
- `docs/`: Updated (both pages).
- `website/`: N/A because no landing-page claim references the IP source.
- Scaffold templates: Updated.

## Test plan

- [x] Tests pass.
- [ ] Render `/docs/middleware` and `/docs/rate-limiting` in dev to confirm the new sections format correctly.