### PR TITLE
Release @webjsdev/server 0.8.4

### DIFF
--- a/changelog/server/0.8.4.md
+++ b/changelog/server/0.8.4.md
@@ -1,0 +1,18 @@
+---
+package: "@webjsdev/server"
+version: 0.8.4
+date: 2026-06-01T18:00:00+05:30
+commit_count: 1
+---
+## Fixes
+
+- **elision ships a display-only component that other code observes** ([#171](https://github.com/webjsdev/webjs/pull/171)) [`f700ddd`](https://github.com/webjsdev/webjs/commit/f700ddd)
+  Display-only elision drops a component's `customElements.define` when its
+  own render is inert, but missed that OTHER client code can observe the
+  tag's registration. A shipping `customElements.whenDefined('the-tag')`, a
+  CSS `the-tag:defined` rule, or an `instanceof TheClass` check now forces the
+  observed component to ship, so the observation no longer silently fails
+  (`whenDefined` never resolving, `:defined` never matching, `instanceof`
+  always false). The `instanceof` form maps the class name back to a tag via
+  the component class name. Verdict-safe: it only ever ships more. Dynamic tag
+  strings and external stylesheets stay an author-facing caveat.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7037,7 +7037,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
## Summary

Patch release for `@webjsdev/server`, 0.8.3 to 0.8.4. Ships the elision cross-module-observation fix (#171 / #169): a display-only component observed via `whenDefined('tag')`, a CSS `tag:defined` rule, or `instanceof TheClass` now ships instead of being elided, so the observation no longer silently fails.

#172 (the e2e probes) was test-only and does not warrant a bump. core (0.7.3) and cli (0.10.0) are current.

## Why patch

A fix in a single minor line. Every in-repo dependent pins `^0.8.0`, so 0.8.4 stays in range with no dependent edits. `package-lock.json` regenerated.

## What merging does

1. Adds `changelog/server/0.8.4.md` to `main`, triggering `release.yml` to `npm publish @webjsdev/server@0.8.4` and cut its GitHub Release (idempotent).
2. Changes `package-lock.json`, which the four deployed services watch, so they redeploy onto the new `main`, putting the #169 elision fix on the live blog and docs.

## Test plan

No code change beyond the version + changelog. The underlying fix (#171) merged with its own unit + integration coverage and green CI. The pre-commit suite ran on this commit. CI runs the full gates.
