### PR TITLE
scaffold: pass the pre-merge self-review loop to end-user apps

### DIFF
--- a/packages/cli/templates/.cursorrules
+++ b/packages/cli/templates/.cursorrules
@@ -61,6 +61,17 @@ Quality bar stays the same - just no blocking on questions.
 
 3. CONVENTIONS: Run `webjs check` and fix violations before committing.
 
+4. PRE-MERGE SELF-REVIEW LOOP: Before saying the PR is ready for
+   merge, run fresh-context review rounds until one round finds zero
+   issues. Cursor primitive: open a NEW composer tab and prompt the
+   review there so the reviewer has no prior context on your
+   decisions. Minimum two rounds; rotate focus each round. The full
+   rule, prompt template, and reporting contract live in the
+   **Pre-merge self-review loop** section of CONVENTIONS.md. Skipping
+   the loop on a change that touches logic / public surface / build /
+   security / multiple files is the exact failure mode the loop
+   exists to prevent.
+
 ## Git rules
 
 - COMMIT AND PUSH PER LOGICAL UNIT, NOT AT THE END. One feature, one fix,

--- a/packages/cli/templates/.cursorrules
+++ b/packages/cli/templates/.cursorrules
@@ -65,12 +65,12 @@ Quality bar stays the same - just no blocking on questions.
    merge, run fresh-context review rounds until one round finds zero
    issues. Cursor primitive: open a NEW composer tab and prompt the
    review there so the reviewer has no prior context on your
-   decisions. Minimum two rounds; rotate focus each round. The full
+   decisions. Minimum two rounds; rotate focus each round. Skip the
+   loop only for one-line trivial changes; skipping on a change that
+   touches logic, public surface, build, security, or multiple files
+   is the exact failure mode the loop exists to prevent. The full
    rule, prompt template, and reporting contract live in the
-   **Pre-merge self-review loop** section of CONVENTIONS.md. Skipping
-   the loop on a change that touches logic / public surface / build /
-   security / multiple files is the exact failure mode the loop
-   exists to prevent.
+   **Pre-merge self-review loop** section of CONVENTIONS.md.
 
 ## Git rules
 

--- a/packages/cli/templates/.github/copilot-instructions.md
+++ b/packages/cli/templates/.github/copilot-instructions.md
@@ -62,11 +62,12 @@ Every code change must include:
    issues. Copilot primitive: open a NEW chat session (reset the
    side panel) for each round so the reviewer has no prior context
    on the implementation decisions. Minimum two rounds; rotate focus
-   each round. The full rule, prompt template, and reporting contract
-   live in the **Pre-merge self-review loop** section of
-   CONVENTIONS.md. Skipping the loop on a change that touches logic
-   / public surface / build / security / multiple files is the exact
-   failure mode the loop exists to prevent.
+   each round. Skip the loop only for one-line trivial changes;
+   skipping on a change that touches logic, public surface, build,
+   security, or multiple files is the exact failure mode the loop
+   exists to prevent. The full rule, prompt template, and reporting
+   contract live in the **Pre-merge self-review loop** section of
+   CONVENTIONS.md.
 
 ## Git rules
 

--- a/packages/cli/templates/.github/copilot-instructions.md
+++ b/packages/cli/templates/.github/copilot-instructions.md
@@ -57,6 +57,16 @@ Every code change must include:
    write "N/A because <reason>" in the PR body. Docs land on the same
    PR as the code.
 5. Convention validation: `webjs check` must pass
+6. Pre-merge self-review loop. Before saying the PR is ready for
+   merge, run fresh-context review rounds until one round finds zero
+   issues. Copilot primitive: open a NEW chat session (reset the
+   side panel) for each round so the reviewer has no prior context
+   on the implementation decisions. Minimum two rounds; rotate focus
+   each round. The full rule, prompt template, and reporting contract
+   live in the **Pre-merge self-review loop** section of
+   CONVENTIONS.md. Skipping the loop on a change that touches logic
+   / public surface / build / security / multiple files is the exact
+   failure mode the loop exists to prevent.
 
 ## Git rules
 

