### PR TITLE
Fix client router intercepting JS-handled forms (chat/comments navigate on send)

### DIFF
--- a/packages/core/src/router-client.js
+++ b/packages/core/src/router-client.js
@@ -150,6 +150,13 @@ let prevScrollRestoration = null;
 export function enableClientRouter() {
   if (enabled || typeof document === 'undefined') return;
   enabled = true;
+  // NOTE: `click` is still capture, which carries the same latent issue the
+  // submit listener below fixes: a component `<a @click=preventDefault>` runs
+  // at-target, AFTER this capture listener, so onClick's defaultPrevented guard
+  // does not see it and the router hijacks the link. The blog does not hit this
+  // (its nav is plain `<a href>`), so flipping click to bubble is deferred to
+  // its own change (more cases: modifier/middle clicks, downloads, hash links).
+  // Tracked in #153.
   document.addEventListener('click', onClick, true);
   // `submit` is BUBBLE, not capture. A component's `@submit` handler is bound
   // per-element (render-client.js), so it runs in the at-target phase, BEFORE a
@@ -267,11 +274,14 @@ function onPopState(_e) {
 }
 
 /**
- * Intercept form submissions. Capture phase so we run before user
- * `@submit` handlers in component templates: they can call
- * `e.preventDefault()` or `e.stopImmediatePropagation()` first if they
- * want to handle the submission themselves (server-action RPC stubs do
- * this).
+ * Intercept form submissions. BUBBLE phase (see enableClientRouter) so we run
+ * AFTER a component's per-element `@submit` handler, which is bound at-target.
+ * That ordering is what makes the `if (e.defaultPrevented) return` guard below
+ * work: a component that calls `e.preventDefault()` (the chat / comments forms,
+ * or any JS-handled form) has already run, so we see the prevented default and
+ * leave the form alone. A capture listener would fire us first, before the
+ * component, defeating the guard and wrongly navigating the page out from under
+ * a JS-handled form.
  *
  * Filtering mirrors Turbo's `form_submit_observer.js`:
  *   - `data-no-router` on form or submitter → full browser submit.

--- a/packages/core/src/router-client.js
+++ b/packages/core/src/router-client.js
@@ -151,7 +151,17 @@ export function enableClientRouter() {
   if (enabled || typeof document === 'undefined') return;
   enabled = true;
   document.addEventListener('click', onClick, true);
-  document.addEventListener('submit', onSubmit, true);
+  // `submit` is BUBBLE, not capture. A component's `@submit` handler is bound
+  // per-element (render-client.js), so it runs in the at-target phase, BEFORE a
+  // document-level bubble listener. onSubmit's `if (e.defaultPrevented) return`
+  // guard therefore sees the component's `preventDefault` and leaves the form
+  // alone (the documented "forms that preventDefault in @submit are untouched"
+  // contract). A capture listener would run FIRST, before the component, so the
+  // guard would always see `false` and the router would wrongly intercept a
+  // JS-handled form (e.g. the live chat / comments forms, which preventDefault
+  // and send over WebSocket / fetch) and navigate the page out from under it.
+  // Mirrors hotwired/turbo, which performs the submission in a bubble listener.
+  document.addEventListener('submit', onSubmit, false);
   window.addEventListener('popstate', onPopState);
   ensureUpgradeObserver();
   // Take control of scroll restoration so the browser doesn't fight
@@ -170,7 +180,7 @@ export function disableClientRouter() {
   if (!enabled) return;
   enabled = false;
   document.removeEventListener('click', onClick, true);
-  document.removeEventListener('submit', onSubmit, true);
+  document.removeEventListener('submit', onSubmit, false);
   window.removeEventListener('popstate', onPopState);
   if (typeof history !== 'undefined' && prevScrollRestoration !== null) {
     history.scrollRestoration = prevScrollRestoration;

--- a/test/e2e/e2e.test.mjs
+++ b/test/e2e/e2e.test.mjs
@@ -1311,6 +1311,32 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
     assert.equal(aboutPageFetched, false, 'inert /about page module must NOT be downloaded');
     assert.equal(aLayoutFetched, true, 'the router-enabling layout still ships (SPA nav intact)');
   });
+
+  test('chat: sending a message keeps you on the page and the message survives (#150)', async () => {
+    // The chat form calls e.preventDefault() and sends over WebSocket, so the
+    // client router must NOT intercept it (its submit listener is bubble, so the
+    // component's preventDefault is honored). Before the fix, the router's
+    // capture-phase submit listener navigated the page on send: it scrolled to
+    // the top and the just-sent message vanished (the chat-box re-rendered from
+    // its empty SSR state and the WebSocket reconnected fresh).
+    await page.goto(`${baseUrl}/`, { waitUntil: 'domcontentloaded', timeout: 15000 });
+    // Wait for the chat WebSocket to connect (the input enables once 'live').
+    await page.waitForFunction(
+      () => { const i = document.querySelector('chat-box input'); return !!i && !i.disabled; },
+      { timeout: 12000 },
+    );
+    const msg = 'e2e-chat-stays-onpage';
+    await page.type('chat-box input', msg);
+    await page.keyboard.press('Enter');
+    await sleep(1500); // WS round-trip: send -> server broadcast -> onMessage -> re-render
+    const present = await page.evaluate(
+      (m) => { const box = document.querySelector('chat-box'); return !!box && (box.textContent || '').includes(m); },
+      msg,
+    );
+    assert.ok(present, 'the sent chat message must remain visible (the page must not have navigated/swapped)');
+    const path = await page.evaluate(() => location.pathname);
+    assert.equal(path, '/', 'must stay on the home page after sending a chat message');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/e2e/e2e.test.mjs
+++ b/test/e2e/e2e.test.mjs
@@ -1328,11 +1328,18 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
     const msg = 'e2e-chat-stays-onpage';
     await page.type('chat-box input', msg);
     await page.keyboard.press('Enter');
-    await sleep(1500); // WS round-trip: send -> server broadcast -> onMessage -> re-render
-    const present = await page.evaluate(
-      (m) => { const box = document.querySelector('chat-box'); return !!box && (box.textContent || '').includes(m); },
-      msg,
-    );
+    // Poll (not a fixed sleep) for the message to land in the chat-box via the
+    // WS round-trip: send -> server broadcast -> onMessage -> re-render. On the
+    // buggy (capture) code the page swaps and the message never appears, so this
+    // times out and `present` stays false, failing the assertion below.
+    let present = false;
+    try {
+      await page.waitForFunction(
+        (m) => { const box = document.querySelector('chat-box'); return !!box && (box.textContent || '').includes(m); },
+        { timeout: 6000 }, msg,
+      );
+      present = true;
+    } catch { present = false; }
     assert.ok(present, 'the sent chat message must remain visible (the page must not have navigated/swapped)');
     const path = await page.evaluate(() => location.pathname);
     assert.equal(path, '/', 'must stay on the home page after sending a chat message');


### PR DESCRIPTION
## Summary

Closes #150.

In the demo blog, sending a live chat message sent the message but then scrolled
the page to the top and the just-sent message vanished. Same class of bug for
the live comments thread.

Root cause: the client router's `submit` listener was on `document` in CAPTURE
phase (since `e59f381`, not a recent change), but a component's `@submit` is
bound per-element and runs at-target, AFTER document capture. So for a
JS-handled form (chat/comments `e.preventDefault()` and send over WebSocket /
fetch), the router's `onSubmit` ran first; its `if (e.defaultPrevented) return`
guard saw `false` (the component had not run yet), so it intercepted the form:
with no `action` it fell back to the current URL and navigated/swapped the page.
The message was sent AND the page swapped, scrolling to top and wiping the
WebSocket-driven chat state.

Fix: register `submit` in the BUBBLE phase (`capture: false`) so the component's
`@submit` runs first and its `preventDefault` makes the guard skip the form,
honoring the documented "forms that preventDefault in @submit are untouched"
contract. Plain progressive-enhancement forms (no `@submit`) still get
intercepted and SPA-submitted. Click stays capture. Mirrors hotwired/turbo,
which performs the submission in a bubble listener.

## Test plan

- [x] New e2e regression: sending a chat message keeps you on the page and the
      message survives. **Verified it FAILS on the reverted (capture) code**
      ("the sent chat message must remain visible") and passes with the fix.
- [x] `npm test` green (1476)
- [x] e2e green (51) against the blog in dist mode (dist rebuilt with the fix)
- [x] Dogfood: blog e2e 51/51 (incl. the chat regression); website / docs /
      ui-website boot 200 in dist mode

Note: the unit env (linkedom) does not model capture/bubble ordering of a
document-level vs element-level submit listener faithfully, so the regression
lives at the e2e layer where real event phases apply.

## After merge

Needs a Railway redeploy to reach the live blog (the deployed services auto-deploy
on push to `main`).