### PR TITLE
Route prompts to matching skills + fix check-ignore git env leak in worktrees

### DIFF
--- a/.claude/hooks/route-skills.sh
+++ b/.claude/hooks/route-skills.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# UserPromptSubmit hook: route every prompt to the skills it matches, so a
+# relevant skill is never silently skipped.
+#
+# Why this exists: a Skill is model-invoked. It fires only when the model
+# judges the request to match the skill's triggers, and that judgement can
+# be wrong. In one session a "can we add prefetch, verify in the remix
+# repo, let me know" request was treated as pure research, so the
+# webjs-file-issue workflow was skipped and code investigation started with
+# no tracked issue. Skill descriptions and AGENTS.md prose are advisory;
+# only a hook is deterministic. This hook closes the gap the same way the
+# em-dash hook does: it runs on every prompt, decides from the prompt TEXT
+# (not from model judgement), and injects a high-priority directive.
+#
+# What it can and cannot do (verified against the Claude Code hooks
+# reference): a hook CANNOT invoke a Skill tool-call itself. The strongest
+# deterministic lever is UserPromptSubmit additionalContext, injected as a
+# system reminder the model reads before acting. So this hook does two
+# things on every webjs prompt:
+#
+#   1. KEYWORD ROUTING. Match the prompt against each skill's documented
+#      triggers. For each hit, name the skill and direct that it be
+#      invoked via the Skill tool BEFORE any other work.
+#   2. STANDING RULE. Always inject the generic policy: before acting,
+#      check the available skills and invoke any whose purpose matches the
+#      request, because skills encode required workflow. This catches the
+#      case keyword routing misses, where a research or design request
+#      turns into tracked work mid-stream.
+#
+# The rule is generic across ALL skills by design. It is NOT a rule about
+# any single skill or about filing GitHub issues specifically; it enforces
+# that whatever the matching skill says is followed.
+#
+# Output contract: print one JSON object with
+# hookSpecificOutput.additionalContext and exit 0. The hook never blocks a
+# prompt (exit 2 would erase it); routing must inform, not gate, since the
+# model still owns the Skill call.
+
+set -euo pipefail
+
+payload=$(cat)
+
+prompt=$(printf '%s' "$payload" | jq -r '.prompt // empty' 2>/dev/null || true)
+if [ -z "$prompt" ]; then
+  exit 0
+fi
+
+# Case-fold once for matching. Keep the original only for nothing; all
+# matches are case-insensitive.
+lc=$(printf '%s' "$prompt" | tr '[:upper:]' '[:lower:]')
+
+# has PATTERN: extended-regex test against the lowercased prompt.
+has() { printf '%s' "$lc" | grep -Eq "$1"; }
+
+# Accumulate the per-skill routing lines that fired.
+matches=""
+add_match() { matches="${matches}${matches:+$'\n'}- $1"; }
+
+# --- webjs-file-issue: create new tracked work --------------------------
+# Triggers per its SKILL.md: file a task, create an issue, track as a todo,
+# add to the todo list, open an issue, make this an issue, file a bug, add
+# a new task.
+if has '(file|open|create|add|make).{0,20}(task|issue|todo|bug)' \
+   || has 'track (this|it|that).{0,12}(as|on|in).{0,12}(todo|issue|board)' \
+   || has 'add (a )?new (task|todo|item)' \
+   || has 'make (this|it) (an? )?issue'; then
+  add_match "webjs-file-issue: the request involves creating new tracked work. Invoke the webjs-file-issue skill (it files the GitHub issue, assigns vivek7405, adds it to the board) BEFORE writing code for that work."
+fi
+
+# --- webjs-start-work: begin a tracked issue ----------------------------
+# Triggers: work on #N, start work on issue N, tackle #N, pick up #N,
+# begin issue N, let's work on the X issue.
+if has '(work on|start work|pick up|tackle|begin).{0,24}#?[0-9]+' \
+   || has '(start|begin|pick up).{0,16}(work|issue|the .* issue)' \
+   || has "let'?s (work on|start)"; then
+  add_match "webjs-start-work: the request is to begin a tracked issue. Invoke the webjs-start-work skill (it branches off main, moves the card to In progress, sets up the workspace) BEFORE starting the work."
+fi
+
+# --- webjs-list-todos: what is open / pending ---------------------------
+# Triggers: what's open, what's pending, list todos, current todo, what
+# should I work on, show open issues, what's in progress, on the board.
+if has "what'?s (open|pending|in progress|on the board|next)" \
+   || has '(list|show).{0,16}(todo|open issue|pending|board)' \
+   || has '(current|open|pending) (todo|issue|work|item)' \
+   || has 'what should i work on'; then
+  add_match "webjs-list-todos: the request asks what work is open or pending. Invoke the webjs-list-todos skill (it reads the project board, the source of truth) instead of guessing."
+fi
+
+# --- use-railway: infra / deploy ----------------------------------------
+# Triggers: railway, deploy, redeploy, service(s), environment, bucket,
+# object storage, build failure, infrastructure.
+if has '(railway|redeploy|deploy(ed|ment)?|provision)' \
+   || has '(object storage|bucket|infrastructure)' \
+   || has '(build|deploy) (failure|failed|error)'; then
+  add_match "use-railway: the request touches deployment or infrastructure. Invoke the use-railway skill for any Railway operation rather than ad-hoc commands."
+fi
+
+# Assemble the additional context. The standing rule is always present; the
+# per-skill routing block appears only when something matched.
+read -r -d '' standing <<'EOF' || true
+webjs skill policy (enforced, read before acting):
+Before doing the work in this prompt, check the available skills. If the
+request matches ANY skill's purpose, you MUST invoke that skill via the
+Skill tool BEFORE other work. Skills encode required project workflow;
+skipping a matching skill is a policy violation, not a shortcut. This holds
+even when the prompt reads as research, a question, or a design ask but the
+work it leads to is something a skill governs (for example, investigation
+that turns into new tracked work must still go through the issue-filing
+skill before code is written). Treat the routing below as authoritative for
+THIS prompt.
+EOF
+
+if [ -n "$matches" ]; then
+  ctx="${standing}"$'\n\n'"Skills matched by this prompt:"$'\n'"${matches}"
+else
+  ctx="${standing}"$'\n\n'"No skill triggers matched by keyword. Still apply the policy above: if you determine mid-task that the work matches a skill, invoke it before proceeding."
+fi
+
+jq -n --arg ctx "$ctx" '{
+  hookSpecificOutput: {
+    hookEventName: "UserPromptSubmit",
+    additionalContext: $ctx
+  }
+}'
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/route-skills.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Write|Edit|MultiEdit|NotebookEdit|Bash",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ config files that each agent reads automatically.**
 | `AGENTS.md` | All agents | Framework API, conventions, recipes (this file) |
 | `CONVENTIONS.md` | All agents | Project-specific overridable conventions |
 | `CLAUDE.md` | Claude Code | Points to AGENTS.md + CONVENTIONS.md, no duplication |
