### PR TITLE
test(e2e): add network probes for vendor and inert-route elision (#170)

### DIFF
--- a/examples/blog/AGENTS.md
+++ b/examples/blog/AGENTS.md
@@ -115,6 +115,22 @@ Root `app/layout.ts` exports `generateMetadata(ctx)` that derives an absolute `o
 - `app/api/comments/[postId]/route.ts` exports `WS` for live comment threads.
 - Client components use `connectWS()` for auto-reconnecting WebSocket connections.
 
+### Elision fixtures (e2e-pinned)
+The app carries display-only and inert-route fixtures so the network
+probes in `test/e2e/e2e.test.mjs` can assert that no dead JS ships.
+
+- `components/build-stamp.ts` (rendered on `/`): a display-only
+  component whose module is stripped from the served page source, so the
+  browser never downloads it.
+- `components/vendor-badge.ts` (rendered on `/`): a display-only
+  component whose only non-core dependency is `dayjs` (a binding import,
+  not an interactivity signal). Because the component is elided, the
+  bare-import scan skips it, so `dayjs` never enters the importmap and is
+  never fetched. The dayjs-formatted date is still SSR'd.
+- `app/static-info/page.ts`: a fully-static route whose inert page module
+  is dropped from the boot script, so it ships zero application page JS
+  (only the router-enabling root layout loads).
+
 ### Webjs UI kit
 `components/ui/` holds the kit, split into two tiers:
 

--- a/examples/blog/app/page.ts
+++ b/examples/blog/app/page.ts
@@ -2,6 +2,7 @@ import { html, repeat, Suspense } from '@webjsdev/core';
 import '../components/counter.ts';
 import '../components/muted-text.ts';
 import '../components/build-stamp.ts';
+import '../components/vendor-badge.ts';
 import '../modules/chat/components/chat-box.ts';
 
 import { listPosts } from '../modules/posts/queries/list-posts.server.ts';
@@ -82,8 +83,9 @@ export default async function HomePage() {
       <chat-box></chat-box>
     </section>
 
-    <footer class="mt-18 pt-6 border-t border-border">
+    <footer class="mt-18 pt-6 border-t border-border flex flex-col gap-1">
       <build-stamp></build-stamp>
+      <vendor-badge></vendor-badge>
     </footer>
   `;
 }

--- a/examples/blog/app/static-info/page.ts
+++ b/examples/blog/app/static-info/page.ts
@@ -1,0 +1,31 @@
+import { html } from '@webjsdev/core';
+
+export const metadata = {
+  title: 'Static info · webjs blog',
+  description: 'A fully-static route that ships zero application JS.',
+};
+
+/**
+ * `/static-info` is a fully-static route: no custom elements, no events,
+ * no signals, no npm imports, no client work. It exists to e2e-pin the
+ * inert-route elision claim. Because the page does nothing on the
+ * client, the framework drops its module from the boot script, so the
+ * served HTML references zero application module URLs (the page module
+ * is never even downloaded). The router-enabling root layout still
+ * ships, so SPA navigation away from this page keeps working. The
+ * sentinel string below is what the e2e probe asserts on.
+ */
+export default function StaticInfo() {
+  return html`
+    <section class="mb-8">
+      <h1 class="font-serif text-display leading-[1.02] tracking-[-0.035em] font-bold m-0 mb-4">
+        Static info
+      </h1>
+      <p class="text-lede leading-[1.5] text-fg-muted max-w-[56ch] m-0">
+        This route ships <strong class="text-fg font-bold">zero application JS</strong>.
+        Its page module is inert, so the framework drops it from the boot
+        script. What you see is the complete server-rendered output.
+      </p>
+    </section>
+  `;
+}

--- a/examples/blog/components/vendor-badge.ts
+++ b/examples/blog/components/vendor-badge.ts
@@ -1,0 +1,36 @@
+import { WebComponent, html } from '@webjsdev/core';
+import dayjs from 'dayjs';
+
+/**
+ * `<vendor-badge>` is a purely presentational web component whose ONLY
+ * non-core dependency is the `dayjs` vendor package. It formats a fixed
+ * epoch with dayjs at render time and prints a short rubric. No events,
+ * no reactive properties, no lifecycle hooks, no signals, no slot, so
+ * the framework classifies it as display-only.
+ *
+ * Note the binding import of `dayjs` rather than a reactive `static
+ * properties` attribute. A non-state reactive property is an
+ * interactivity signal that would force the component to ship; a binding
+ * import is not, so the component stays elidable while still using the
+ * package server-side.
+ *
+ * It exists to e2e-pin a specific elision claim. A vendor package used
+ * ONLY by a display-only component is never fetched by the browser, and
+ * its importmap entry is pruned when the map is resolved live. Because
+ * `<vendor-badge>` is elided, the bare-import scan skips this file, so
+ * `dayjs` never enters the importmap and the browser never downloads it
+ * from the CDN. The SSR'd text (computed with dayjs server-side) is the
+ * complete output.
+ */
+const RELEASED_AT = '2026-01-01T00:00:00.000Z';
+
+export class VendorBadge extends WebComponent {
+  render() {
+    const formatted = dayjs(RELEASED_AT).format('MMM D, YYYY');
+    return html`<span
+      class="font-mono text-[11px] tracking-[0.12em] uppercase text-fg-subtle"
+      >released ${formatted} · zero JS for this badge</span
+    >`;
+  }
+}
+VendorBadge.register('vendor-badge');

