### PR TITLE
Require one approving review to merge into main

### DIFF
--- a/scripts/protect-main.sh
+++ b/scripts/protect-main.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
-# Make all three CI test layers required before a PR can merge into main.
+# Require an approving review + all CI checks before a PR can merge into main.
 #
 # This is the enforcement half of .github/workflows/ci.yml: the workflow
-# RUNS the tests, this rule BLOCKS merge until unit, browser, and e2e are
-# all green. Run once (needs repo admin). Re-running is idempotent.
+# RUNS the tests, this rule BLOCKS merge until every required check is green
+# AND the PR has at least one approving review. Run once (needs repo admin).
+# Re-running is idempotent.
+#
+# NOTE on the review requirement: GitHub does not let a PR author approve
+# their own PR, and this repo is effectively a solo org. enforce_admins is
+# left false so the org owner can still merge via the admin bypass (a
+# confirm step), which keeps the approval as a visible speed-bump without
+# locking solo PRs. Flip enforce_admins to true only once a second reviewer
+# (a human or a bot account) exists to provide the non-author approval.
 #
 #   bash scripts/protect-main.sh
 #
@@ -28,9 +36,13 @@ gh api -X PUT "repos/${REPO}/branches/main/protection" \
     ]
   },
   "enforce_admins": false,
-  "required_pull_request_reviews": null,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1,
+    "dismiss_stale_reviews": false,
+    "require_code_owner_reviews": false
+  },
   "restrictions": null
 }
 JSON
 
-echo "main is now protected: unit, browser, and e2e must pass before merge."
+echo "main is now protected: 1 approving review + all CI checks required before merge."


### PR DESCRIPTION
## Summary

Branch protection on `main` now requires **one approving review** in addition to the 5 CI status checks. The live setting was applied via the API; this commit updates `scripts/protect-main.sh` so re-running it preserves the requirement instead of resetting `required_pull_request_reviews` to `null` and silently dropping the gate.

## Why `enforce_admins` stays false

GitHub does not let a PR author approve their own PR, and this is effectively a solo org. With `enforce_admins: false`, every PR shows `REVIEW_REQUIRED` and the normal merge path is blocked, but the org owner can still merge via the admin bypass (a confirm step). This keeps the approval as a visible speed-bump without locking solo PRs. Flip `enforce_admins` to true once a second reviewer (human or bot account) exists.

## Test plan

- `bash -n scripts/protect-main.sh` passes.
- Re-running the script is idempotent and sets `required_approving_review_count: 1` (verified live: protection now reports `required_approvals: 1`, `checks: 5`, `strict: true`).