-| `.claude/settings.json` | Claude Code | PreToolUse hook guarding git merge/push to main |
+| `.claude/settings.json` | Claude Code | PreToolUse hook guarding git merge/push to main; UserPromptSubmit hook routing prompts to matching skills |
 | `.cursorrules` | Cursor | Workflow rules, git rules, framework patterns |
 | `.agents/rules/workflow.md` | Antigravity (Google) | Workspace rules. Google's documented convention is `.agents/rules/*.md` per the official Antigravity Codelab. Replaces the legacy `.windsurfrules` shipped pre-acquisition. |
 | `.github/copilot-instructions.md` | GitHub Copilot | Same rules in Copilot format |
@@ -49,6 +49,10 @@ config files that each agent reads automatically.**
 3. Sync with parent: `git fetch origin && git log HEAD..origin/main --oneline`. If there are upstream commits, `git rebase origin/main` before starting.
 
 Claude Code enforces step 1 via `.claude/hooks/guard-branch-context.sh` (intercepts Edit/Write when on main). Other agents check manually.
+
+### Skills are routed deterministically, never skipped
+
+A Skill is model-invoked, so it fires only when the model judges a request to match. That judgement can be wrong (a research-framed prompt whose work a skill governs can slip past). The `.claude/hooks/route-skills.sh` `UserPromptSubmit` hook makes routing deterministic: on every prompt it keyword-matches the text against each skill's documented triggers and injects a directive to invoke the matched skill via the Skill tool before other work, plus a standing policy to check the available skills whenever a task matches one. A hook cannot force a Skill tool-call (Claude Code only lets `UserPromptSubmit` inject context, not invoke tools), so keyword cases are deterministic and genuinely-ambiguous prompts lean on the always-injected policy. Tests live in `test/hooks/route-skills.test.mjs`.
 
 ### Autonomous mode (sandbox / bypass permissions)
 

