### PR TITLE
Add e2e probe: an observed display-only component ships (#169)

### DIFF
--- a/examples/blog/AGENTS.md
+++ b/examples/blog/AGENTS.md
@@ -130,6 +130,12 @@ probes in `test/e2e/e2e.test.mjs` can assert that no dead JS ships.
 - `app/static-info/page.ts`: a fully-static route whose inert page module
   is dropped from the boot script, so it ships zero application page JS
   (only the router-enabling root layout loads).
+- `components/observed-badge.ts` + `components/observe-badge.ts` (rendered
+  on `/observed`): a display-only component that WOULD elide, paired with a
+  module that observes it via `customElements.whenDefined('observed-badge')`.
+  The observation forces the badge to ship, so the probe asserts its module
+  IS downloaded (the cross-module-registration fix, #169). The unobserved
+  `build-stamp` is the negative control.
 
 ### Webjs UI kit
 `components/ui/` holds the kit, split into two tiers:

--- a/examples/blog/app/observed/page.ts
+++ b/examples/blog/app/observed/page.ts
@@ -1,0 +1,30 @@
+import { html } from '@webjsdev/core';
+import '../../components/observed-badge.ts';
+import '../../components/observe-badge.ts';
+
+export const metadata = {
+  title: 'Observed badge · webjs blog',
+  description: 'Pins the cross-module-registration elision fix (#169).',
+};
+
+/**
+ * `/observed` renders a display-only `<observed-badge>` AND imports a
+ * module that observes its registration via `whenDefined`. The observation
+ * forces the otherwise-elidable badge to ship, so the e2e probe can assert
+ * the browser actually downloads `observed-badge.ts`.
+ */
+export default function Observed() {
+  return html`
+    <section class="mb-8">
+      <h1 class="font-serif text-display leading-[1.02] tracking-[-0.035em] font-bold m-0 mb-4">
+        Observed badge
+      </h1>
+      <p class="text-lede leading-[1.5] text-fg-muted max-w-[56ch] m-0 mb-6">
+        This page waits for the badge to upgrade, so the framework keeps its
+        module on the wire even though the badge itself only renders static
+        markup.
+      </p>
+      <observed-badge></observed-badge>
+    </section>
+  `;
+}

--- a/examples/blog/components/observe-badge.ts
+++ b/examples/blog/components/observe-badge.ts
@@ -1,13 +1,17 @@
 /**
- * A shipping side-effect module that OBSERVES `<observed-badge>`'s
- * registration via `customElements.whenDefined`. This is the cross-module
- * observation the #169 fix detects: because a graph-reachable module waits
- * for the tag to upgrade, the analyser forces `observed-badge` to ship
- * instead of eliding it. Without the observation the badge would be elided
- * (like `<build-stamp>`), and this `whenDefined` would never resolve.
+ * A shipping side-effect module that observes the observed-badge element's
+ * registration. This is the cross-module observation the #169 fix detects:
+ * because a graph-reachable module waits for the tag to upgrade, the
+ * analyser forces observed-badge to ship instead of eliding it. Without
+ * the observation the badge would be elided like the build-stamp element.
  *
  * The returned promise is intentionally unused. The call is SSR-safe: the
- * server's `customElements` shim returns a promise that simply never
- * resolves there, so no browser-only API is touched during SSR.
+ * server's customElements shim returns a promise that simply never resolves
+ * there, so no browser-only API is touched during SSR.
+ *
+ * Note: the doc prose avoids angle-bracket tag syntax on purpose. The
+ * elision analyser scans raw source including comments, so a tag written in
+ * angle brackets would be misread as a rendered tag. The real observation
+ * is the executable line below.
  */
 void customElements.whenDefined('observed-badge');

--- a/examples/blog/components/observe-badge.ts
+++ b/examples/blog/components/observe-badge.ts
@@ -1,0 +1,13 @@
+/**
+ * A shipping side-effect module that OBSERVES `<observed-badge>`'s
+ * registration via `customElements.whenDefined`. This is the cross-module
+ * observation the #169 fix detects: because a graph-reachable module waits
+ * for the tag to upgrade, the analyser forces `observed-badge` to ship
+ * instead of eliding it. Without the observation the badge would be elided
+ * (like `<build-stamp>`), and this `whenDefined` would never resolve.
+ *
+ * The returned promise is intentionally unused. The call is SSR-safe: the
+ * server's `customElements` shim returns a promise that simply never
+ * resolves there, so no browser-only API is touched during SSR.
+ */
+void customElements.whenDefined('observed-badge');

--- a/examples/blog/components/observed-badge.ts
+++ b/examples/blog/components/observed-badge.ts
@@ -1,19 +1,24 @@
 import { WebComponent, html } from '@webjsdev/core';
 
 /**
- * `<observed-badge>` is a purely presentational web component: static
- * markup, no events, no reactive properties, no lifecycle hooks, no
- * signals, no slot. On its own the framework would classify it as
+ * The observed-badge element is a purely presentational web component:
+ * static markup, no events, no reactive properties, no lifecycle hooks,
+ * no signals, no slot. On its own the framework would classify it as
  * display-only and elide its module from the browser.
  *
  * It exists to e2e-pin the cross-module-registration fix (#169). The
- * `/observed` route observes this tag with
- * `customElements.whenDefined('observed-badge')`, which forces the
+ * observed route waits for this tag to upgrade, which forces the
  * component to ship even though its own render is inert. The probe
  * asserts the browser actually downloads THIS module (the observation
- * would silently break if it were elided, since `whenDefined` would
- * never resolve). The counterpart is `<build-stamp>`, an unobserved
- * display-only component that is never downloaded.
+ * would silently break if it were elided). The build-stamp element is the
+ * counterpart, an unobserved display-only component that is never
+ * downloaded.
+ *
+ * The doc comments here deliberately avoid literal tag-in-angle-brackets
+ * and whenDefined-call syntax, because the elision analyser scans raw
+ * source (comments included), so such prose would be read as a real
+ * rendered tag or observation and skew the verdict. See observe-badge.ts
+ * for the actual observer code.
  */
 export class ObservedBadge extends WebComponent {
   render() {

--- a/examples/blog/components/observed-badge.ts
+++ b/examples/blog/components/observed-badge.ts
@@ -1,0 +1,26 @@
+import { WebComponent, html } from '@webjsdev/core';
+
+/**
+ * `<observed-badge>` is a purely presentational web component: static
+ * markup, no events, no reactive properties, no lifecycle hooks, no
+ * signals, no slot. On its own the framework would classify it as
+ * display-only and elide its module from the browser.
+ *
+ * It exists to e2e-pin the cross-module-registration fix (#169). The
+ * `/observed` route observes this tag with
+ * `customElements.whenDefined('observed-badge')`, which forces the
+ * component to ship even though its own render is inert. The probe
+ * asserts the browser actually downloads THIS module (the observation
+ * would silently break if it were elided, since `whenDefined` would
+ * never resolve). The counterpart is `<build-stamp>`, an unobserved
+ * display-only component that is never downloaded.
+ */
+export class ObservedBadge extends WebComponent {
+  render() {
+    return html`<span
+      class="font-mono text-[11px] tracking-[0.12em] uppercase text-fg-subtle"
+      >observed badge · registers because something waits for it</span
+    >`;
+  }
+}
+ObservedBadge.register('observed-badge');

--- a/test/e2e/e2e.test.mjs
+++ b/test/e2e/e2e.test.mjs
@@ -1308,6 +1308,36 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
     assert.equal(counter, true, 'interactive counter module must be downloaded');
   });
 
+  test('a display-only component observed via whenDefined IS downloaded (#169)', async () => {
+    // Counterpart to the build-stamp probe above. <observed-badge> is just as
+    // display-only, but the /observed route imports a module that calls
+    // customElements.whenDefined('observed-badge'). That observation forces
+    // the badge to ship (eliding it would leave whenDefined unresolved), so
+    // the browser MUST download its module. The unobserved build-stamp is the
+    // negative control (proven not downloaded by the test above).
+    /** @type {string[]} */
+    const requested = [];
+    const onRequest = (req) => requested.push(req.url());
+    page.on('request', onRequest);
+    try {
+      await page.setCacheEnabled(false);
+      await page.goto(`${baseUrl}/observed`, { waitUntil: 'domcontentloaded', timeout: 15000 });
+      await sleep(3000);
+    } finally {
+      page.off('request', onRequest);
+      await page.setCacheEnabled(true);
+    }
+
+    const badgeFetched = requested.some((u) => /\/components\/observed-badge\.(ts|js)/.test(u));
+    const badgeText = await page.evaluate(
+      () => document.querySelector('observed-badge')?.textContent?.trim() || '',
+    );
+
+    assert.match(badgeText, /observed badge/i, 'observed-badge SSR content is present');
+    assert.equal(badgeFetched, true,
+      'an observed display-only component module MUST be downloaded (forced to ship)');
+  });
+
   test('a fully-static route (/about) drops its page module from the boot', async () => {
     // /about renders only static markup (no events, signals, or custom
     // elements), so its page module is inert and dropped from the boot


### PR DESCRIPTION
## Summary

Closes #175

Follow-up that closes the all-test-layers gap on the merged #169 work. PR #171 (the cross-module-observation elision fix) shipped with unit + integration coverage, but the e2e network-probe layer was deferred to #172 and never landed (#172 only added the vendor-never-fetched and inert-route probes). So there was no real-browser proof that an OBSERVED display-only component's module is actually downloaded. This adds it.

## What changed

- `examples/blog/components/observed-badge.ts`: a genuinely display-only component (no event, reactive prop, lifecycle, or signal) that would elide on its own.
- `examples/blog/components/observe-badge.ts`: a shipping side-effect module that observes it via `customElements.whenDefined('observed-badge')`. SSR-safe (the call returns a promise that never resolves server-side; no browser-only API is touched).
- `examples/blog/app/observed/page.ts`: renders `<observed-badge>` and imports the observer.
- `test/e2e/e2e.test.mjs`: a probe that visits `/observed`, asserts the browser DOES download `observed-badge.ts` (forced to ship by the observation), and that the badge still SSRs. The unobserved `build-stamp` probe right above is the negative control.
- `examples/blog/AGENTS.md`: documents the new fixture.

## Test plan

- Verified in-process: `/observed` returns 200, `observed-badge.ts` is preloaded (forced to ship) and SSRs its markup.
- E2E: the new probe passes under `WEBJS_E2E=1` (running it as part of this PR; CI runs the full suite).
- `webjs check` on the blog passes.
- This is test/fixture-only; no shipped package code changes, so no version bump and no other docs surface applies.
