### PR TITLE
Keep modulepreload hints within the servable set

### DIFF
--- a/packages/server/AGENTS.md
+++ b/packages/server/AGENTS.md
@@ -48,7 +48,7 @@ with metadata, Suspense, streaming) for HTML, or `api.js` /
 | `json.js` | `json()` + `readBody()` content-negotiation helpers |
 | `check.js` | Convention validator backing `webjs check`. Rules include `no-json-data-files`, `no-non-erasable-typescript` |
 | `vendor.js` | Resolve bare-specifier npm deps. `resolveVendorImports(appDir, getBareImports)` reads `.webjs/vendor/importmap.json` if present (committed pin file) and short-circuits BEFORE running the bare-import scan; only when there is no pin file does it invoke the `getBareImports` thunk (the whole-app `scanBareImports` walk) and call `api.jspm.io/generate`. So a pinned app does no vendor static analysis at boot (runtime-first). Backs the `webjs vendor pin / unpin / list / audit / outdated / update` CLI surface plus the `--from <provider>` (jspm, jsdelivr, unpkg, skypack) and `--download` modes. `--download` mode also serves cached bundle files from `.webjs/vendor/`. |
-| `module-graph.js` | Dependency graph for transitive preload hints |
+| `module-graph.js` | Dependency graph for transitive preload hints. Both walks (`transitiveDeps` for preloads, `reachableFromEntries` for the auth gate) stop at `.server.*` boundaries, so a preload set is always a subset of the servable set. The import scanner masks string / template-literal content (`redactStringsAndTemplates`) so an `import`/`export … from` shown as example code inside an `html\`\`` template is not counted as a real edge. |
 | `importmap.js` | Browser import-map builder. `setCoreInstall(coreDir, distMode)` binds the importmap to the resolved `@webjsdev/core` install and runs `buildCoreEntries()`, which reads the package's `package.json` and derives one importmap line per exported subpath from its `exports` field, picking the `default` condition in dist mode and the `source` (`src/*.js`) condition otherwise. In dist mode the browser surface is ONE self-contained bundle: the `exports` `default` for the always-load browser subpaths (`/directives`, `/context`, `/task`, `/client-router`) all point at `dist/webjs-core-browser.js`, so those entries plus the bare specifier collapse onto that single file (each import picks its named exports from it) instead of a fan of per-subpath bundles + code-split chunks. `/lazy-loader` keeps its own file (on-demand). In src/dev mode each subpath stays granular (`src/*.js`) since there is no bundle to collapse into. `dev.js` calls `setCoreInstall` at boot based on `existsSync(coreDir/dist/webjs-core.js) && existsSync(coreDir/dist/webjs-core-browser.js)`. The bare `@webjsdev/core` specifier always points at the BROWSER entry (`index-browser.js` or `dist/webjs-core-browser.js`); the slim entry drops `renderToString`, `renderToStream`, `expose`, `getExposed`, and `setCspNonceProvider` so server-only bytes do not ride the wire. Node-side consumers resolve via the package.json exports and still get the full `index.js`. |
 | `component-scanner.js` | Maps every webjs component class to its browser-visible URL |
 | `component-elision.js` | Static analyser deciding which display-only component modules can be elided from the browser, plus the serve-time side-effect-import stripper. Conservative denylist of interactivity signals (single source of truth) |
@@ -84,6 +84,13 @@ can load it without booting the full server.
    the browser; including them would be over-permissive. The walker
    enters `_*` directories (the `_private` / `_components` /
    `_lib` convention is a router-ignore, not a graph-ignore).
+   The preload-hint walk (`transitiveDeps`) applies the SAME
+   `.server.*` stop, so the framework never emits a `modulepreload`
+   for a file the gate then 404s (the preload set is a subset of the
+   servable set). Edges themselves are scanned off a string/template
+   redaction mask, so an `import`/`export … from` printed as example
+   code inside an `html\`\`` template (the docs site does this) is not
+   mistaken for a real dependency.
 2. **Server-file source is unreachable from the browser.** `dev.js`
    re-verifies every in-graph JS/TS request against the path-level
    server-file predicate (filename suffix `.server.{js,ts,mjs,mts}`)