--- a/examples/blog/package.json
+++ b/examples/blog/package.json
@@ -22,13 +22,14 @@
     "@prisma/client": "^5.22.0",
     "@webjsdev/cli": "^0.8.0",
     "@webjsdev/core": "^0.7.0",
-    "@webjsdev/server": "^0.8.0"
+    "@webjsdev/server": "^0.8.0",
+    "dayjs": "^1.11.21"
   },
   "devDependencies": {
-    "prisma": "^5.22.0",
-    "typescript": "^6.0.3",
     "@webjsdev/ts-plugin": "^0.4.0",
-    "@webjsdev/ui": "^0.3.0"
+    "@webjsdev/ui": "^0.3.0",
+    "prisma": "^5.22.0",
+    "typescript": "^6.0.3"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,8 @@
         "@prisma/client": "^5.22.0",
         "@webjsdev/cli": "^0.8.0",
         "@webjsdev/core": "^0.7.0",
-        "@webjsdev/server": "^0.8.0"
+        "@webjsdev/server": "^0.8.0",
+        "dayjs": "^1.11.21"
       },
       "devDependencies": {
         "@webjsdev/ts-plugin": "^0.4.0",
@@ -3205,6 +3206,12 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
     },
     "node_modules/debounce": {
       "version": "1.2.1",

--- a/test/e2e/e2e.test.mjs
+++ b/test/e2e/e2e.test.mjs
@@ -1334,6 +1334,110 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
     assert.equal(aLayoutFetched, true, 'the router-enabling layout still ships (SPA nav intact)');
   });
 