--- a/packages/cli/templates/.github/pull_request_template.md
+++ b/packages/cli/templates/.github/pull_request_template.md
@@ -32,9 +32,7 @@ in [`CONVENTIONS.md`](../CONVENTIONS.md) for the full guidance.
       there.
 - [ ] **Scaffold scripts / codegen** (if the project has any). Updated
       when the change affects what new instances generate.
-- [ ] **Pre-merge self-review loop ran N rounds; last round clean.**
-      See the **Pre-merge self-review loop** section in
-      [`CONVENTIONS.md`](../CONVENTIONS.md). Skipping the loop on a
-      change that touches logic / public surface / build / security
-      / multiple files is the exact failure mode the loop exists to
-      prevent.
+- [ ] **Pre-merge self-review loop.** Ran N rounds; last round clean.
+      Skip only for one-line trivial changes. See the **Pre-merge
+      self-review loop** section in [`CONVENTIONS.md`](../CONVENTIONS.md)
+      for the prompt template and reporting contract.

--- a/packages/cli/templates/.github/pull_request_template.md
+++ b/packages/cli/templates/.github/pull_request_template.md
@@ -32,3 +32,9 @@ in [`CONVENTIONS.md`](../CONVENTIONS.md) for the full guidance.
       there.
 - [ ] **Scaffold scripts / codegen** (if the project has any). Updated
       when the change affects what new instances generate.
+- [ ] **Pre-merge self-review loop ran N rounds; last round clean.**
+      See the **Pre-merge self-review loop** section in
+      [`CONVENTIONS.md`](../CONVENTIONS.md). Skipping the loop on a
+      change that touches logic / public surface / build / security
+      / multiple files is the exact failure mode the loop exists to
+      prevent.

--- a/packages/cli/templates/.windsurfrules
+++ b/packages/cli/templates/.windsurfrules
@@ -52,8 +52,19 @@ Every code change must include:
    or write "N/A because <reason>" in the PR body. Docs land on the
    same PR as the code, never as a follow-up.
 4. Convention check: `webjs check` must pass
+5. Pre-merge self-review loop. Before saying the PR is ready for
+   merge, run fresh-context review rounds until one round finds zero
+   issues. Windsurf primitive: open a NEW Cascade thread for each
+   round so the reviewer has no prior context on the implementation
+   decisions. Minimum two rounds; rotate focus each round. The full
+   rule, prompt template, and reporting contract live in the
+   **Pre-merge self-review loop** section of CONVENTIONS.md. Skipping
+   the loop on a change that touches logic / public surface / build /
+   security / multiple files is the exact failure mode the loop
+   exists to prevent.
 
-The user should never have to ask for tests or documentation.
+The user should never have to ask for tests, documentation, or the
+self-review loop.
 
 ## Git rules
 

--- a/packages/cli/templates/.windsurfrules
+++ b/packages/cli/templates/.windsurfrules
@@ -56,12 +56,12 @@ Every code change must include:
    merge, run fresh-context review rounds until one round finds zero
    issues. Windsurf primitive: open a NEW Cascade thread for each
    round so the reviewer has no prior context on the implementation
-   decisions. Minimum two rounds; rotate focus each round. The full
+   decisions. Minimum two rounds; rotate focus each round. Skip the
+   loop only for one-line trivial changes; skipping on a change that
+   touches logic, public surface, build, security, or multiple files
+   is the exact failure mode the loop exists to prevent. The full
    rule, prompt template, and reporting contract live in the
-   **Pre-merge self-review loop** section of CONVENTIONS.md. Skipping
-   the loop on a change that touches logic / public surface / build /
-   security / multiple files is the exact failure mode the loop
-   exists to prevent.
+   **Pre-merge self-review loop** section of CONVENTIONS.md.
 
 The user should never have to ask for tests, documentation, or the
 self-review loop.

