### PR TITLE
Enforce test coverage on every code change (framework + scaffolded apps)

### DIFF
--- a/.claude/hooks/require-tests-with-src.sh
+++ b/.claude/hooks/require-tests-with-src.sh
@@ -39,17 +39,23 @@ payload=$(cat)
 cmd=$(printf '%s' "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
 if [ -z "$cmd" ]; then exit 0; fi
 
-case "$cmd" in
-  *"git commit"*) : ;;
-  *) exit 0 ;;
-esac
+# Match `git commit` as a whole word: the char after `commit` must not be
+# a letter, digit, or hyphen, so a real commit (followed by a space, end,
+# newline, `;`, `&`, etc.) trips the gate while sibling subcommands
+# (git commit-graph, git commit-tree) do not.
+if ! printf '%s' "$cmd" | grep -Eq '(^|[^[:alnum:]-])git commit([^[:alnum:]-]|$)'; then
+  exit 0
+fi
 
 if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then exit 0; fi
 
 staged=$(git diff --cached --name-only 2>/dev/null || true)
 if [ -z "$staged" ]; then exit 0; fi
 
-src_touched=$(printf '%s\n' "$staged" | grep -E '^packages/[^/]+/src/' || true)
+# Framework source lives under each package's src/, EXCEPT the CLI, which
+# keeps its logic in packages/cli/lib/. Gate both so a CLI change (the
+# framework's own installer) is not a blind spot.
+src_touched=$(printf '%s\n' "$staged" | grep -E '^packages/([^/]+/src|cli/lib)/' || true)
 if [ -z "$src_touched" ]; then exit 0; fi
 
 test_staged=$(printf '%s\n' "$staged" | grep -E '(^|/)test/|\.test\.[mc]?[jt]sx?$|\.spec\.[mc]?[jt]sx?$' || true)

