### PR TITLE
Release @webjsdev/core 0.7.4 and @webjsdev/cli 0.10.1

### DIFF
--- a/changelog/cli/0.10.1.md
+++ b/changelog/cli/0.10.1.md
@@ -1,0 +1,20 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.1
+date: 2026-06-01T12:00:00+05:30
+commit_count: 1
+---
+## Features
+
+- **Scaffolded apps ship a test-coverage gate** ([#164](https://github.com/webjsdev/webjs/pull/164)) [`72e4af8`](https://github.com/webjsdev/webjs/commit/72e4af8)
+  `webjs create` now wires a commit-time gate into every new app so a change
+  cannot ship with the wrong test layers. The scaffold carries a
+  `.claude/hooks/require-tests-with-src.sh` PreToolUse hook (registered in
+  `.claude/settings.json`) that blocks a `git commit` staging source with no
+  accompanying test, and blocks a commit that net-removes test lines, with
+  `WEBJS_NO_TEST_GATE` / `WEBJS_ALLOW_TEST_REMOVAL` escape hatches. The same
+  floor is enforced for non-Claude agents through the universal
+  `.hooks/pre-commit`, and the scaffold `AGENTS.md` / `CONVENTIONS.md` spell
+  out unit / browser / e2e / smoke as a per-layer Definition of done. Most
+  webjs apps are built with an AI agent, so the gate reaches end-user
+  projects, not just the framework repo.

--- a/changelog/core/0.7.4.md
+++ b/changelog/core/0.7.4.md
@@ -1,0 +1,24 @@
+---
+package: "@webjsdev/core"
+version: 0.7.4
+date: 2026-06-01T12:00:00+05:30
+commit_count: 1
+---
+## Features
+
+- **Automatic link prefetch in the client router** ([#160](https://github.com/webjsdev/webjs/pull/160)) [`7420f60`](https://github.com/webjsdev/webjs/commit/7420f60)
+  Internal `<a href>` links now prefetch on intent (hover, focus, or
+  touchstart) by default, so the destination is usually already in cache by
+  the time the click lands and navigation feels instant. Strategy is
+  controlled per link with a Next-style `data-prefetch` attribute:
+  `intent` (default), `render` (warm as soon as the link renders),
+  `viewport` (warm when the link scrolls into view), or `none` to opt out.
+  The aliases `true` / `false` / `auto` map to `render` / `none` / `intent`
+  to match Next's `prefetch` prop values. Only same-origin GET-idempotent
+  links are eligible; cross-origin links, `download`, `target=_blank`, and
+  anchors carrying a `rel` the framework should not second-guess are left
+  untouched, as is the native `<link rel=prefetch>` mechanism. Prefetches
+  ride a bounded FIFO queue (concurrency cap, LRU eviction, TTL) and are
+  suppressed under `Save-Data` / `prefers-reduced-data`. The prefetch cache
+  is evicted on any mutation (`revalidate()`, non-GET form submission) so a
+  warmed snapshot can never serve stale post-write content.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7001,7 +7001,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/server": "^0.8.0",
@@ -7016,7 +7016,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.24.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",


### PR DESCRIPTION
Release PR for the two user-facing features merged to main since the last publish.

## Packages

- **@webjsdev/core 0.7.3 to 0.7.4** (patch, carries a feat): automatic link prefetch in the client router (#160). Internal links prefetch on intent by default; `data-prefetch` controls the strategy.
- **@webjsdev/cli 0.10.0 to 0.10.1** (patch, carries a feat): scaffolded apps now ship the commit-time test-coverage gate (#164).

Server was already published as 0.8.4 (#173); no further unreleased changes there.

## Why patch, not minor

Every in-repo consumer pins these packages with a sub-0.8 / sub-0.11 caret range (`@webjsdev/core: ^0.7.0` in server, docs, examples/blog; `@webjsdev/cli: ^0.10.0` in the wrappers). A minor bump would fall out of those ranges and force nested registry copies into the lockfile, the same lockstep pattern the repo handles separately. Patch bumps keep every consumer on the workspace link, so the lockfile change is the minimal two workspace-version lines (matching the shape of the server 0.8.4 release in #173).

## Changelogs

Hand-written: the squash-merge subjects for #160 / #164 carry no conventional-commit prefix, so the backfill generator emits nothing for the range. On merge, the release workflow publishes both packages to npm and creates the matching GitHub Releases from these files.