--- a/packages/cli/templates/AGENTS.md
+++ b/packages/cli/templates/AGENTS.md
@@ -889,7 +889,15 @@ composition, so a nested shell ends up dropped by the HTML parser.
    Tool-agnostic fallback: `.hooks/pre-commit` runs `webjs test` + `webjs check`
    on every commit, regardless of which agent (or human) made it. No AI
    attribution trailers in commit messages.
-4. When unsure how a framework feature works, `grep` or `cat` the
+4. Run the **pre-merge self-review loop** before signaling the PR is
+   ready. After committing the work, trigger a fresh-context review
+   pass (a new chat / composer tab / subagent / Cascade thread
+   depending on your tool) and iterate fix-then-review rounds until
+   one round finds zero issues. Minimum two rounds. The full rule,
+   prompt template, and reporting contract live in the **Pre-merge
+   self-review loop** section of `CONVENTIONS.md`. Skip the loop only
+   for one-line trivial changes.
+5. When unsure how a framework feature works, `grep` or `cat` the
    relevant `node_modules/@webjsdev/*/src/` file before asking the user.
 
 Project-specific conventions and overrides live in

--- a/packages/cli/templates/AGENTS.md
+++ b/packages/cli/templates/AGENTS.md
@@ -893,10 +893,14 @@ composition, so a nested shell ends up dropped by the HTML parser.
    ready. After committing the work, trigger a fresh-context review
    pass (a new chat / composer tab / subagent / Cascade thread
    depending on your tool) and iterate fix-then-review rounds until
-   one round finds zero issues. Minimum two rounds. The full rule,
-   prompt template, and reporting contract live in the **Pre-merge
-   self-review loop** section of `CONVENTIONS.md`. Skip the loop only
-   for one-line trivial changes.
+   one round finds zero issues. Minimum two rounds; rotate focus each
+   round so the reviewer does not rediscover the same surface twice.
+   Skip the loop only for one-line trivial changes; skipping on a
+   change that touches logic, public surface, build, security, or
+   multiple files is the exact failure mode the loop exists to
+   prevent. The full rule, prompt template, and reporting contract
+   live in the **Pre-merge self-review loop** section of
+   `CONVENTIONS.md`.
 5. When unsure how a framework feature works, `grep` or `cat` the
    relevant `node_modules/@webjsdev/*/src/` file before asking the user.
 

--- a/packages/cli/templates/CONVENTIONS.md
+++ b/packages/cli/templates/CONVENTIONS.md
@@ -181,22 +181,22 @@ file and either `AGENTS.md` or `CONVENTIONS.md`.
 
 ### Pre-merge self-review loop (MUST run before signaling the PR is ready)
 
-Saying "ready for merge" before a self-review loop converges is the single biggest source of low-quality PRs. The recurring pattern to avoid: agent claims ready-for-merge, user requests a code review, agent finds issues, fixes them, claims ready-for-merge again, repeat 4-5 cycles before a review comes back clean. The cure is to run that loop internally before the first "ready" signal, so the user only hears "ready to merge" after the loop has converged on a clean round.
+Saying "ready for merge" before a self-review loop converges is a recurring source of low-quality PRs. The pattern to avoid: agent claims ready-for-merge, user requests a code review, agent finds issues, fixes them, claims ready-for-merge again, repeat 4-5 cycles before a review comes back clean. The cure is to run that loop internally before the first "ready" signal, so the user only hears "ready to merge" after the loop has converged on a clean round.
 
 **How the loop works:**
 
 1. After committing the work and (if remote pushes are in use) pushing the branch, do NOT report "ready for merge" yet. Trigger a **fresh-context review pass**: an AI review with NO prior knowledge of the decisions you made during the implementation. Each AI tool exposes its own primitive for this:
 
-   - **Cursor**: open a new composer tab and prompt the review there.
+   - **Cursor**: open a new composer tab.
    - **Claude Code**: spawn a `general-purpose` subagent via the Agent tool.
