### PR TITLE
Release @webjsdev/core 0.7.2 and @webjsdev/server 0.8.2

### DIFF
--- a/changelog/core/0.7.2.md
+++ b/changelog/core/0.7.2.md
@@ -1,0 +1,26 @@
+---
+package: "@webjsdev/core"
+version: 0.7.2
+date: 2026-05-31T16:00:00+05:30
+commit_count: 2
+---
+## Performance
+
+- **serve the browser runtime as a single bundle** ([#148](https://github.com/webjsdev/webjs/pull/148)) [`1b072e1`](https://github.com/webjsdev/webjs/commit/1b072e1)
+  The dist build no longer code-splits core into per-subpath entries plus
+  shared chunks. It ships one self-contained `webjs-core-browser.js` that the
+  bare `@webjsdev/core` specifier and the `/directives`, `/context`, `/task`,
+  and `/client-router` subpaths all resolve to, so a dist-mode page makes a
+  single cacheable framework request with no chunk-discovery waterfall.
+  `/lazy-loader` stays its own on-demand file; static / elided pages still ship
+  zero core.
+
+## Fixes
+
+- **never hard-reload against an empty importmap build id** ([#147](https://github.com/webjsdev/webjs/pull/147)) [`8853e0a`](https://github.com/webjsdev/webjs/commit/8853e0a)
+  The client router treats an empty or absent `data-webjs-build` on either side
+  as "version unknown" and stays on a soft swap instead of a full page reload
+  (the importmap-textContent fallback is dropped). A genuine cross-deploy still
+  reloads, since both sides then carry non-empty, differing ids. This stops a
+  runtime-first-boot server's warmup window from hard-reloading mid-interaction
+  and wiping a half-filled form.

--- a/changelog/server/0.8.2.md
+++ b/changelog/server/0.8.2.md
@@ -1,0 +1,28 @@
+---
+package: "@webjsdev/server"
+version: 0.8.2
+date: 2026-05-31T16:00:00+05:30
+commit_count: 1
+---
+## Features
+
+- **gate readiness on a fully warm instance; publish the pinned build id at boot** ([#147](https://github.com/webjsdev/webjs/pull/147)) [`8853e0a`](https://github.com/webjsdev/webjs/commit/8853e0a)
+  `/__webjs/ready` now returns 200 only after the deterministic analysis AND
+  the first vendor attempt have both completed, so a readiness-gated platform
+  (Railway `healthcheckPath`, a k8s readinessProbe) admits traffic only once the
+  importmap build id is settled, never mid vendor-resolution. A pinned app
+  (committed `.webjs/vendor/importmap.json`) reads that map at boot and publishes
+  its build id immediately, so a freshly-deployed pinned instance is detected as
+  a new deploy with zero warmup window. The first vendor attempt is bounded by
+  the jspm timeout, so an offline app still becomes ready shortly after.
+
+## Fixes
+
+- **stabilize the importmap build id across the warmup window** ([#147](https://github.com/webjsdev/webjs/pull/147)) [`8853e0a`](https://github.com/webjsdev/webjs/commit/8853e0a)
+  Runtime-first boot resolved vendor lazily, so the `data-webjs-build` /
+  `X-Webjs-Build` value changed across the first few responses (empty while
+  warming, then resolved), and the client router treated that drift as a deploy
+  and hard-reloaded, wiping form input on a fresh deploy. The server now
+  advertises a PUBLISHED build id promoted only when the importmap is
+  authoritatively final, and early requests await the first resolve so the first
+  served response already carries the complete map. An empty id is reload-safe.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7009,7 +7009,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.24.0"
@@ -7030,7 +7030,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
## Summary

Version bumps for the user-facing changes already merged in #147 (warmup
importmap-hash fix) and #148 (single core browser bundle).

| Package | Bump | Why |
|---|---|---|
| `@webjsdev/core` | 0.7.1 → 0.7.2 | perf: single browser bundle (#148); fix: client router never hard-reloads against an empty build id (#147) |
| `@webjsdev/server` | 0.8.1 → 0.8.2 | fix: importmap build-id stability across warmup; feat: readiness gates on a fully warm instance + pinned-at-boot publish (#147) |

Both are patch bumps within the existing `^0.7` / `^0.8` lines, so the in-repo
dependents' caret ranges (`^0.7.0`, `^0.8.0`) still resolve with no range
updates. `package-lock.json` regenerated.

Scope note: this release covers ONLY the packages that #147 / #148 changed
(core, server). `ui` / `ts-plugin` are genuinely current. `cli` was not changed
by #147 / #148 (only a template doc tweak), BUT it separately carries unreleased
features from earlier PRs (the `webjs vendor pin --from` / `audit` / `outdated` /
`update` surface from #105, jspm-direct vendoring from #89) that `/cli.9.1`
predates and no cli changelog covers. That is pre-existing release debt, owed its
own cli release, and deliberately out of scope here.

Changelogs are hand-written (`changelog/core/0.7.2.md`,
`changelog/server/0.8.2.md`) because the squash-merge subjects carry no
conventional-commit prefix for the generator to parse.

## On merge

Merging adds the two new `changelog/**.md` files to `main`, which triggers
`release.yml`: `@webjsdev/core@0.7.2` and `@webjsdev/server@0.8.2` publish to
npm and get GitHub Releases (idempotent; already-published versions are skipped).

## Test plan

- [x] `npm test` green (1476) via the pre-commit hook
- [x] Patch bumps satisfy all dependent caret ranges (verified `^0.7.0` / `^0.8.0`)
- [x] Lockfile regenerated to match