### PR TITLE
scaffold: align per-tool rule files at the section level

### DIFF
--- a/examples/blog/.agents/rules/workflow.md
+++ b/examples/blog/.agents/rules/workflow.md
@@ -92,7 +92,7 @@ self-review loop.
   Wait for approval AND the delete/keep preference. Applies to ALL merges.
 - Run `webjs test` before every commit.
 
-## Framework specifics
+## Framework rules
 
 - No build step: ES modules served directly.
 - **Erasable TypeScript only.** Node 24+ strips types via

--- a/packages/cli/templates/.agents/rules/workflow.md
+++ b/packages/cli/templates/.agents/rules/workflow.md
@@ -92,7 +92,7 @@ self-review loop.
   Wait for approval AND the delete/keep preference. Applies to ALL merges.
 - Run `webjs test` before every commit.
 
-## Framework specifics
+## Framework rules
 
 - No build step: ES modules served directly.
 - **Erasable TypeScript only.** Node 24+ strips types via

--- a/packages/cli/templates/.cursorrules
+++ b/packages/cli/templates/.cursorrules
@@ -36,7 +36,7 @@ FIRST, before writing any code:
    - If upstream has new commits: `git rebase origin/main` before starting.
    - Resolve any conflicts before proceeding with the task.
 
-## Autonomous mode (sandbox / no-prompt mode)
+## Autonomous mode (sandbox / no-prompt)
 
 If running without interactive approval, auto-decide:
 - On main? Auto-create feature/<task-slug> branch
@@ -98,7 +98,6 @@ self-review loop.
   Wait for approval AND the delete/keep preference before proceeding.
   This applies to ALL merges, not just merges into main.
 - Run tests before every commit
-- Keep commits small and focused
 
 ## Framework rules
 

--- a/packages/cli/templates/.cursorrules
+++ b/packages/cli/templates/.cursorrules
@@ -44,7 +44,7 @@ If running without interactive approval, auto-decide:
 - Merge? Auto-merge in autonomous mode, delete feature branches after
 - Commit message? Auto-generate (meaningful, no AI attribution)
 - Tests failing? Fix them. Convention violations? Fix them.
-Quality bar stays the same - just no blocking on questions.
+Quality bar stays the same, no blocking on questions.
 
 ## Mandatory workflow (never skip)
 

--- a/packages/cli/templates/.github/copilot-instructions.md
+++ b/packages/cli/templates/.github/copilot-instructions.md
@@ -33,7 +33,7 @@ FIRST, before writing any code:
    - If on a feature branch: verify it matches the task at hand.
 2. Sync: `git fetch origin && git rebase origin/main` if behind.
 
-## Autonomous mode
+## Autonomous mode (sandbox / no-prompt)
 
 If running without interactive approval (sandbox, auto-approve, etc.):
 - On main? Auto-create feature/<task-slug> branch
@@ -71,34 +71,40 @@ each change must include.
 
 - COMMIT AND PUSH PER LOGICAL UNIT, NOT AT THE END. One feature, one fix,
   one rename, one doc rewrite per commit. Always `git push` after
-  committing. Don't accumulate changes. If you have 5+ unstaged files
-  spanning different concerns, commit before continuing. The Claude Code
-  hook at `.claude/hooks/nudge-uncommitted.sh` enforces threshold 4 for
-  Claude users; Copilot users should self-enforce the same rule. The user
-  should never have to ask for a commit.
+  committing. The user should never have to ask for a commit.
+- HARD LIMIT: if you have 5+ unstaged files spanning different concerns,
+  commit before continuing. The Claude Code hook at
+  `.claude/hooks/nudge-uncommitted.sh` enforces threshold 4 for Claude
+  users. Copilot has no equivalent hook surface today; self-enforce the
+  same rule. Batching multiple logical units into one commit is the
+  failure mode this rule exists to prevent.
 - Meaningful commit messages: what changed and why
 - NEVER add Co-Authored-By or AI attribution trailers to commits
+- NEVER use em-dashes (U+2014), a hyphen-as-pause (` - `), or a
+  semicolon-as-pause (` ; `) in commit messages or anywhere else.
+  Rewrite the sentence so no pause-punctuation crutch is needed. Use a
+  period, comma, colon, parentheses, or a restructured phrasing. Plain
+  hyphens stay fine in compound words, CLI flags, filenames, and ranges.
+  Semicolons stay fine inside code.
 - Work on feature branches, create PRs, never push directly to main
 - NEVER merge any branch without explicit user permission. Always ask:
   "Ready to merge <branch> into <target>? Delete or keep <branch> after?"
   Wait for approval AND the delete/keep preference. Applies to ALL merges.
 - Run `webjs test` before every commit
 
-## Code patterns
+## Framework rules
 
+- No build step: source files are served as ES modules. Don't introduce
+  build tools or bundlers in the critical path.
 - **Erasable TypeScript only.** Node 24+ strips types via `module.stripTypeScriptTypes` (whitespace replacement, byte-exact position preservation, no sourcemap). The scaffold's tsconfig.json sets `erasableSyntaxOnly: true`, so the TS compiler rejects `enum`, `namespace` with values, constructor parameter properties, legacy decorators with `emitDecoratorMetadata`, and `import = require`. Use erasable equivalents: `const X = { ... } as const` plus a derived union type instead of `enum`; explicit fields plus constructor body assignments instead of parameter properties. If `erasableSyntaxOnly` is disabled and non-erasable syntax is used, the dev server fails at strip time and returns a 500 pointing at the `no-non-erasable-typescript` lint rule. webjs is buildless end-to-end and has no bundler fallback.