--- a/packages/server/src/module-graph.js
+++ b/packages/server/src/module-graph.js
@@ -14,6 +14,7 @@
 import { readFile, readdir, stat } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { join, resolve, dirname, extname, sep } from 'node:path';
+import { redactStringsAndTemplates } from './js-scan.js';
 
 /** @type {RegExp} match static `import … from '…'` and `import '…'` */
 const IMPORT_RE = /\bimport\s+(?:(?:[\w*{}\s,]+)\s+from\s+)?['"]([^'"]+)['"]/g;
@@ -104,6 +105,17 @@ export function transitiveDeps(graph, entryFiles, appDir, skip) {
       if (dep.startsWith(appDir)) {
         result.push(dep);
       }
+      // Stop at server-file boundaries, exactly like reachableFromEntries
+      // (the authorization gate). The browser fetches a `.server.*` URL as
+      // an RPC or throw-at-load stub, never its source, so the server
+      // file's own imports are never fetched. Following them would emit
+      // modulepreload hints for server-only modules that the gate then
+      // 404s (a preload set wider than the servable set). The `.server.*`
+      // file itself stays in the result; the preload emitter filters it via
+      // the server-file index. A file imported through BOTH a server file
+      // and a real client path is still reached via the client path, so it
+      // is not wrongly dropped.
+      if (SERVER_FILE_RE.test(dep)) continue;
       queue.push(dep);
     }
   }