-   - **GitHub Copilot**: open a fresh chat session (the side panel reset).
+   - **GitHub Copilot**: open a new chat (reset the side panel).
    - **Windsurf**: open a new Cascade thread.
-   - **Aider**: `/ask` mode in a separately-started session (`aider --ask`).
-   - **Gemini CLI**: launch a subagent.
-   - **OpenCode**: spawn a fresh agent via `tool.execute.after`.
+   - **Aider**: invoke a separately-started `aider` session (do NOT use `/ask` inside the same session; `/ask` only flips the mode for the next message and still sees the existing context).
+   - **Gemini CLI**: invoke a separately-started `gemini` session.
+   - **OpenCode**: open a new agent session (the `tool.execute.after` hook is a different surface and not a fresh-context primitive).
    - **Antigravity**: open a fresh side-panel session.
 
-   The shared property is that the reviewer does not see your decision log. That independence is what makes the review catch blind spots.
+   The shared property is that the reviewer does not see your decision log. That independence is what makes the review catch blind spots. If your tool does not expose a true fresh-context primitive, the canonical fallback is a separately-invoked CLI process; what matters is the reviewer starts with an empty context, not the specific UI affordance.
 
 2. Prompt the review for problems only. A working prompt template:
 

--- a/packages/cli/templates/CONVENTIONS.md
+++ b/packages/cli/templates/CONVENTIONS.md
@@ -179,6 +179,52 @@ file and either `AGENTS.md` or `CONVENTIONS.md`.
   on every other markdown file because the public contract did not
   change.
 
+### Pre-merge self-review loop (MUST run before signaling the PR is ready)
+
+Saying "ready for merge" before a self-review loop converges is the single biggest source of low-quality PRs. The recurring pattern to avoid: agent claims ready-for-merge, user requests a code review, agent finds issues, fixes them, claims ready-for-merge again, repeat 4-5 cycles before a review comes back clean. The cure is to run that loop internally before the first "ready" signal, so the user only hears "ready to merge" after the loop has converged on a clean round.
+
+**How the loop works:**
+
+1. After committing the work and (if remote pushes are in use) pushing the branch, do NOT report "ready for merge" yet. Trigger a **fresh-context review pass**: an AI review with NO prior knowledge of the decisions you made during the implementation. Each AI tool exposes its own primitive for this:
+
+   - **Cursor**: open a new composer tab and prompt the review there.
+   - **Claude Code**: spawn a `general-purpose` subagent via the Agent tool.
+   - **GitHub Copilot**: open a fresh chat session (the side panel reset).
+   - **Windsurf**: open a new Cascade thread.
+   - **Aider**: `/ask` mode in a separately-started session (`aider --ask`).
+   - **Gemini CLI**: launch a subagent.
+   - **OpenCode**: spawn a fresh agent via `tool.execute.after`.
+   - **Antigravity**: open a fresh side-panel session.
+
+   The shared property is that the reviewer does not see your decision log. That independence is what makes the review catch blind spots.
+
+2. Prompt the review for problems only. A working prompt template:
+
+   > Review the changes on this branch against the project's `AGENTS.md` and `CONVENTIONS.md`. Look for bugs, regressions, security issues, missed edge cases, broken invariants, doc drift, test gaps, and style violations. Read every file the diff touches in its current state, not just the diff hunks. Specifically check: \<focus rotates per round\>. Report findings as a numbered list with file:line references. Problems only, no suggestions. If you find nothing genuinely wrong, reply exactly `CLEAN` on its own line and stop.
+
+3. For each finding the review reports, either:
+
+   - Fix it on the branch (commit + push), OR
+   - Reject it explicitly with a one-sentence reason. False positives are real, but rejection has to be defensible (e.g. "the reviewer flagged X as a security issue but X runs server-side only and never reaches user input"). Hand-waving doesn't count.
+
+4. If the round found any findings, run another round. The new round picks a slightly different focus: if round 1 was broad, round 2 zooms in on the file you most edited; if round 2 zoomed in, round 3 zooms out to cross-file consistency. Rotate focus to avoid the reviewer rediscovering the same surface twice.
+
+5. If the round reports `CLEAN`, the loop is done.
+
+The minimum is TWO rounds. A clean first round is rare and usually means the review was too shallow; if round 1 is clean, run a second one with a sharper focus before believing the result.
+
+**When to skip the loop:**
+
+Skip only for changes that touch a single line of trivially-correct content (a doc typo, a renamed local variable, a one-token config bump). Anything that touches logic, public surface, build, security, or multiple files goes through the loop without exception. A bias toward running the loop is correct; a bias toward skipping it is the exact failure mode this rule exists to prevent.
+
+**Reporting after the loop:**
+
+When the user is notified the PR is ready, the message should carry:
+
+> Ready for merge. Self-review loop ran \<K\> rounds; last round clean. Issues found and fixed during the loop: \<one-line list, or "none" if rounds 2+ kept finding nothing\>.
+
+If you cannot honestly say "last round clean", you cannot say "ready for merge". If a finding was rejected as a false positive, mention it so the user can second-guess the rejection.
+
 ### Autonomous mode (sandbox / bypass permissions)
 
 When running without interactive approval, agents must NOT ask questions.