--- a/packages/server/src/check.js
+++ b/packages/server/src/check.js
@@ -957,6 +957,17 @@ export async function checkConventions(appDir, opts) {
     const hasGitignore = await pathExists(join(appDir, '.gitignore'));
     if (hasGit && hasGitignore) {
       const { spawnSync } = await import('node:child_process');
+      // Strip inherited git env vars so `cwd` is the sole authority on
+      // which repo `git check-ignore` consults. Git exports GIT_DIR /
+      // GIT_WORK_TREE / GIT_INDEX_FILE / GIT_PREFIX into hook processes
+      // (notably a pre-commit hook run from a linked worktree exports
+      // GIT_WORK_TREE), and those OVERRIDE cwd-based discovery, so
+      // without this the probe would consult the outer repo instead of
+      // `appDir`. See the gitignore-vendor-not-ignored regression test.
+      const {
+        GIT_DIR: _gd, GIT_WORK_TREE: _gwt, GIT_INDEX_FILE: _gif, GIT_PREFIX: _gp,
+        ...gitEnv
+      } = process.env;
       // Check two representative paths: the pin manifest AND a sample
       // downloaded bundle. A `.gitignore` that allows the manifest
       // but blocks bundles (e.g. `*.js` higher up) would still break
@@ -970,6 +981,7 @@ export async function checkConventions(appDir, opts) {
         const result = spawnSync('git', ['check-ignore', '-q', probe], {
           cwd: appDir,
           stdio: 'pipe',
+          env: gitEnv,
         });
         if (result.status === 0) {
           violations.push({

--- a/packages/server/test/check/check.test.js
+++ b/packages/server/test/check/check.test.js
@@ -1244,6 +1244,45 @@ test('gitignore-vendor-not-ignored: skipped when no .gitignore exists', async ()
   }
 });
 
+test('gitignore-vendor-not-ignored: ignores leaked GIT_WORK_TREE/GIT_DIR (worktree pre-commit)', async () => {
+  // Regression for the env-leak fix in check.js. The rule shells out to
+  // `git check-ignore` with cwd set to appDir. When `webjs check` (or
+  // `npm test`) runs inside a git hook from a linked worktree, git
+  // exports GIT_WORK_TREE / GIT_DIR / GIT_INDEX_FILE into the env, and
+  // those OVERRIDE cwd-based repo discovery, so the probe would consult
+  // the outer repo instead of appDir. We simulate that by pointing those
+  // vars at THIS monorepo (process.cwd()), then assert the rule still
+  // reads appDir's .gitignore (flags the broken `*.js` rule). Without the
+  // `env` strip in check.js this fails: the probe resolves against the
+  // outer repo where `.webjs/vendor/*.js` is not ignored.
+  const appDir = await makeTempApp();
+  const saved = {
+    GIT_DIR: process.env.GIT_DIR,
+    GIT_WORK_TREE: process.env.GIT_WORK_TREE,
+    GIT_INDEX_FILE: process.env.GIT_INDEX_FILE,
+  };
+  try {
+    if (!initGit(appDir)) return;
+    await writeFile(
+      join(appDir, '.gitignore'),
+      '.webjs/*\n!.webjs/vendor/\n!.webjs/vendor/**\n*.js\n',
+    );
+    // Leak outer-repo git context, the way a worktree pre-commit hook does.
+    process.env.GIT_DIR = join(process.cwd(), '.git');
+    process.env.GIT_WORK_TREE = process.cwd();
+    delete process.env.GIT_INDEX_FILE;
+    const violations = await checkConventions(appDir);
+    const v = violations.find((v) => v.rule === 'gitignore-vendor-not-ignored');
+    assert.ok(v, 'rule must read appDir gitignore despite leaked GIT_* env');
+  } finally {
+    for (const [k, val] of Object.entries(saved)) {
+      if (val === undefined) delete process.env[k];
+      else process.env[k] = val;
+    }
+    await rm(appDir, { recursive: true, force: true });
+  }
+});
+
 // --- Template-literal-aware scanner: docs-page false-positive regressions ---
 
 test('tag-name-has-hyphen: ignores register(\'tag\') inside a template literal (docs example)', async () => {

--- a/packages/server/test/check/check.test.js
+++ b/packages/server/test/check/check.test.js
@@ -1156,7 +1156,11 @@ export async function login() { return 1; }
  */
 
 function initGit(appDir) {
-  const result = spawnSync('git', ['init', '-q'], { cwd: appDir, stdio: 'pipe' });
+  // Clear inherited git env so `git init` (and the rule's later
+  // check-ignore) target appDir, not an outer repo whose GIT_DIR /
+  // GIT_WORK_TREE leaked in via a worktree pre-commit hook.
+  const { GIT_DIR, GIT_WORK_TREE, GIT_INDEX_FILE, GIT_PREFIX, ...env } = process.env;
+  const result = spawnSync('git', ['init', '-q'], { cwd: appDir, stdio: 'pipe', env });
   return result.status === 0;
 }
 

--- a/test/hooks/route-skills.test.mjs
+++ b/test/hooks/route-skills.test.mjs
@@ -1,0 +1,119 @@
+// Tests for the UserPromptSubmit skill-routing hook
+// (.claude/hooks/route-skills.sh). The hook reads a prompt on stdin and
+// emits hookSpecificOutput.additionalContext that routes the prompt to the
+// skills it matches, so a relevant skill is never silently skipped.
+//
+// We exercise the hook as a black box: feed it the JSON the harness would,
+// parse its stdout, and assert which skills it routed to. The standing
+// policy must always be present; per-skill routing must fire on the
+// documented trigger phrases and stay quiet on unrelated prompts.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const HOOK = resolve(here, '../../.claude/hooks/route-skills.sh');
+
+/**
+ * Run the hook with a prompt and return { code, ctx } where ctx is the
+ * parsed additionalContext string (or '' if none).
+ */
+function run(prompt) {
+  const r = spawnSync('bash', [HOOK], {
+    input: JSON.stringify({ prompt }),
+    encoding: 'utf8',
+  });
+  assert.equal(r.status, 0, `hook exited non-zero: ${r.stderr}`);
+  if (!r.stdout.trim()) return { code: 0, ctx: '' };
+  const parsed = JSON.parse(r.stdout);
+  return { code: 0, ctx: parsed.hookSpecificOutput?.additionalContext ?? '' };
+}
+
+/** Count how many times a skill name was routed (one bullet per skill). */
+function routed(ctx, skill) {
+  const re = new RegExp(`^- ${skill}:`, 'm');
+  return re.test(ctx);
+}
+
+test('standing policy is injected on every prompt', () => {
+  for (const p of ['file a task for X', 'explain the SSR pipeline', '']) {
+    const { ctx } = run(p);
+    if (p === '') {
+      // Empty prompt is a no-op (nothing to route).
+      assert.equal(ctx, '');
+    } else {
+      assert.match(ctx, /skill policy/i);
+      // Newlines wrap the sentence, so match the salient tokens flexibly.
+      assert.match(ctx, /invoke that skill via the[\s\S]*Skill tool BEFORE other work/i);
+    }
+  }
+});
+
+test('webjs-file-issue routes on its trigger phrases', () => {
+  for (const p of [
+    'file a task for adding dark mode',
+    'create an issue for the streaming bug',
+    'track this as a todo: refactor the rate limiter',
+    'make this an issue',
+    'add a new task to investigate the SSR race',
+  ]) {
+    const { ctx } = run(p);
+    assert.ok(routed(ctx, 'webjs-file-issue'), `expected file-issue route for: ${p}`);
+  }
+});
+
+test('webjs-start-work routes on its trigger phrases', () => {
+  for (const p of [
+    'work on #112',
+    "let's start work on the rate-limit issue",
+    'pick up #114',
+    'tackle the dist issue (#113)',
+  ]) {
+    const { ctx } = run(p);
+    assert.ok(routed(ctx, 'webjs-start-work'), `expected start-work route for: ${p}`);
+  }
+});
+
+test('webjs-list-todos routes on its trigger phrases', () => {
+  for (const p of [
+    "what's pending",
+    'what should I work on next',
+    'show me the open issues',
+    'list webjs todos',
+  ]) {
+    const { ctx } = run(p);
+    assert.ok(routed(ctx, 'webjs-list-todos'), `expected list-todos route for: ${p}`);
+  }
+});
+
+test('use-railway routes on infra phrases', () => {
+  for (const p of [
+    'redeploy the docs service',
+    'check the railway deployment',
+    'the build failed on deploy',
+  ]) {
+    const { ctx } = run(p);
+    assert.ok(routed(ctx, 'use-railway'), `expected railway route for: ${p}`);
+  }
+});
+
+test('unrelated prompt routes to no skill but still carries the policy', () => {
+  const { ctx } = run('explain how the SSR pipeline works');
+  assert.match(ctx, /skill policy/i);
+  assert.ok(!routed(ctx, 'webjs-file-issue'));
+  assert.ok(!routed(ctx, 'webjs-start-work'));
+  assert.ok(!routed(ctx, 'webjs-list-todos'));
+  assert.ok(!routed(ctx, 'use-railway'));
+  // The no-match branch tells the model to apply the policy if the task
+  // turns out to match a skill mid-stream.
+  assert.match(ctx, /if you determine mid-task that the work matches a skill/i);
+});
+
+test('a single prompt routes each matched skill exactly once', () => {
+  const { ctx } = run('file a task for dark mode');
+  const count = (ctx.match(/^- webjs-file-issue:/gm) || []).length;
+  assert.equal(count, 1);
+});


### PR DESCRIPTION
## Summary

Closes #154
Closes #155

Two related fixes to agent tooling and test isolation, found while investigating why a skill (the issue-filing workflow) was silently skipped during a session.

### 1. Deterministic skill routing (#154)

Skills are model-invoked, so a relevant one can be skipped when a prompt reads as research or a question but the work it leads to is governed by a skill. (This happened: a "can we add prefetch, verify in remix, let me know" request was treated as pure research, so the issue-filing workflow never ran.) Skill descriptions and AGENTS.md prose are advisory; only a hook is deterministic, the same posture `block-prose-punctuation.sh` takes for the em-dash rule.

- `.claude/hooks/route-skills.sh` (new): a `UserPromptSubmit` hook. On every prompt it keyword-matches the text against each skill's documented triggers (webjs-file-issue, webjs-start-work, webjs-list-todos, use-railway) and injects a directive to invoke the matched skill via the Skill tool before other work, plus a standing generic policy to check the available skills whenever a task matches one. The policy is generic across ALL skills, not a rule about filing GitHub issues specifically.
- `.claude/settings.json`: registers the hook.
- `AGENTS.md`: documents it in the agent-config table and a new subsection.
- `test/hooks/route-skills.test.mjs` (new): covers each skill's triggers, the no-match standing-only case, single-route-per-skill.

Honest limitation (documented in the hook + AGENTS.md): a hook CANNOT force a Skill tool-call. `UserPromptSubmit` can only inject `additionalContext`. So keyword-matched prompts route deterministically, but genuinely-ambiguous prompts lean on the always-injected standing policy rather than a mechanical guarantee. The hook never blocks a prompt.

### 2. check-ignore git env leak (#155)

The `gitignore-vendor-not-ignored` rule shells out to `git check-ignore` with `cwd` set to the target app dir, but inherited the process git environment. When `webjs check` (and thus `npm test`) runs inside a pre-commit hook from a linked worktree, git exports `GIT_WORK_TREE` / `GIT_DIR` / `GIT_INDEX_FILE` into the hook env, and those override cwd-based repo discovery, so the probe consulted the outer repo instead of the temp fixture. Net effect: the pre-commit test suite could not pass from any git worktree (the workflow this session needed).

Fix: strip `GIT_DIR` / `GIT_WORK_TREE` / `GIT_INDEX_FILE` / `GIT_PREFIX` before spawning `git check-ignore` (and in the `initGit` test helper) so `cwd` is authoritative. Added a regression test that leaks `GIT_WORK_TREE` at the real repo and asserts the rule still reads the temp app's gitignore. Verified: with the env-clear reverted, the regression test fails; with it, the full suite passes from a worktree.

## Test plan

- [x] `node --test test/hooks/route-skills.test.mjs` (7/7)
- [x] `gitignore-vendor-not-ignored` tests pass with `GIT_WORK_TREE` set in env (was failing)
- [x] Full suite `node scripts/run-node-tests.js` 1478/1478, from a linked worktree
- [x] Both commits passed the pre-commit `npm test` gate from the worktree (the thing #155 unblocks)
- N/A docs site / scaffold / dogfood apps: #154 is repo-local agent tooling under `.claude/`; #155 touches a convention-check rule and its test, no served wire or user-facing surface changed.
