### PR TITLE
Release core 0.7.3, server 0.8.3, and cli 0.10.0

### DIFF
--- a/changelog/cli/0.10.0.md
+++ b/changelog/cli/0.10.0.md
@@ -1,0 +1,24 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.0
+date: 2026-06-01T12:00:00+05:30
+commit_count: 2
+---
+## Features
+
+- **`webjs vendor` command surface for importmap pinning** ([#105](https://github.com/webjsdev/webjs/pull/105)) [`4db2360`](https://github.com/webjsdev/webjs/commit/4db2360)
+  Brings Rails `importmap-rails` parity to the CLI. `webjs vendor pin [pkg]`
+  resolves bare npm specifiers and writes them to a committed
+  `.webjs/vendor/importmap.json`, with `unpin` / `list` to manage it.
+  `--from <provider>` selects the CDN (`jspm` default, plus `jsdelivr`,
+  `unpkg`, `skypack`) and persists the choice in the pin file so later
+  `update` runs stay on the same CDN. `webjs vendor audit` checks pinned
+  versions against the npm security-advisory endpoint and exits non-zero on
+  any CVE; `webjs vendor outdated` lists pinned packages trailing their
+  registry `latest`; `webjs vendor update` re-resolves the outdated set.
+  `--download` caches the bundles under `.webjs/vendor/` for offline serving.
+
+- **direct jspm.io vendor resolution (Rails-style no-build)** ([#89](https://github.com/webjsdev/webjs/pull/89)) [`988b37b`](https://github.com/webjsdev/webjs/commit/988b37b)
+  Adds the first `webjs vendor pin` path and the scaffold wiring behind it,
+  resolving npm dependencies to CDN URLs at serve time with no bundler, so a
+  freshly scaffolded app can pin its vendor dependencies out of the box.

--- a/changelog/core/0.7.3.md
+++ b/changelog/core/0.7.3.md
@@ -1,0 +1,23 @@
+---
+package: "@webjsdev/core"
+version: 0.7.3
+date: 2026-06-01T12:00:00+05:30
+commit_count: 2
+---
+## Fixes
+
+- **client router no longer intercepts JS-handled links** ([#157](https://github.com/webjsdev/webjs/pull/157)) [`c70860b`](https://github.com/webjsdev/webjs/commit/c70860b)
+  The router's click listener ran in the capture phase, ahead of a
+  component's own `@click` handler, so a link whose handler calls
+  `e.preventDefault()` was still hijacked and SPA-navigated. The listener
+  is now registered in the bubble phase, so the router sees
+  `event.defaultPrevented` and leaves the link alone. Plain `<a href>`
+  links are still SPA-navigated as before.
+
+- **client router no longer intercepts JS-handled forms** ([#151](https://github.com/webjsdev/webjs/pull/151)) [`7d84355`](https://github.com/webjsdev/webjs/commit/7d84355)
+  The submit listener had the same capture-phase bug: a form that handles
+  submission in JS (`@submit=${e => { e.preventDefault(); ... }}`, the live
+  chat and comment boxes) was hijacked by the router, which navigated the
+  page and dropped the just-sent message. The submit listener is now a
+  bubble listener too, so a preventDefaulted form keeps its submission and
+  the router stays out of it.

--- a/changelog/server/0.8.3.md
+++ b/changelog/server/0.8.3.md
@@ -1,0 +1,25 @@
+---
+package: "@webjsdev/server"
+version: 0.8.3
+date: 2026-06-01T12:00:00+05:30
+commit_count: 2
+---
+## Fixes
+
+- **modulepreload hints stay within the servable set** ([#161](https://github.com/webjsdev/webjs/pull/161)) [`04f6cef`](https://github.com/webjsdev/webjs/commit/04f6cef)
+  The SSR preload emitter (`transitiveDeps`) walked the module graph
+  differently from the source-serving authorization gate
+  (`reachableFromEntries`), so the framework emitted
+  `<link rel="modulepreload">` hints for URLs it then 404s. Two causes,
+  both fixed: the preload walk now stops at `.server.*` boundaries like the
+  gate (a server-only util reached through a server action is no longer
+  preloaded), and the import scanner masks string / template-literal
+  content so an `import` shown as example code inside an `html\`\`` template
+  is no longer mistaken for a real dependency. The preload set is now a
+  subset of the servable set by construction.
+
+- **`webjs check` no longer leaks a git env var across worktrees** ([#156](https://github.com/webjsdev/webjs/pull/156)) [`9a83ea2`](https://github.com/webjsdev/webjs/commit/9a83ea2)
+  The check-ignore lookup inherited a `GIT_*` environment variable that, in
+  a git worktree, pointed at the parent checkout, so ignore resolution ran
+  against the wrong directory. The lookup now runs with a clean env scoped
+  to the target repo.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6994,7 +6994,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/server": "^0.8.0",
@@ -7019,7 +7019,7 @@
       "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
-        "@webjsdev/cli": "^0.9.0"
+        "@webjsdev/cli": "^0.10.0"
       },
       "bin": {
         "create-webjs": "bin/create-webjs.js"
@@ -7124,7 +7124,7 @@
       "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
-        "@webjsdev/cli": "^0.9.0"
+        "@webjsdev/cli": "^0.10.0"
       },
       "bin": {
         "webjs": "bin/webjsdev.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7009,7 +7009,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.24.0"
@@ -7030,7 +7030,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/create-webjs/package.json
+++ b/packages/create-webjs/package.json
@@ -11,7 +11,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@webjsdev/cli": "^0.9.0"
+    "@webjsdev/cli": "^0.10.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",

--- a/packages/webjsdev/package.json
+++ b/packages/webjsdev/package.json
@@ -11,7 +11,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@webjsdev/cli": "^0.9.0"
+    "@webjsdev/cli": "^0.10.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

Cuts the accumulated release debt since the 0.7.2 / 0.8.2 release (#149). Two packages carry unreleased fixes.

**`@webjsdev/core` 0.7.2 to 0.7.3** (patch)
- #157 stops the client router from intercepting JS-handled links (`@click` + `preventDefault` was hijacked by a capture-phase listener).
- #151 stops the client router from intercepting JS-handled forms (the live chat / comment boxes lost the sent message when the router navigated the page).

**`@webjsdev/server` 0.8.2 to 0.8.3** (patch)
- #161 keeps modulepreload hints within the servable set (no more preloads pointing at server-only or template-embedded files the auth gate 404s).
- #156 stops `webjs check` from leaking a git env var across worktrees.

## Why now

These fixes are already on `main` but unpublished. The version-bump assessment after merging #161 found both `core` and `server` owed a patch release. Both stay in a single minor line; every in-repo dependent pins `^0.7.0` / `^0.8.0`, so the patch bumps stay in range and no dependent edits were needed. `package-lock.json` regenerated.

## What merging does

1. Adds `changelog/core/0.7.3.md` and `changelog/server/0.8.3.md` to `main`, which triggers `release.yml` to `npm publish` both packages and cut their GitHub Releases (idempotent, already-published versions are skipped).
2. Changes `package-lock.json`, which all four deployed dogfood services watch, so it redeploys `examples/blog`, `website`, `docs`, and `ui-website` onto the new `main`. This is what finally clears the live preload-404s on blog and docs, since the #161 fix is framework-only and did not auto-redeploy the apps on its own merge.

## Test plan

No code change beyond version + changelog files. CI runs the full suite against the bumped workspace (the lockfile being in sync is enforced by `npm ci`).

---

**Update: added `@webjsdev/cli` 0.9.1 to 0.10.0** (minor)

Per the version-bump assessment, cli was also owed a release. cli 0.9.1 shipped without the `webjs vendor` command surface that #105 and #89 landed (`pin` / `unpin` / `list` / `audit` / `outdated` / `update`, the `--from` multi-CDN selector, `--download` caching). That is feature-level, so a minor bump (the published cli is 0.9.1; the vendor commits are not ancestors of the 0.9.1 release).

`create-webjs` and `webjsdev` are thin shims that delegate to cli; their `@webjsdev/cli` range is widened `^0.9.0` to `^0.10.0` so the workspace keeps linking the local cli (a minor falls outside the old caret). They are not in the changelog auto-publish system, so they carry no changelog of their own and are NOT version-bumped here.

**One thing to know:** the published `create-webjs@0.9.0` / `webjsdev@0.9.0` still pin cli `^0.9.0`, so `npm create webjs` will keep pulling cli 0.9.x until those two shims are themselves bumped and republished (a manual step, since they are outside the `changelog/**` auto-publish). Not blocking this release; flagging it so new scaffolds picking up the vendor commands is a deliberate follow-up.