--- a/.claude/hooks/require-tests-with-src.sh
+++ b/.claude/hooks/require-tests-with-src.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# PreToolUse hook: block a `git commit` that changes framework source
+# without touching any test, and reject commits that look like they strip
+# tests to slip past the gate. Deterministic floor for the project rule
+# "every code change ships with tests" (AGENTS.md "Definition of done").
+#
+# What a hook CANNOT do: know which test LAYER a change needs (unit vs
+# browser vs e2e is a judgement call). So it enforces the floor (a real
+# test change must accompany source) and, for client/browser-facing
+# source, injects a reminder naming the layers to cover. The substantive
+# check (do the tests exercise the behaviour, are they green, were any
+# silently removed) stays the reviewer/test-audit step in AGENTS.md.
+#
+# Scope: only fires on `git commit` Bash calls. Inspects the STAGED diff
+# (what the commit records), so `git add` choices drive it.
+#
+# Blocks (exit 2) when EITHER:
+#   1. The staged diff modifies `packages/*/src/**` but stages no test
+#      file (`**/test/**`, `*.test.*`, or `*.spec.*`), OR
+#   2. The staged test files have a net-negative line count while source
+#      also changes (a signal tests were trimmed to pass), unless
+#      WEBJS_ALLOW_TEST_REMOVAL=1 marks an intentional test refactor.
+#
+# Allowed (exit 0): commits touching no `packages/*/src/**`; commits that
+# stage tests alongside source; and WEBJS_NO_TEST_GATE=1 for a genuine
+# one-off. (`git commit --no-verify` also skips it, but the messages name
+# the env escape hatches since this is a PreToolUse hook, not git's own.)
+#
+# Rule: AGENTS.md "Definition of done" plus the test-audit reviewer step.
+
+set -euo pipefail
+
+if [ "${WEBJS_NO_TEST_GATE:-}" = "1" ]; then
+  exit 0
+fi
+
+payload=$(cat)
+cmd=$(printf '%s' "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+if [ -z "$cmd" ]; then exit 0; fi
+
+case "$cmd" in
+  *"git commit"*) : ;;
+  *) exit 0 ;;
+esac
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then exit 0; fi
+
+staged=$(git diff --cached --name-only 2>/dev/null || true)
+if [ -z "$staged" ]; then exit 0; fi
+
+src_touched=$(printf '%s\n' "$staged" | grep -E '^packages/[^/]+/src/' || true)
+if [ -z "$src_touched" ]; then exit 0; fi
+
+test_staged=$(printf '%s\n' "$staged" | grep -E '(^|/)test/|\.test\.[mc]?[jt]sx?$|\.spec\.[mc]?[jt]sx?$' || true)
+
+if [ -z "$test_staged" ]; then
+  cat >&2 <<'EOF'
+BLOCKED: this commit changes framework source but stages no test.
+
+Staged source under packages/*/src/** with no accompanying test file.
+Every code change ships with tests (AGENTS.md "Definition of done"). Add
+or update the test that proves the new behaviour, then `git add` it.
+
+Walk the layers the change can affect, do NOT stop at unit:
+  unit:    packages/*/test/** , test/**
+  browser: */test/**/browser/*   (hydration, client render, DOM, router)
+  e2e:     test/e2e/*.test.mjs    (full stack, network probes, navigation)
+  smoke:   test/examples/*/smoke/*   (example apps still serve)
+
+For a client-router / component / browser-facing change a unit test is
+necessary but NOT sufficient. Add the browser and/or e2e coverage that
+asserts the real behaviour (for example a network probe that a fetch did
+or did not happen).
+
+Genuine non-code commit (pure docs, release bump) that needs no test?
+Re-run with WEBJS_NO_TEST_GATE=1.
+
+Hook: .claude/hooks/require-tests-with-src.sh
+EOF
+  exit 2
+fi
+
+if [ "${WEBJS_ALLOW_TEST_REMOVAL:-}" != "1" ]; then
+  nums=$(git diff --cached --numstat -- \
+    '**/test/**' '*.test.*' '*.spec.*' 'test/**' 2>/dev/null || true)
+  if [ -n "$nums" ]; then
+    added=$(printf '%s\n' "$nums" | awk '{a+=$1} END{print a+0}')
+    deleted=$(printf '%s\n' "$nums" | awk '{d+=$2} END{print d+0}')
+    if [ "$deleted" -gt "$added" ]; then
+      cat >&2 <<EOF
+BLOCKED: this commit removes more test lines than it adds (+$added / -$deleted).
+
+A net reduction in tests alongside a source change is the signature of
+tests trimmed to pass. If this is a real test refactor or files moving,
+re-run with WEBJS_ALLOW_TEST_REMOVAL=1. Otherwise add the coverage back.
+
+Hook: .claude/hooks/require-tests-with-src.sh
+EOF
+      exit 2
+    fi
+  fi
+fi
+
+client_facing=$(printf '%s\n' "$src_touched" | grep -E 'router-client|render-client|component\.js|slot\.js|lazy-loader|websocket-client|client-router|directives' || true)
+if [ -n "$client_facing" ]; then
+  list=$(printf '%s' "$client_facing" | tr '\n' ' ')
+  jq -n --arg ctx "Reminder: this commit changes client/browser-facing source ($list). A unit test alone is not sufficient. Confirm browser and/or e2e coverage (network probes, navigation, hydration) asserts the real behaviour, and run a test-audit review before declaring the PR ready." '{
+    hookSpecificOutput: { hookEventName: "PreToolUse", additionalContext: $ctx }
+  }'
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,6 +19,15 @@
             "command": ".claude/hooks/block-prose-punctuation.sh"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/require-tests-with-src.sh"
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,12 @@ The principle: autonomous mode is MORE disciplined, not less. Same quality bar (
 
 Every code change MUST include, automatically:
 
-1. **Tests.** Unit test for logic, E2E for user-facing behaviour. See `agent-docs/testing.md`. Run `webjs test`; never report work done with failing tests.
+1. **Tests, every applicable layer (not just unit).** A change ships with the tests that prove it, across EVERY layer it can affect. Walk them explicitly and add coverage where the change reaches:
+   - **unit** (`packages/*/test/**`, `test/**`): logic, helpers, analysers, including the counterfactual (the negative case that fails when the change is reverted).
+   - **browser** (`*/test/**/browser/*`, run via `npm run test:browser`): anything touching hydration, client render, DOM, slots, the client router, custom-element upgrade.
+   - **e2e** (`test/e2e/*.test.mjs`, run via `WEBJS_E2E=1`): full-stack behaviour observable only in a real browser, including **network probes** (was a request issued or not), navigation, streaming.
+   - **smoke** (`test/examples/*/smoke/*`): the example apps still boot and serve.
+   A unit test is NECESSARY BUT NOT SUFFICIENT for any client-router / component / browser-facing change: the headline behaviour ("a prefetch fired on hover", "the click avoided a second fetch", "the component hydrated") is a browser/e2e assertion, and shipping unit-only there is the exact gap this rule closes. `npm test` does NOT run the browser or e2e layers; run them yourself and report the result. Never report work done with failing or missing tests. See `agent-docs/testing.md`. Enforced for Claude Code by `.claude/hooks/require-tests-with-src.sh` (blocks a commit that stages `packages/*/src/**` with no test, and a commit that net-removes test lines); the same gate ships to scaffolded apps via `webjs create`.
 2. **Documentation.** Update `AGENTS.md` for new API surface, `CONVENTIONS.md` for new conventions, `docs/` or `website/` for user-facing features.
 3. **Convention validation.** Run `webjs check` and fix violations.
 

--- a/packages/cli/lib/create.js
+++ b/packages/cli/lib/create.js
@@ -373,6 +373,7 @@ export async function scaffoldApp(name, cwd, opts = {}) {
     '.claude/hooks/block-prose-punctuation.sh',
     '.claude/hooks/guard-branch-context.sh',
     '.claude/hooks/nudge-uncommitted.sh',
+    '.claude/hooks/require-tests-with-src.sh',
     // Gemini CLI config + hooks
     '.gemini/settings.json',
     '.gemini/hooks/nudge-uncommitted.sh',
@@ -405,7 +406,7 @@ export async function scaffoldApp(name, cwd, opts = {}) {
 
   // Make hook scripts executable
   const { chmod } = await import('node:fs/promises');
-  for (const hook of ['block-prose-punctuation.sh', 'guard-branch-context.sh', 'nudge-uncommitted.sh']) {
+  for (const hook of ['block-prose-punctuation.sh', 'guard-branch-context.sh', 'nudge-uncommitted.sh', 'require-tests-with-src.sh']) {
     const hookPath = join(appDir, '.claude', 'hooks', hook);
     if (existsSync(hookPath)) await chmod(hookPath, 0o755);
   }

--- a/packages/cli/templates/.claude/hooks/require-tests-with-src.sh
+++ b/packages/cli/templates/.claude/hooks/require-tests-with-src.sh
@@ -31,10 +31,11 @@ fi
 payload=$(cat)
 cmd=$(printf '%s' "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
 if [ -z "$cmd" ]; then exit 0; fi
-case "$cmd" in
-  *"git commit"*) : ;;
-  *) exit 0 ;;
-esac
+# Match `git commit` as a whole word so sibling subcommands
+# (git commit-graph, git commit-tree) and string mentions do not trip it.
+if ! printf '%s' "$cmd" | grep -Eq '(^|[^[:alnum:]-])git commit([^[:alnum:]-]|$)'; then
+  exit 0
+fi
 
 if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then exit 0; fi
 

--- a/packages/cli/templates/.claude/hooks/require-tests-with-src.sh
+++ b/packages/cli/templates/.claude/hooks/require-tests-with-src.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# PreToolUse hook (scaffolded by `webjs create`): block a `git commit`
+# that adds or changes application code without any accompanying test.
+#
+# webjs is AI-first: most apps are built with an AI agent, and the
+# easiest corner to cut is shipping a feature with no test. This gate
+# makes "every change ships with a test" a hard floor, not a suggestion.
+#
+# What a hook CANNOT do: judge WHICH test layer a change needs (a unit
+# test vs a browser/e2e test is a judgement call). So it enforces the
+# floor (some real test must accompany app code) and reminds you to add
+# browser/e2e coverage for interactive surfaces. `webjs test` runs the
+# actual suite in the commit hook.
+#
+# Scope: fires only on `git commit`. Inspects the STAGED diff.
+#
+# Blocks (exit 2) when the staged diff changes app code (app/, modules/,
+# components/, lib/) but stages no test (test/** or *.test.* / *.spec.*).
+# Allowed: commits with no app-code change, commits that stage a test
+# alongside, and WEBJS_NO_TEST_GATE=1 for a genuine non-code commit.
+#
+# Bypass (humans, emergencies): git commit --no-verify.
+
+set -euo pipefail
+
+if [ "${WEBJS_NO_TEST_GATE:-}" = "1" ]; then
+  exit 0
+fi
+
+payload=$(cat)
+cmd=$(printf '%s' "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+if [ -z "$cmd" ]; then exit 0; fi
+case "$cmd" in
+  *"git commit"*) : ;;
+  *) exit 0 ;;
+esac
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then exit 0; fi
+
+staged=$(git diff --cached --name-only 2>/dev/null || true)
+if [ -z "$staged" ]; then exit 0; fi
+
+# App code lives under app/, modules/, components/, lib/. A `.server.*`
+# file is still app code. Match source extensions only (skip .css, .md).
+app_code=$(printf '%s\n' "$staged" \
+  | grep -E '^(app|modules|components|lib)/.*\.([mc]?[jt]sx?)$' || true)
+if [ -z "$app_code" ]; then exit 0; fi
+
+test_staged=$(printf '%s\n' "$staged" \
+  | grep -E '(^|/)test/|\.test\.[mc]?[jt]sx?$|\.spec\.[mc]?[jt]sx?$' || true)
+
+if [ -z "$test_staged" ]; then
+  cat >&2 <<'EOF'
+BLOCKED: this commit changes app code but stages no test.
+
+You staged application code (app/, modules/, components/, lib/) with no
+accompanying test. Every change ships with a test. Add or update the test
+that proves the new behaviour, then `git add` it.
+
+Pick the layer the change needs (a unit test is not always enough):
+  - logic / actions / queries / utils  -> a unit test
+  - a component, hydration, a server action called from the client, the
+    router, anything interactive -> a browser or e2e test that asserts the
+    real behaviour in a browser, not just the function in isolation.
+
+See `webjs test` and the testing guide. Genuine non-code commit (docs,
+config) that needs no test? Re-run with WEBJS_NO_TEST_GATE=1.
+
+Hook: .claude/hooks/require-tests-with-src.sh
+EOF
+  exit 2
+fi
+
+# Reminder for interactive surfaces: a unit test alone rarely covers them.
+interactive=$(printf '%s\n' "$app_code" | grep -E '^components/|/components/' || true)
+if [ -n "$interactive" ]; then
+  jq -n --arg ctx "Reminder: this commit changes component code. A unit test alone usually is not enough for an interactive component; add a browser test (webjs test --browser) that asserts the rendered/hydrated behaviour." '{
+    hookSpecificOutput: { hookEventName: "PreToolUse", additionalContext: $ctx }
+  }'
+fi
+exit 0

--- a/packages/cli/templates/.claude/settings.json
+++ b/packages/cli/templates/.claude/settings.json
@@ -18,6 +18,15 @@
             "command": ".claude/hooks/guard-branch-context.sh"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/require-tests-with-src.sh"
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/packages/cli/templates/.hooks/pre-commit
+++ b/packages/cli/templates/.hooks/pre-commit
@@ -21,6 +21,31 @@ if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
   exit 1
 fi
 
+# Require a test to accompany app-code changes. Tool-agnostic floor: a
+# commit that stages app code (app/, modules/, components/, lib/) with no
+# test (test/** or *.test.* / *.spec.*) is blocked. The full suite below
+# proves tests PASS; this proves a test was WRITTEN. Bypass for a genuine
+# non-code commit with WEBJS_NO_TEST_GATE=1, or --no-verify in emergencies.
+if [ "${WEBJS_NO_TEST_GATE:-}" != "1" ]; then
+  STAGED=$(git diff --cached --name-only 2>/dev/null)
+  APP_CODE=$(printf '%s\n' "$STAGED" | grep -E '^(app|modules|components|lib)/.*\.([mc]?[jt]sx?)$' || true)
+  if [ -n "$APP_CODE" ]; then
+    TESTS=$(printf '%s\n' "$STAGED" | grep -E '(^|/)test/|\.test\.[mc]?[jt]sx?$|\.spec\.[mc]?[jt]sx?$' || true)
+    if [ -z "$TESTS" ]; then
+      echo ""
+      echo "ERROR: app code changed but no test is staged."
+      echo "Every change ships with a test. Add or update the test that"
+      echo "proves the new behaviour (a browser/e2e test for interactive"
+      echo "or component code), then git add it."
+      echo ""
+      echo "Genuine non-code commit? WEBJS_NO_TEST_GATE=1 git commit ..."
+      echo "Emergency bypass: git commit --no-verify"
+      echo ""
+      exit 1
+    fi
+  fi
+fi
+
 # webjs test + webjs check on every commit. Tool-agnostic enforcement:
 # fires regardless of which agent (Claude, Cursor, Antigravity, Copilot,
 # human) is making the commit. Skipped if the CLI is not yet installed

--- a/packages/cli/templates/AGENTS.md
+++ b/packages/cli/templates/AGENTS.md
@@ -883,8 +883,15 @@ composition, so a nested shell ends up dropped by the HTML parser.
 ## Workflow expectations for AI agents
 
 1. Branch before editing. Never push to `main` directly.
-2. Every code change comes with: unit test(s), AGENTS.md / docs updates if
-   the feature surface changed, `webjs check` passing.
+2. Every code change comes with a test, AGENTS.md / docs updates if the
+   feature surface changed, `webjs check` passing. A unit test is not
+   always enough: a component, hydration, the client router, or a server
+   action called from the client needs a browser test
+   (`webjs test --browser`) asserting the behaviour in a real browser. A
+   commit that stages app code (`app/`, `modules/`, `components/`, `lib/`)
+   with no test is blocked by `.claude/hooks/require-tests-with-src.sh`
+   and the `.hooks/pre-commit` floor (bypass a genuine non-code commit
+   with `WEBJS_NO_TEST_GATE=1`).
 3. Commit and push **per logical unit**, not at the end. A logical unit is one
    feature, one fix, one rename, one doc rewrite. If you have 5+ unstaged files
    spanning different concerns, commit the current group before continuing.

--- a/packages/cli/templates/CONVENTIONS.md
+++ b/packages/cli/templates/CONVENTIONS.md
@@ -451,6 +451,15 @@ test/
 - `webjs test --browser` (or `npx wtr`) runs the browser tests.
 - `WEBJS_E2E=1 webjs test` adds the e2e tests.
 
+**Every change ships with a test, enforced at commit time.** A commit
+that stages app code (`app/`, `modules/`, `components/`, `lib/`) without
+staging a test is blocked by `.claude/hooks/require-tests-with-src.sh`
+(Claude Code) and the universal `.hooks/pre-commit` (any agent or human).
+A unit test alone is not enough for interactive or component code: add
+the browser test that asserts the rendered/hydrated behaviour. Bypass a
+genuine non-code commit with `WEBJS_NO_TEST_GATE=1`, or `--no-verify` in
+an emergency.
+
 ### Choosing a feature folder
 
 Use the same name as the matching module folder when one exists:

--- a/test/hooks/require-tests-with-src.test.mjs
+++ b/test/hooks/require-tests-with-src.test.mjs
@@ -1,0 +1,108 @@
+// Tests for the require-tests-with-src PreToolUse hook
+// (.claude/hooks/require-tests-with-src.sh). The hook reads a tool-call
+// payload on stdin and, for a `git commit` that stages framework source
+// without a test (or that net-removes test lines), exits 2 to block it.
+//
+// Each case builds a throwaway git repo, stages a specific shape of
+// change, and feeds the hook the commit payload, asserting the exit code.
+
+import { test, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HOOK = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../.claude/hooks/require-tests-with-src.sh',
+);
+
+/** Init a throwaway repo with one src file and one test file committed. */
+function makeRepo() {
+  const dir = mkdtempSync(join(tmpdir(), 'webjs-testgate-'));
+  const git = (...args) => execFileSync('git', args, { cwd: dir, stdio: 'pipe' });
+  git('init', '-q');
+  git('config', 'user.email', 't@t');
+  git('config', 'user.name', 't');
+  mkdirSync(join(dir, 'packages/core/src'), { recursive: true });
+  mkdirSync(join(dir, 'packages/core/test'), { recursive: true });
+  writeFileSync(join(dir, 'packages/core/test/x.test.js'), 'a\nb\nc\nd\ne\n');
+  writeFileSync(join(dir, 'packages/core/src/x.js'), 'v1\n');
+  git('add', '-A');
+  git('commit', '-qm', 'init');
+  return { dir, git };
+}
+
+/** Run the hook in `dir` with a commit payload and the given env, return exit code. */
+function runHook(dir, env = {}) {
+  const r = spawnSync('bash', [HOOK], {
+    cwd: dir,
+    input: JSON.stringify({ tool_input: { command: 'git commit -m x' } }),
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return r.status;
+}
+
+test('blocks a commit that stages src with no test', () => {
+  const { dir, git } = makeRepo();
+  try {
+    writeFileSync(join(dir, 'packages/core/src/x.js'), 'v2\n');
+    git('add', 'packages/core/src/x.js');
+    assert.equal(runHook(dir), 2);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('allows a commit that stages src AND a test', () => {
+  const { dir, git } = makeRepo();
+  try {
+    writeFileSync(join(dir, 'packages/core/src/x.js'), 'v2\n');
+    writeFileSync(join(dir, 'packages/core/test/x.test.js'), 'a\nb\nc\nd\ne\nf\n');
+    git('add', '-A');
+    assert.equal(runHook(dir), 0);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('allows a docs-only commit (no src touched)', () => {
+  const { dir, git } = makeRepo();
+  try {
+    writeFileSync(join(dir, 'README.md'), 'docs\n');
+    git('add', 'README.md');
+    assert.equal(runHook(dir), 0);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('blocks a commit that net-removes test lines alongside src', () => {
+  const { dir, git } = makeRepo();
+  try {
+    writeFileSync(join(dir, 'packages/core/src/x.js'), 'v3\n');
+    writeFileSync(join(dir, 'packages/core/test/x.test.js'), 'a\n'); // shrink 5 -> 1
+    git('add', '-A');
+    assert.equal(runHook(dir), 2);
+    // The override lets an intentional test refactor through.
+    assert.equal(runHook(dir, { WEBJS_ALLOW_TEST_REMOVAL: '1' }), 0);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('WEBJS_NO_TEST_GATE=1 skips the gate entirely', () => {
+  const { dir, git } = makeRepo();
+  try {
+    writeFileSync(join(dir, 'packages/core/src/x.js'), 'v2\n');
+    git('add', 'packages/core/src/x.js');
+    assert.equal(runHook(dir, { WEBJS_NO_TEST_GATE: '1' }), 0);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('does not fire on a non-commit git command', () => {
+  const { dir } = makeRepo();
+  try {
+    const r = spawnSync('bash', [HOOK], {
+      cwd: dir,
+      input: JSON.stringify({ tool_input: { command: 'git status' } }),
+      encoding: 'utf8',
+    });
+    assert.equal(r.status, 0);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});

--- a/test/scaffolds/scaffold-integration.test.js
+++ b/test/scaffolds/scaffold-integration.test.js
@@ -79,6 +79,26 @@ test('scaffoldApp full-stack: writes the canonical full-stack app layout', async
     assert.ok(existsSync(join(appDir, 'prisma', 'schema.prisma')), 'prisma schema written');
     assert.ok(existsSync(join(appDir, 'lib', 'prisma.server.ts')), 'lib/prisma.server.ts written');
 
+    // require-tests gate reaches the scaffolded app three ways: the hook
+    // file is copied, the Claude settings wire it into PreToolUse, and the
+    // tool-agnostic pre-commit floor carries the block. All three must be
+    // present so an app-code commit with no test is blocked regardless of
+    // which agent (or human) commits.
+    assert.ok(existsSync(join(appDir, '.claude/hooks/require-tests-with-src.sh')),
+      'require-tests hook is scaffolded');
+    const claudeSettings = JSON.parse(
+      readFileSync(join(appDir, '.claude/settings.json'), 'utf8'),
+    );
+    const preCommands = (claudeSettings.hooks?.PreToolUse ?? [])
+      .flatMap((g) => g.hooks.map((h) => h.command));
+    assert.ok(
+      preCommands.includes('.claude/hooks/require-tests-with-src.sh'),
+      'settings.json wires the require-tests hook into PreToolUse',
+    );
+    const preCommit = readFileSync(join(appDir, '.hooks/pre-commit'), 'utf8');
+    assert.match(preCommit, /no test is staged/,
+      'pre-commit carries the tool-agnostic require-tests floor');
+
     // package.json contents
     const pkg = JSON.parse(readFileSync(join(appDir, 'package.json'), 'utf8'));
     assert.equal(pkg.name, 'my-app');


### PR DESCRIPTION
## Summary

Closes #162

A code change could ship with unit tests only and miss the browser / e2e layers it actually needs. This happened with the link-prefetch work (browser behaviour that initially had only unit tests). Skill descriptions and AGENTS.md prose are advisory; this adds a deterministic gate, in the framework repo and in every scaffolded app.

## Part A: framework repo

- **`.claude/hooks/require-tests-with-src.sh`** (PreToolUse, Bash): blocks a `git commit` that stages `packages/*/src/**` with no accompanying test, and blocks a commit that net-removes test lines (the tests-trimmed-to-pass guard). Escape hatches: `WEBJS_NO_TEST_GATE=1`, `WEBJS_ALLOW_TEST_REMOVAL=1`. For client-facing source it injects a reminder that a unit test alone is not sufficient.
- **AGENTS.md** "Definition of done": the test bullet becomes an explicit unit / browser / e2e / smoke checklist.
- **`test/hooks/require-tests-with-src.test.mjs`**: 6 cases covering block, allow, both overrides, test-shrink, non-commit.

## Part B: scaffolded apps (end users)

Most webjs apps are built with an AI agent, so the gate must reach users, not just this repo.

- `webjs create` now scaffolds `.claude/hooks/require-tests-with-src.sh` (chmod +x) and wires it into the app's `.claude/settings.json` PreToolUse.
- The universal `.hooks/pre-commit` gains a tool-agnostic floor: an app-code commit (`app/`, `modules/`, `components/`, `lib/`) that stages no test is blocked, for any agent or human.
- Scaffold `AGENTS.md` and `CONVENTIONS.md` document the per-layer test rule and the gate.
- `test/scaffolds/scaffold-integration.test.js` asserts a freshly-created app carries the hook, the settings wiring, and the pre-commit floor.

## Honest limitation

A hook cannot judge WHICH layer a change needs (unit vs browser vs e2e is a judgement call). It enforces the floor (a real test must accompany source) and reminds about layers for client-facing code; the substantive "do the tests exercise the behaviour" check stays the reviewer step.

## Test plan

- [x] `test/hooks/require-tests-with-src.test.mjs`: 6/6
- [x] `test/scaffolds/scaffold-integration.test.js`: 9/9 (includes the new gate assertion)
- [x] Full suite `node scripts/run-node-tests.js`: 1497 pass, 0 fail