-- Tagged template: html`<div>${value}</div>` with css`...` for styles
+- Tagged template: html`<div>${value}</div>` with css`...` for styles.
+  Don't use inline `style="..."` on components (use `static styles = css\`...\``).
 - Components: extend WebComponent, declare `static properties` (and `static styles` for shadow-DOM components), call `Class.register('tag-name')` at the bottom of the file. The tag name is the argument to `.register()`, not a static field.
-- Server actions: *.server.ts files with one exported async function each
-- Directives: webjs ships only `unsafeHTML`, `live`, and `repeat`. Lit's `classMap` / `styleMap` / `ref` / `when` / `choose` / `guard` are NOT exported - use plain template-literal expressions and lifecycle hooks instead.
+- Server actions: *.server.ts files with one exported async function each.
+- Server-only code (@prisma/client, node:*, anything needing Node APIs) goes only in .server.{js,ts} files, route.ts handlers, or middleware.ts. Never in pages, layouts, or components. Wrap in a .server.{js,ts} file; the framework rewrites that import to an RPC stub for the browser. lib/ holds both server-only infra (lib/prisma.server.ts) and browser-safe utilities (lib/utils/cn.ts with cn); apply the same rule per file.
+- Directives: webjs ships only `unsafeHTML`, `live`, and `repeat`. Lit's `classMap` / `styleMap` / `ref` / `when` / `choose` / `guard` are NOT exported. Use plain template-literal expressions and lifecycle hooks instead.
 - Context: import { createContext, ContextProvider, ContextConsumer } from '@webjsdev/core/context'
 - Task: import { Task, TaskStatus } from '@webjsdev/core/task'
-- Routing: file-based under app/ (page.ts, layout.ts, route.ts, middleware.ts)
-
-## What NOT to do
-
-- Don't introduce build tools or bundlers in the critical path
-- Server-only code (@prisma/client, node:*, anything needing Node APIs) goes only in .server.{js,ts} files, route.ts handlers, or middleware.ts. Never in pages, layouts, or components. Wrap in a .server.{js,ts} file; the framework rewrites that import to an RPC stub for the browser. lib/ holds both server-only infra (lib/prisma.server.ts) and browser-safe utilities (lib/utils/cn.ts with cn); apply the same rule per file.
-- Don't use inline style="..." on components (use static styles = css`...`)
+- Routing: file-based under app/ (page.ts, layout.ts, route.ts, middleware.ts).
 - Component state lives in signals from @webjsdev/core. Module-scope signals share state across components; instance signals (created in the constructor) carry component-local state. Reactive properties (static properties + declare) are for HTML attributes and .prop=${...} hydration.
-- Don't skip tests or documentation updates
+- Don't skip tests or documentation updates.

--- a/packages/cli/templates/.github/copilot-instructions.md
+++ b/packages/cli/templates/.github/copilot-instructions.md
@@ -40,6 +40,8 @@ If running without interactive approval (sandbox, auto-approve, etc.):
 - Parent behind? Auto-rebase. Merge? Auto-merge + delete feature branches.
 - Auto-generate meaningful commit messages. Fix tests and violations.
 
+Quality bar stays the same, no blocking on questions.
+
 ## Mandatory workflow (never skip)
 
 Every code change must include:


### PR DESCRIPTION
## Summary

Closes #136.

PR #135 unified the **Mandatory workflow** section across the three per-tool rule files (`.cursorrules`, `.agents/rules/workflow.md`, `.github/copilot-instructions.md`). #136 deferred the broader section-level divergence beyond Mandatory workflow. This PR addresses that.

## Section parity

All three files now have exactly the same six top-level headings in the same order:

1. Persistence + scaffold rules (non-negotiable)
2. Before starting ANY work
3. Autonomous mode (sandbox / no-prompt)
4. Mandatory workflow (never skip)
5. Git rules
6. Framework rules

## Edits

- `packages/cli/templates/.cursorrules`: rename Autonomous mode heading; drop the redundant "Keep commits small and focused" bullet.
- `packages/cli/templates/.agents/rules/workflow.md`: rename `Framework specifics` to `Framework rules`.
- `packages/cli/templates/.github/copilot-instructions.md`:
  - Rename `Autonomous mode` to `Autonomous mode (sandbox / no-prompt)`.
  - Restructure Git rules: split the inlined HARD LIMIT sub-clause out into a dedicated bullet; add the em-dash and pause-punctuation ban bullet that was missing (substantively important; the rule is enforced by the block-prose-punctuation hook).
  - Merge `Code patterns` + `What NOT to do` into one `Framework rules` section.

## Substance preservation

Every pre-PR bullet in each section still exists in the same file post-PR (or, for the em-dash ban added to copilot, was missing and is now present). The PR does NOT normalize the *contents* of Framework rules across the three files; per-tool wording divergence (Cursor's `customElements.define` phrasing vs workflow.md's `.register('tag-name')` phrasing, etc.) is pre-existing drift not in this issue's scope.

## Definition of done

- Tests: `node scripts/run-node-tests.js` 1349/1349.
- Markdown sweep: heading parity verified (`grep "^## " ...` returns identical lists for all three files).
- `docs/`, `website/`, `CHANGELOG.md`, framework root + per-package `AGENTS.md`, `README.md`: N/A. The change is internal-to-scaffold-templates content normalization with no public surface or invariant shift.

## Pre-merge self-review loop

Will run after this PR body lands.