### PR DESCRIPTION
## Summary

Closes #129.

The framework side now runs a pre-merge self-review loop (fresh-context review rounds until one round is clean). webjs is AI-first and end users drive their apps through Cursor, Claude Code, Copilot, Windsurf, Aider, Gemini CLI, OpenCode, Antigravity, or similar; the same discipline should be baked into scaffolded apps.

- `templates/CONVENTIONS.md`: new "Pre-merge self-review loop" section under the existing Definition of done block. Phrased tool-agnostically; describes loop mechanics, prompt template, focus rotation, reporting contract, and when-to-skip.
- `templates/.github/pull_request_template.md`: add a checklist row that surfaces the loop on every scaffolded-app PR.
- `templates/.cursorrules`, `templates/.windsurfrules`, `templates/.github/copilot-instructions.md`: numbered workflow step pointing at the CONVENTIONS.md section plus a one-line note about each tool's fresh-context primitive (composer tab, side-panel reset, Cascade thread).
- `templates/AGENTS.md`: new bullet under "Workflow expectations for AI agents" so tools that read AGENTS.md before CONVENTIONS.md (Antigravity, future agents) see the rule too.

## Constraints honored

- **No third-party API enforcement.** The rule says "before signaling the PR is ready for merge", not "after `gh pr create`". End users on GitLab, Forgejo, internal Gerrit, etc., still apply the rule.
- **Tool-agnostic invocation.** CONVENTIONS.md enumerates the fresh-context primitive each common tool exposes (Cursor composer tab, Claude Code subagent, Copilot side-panel reset, Windsurf Cascade thread, Aider `--ask` session, Gemini CLI subagent, OpenCode plugin, Antigravity side panel). The rule does not dictate the implementation; each agent picks its idiom.

## Definition of done

- Tests: `node scripts/run-node-tests.js` 1346/1346.
- Markdown sweep: framework root `AGENTS.md`, `README.md`, `agent-docs/*.md` describe framework-side workflow only; the scaffold rule is properly homed in `templates/` content. No drift on the framework-side surface.
- `docs/`: N/A because the docs site does not document end-user AI workflow rules (those live in the scaffolded `CONVENTIONS.md` the user receives).
- `website/`: N/A.
- Scaffold templates: Updated (the five files listed in Summary).
- `CHANGELOG.md`: N/A (no version bump in this PR).

## Self-review loop

Will run after this PR body lands; reporting back per the new rule once the loop converges.

## Test plan

- [x] Tests pass.
- [ ] `webjs create demo` produces a scaffolded app whose `CONVENTIONS.md`, agent rule files, and PR template carry the self-review loop language.