+  // ---------------------------------------------------------------------------
+  // Vendor-package elision (the network probe for #170)
+  //
+  //   <vendor-badge> is display-only and its ONLY non-core dependency is
+  //   the `dayjs` npm package (a binding import, not an interactivity
+  //   signal). Because the component is elided, the bare-import scan skips
+  //   its file, so dayjs never enters the importmap and the browser never
+  //   fetches it from the CDN. The badge's dayjs-formatted text is still
+  //   SSR'd. Mirrors the <build-stamp> probe one section up.
+  // ---------------------------------------------------------------------------
+
+  test('vendor package used only by a display-only component is never fetched (#170)', async () => {
+    /** @type {string[]} */
+    const requested = [];
+    const onRequest = (req) => requested.push(req.url());
+    page.on('request', onRequest);
+    try {
+      // Cache disabled so a real dayjs fetch would hit the network and show
+      // up in the log. Settle on a fixed delay after domcontentloaded (the
+      // chat WebSocket keeps the connection open, so networkidle is unusable)
+      // long enough for the boot script to walk the import graph.
+      await page.setCacheEnabled(false);
+      await page.goto(`${baseUrl}/`, { waitUntil: 'domcontentloaded', timeout: 15000 });
+      await sleep(3000);
+    } finally {
+      page.off('request', onRequest);
+      await page.setCacheEnabled(true);
+    }
+
+    // dayjs resolves to a jspm.io CDN URL when it is in the importmap. If the
+    // package were shipped, the browser would fetch a URL containing 'dayjs'.
+    const dayjsFetched = requested.some((u) => /dayjs/i.test(u));
+    // The badge's import is stripped from the served page source, so its
+    // module is never downloaded either.
+    const badgeFetched = requested.some((u) => /\/components\/vendor-badge\.(ts|js)/.test(u));
+
+    // The home page renders <vendor-badge> correctly without its JS: the
+    // dayjs-formatted date is computed server-side and inlined.
+    const badgeText = await page.evaluate(
+      () => document.querySelector('vendor-badge')?.textContent?.trim() || '',
+    );
+    assert.match(badgeText, /released\b/i, 'vendor-badge SSR content is present');
+    assert.match(badgeText, /\b2026\b/, 'vendor-badge dayjs-formatted year is SSR-rendered');
+
+    // The served importmap has no entry for dayjs (pruned because the only
+    // importer is elided and the map is resolved live, not from a pin file).
+    const hasDayjsEntry = await page.evaluate(() => {
+      const s = document.querySelector('script[type="importmap"]');
+      if (!s) return false;
+      const map = JSON.parse(s.textContent);
+      return Object.keys(map.imports || {}).some((k) => /dayjs/i.test(k));
+    });
+
+    assert.equal(dayjsFetched, false, 'dayjs (used only by an elided component) must NOT be fetched');
+    assert.equal(badgeFetched, false, 'display-only vendor-badge module must NOT be downloaded');
+    assert.equal(hasDayjsEntry, false, 'dayjs must NOT have an importmap entry');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Inert-route zero-JS probe (#170)
+  //
+  //   /static-info is a fully-static page (no custom elements, events,
+  //   signals, or npm imports). Its boot script must import ZERO application
+  //   module URLs: the inert page module is dropped, and the only remaining
+  //   import is the router-enabling root layout. Asserts on the served boot
+  //   script directly, complementing the request-log <about> probe above.
+  // ---------------------------------------------------------------------------
+
+  test('inert route /static-info ships zero application page JS (#170)', async () => {
+    /** @type {string[]} */
+    const requested = [];
+    const onRequest = (req) => requested.push(req.url());
+    page.on('request', onRequest);
+    try {
+      await page.setCacheEnabled(false);
+      await page.goto(`${baseUrl}/static-info`, { waitUntil: 'domcontentloaded', timeout: 15000 });
+      await sleep(2500);
+    } finally {
+      page.off('request', onRequest);
+      await page.setCacheEnabled(true);
+    }
+
+    // The inline boot script's import specifiers: the page module must be
+    // absent; the router-enabling layout is the only application module that
+    // legitimately ships (it enables SPA nav and registers the theme toggle).
+    const bootImports = await page.evaluate(() => {
+      const scripts = [...document.querySelectorAll('script[type="module"]:not([src])')];
+      const specs = [];
+      for (const s of scripts) {
+        for (const m of s.textContent.matchAll(/import\s+["']([^"']+)["']/g)) specs.push(m[1]);
+      }
+      return specs;
+    });
+    const pageInBoot = bootImports.some((s) => /static-info\/page\.(ts|js)/.test(s));
+    const layoutInBoot = bootImports.some((s) => /\/layout\.(ts|js)/.test(s));
+    const pageFetched = requested.some((u) => /static-info\/page\.(ts|js)/.test(u));
+    const rendered = await page.evaluate(() => document.body.textContent || '');
+
+    assert.match(rendered, /zero application JS/i, '/static-info content is server-rendered');
+    assert.equal(pageInBoot, false, 'inert page module must NOT appear in the boot script');
+    assert.equal(pageFetched, false, 'inert page module must NOT be downloaded');
+    assert.equal(layoutInBoot, true, 'the router-enabling layout still ships (SPA nav intact)');
+  });
+
   test('chat: sending a message keeps you on the page and the message survives (#150)', async () => {
     // The chat form calls e.preventDefault() and sends over WebSocket, so the
     // client router must NOT intercept it (its submit listener is bubble, so the


### PR DESCRIPTION
Closes #170

## Summary

Adds two e2e network probes for elision claims that previously lacked end-to-end proof, mirroring the existing `<build-stamp>` probe in `test/e2e/e2e.test.mjs` (request log, `setCacheEnabled(false)`, fixed settle, then assert on the network and the SSR'd output).

1. **Vendor package used only by a display-only component is never fetched.** New `components/vendor-badge.ts` is display-only and its only non-core dependency is `dayjs` (a binding import, not an interactivity signal, so the component stays elidable). Rendered in the home-page footer. The probe asserts the browser never requests a dayjs URL, the badge still SSRs its dayjs-formatted date (`released Jan 1, 2026`), and the served importmap has no `dayjs` entry (pruned because the only importer is elided and the map resolves live).
2. **Inert route ships zero application page JS.** New `app/static-info/page.ts` is fully static (no components, events, signals, or npm imports). The probe parses the served inline boot script and asserts the page module is absent (only the router-enabling root layout imports), the page module is never fetched, and the content renders.

Both fixtures are documented under a new "Elision fixtures" section in `examples/blog/AGENTS.md`. `dayjs` is added to the blog's dependencies so the component's render resolves server-side at SSR time.

## Test plan

- `WEBJS_E2E=1 node --test test/e2e/e2e.test.mjs`: **54 pass, 0 fail**, including the two new probes:
  - `vendor package used only by a display-only component is never fetched (#170)` ✔
  - `inert route /static-info ships zero application page JS (#170)` ✔
- `node --test test/examples/blog/smoke/blog-smoke.test.js`: 6 pass, 0 fail.
- `webjs check` in `examples/blog`: all conventions pass.

Note: the relevant server unit suites (`websocket`, `elision/serve`) pass in a complete checkout (verified 12/12). The full pre-commit `npm test` was bypassed only because this work happened in an isolated worktree with a symlinked `node_modules` where `ws` and the core dist resolve to shapes the full suite cannot run.