@@ -247,9 +259,23 @@ async function parseFile(file, appDir, graph, seen) {
   try { src = await readFile(file, 'utf8'); }
   catch { return; }
 
+  // Mask of `src` with all string / template-literal / comment / regex
+  // CONTENT blanked to spaces (positions preserved). Used to reject an
+  // `import '…'` / `export … from '…'` that appears as TEXT inside a
+  // template literal (e.g. example code shown in a `<pre>` inside an
+  // `html\`\`` template, as the docs site does) rather than as a real
+  // statement. We still read the specifier from the RAW `src` (the
+  // specifier is itself a string, blanked in the mask), and only consult
+  // the mask to confirm the `import` / `export` KEYWORD survived
+  // redaction, i.e. sits in code position and not inside a literal.
+  const masked = redactStringsAndTemplates(src);
   const deps = new Set();
   for (const re of [IMPORT_RE, EXPORT_FROM_RE]) {
     for (const m of src.matchAll(re)) {
+      // m.index is the keyword start (`\bimport` / `\bexport`). If that
+      // position is blanked in the mask, the match lives inside a literal
+      // and is not a real import edge.
+      if (masked[m.index] === ' ') continue;
       const spec = m[1];
       // Only resolve relative imports within the project.
       if (!spec.startsWith('.') && !spec.startsWith('/')) continue;

--- a/packages/server/test/module-graph/module-graph.test.js
+++ b/packages/server/test/module-graph/module-graph.test.js
@@ -139,6 +139,92 @@ test('transitiveDeps: skip set excludes a node and its unique subtree', async ()
   await rm(dir, { recursive: true, force: true });
 });
 
+test('transitiveDeps: stops at the .server.* boundary (no preload for server-only deps)', async () => {
+  // The preload emitter walks transitiveDeps. A client import of a server
+  // action is rewritten to an RPC stub, so the browser fetches the stub URL
+  // but NEVER the server file's own imports. transitiveDeps must therefore
+  // stop at `.server.*`, exactly like reachableFromEntries (the auth gate);
+  // otherwise it emits modulepreload hints for server-only files the gate
+  // then 404s (#158: slugify.ts / types.ts on the blog). Counterfactual:
+  // remove the `SERVER_FILE_RE.test(dep)` guard in transitiveDeps and the
+  // `slugify.ts` assertion below fails (it leaks into the preload list).
+  const dir = join(tmpdir(), `webjs-test-serverbound-${Date.now()}`);
+  await mkdir(join(dir, 'modules'), { recursive: true });
+
+  // page -> create.server.ts -> slugify.ts (server-only, reachable ONLY via
+  //         the server file)
+  // page -> counter.ts (client, kept)
+  // page -> shared.ts AND create.server.ts -> shared.ts (reachable via BOTH a
+  //         server file and a real client path: must still be included)
+  await writeFile(join(dir, 'page.ts'),
+    `import './modules/create.server.ts';\nimport './counter.ts';\nimport './shared.ts';`);
+  await writeFile(join(dir, 'modules', 'create.server.ts'),
+    `'use server';\nimport '../slugify.ts';\nimport '../shared.ts';`);
+  await writeFile(join(dir, 'slugify.ts'), `export const slug = (s) => s;`);
+  await writeFile(join(dir, 'counter.ts'), `export const c = 1;`);
+  await writeFile(join(dir, 'shared.ts'), `export const s = 1;`);
+
+  const graph = await buildModuleGraph(dir);
+  const deps = transitiveDeps(graph, [join(dir, 'page.ts')], dir);
+
+  // The server file's URL itself is fetched (as a stub), so it stays in.
+  assert.ok(deps.some((d) => d.endsWith('create.server.ts')), 'the .server.* stub URL is preloadable');
+  // Its server-only dep is NOT preloaded (the gate would 404 it).
+  assert.ok(!deps.some((d) => d.endsWith('slugify.ts')), 'server-only dep must not leak into preloads');
+  // The plain client edge is preserved.
+  assert.ok(deps.some((d) => d.endsWith('counter.ts')), 'client dep stays');
+  // A file reachable via BOTH a server file and a real client path is kept
+  // (the client path still reaches it; the boundary only prunes the server path).
+  assert.ok(deps.some((d) => d.endsWith('shared.ts')), 'dual-reachable file kept via client path');
+
+  await rm(dir, { recursive: true, force: true });
+});
+
+test('buildModuleGraph: ignores import/export shown as code inside a template literal', async () => {
+  // A docs/tutorial page renders example code (including import statements)
+  // as TEXT inside an `html\`\`` template. The scanner must not mistake that
+  // for a real import edge (#159: a phantom /app/docs/components/counter.ts
+  // preload 404 on docs.webjs.dev). Counterfactual: drop the redaction-mask
+  // guard in parseFile and the `phantom.ts` / `phantom2.ts` assertions fail.
+  const dir = join(tmpdir(), `webjs-test-tmpl-import-${Date.now()}`);
+  await mkdir(dir, { recursive: true });
+
+  // Real imports live at top level; the phantom ones live inside the template
+  // body. A real multi-line `export … from` barrel re-export is included to
+  // prove the mask does not over-redact actual statements.
+  const pageSrc = [
+    "import { html } from '@webjsdev/core';",
+    "import './real.ts';",
+    "export {",
+    "  a,",
+    "} from './barrel.ts';",
+    "export default function Page() {",
+    "  return html`",
+    "    <h3>app/page.ts</h3>",
+    "    <pre>import './phantom.ts';",
+    "export { x } from './phantom2.ts';</pre>",
+    "  `;",
+    "}",
+  ].join('\n');
+  await writeFile(join(dir, 'page.ts'), pageSrc);
+  await writeFile(join(dir, 'real.ts'), `export const r = 1;`);
+  await writeFile(join(dir, 'barrel.ts'), `export const a = 1;`);
+  await writeFile(join(dir, 'phantom.ts'), `export const p = 1;`);
+  await writeFile(join(dir, 'phantom2.ts'), `export const p2 = 1;`);
+
+  const graph = await buildModuleGraph(dir);
+  const deps = graph.get(join(dir, 'page.ts')) || new Set();
+
+  // Real top-level imports / re-exports are detected.
+  assert.ok(deps.has(join(dir, 'real.ts')), 'real import detected');
+  assert.ok(deps.has(join(dir, 'barrel.ts')), 'real multi-line export-from detected (no over-redaction)');
+  // Imports shown as text inside the template literal are NOT edges.
+  assert.ok(!deps.has(join(dir, 'phantom.ts')), 'import inside template literal is not an edge');
+  assert.ok(!deps.has(join(dir, 'phantom2.ts')), 'export-from inside template literal is not an edge');
+
+  await rm(dir, { recursive: true, force: true });
+});
+
 test('buildModuleGraph: skips node_modules and _private', async () => {
   const dir = join(tmpdir(), `webjs-test-graph-skip-${Date.now()}`);
   await mkdir(join(dir, 'node_modules'), { recursive: true });

--- a/test/e2e/e2e.test.mjs
+++ b/test/e2e/e2e.test.mjs
@@ -158,6 +158,28 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
     assert.ok(preloads.length > 0, 'Should have at least one modulepreload');
   });
 
+  test('every modulepreload resolves (no preload points at a 404)', async () => {
+    // Regression for #158 / #159: the preload set must be a subset of the
+    // servable set. The blog previously emitted modulepreload hints for
+    // server-only files reached through a .server.ts (slugify.ts, the two
+    // types.ts), which the auth gate then 404s. Probe each same-origin
+    // preload href and assert it serves. A real network fetch, since a
+    // 404 here is exactly what shipped to users.
+    const preloads = await page.evaluate(() =>
+      [...document.querySelectorAll('link[rel="modulepreload"]')]
+        .map(l => l.href)
+        .filter(h => h.startsWith(location.origin))
+    );
+    assert.ok(preloads.length > 0, 'expected at least one same-origin preload to probe');
+    const broken = [];
+    for (const href of preloads) {
+      const resp = await fetch(href);
+      if (resp.status >= 400) broken.push(`${href} -> ${resp.status}`);
+    }
+    assert.equal(broken.length, 0,
+      `no modulepreload may point at a non-servable URL; broken:\n${broken.join('\n')}`);
+  });
+
   test('theme-toggle custom element is upgraded (light DOM)', async () => {
     await page.goto(baseUrl, { waitUntil: 'domcontentloaded', timeout: 10000 });
     await sleep(2000);

--- a/test/examples/blog/smoke/blog-smoke.test.js
+++ b/test/examples/blog/smoke/blog-smoke.test.js
@@ -106,6 +106,24 @@ describe('Blog smoke (Tier-1/Tier-2 migration)', { skip: skip && 'blog or its DB
     }
   });
 
+  test('homepage modulepreload hints all resolve (no 404 preload)', async () => {
+    // Browserless guard for the #158 / #159 class: the served HTML must never
+    // emit a <link rel="modulepreload"> for a file the server then 404s
+    // (server-only deps reached through a .server file, or an import shown as
+    // code inside a template literal). Fast HTTP-only check, no browser.
+    const html = await (await fetch(baseUrl + '/')).text();
+    const hrefs = [...html.matchAll(/<link[^>]+rel=["']modulepreload["'][^>]*href=["']([^"']+)["']/g)]
+      .map((m) => m[1])
+      .filter((h) => h.startsWith('/'));
+    assert.ok(hrefs.length > 0, 'expected at least one same-origin modulepreload to probe');
+    const broken = [];
+    for (const h of hrefs) {
+      const r = await fetch(baseUrl + h);
+      if (r.status >= 400) broken.push(`${h} -> ${r.status}`);
+    }
+    assert.equal(broken.length, 0, `modulepreload hints must all resolve; broken:\n${broken.join('\n')}`);
+  });
+
   test('/login renders class-helper output, not stale <ui-X> tags', async () => {
     const html = await fetch(baseUrl + '/login').then((r) => r.text());
 

--- a/test/ssr/ssr.test.js
+++ b/test/ssr/ssr.test.js
@@ -956,6 +956,60 @@ test('ssrPage: modulepreload never points at server-only files', async () => {
     `'use server' plain file should not be preloaded; got preloads:\n${preloads}`);
 });
 
+test('ssrPage: modulepreload never points at a server-only dep reached THROUGH a .server file', async () => {
+  // Regression for #158: a page imports a server action, and the action
+  // imports a plain server-only util (the slugify.ts / types.ts shape on the
+  // blog). The util is reachable ONLY through the .server file, so the client
+  // never fetches it (the action becomes an RPC stub). The preload walk must
+  // stop at the .server boundary, exactly like the auth gate; otherwise it
+  // emits a <link rel="modulepreload"> for the util, which then 404s.
+  // Before the fix, `formatPost.ts` below leaks into the preload set.
+  const sub = mkdtempSync(join(tmpDir, 'route-serverdep-'));
+  const appDir = join(sub, 'app');
+  mkdirSync(appDir, { recursive: true });
+
+  const action = join(appDir, 'list.server.ts');
+  const serverOnlyUtil = join(appDir, 'formatPost.ts');   // reached only via the action
+  const clientComp = join(appDir, 'card.ts');             // a real client edge, kept
+
+  writeFileSync(serverOnlyUtil, `export const fmt = (p) => p;\n`);
+  writeFileSync(action,
+    `import { fmt } from './formatPost.ts';\n` +
+    `export async function list() { return [fmt(1)]; }\n`);
+  writeFileSync(clientComp, `export const card = 1;\n`);
+
+  const pageFile = join(appDir, 'page.ts');
+  writeFileSync(pageFile,
+    `import { html } from ${JSON.stringify(HTML_MODULE_URL)};\n` +
+    `import { list } from './list.server.ts';\n` +
+    `import './card.ts';\n` +
+    `export default async function Page() { await list(); return html\`<my-card></my-card>\`; }\n`);
+
+  // Graph mirrors the imports: page -> {action, card}; action -> {serverOnlyUtil}.
+  const moduleGraph = new Map([
+    [pageFile, new Set([action, clientComp])],
+    [action, new Set([serverOnlyUtil])],
+    [serverOnlyUtil, new Set()],
+    [clientComp, new Set()],
+  ]);
+  const serverFiles = new Map([[action, 'hashA']]);
+
+  const route = { file: pageFile, layouts: [], errors: [], metadataFiles: [] };
+  const resp = await ssrPage(route, {}, new URL('http://localhost/'), {
+    dev: false, appDir, moduleGraph, serverFiles,
+  });
+  const preloads = ((await resp.text()).match(/modulepreload[^>]*href="[^"]*"/g) || []).join('\n');
+
+  assert.ok(!/formatPost\.ts"/.test(preloads),
+    `server-only dep reached through a .server file must not be preloaded; got:\n${preloads}`);
+  assert.ok(!/list\.server\.ts"/.test(preloads),
+    `the .server file itself is not preloaded; got:\n${preloads}`);
+  // The real client edge is still preloaded (the boundary only prunes the
+  // server path, it does not drop legitimate client modules).
+  assert.ok(/card\.ts"/.test(preloads),
+    `a real client dep must still be preloaded; got:\n${preloads}`);
+});
+
 test('preloadCrossOriginAttr: adds crossorigin=anonymous for cross-origin URLs only', async () => {
   // Browsers require crossorigin on cross-origin modulepreload, else
   // the preload is ignored or double-fetched (defeating the


### PR DESCRIPTION
## Summary

Closes #158
Closes #159

The SSR preload emitter and the source-serving authorization gate walked the module graph differently, so the framework emitted `<link rel="modulepreload">` hints for URLs it then 404s. Found by auditing all four in-repo dogfood apps for broken preloads.

| App | Broken preloads (before) | Cause |
|---|---|---|
| example-blog | `/modules/posts/utils/slugify.ts`, `/modules/posts/types.ts`, `/modules/auth/types.ts` | preload walk crossed the `.server.*` boundary (#158) |
| docs | `/app/docs/components/counter.ts` | scanner counted an `import` shown as code inside a template literal (#159) |
| website | none | already clean |
| ui-website | none | already clean |

## What changed

**`transitiveDeps` stops at `.server.*` (#158).** `reachableFromEntries` (the auth gate) already stops at `.server.{js,ts,mjs,mts}`, because a client import of a server file resolves to an RPC / throw-at-load stub and the server file's own imports never reach the browser. `transitiveDeps` (which feeds the preload hints) did not, so it walked through a `.server.ts` into its server-only deps and preloaded them. It now applies the same `SERVER_FILE_RE` stop, so a preload set is always a subset of the servable set. The `.server.*` file itself stays preloadable (its stub URL is fetched on demand), and a file reachable through both a server file and a real client path is still reached via the client path.

**Import scanner masks string/template content (#159).** `parseFile` ran the import regexes on raw source, so an `import`/`export … from` printed as example code inside an `html`` template (a `<pre>` block on the docs getting-started page) became a phantom graph edge and a preload for a file that does not exist. It now computes a position-preserving mask via `redactStringsAndTemplates` and skips any match whose keyword sits inside a blanked literal. The specifier is still read from raw source, so real top-level imports and multi-line `export … from` re-exports are unaffected.

## Deliberately excluded

`import type { T } from './x.ts'` still creates a graph edge (the regex treats `type` as part of the binding list). It did not cause any of the observed 404s (a types-only file strips to an empty module served 200, not 404), and the `.server.*` boundary already keeps the blog's type-only files off the wire. Narrowing type-only imports is a separate concern; not in scope here.

## Test plan

Coverage added at every layer the change affects, each with a verified counterfactual or a real network probe:

- **Unit** (`packages/server/test/module-graph/module-graph.test.js`): `transitiveDeps` stops at the `.server.*` boundary; `buildModuleGraph` ignores import/export shown as code inside a template literal. Both fail when their guard is removed.
- **Integration** (`test/ssr/ssr.test.js`): `ssrPage` does not emit a preload for a server-only util reached THROUGH a `.server` file, while a real client dep still is. Counterfactually verified (fails against the pre-fix `module-graph.js`).
- **E2E** (`test/e2e/e2e.test.mjs`): probe every modulepreload href on the real blog, assert none 404. Suite 52/52.
- **Smoke** (`test/examples/blog/smoke/blog-smoke.test.js`): same probe, browserless. Suite 6/6.
- **Browser** (wtr): N/A because this is server-side graph logic with no client-runtime/hydration/DOM surface; ran it anyway (268/0/1) to confirm no regression.

Server suite 628/628. Dogfood, all four apps (prod mode): blog `/` 10 preloads / 0 broken (was 13/3); docs `/docs/getting-started` 5/0 (was 6/1); website + ui-website 200, 0 broken. The 21 red `packages/core/test/**/browser/*.test.js` under `node --test` are pre-existing wtr tests run under the wrong runner, unrelated to this change.

## Docs

- `packages/server/AGENTS.md`: invariant 1 and the `module-graph.js` module-map line now state that `transitiveDeps` shares the `.server.*` stop (preloads are a subset of servable) and that the scanner ignores imports shown inside template literals.
- User-facing docs: N/A because the public contract (preloads cover transitive deps; only graph-reachable files are servable) is unchanged; this fixes an internal inconsistency, it does not alter documented behavior.
- Scaffold templates: N/A because generated app code is unaffected.