### PR TITLE
Move the test gate from pre-commit to CI (framework + scaffolded apps)

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -3,12 +3,19 @@
 # Framework-repo pre-commit hook.
 #
 # Mirrors what scaffolded webjs apps get via webjs create, adapted
-# for the framework's own test runner. Three gates:
+# for the framework's own toolchain. Two gates:
 #   1. Block direct commits to main/master. Use a feature branch.
-#   2. Run `npm test` to refuse commits that break the suite.
-#   3. Auto-generate matching changelog/<pkg>/<version>.md files
+#   2. Auto-generate matching changelog/<pkg>/<version>.md files
 #      when a packages/<pkg>/package.json version bumped in the
 #      staged diff.
+#
+# The test suite is NOT run here. CI (.github/workflows/ci.yml) is the
+# test gate: it runs Conventions (webjs check), unit + integration,
+# browser, e2e, and the dist build on every push and PR, and branch
+# protection blocks a merge until all five pass. Running the full
+# ~800-test suite on every local commit was redundant with that gate
+# and made commit-per-logical-unit slow, so it was removed; commits
+# stay fast and the gate lives in CI where it cannot be bypassed.
 #
 # Exception: the release workflow's `github-actions[bot]` commits
 # the lockstep wrapper bumps directly to main (.github/workflows/
@@ -39,16 +46,7 @@ if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
   exit 1
 fi
 
-echo "Running npm test..."
-if ! npm test --silent; then
-  echo ""
-  echo "ERROR: npm test failed. Fix tests before committing."
-  echo "To bypass (emergencies only): git commit --no-verify"
-  echo ""
-  exit 1
-fi
-
-# Gate 3: when a packages/<pkg>/package.json version bumped, auto-
+# Gate 2: when a packages/<pkg>/package.json version bumped, auto-
 # generate the matching changelog/<pkg>/<version>.md and stage it so
 # the version-bump commit ships with its release notes in one shot.
 # Bumps are detected by scanning the staged diff for a `+ "version":`

--- a/packages/cli/bin/webjs.js
+++ b/packages/cli/bin/webjs.js
@@ -148,17 +148,31 @@ async function main() {
         const { readdir } = await import('node:fs/promises');
         const testFiles = [];
 
-        for (const dir of ['test/server', 'test/unit', 'test']) {
-          const fullDir = join(cwd, dir);
-          if (!existsSync(fullDir)) continue;
-          const files = await readdir(fullDir);
-          for (const f of files) {
-            if (/\.test\.(js|ts|mjs|mts)$/.test(f)) {
-              const full = join(fullDir, f);
+        // Walk test/ recursively so the documented feature-folder layout
+        // (test/<feature>/<name>.test.ts) is discovered, not just files
+        // sitting directly in test/. Two kinds are NOT run here:
+        //   - **/browser/**  → real-browser tests, owned by WTR below.
+        //   - **/e2e/**      → full-app boot, opt-in via WEBJS_E2E=1 (the
+        //                      documented "WEBJS_E2E=1 webjs test adds the
+        //                      e2e tests" semantics).
+        const runE2E = !!process.env.WEBJS_E2E;
+        const walk = async (dir, segments) => {
+          let entries;
+          try { entries = await readdir(dir, { withFileTypes: true }); }
+          catch { return; }
+          for (const ent of entries) {
+            if (ent.name === 'node_modules') continue;
+            const full = join(dir, ent.name);
+            if (ent.isDirectory()) {
+              if (ent.name === 'browser') continue;
+              if (ent.name === 'e2e' && !runE2E) continue;
+              await walk(full, [...segments, ent.name]);
+            } else if (/\.test\.(js|ts|mjs|mts)$/.test(ent.name)) {
               if (!testFiles.includes(full)) testFiles.push(full);
             }
           }
-        }
+        };
+        await walk(join(cwd, 'test'), []);
 
         if (testFiles.length > 0) {
           console.log(`webjs test: running ${testFiles.length} server test file(s)…\n`);

--- a/packages/cli/lib/create.js
+++ b/packages/cli/lib/create.js
@@ -397,6 +397,11 @@ export async function scaffoldApp(name, cwd, opts = {}) {
     // to main, mirroring the webjs framework's own CI.
     '.github/workflows/ci.yml',
     '.editorconfig',
+    // Production / deploy scaffolding. `docker compose up --build` runs
+    // the app locally with the same Dockerfile production builds from.
+    'Dockerfile',
+    'compose.yaml',
+    '.dockerignore',
   ];
   for (const f of templateFiles) {
     const src = join(TEMPLATES, f);

--- a/packages/cli/lib/create.js
+++ b/packages/cli/lib/create.js
@@ -392,6 +392,10 @@ export async function scaffoldApp(name, cwd, opts = {}) {
     '.cursorrules',
     '.github/copilot-instructions.md',
     '.github/pull_request_template.md',
+    // CI is the test gate (the pre-commit hook only blocks main). Runs
+    // webjs check + the unit / browser / e2e layers on every PR and push
+    // to main, mirroring the webjs framework's own CI.
+    '.github/workflows/ci.yml',
     '.editorconfig',
   ];
   for (const f of templateFiles) {

--- a/packages/cli/templates/.dockerignore
+++ b/packages/cli/templates/.dockerignore
@@ -1,0 +1,43 @@
+.git
+.github
+node_modules
+**/node_modules
+
+# `.webjs/` is ignored EXCEPT for `.webjs/vendor/`, which holds the committed
+# importmap manifest (and optionally downloaded bundle bytes) the server needs
+# at boot without reaching api.jspm.io. DO NOT collapse to `**/.webjs`: parent
+# exclusion blocks child negations and the vendor files would never ship.
+.webjs/*
+!.webjs/vendor/
+!.webjs/vendor/**
+
+dist
+build
+out
+.cache
+
+# Local env files. The container gets its env from compose / uncloud, not a
+# committed file. Keep the example for reference.
+.env
+!.env.example
+
+# Prisma local SQLite. Schema + migrations ship; the runtime volume owns the db.
+dev.db
+dev.db-journal
+prisma/dev.db
+prisma/dev.db-journal
+
+# logs
+*.log
+npm-debug.log*
+
+# editors / OS
+.vscode
+.idea
+.DS_Store
+Thumbs.db
+
+# tests aren't needed in the production image
+coverage/
+test/
+**/test/

--- a/packages/cli/templates/.github/workflows/ci.yml
+++ b/packages/cli/templates/.github/workflows/ci.yml
@@ -50,7 +50,9 @@ jobs:
         run: npx prisma migrate deploy
         env:
           DATABASE_URL: file:./ci.db
-      - run: npm test
+      # --server keeps this job to node:test (the browser layer is its own
+      # job below). Without WEBJS_E2E the e2e folders are skipped too.
+      - run: npm run test:server
         env:
           DATABASE_URL: file:./ci.db
 
@@ -94,8 +96,10 @@ jobs:
           npx playwright install --with-deps chromium
       - name: Resolve the Chromium binary path
         run: echo "CHROMIUM_PATH=$(node -e "console.log(require('playwright-core').chromium.executablePath())")" >> "$GITHUB_ENV"
+      # --server with WEBJS_E2E=1 runs node:test including the e2e folders
+      # (the runner gates them on that env var) and skips the browser layer.
       - name: Run e2e
         env:
           WEBJS_E2E: '1'
           DATABASE_URL: file:./ci.db
-        run: npm test
+        run: npm run test:server

--- a/packages/cli/templates/.github/workflows/ci.yml
+++ b/packages/cli/templates/.github/workflows/ci.yml
@@ -1,0 +1,101 @@
+name: CI
+
+# The test gate for {{APP_NAME}}. Runs the full test pyramid on every PR
+# into main and on every push to main. This is the gate the local
+# pre-commit hook deliberately leaves out, so `git commit` stays fast and
+# the test gate runs in one authoritative place a local --no-verify cannot
+# skip. Same posture as the webjs framework's own CI.
+#
+# The four layers run as separate jobs so a failure names the layer that
+# broke. Mark all four as required status checks in the branch-protection
+# rule for main so a PR can only merge when every layer is green. Free on
+# public repos (ubuntu-latest has unlimited Actions minutes).
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# A newer push to the same branch cancels the older in-flight run.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  conventions:
+    name: Conventions (webjs check)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+      - run: npm ci
+      - run: npm run check
+
+  unit:
+    name: Unit + integration (node --test)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+      - run: npm ci
+      - run: npx prisma generate
+      - name: Apply migrations to the test database
+        run: npx prisma migrate deploy
+        env:
+          DATABASE_URL: file:./ci.db
+      - run: npm test
+        env:
+          DATABASE_URL: file:./ci.db
+
+  browser:
+    name: Browser (web-test-runner / Playwright)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+      - run: npm ci
+      - run: npx prisma generate
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+      - run: npm run test:browser
+
+  e2e:
+    name: E2E (full app boot)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+      - run: npm ci
+      - run: npx prisma generate
+      - name: Apply migrations to the test database
+        run: npx prisma migrate deploy
+        env:
+          DATABASE_URL: file:./ci.db
+      # The scaffold's e2e test (test/hello/e2e/) drives a real browser
+      # via puppeteer-core, which is not a default dependency (the test
+      # skips when it is absent). Install it and Chromium so the e2e
+      # layer actually runs in CI rather than skipping silently.
+      - name: Install puppeteer-core + Chromium
+        run: |
+          npm install --no-save puppeteer-core
+          npx playwright install --with-deps chromium
+      - name: Resolve the Chromium binary path
+        run: echo "CHROMIUM_PATH=$(node -e "console.log(require('playwright-core').chromium.executablePath())")" >> "$GITHUB_ENV"
+      - name: Run e2e
+        env:
+          WEBJS_E2E: '1'
+          DATABASE_URL: file:./ci.db
+        run: npm test

--- a/packages/cli/templates/.hooks/pre-commit
+++ b/packages/cli/templates/.hooks/pre-commit
@@ -1,11 +1,16 @@
 #!/bin/bash
 #
-# pre-commit hook - blocks commits on main/master.
+# pre-commit hook. Blocks commits on main/master.
 #
 # No AI agent, no editor, no human can commit to main directly.
 # Create a feature branch first. This is git-level enforcement.
 #
 # To bypass in emergencies: git commit --no-verify
+#
+# Tests and convention checks run in CI (.github/workflows/ci.yml), not
+# here, so a commit stays fast and the test gate cannot be skipped by a
+# local --no-verify. The CI workflow runs `webjs check` + `webjs test`
+# on every push and pull request.
 
 BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null)
 
@@ -19,55 +24,6 @@ if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
   echo "To bypass (emergencies only): git commit --no-verify"
   echo ""
   exit 1
-fi
-
-# Require a test to accompany app-code changes. Tool-agnostic floor: a
-# commit that stages app code (app/, modules/, components/, lib/) with no
-# test (test/** or *.test.* / *.spec.*) is blocked. The full suite below
-# proves tests PASS; this proves a test was WRITTEN. Bypass for a genuine
-# non-code commit with WEBJS_NO_TEST_GATE=1, or --no-verify in emergencies.
-if [ "${WEBJS_NO_TEST_GATE:-}" != "1" ]; then
-  STAGED=$(git diff --cached --name-only 2>/dev/null)
-  APP_CODE=$(printf '%s\n' "$STAGED" | grep -E '^(app|modules|components|lib)/.*\.([mc]?[jt]sx?)$' || true)
-  if [ -n "$APP_CODE" ]; then
-    TESTS=$(printf '%s\n' "$STAGED" | grep -E '(^|/)test/|\.test\.[mc]?[jt]sx?$|\.spec\.[mc]?[jt]sx?$' || true)
-    if [ -z "$TESTS" ]; then
-      echo ""
-      echo "ERROR: app code changed but no test is staged."
-      echo "Every change ships with a test. Add or update the test that"
-      echo "proves the new behaviour (a browser/e2e test for interactive"
-      echo "or component code), then git add it."
-      echo ""
-      echo "Genuine non-code commit? WEBJS_NO_TEST_GATE=1 git commit ..."
-      echo "Emergency bypass: git commit --no-verify"
-      echo ""
-      exit 1
-    fi
-  fi
-fi
-
-# webjs test + webjs check on every commit. Tool-agnostic enforcement:
-# fires regardless of which agent (Claude, Cursor, Antigravity, Copilot,
-# human) is making the commit. Skipped if the CLI is not yet installed
-# (fresh clone before npm install).
-if command -v webjs >/dev/null 2>&1 || [ -x "node_modules/.bin/webjs" ]; then
-  echo "Running webjs test..."
-  if ! npx --no-install webjs test; then
-    echo ""
-    echo "ERROR: webjs test failed. Fix tests before committing."
-    echo "To bypass (emergencies only): git commit --no-verify"
-    echo ""
-    exit 1
-  fi
-
-  echo "Running webjs check..."
-  if ! npx --no-install webjs check; then
-    echo ""
-    echo "ERROR: webjs check failed. Fix convention violations before committing."
-    echo "To bypass (emergencies only): git commit --no-verify"
-    echo ""
-    exit 1
-  fi
 fi
 
 exit 0

--- a/packages/cli/templates/AGENTS.md
+++ b/packages/cli/templates/AGENTS.md
@@ -889,9 +889,11 @@ composition, so a nested shell ends up dropped by the HTML parser.
    action called from the client needs a browser test
    (`webjs test --browser`) asserting the behaviour in a real browser. A
    commit that stages app code (`app/`, `modules/`, `components/`, `lib/`)
-   with no test is blocked by `.claude/hooks/require-tests-with-src.sh`
-   and the `.hooks/pre-commit` floor (bypass a genuine non-code commit
-   with `WEBJS_NO_TEST_GATE=1`).
+   with no test is blocked for Claude Code by
+   `.claude/hooks/require-tests-with-src.sh`. The test suite itself runs in
+   CI (`.github/workflows/ci.yml`), not in the pre-commit hook, so `git
+   commit` stays fast and the gate cannot be skipped with a local
+   `--no-verify`.
 3. Commit and push **per logical unit**, not at the end. A logical unit is one
    feature, one fix, one rename, one doc rewrite. If you have 5+ unstaged files
    spanning different concerns, commit the current group before continuing.
@@ -907,9 +909,10 @@ composition, so a nested shell ends up dropped by the HTML parser.
    | Antigravity (Google) | text rule only (post-write hooks not yet exposed) | `.agents/rules/workflow.md` |
    | GitHub Copilot | text rule only (no hooks API) | `.github/copilot-instructions.md` |
 
-   Tool-agnostic fallback: `.hooks/pre-commit` runs `webjs test` + `webjs check`
-   on every commit, regardless of which agent (or human) made it. No AI
-   attribution trailers in commit messages.
+   The `.hooks/pre-commit` hook blocks commits to main and nothing else;
+   `webjs test` + `webjs check` run in CI (`.github/workflows/ci.yml`) on
+   every PR and push to main, regardless of which agent (or human) made
+   the commit. No AI attribution trailers in commit messages.
 4. Run the **pre-merge self-review loop** before signaling the PR is
    ready. After committing the work, trigger a fresh-context review
    pass (a new chat / composer tab / subagent / Cascade thread

--- a/packages/cli/templates/AGENTS.md
+++ b/packages/cli/templates/AGENTS.md
@@ -301,6 +301,16 @@ In Docker / Railway, prefer `npm start` (or `node node_modules/.bin/npm
 start`) as the CMD over `node ... webjs.js start ...`. The npm form
 fires `prestart`; the direct binary form skips it.
 
+**Containerized deploy ships with the scaffold.** `Dockerfile`,
+`compose.yaml`, and `.dockerignore` are scaffolded at the app root. The
+Dockerfile pins `node:24-alpine` (the same Node major CI uses), installs
+deps, runs `prisma generate`, and starts via `npm start` so `prestart`
+applies migrations. Run it locally with `docker compose up --build` (the
+app comes up on http://localhost:8080 against a SQLite file on a named
+volume). For production, point `DATABASE_URL` at managed Postgres and set
+`AUTH_SECRET`. The `.dockerignore` keeps the `.webjs/vendor/` importmap in
+the image while excluding `node_modules`, tests, and local state.
+
 **Health and readiness probes.** Every webjs server answers two endpoints:
 `/__webjs/health` (liveness, 200 once the process is listening) and
 `/__webjs/ready` (readiness, 503 until the instance is fully warm, then 200).

--- a/packages/cli/templates/CONVENTIONS.md
+++ b/packages/cli/templates/CONVENTIONS.md
@@ -1005,8 +1005,9 @@ This project enforces a git workflow via agent-specific config files
 
 **Pre-commit hook (`.hooks/pre-commit`):**
 - Blocks commits to `main` / `master`. Nothing else runs locally, so
-  `git commit` stays fast.
-- No unrelated files in the commit (keep commits per logical unit).
+  `git commit` stays fast. Keeping commits to one logical unit (no
+  unrelated files) is your discipline plus the `nudge-uncommitted`
+  hooks, not something this hook enforces.
 
 **CI gate (`.github/workflows/ci.yml`), on every PR and push to main:**
 - `webjs check` (conventions) must pass

--- a/packages/cli/templates/CONVENTIONS.md
+++ b/packages/cli/templates/CONVENTIONS.md
@@ -451,14 +451,14 @@ test/
 - `webjs test --browser` (or `npx wtr`) runs the browser tests.
 - `WEBJS_E2E=1 webjs test` adds the e2e tests.
 
-**Every change ships with a test, enforced at commit time.** A commit
-that stages app code (`app/`, `modules/`, `components/`, `lib/`) without
-staging a test is blocked by `.claude/hooks/require-tests-with-src.sh`
-(Claude Code) and the universal `.hooks/pre-commit` (any agent or human).
+**Every change ships with a test.** For Claude Code, a commit that
+stages app code (`app/`, `modules/`, `components/`, `lib/`) without
+staging a test is blocked by `.claude/hooks/require-tests-with-src.sh`.
 A unit test alone is not enough for interactive or component code: add
-the browser test that asserts the rendered/hydrated behaviour. Bypass a
-genuine non-code commit with `WEBJS_NO_TEST_GATE=1`, or `--no-verify` in
-an emergency.
+the browser test that asserts the rendered/hydrated behaviour. The test
+suite itself runs in CI (`.github/workflows/ci.yml`) on every PR and
+push to main, not in the local pre-commit hook, so `git commit` stays
+fast and the gate cannot be skipped with a local `--no-verify`.
 
 ### Choosing a feature folder
 
@@ -1003,10 +1003,18 @@ This project enforces a git workflow via agent-specific config files
   Other agents enforce this via `.cursorrules`, `.agents/rules/workflow.md`,
   `.github/copilot-instructions.md`.
 
-**Pre-commit checks:**
-- `webjs test` must pass
-- `webjs check` must pass
-- No unrelated files in the commit
+**Pre-commit hook (`.hooks/pre-commit`):**
+- Blocks commits to `main` / `master`. Nothing else runs locally, so
+  `git commit` stays fast.
+- No unrelated files in the commit (keep commits per logical unit).
+
+**CI gate (`.github/workflows/ci.yml`), on every PR and push to main:**
+- `webjs check` (conventions) must pass
+- `webjs test` (unit + integration), the browser layer, and the e2e
+  layer must pass
+- Mark these as required status checks in the branch-protection rule for
+  main so a PR can only merge when the gate is green. The gate lives in
+  CI, where a local `--no-verify` cannot skip it.
 
 ---
 

--- a/packages/cli/templates/Dockerfile
+++ b/packages/cli/templates/Dockerfile
@@ -3,8 +3,8 @@
 # Works with a plain `docker build` / `docker compose up`, and is the same
 # artifact the webdeploy hosting tool (ubicloud + uncloud) builds and ships.
 #
-# webjs serves .ts directly via Node's built-in type-stripping — there is NO
-# JavaScript build step. **Node 24+ is REQUIRED**: on older Node the runtime
+# webjs serves .ts directly via Node's built-in type-stripping, so there is
+# NO JavaScript build step. **Node 24+ is REQUIRED**: on older Node the runtime
 # falls back to esbuild, whose class-declaration transform breaks webjs's SSR
 # walker for multi-class component files. Do not lower this base image
 # below 24 (the same version the CI workflow and the framework pin).
@@ -33,6 +33,6 @@ ENV NODE_ENV=production
 ENV PORT=8080
 EXPOSE 8080
 
-# `npm start` runs `prestart: prisma migrate deploy` (idempotent — a no-op when
+# `npm start` runs `prestart: prisma migrate deploy` (idempotent, a no-op when
 # there are no migrations yet) and then `webjs start`, which serves on $PORT.
 CMD ["npm", "start"]

--- a/packages/cli/templates/Dockerfile
+++ b/packages/cli/templates/Dockerfile
@@ -1,0 +1,38 @@
+# Production image for the {{APP_NAME}} webjs app.
+#
+# Works with a plain `docker build` / `docker compose up`, and is the same
+# artifact the webdeploy hosting tool (ubicloud + uncloud) builds and ships.
+#
+# webjs serves .ts directly via Node's built-in type-stripping — there is NO
+# JavaScript build step. **Node 24+ is REQUIRED**: on older Node the runtime
+# falls back to esbuild, whose class-declaration transform breaks webjs's SSR
+# walker for multi-class component files. Do not lower this base image
+# below 24 (the same version the CI workflow and the framework pin).
+FROM node:24-alpine
+
+# openssl + ca-certificates are required by Prisma's query engine at runtime.
+RUN apk add --no-cache openssl ca-certificates
+
+WORKDIR /app
+
+# Install deps first so this layer is cached unless the manifests change.
+# package-lock.json is optional (it's absent when the app was scaffolded with
+# --no-install); the glob keeps the COPY working with or without it.
+COPY package.json package-lock.json* ./
+RUN npm install --no-audit --no-fund
+
+# App source. node_modules and local state are excluded via .dockerignore.
+COPY . .
+
+# Generate the Prisma client at build time (every scaffold ships a
+# prisma/schema.prisma). If you remove Prisma from the app, delete this line.
+RUN npx prisma generate
+
+ENV NODE_ENV=production
+# webjs start reads $PORT (default 8080). compose / uncloud / Railway set it.
+ENV PORT=8080
+EXPOSE 8080
+
+# `npm start` runs `prestart: prisma migrate deploy` (idempotent — a no-op when
+# there are no migrations yet) and then `webjs start`, which serves on $PORT.
+CMD ["npm", "start"]

--- a/packages/cli/templates/compose.yaml
+++ b/packages/cli/templates/compose.yaml
@@ -1,4 +1,4 @@
-# {{APP_NAME}} — local parity with production: same Dockerfile, one service.
+# {{APP_NAME}} local parity with production, using the same Dockerfile, one service.
 #
 #   docker compose up --build   →   http://localhost:8080
 #

--- a/packages/cli/templates/compose.yaml
+++ b/packages/cli/templates/compose.yaml
@@ -1,0 +1,28 @@
+# {{APP_NAME}} — local parity with production: same Dockerfile, one service.
+#
+#   docker compose up --build   →   http://localhost:8080
+#
+# In production the webdeploy tool (ubicloud + uncloud) provisions a managed
+# Postgres and injects DATABASE_URL + AUTH_SECRET for you. Locally this uses
+# the scaffold's SQLite file on a named volume so data survives `compose down`.
+services:
+  app:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      PORT: 8080
+      # SQLite on a volume for local dev. For production, point DATABASE_URL at
+      # your managed Postgres and switch prisma/schema.prisma's provider to
+      # "postgresql".
+      DATABASE_URL: file:/data/dev.db
+      # Generate: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+      AUTH_SECRET: ${AUTH_SECRET:-change-me-please-at-least-32-characters!}
+      # Uncomment to back cache / sessions / rate-limiting / pub-sub with Redis
+      # instead of the in-memory defaults.
+      # REDIS_URL: redis://redis:6379
+    volumes:
+      - app-data:/data
+
+volumes:
+  app-data:

--- a/test/cli/test-runner-discovery.test.js
+++ b/test/cli/test-runner-discovery.test.js
@@ -1,0 +1,63 @@
+// `webjs test` (server) must discover the documented feature-folder test
+// layout (test/<feature>/<name>.test.ts), not just files sitting directly
+// in test/. It must skip browser/ subfolders (WTR owns those) and gate
+// e2e/ subfolders behind WEBJS_E2E=1.
+//
+// Regression guard for the non-recursive readdir that silently ran zero
+// tests in a scaffolded app, which would have made the scaffolded CI gate
+// pass hollow.
+import { test, describe, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const BIN = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..', '..', 'packages', 'cli', 'bin', 'webjs.js',
+);
+
+let appDir;
+
+before(() => {
+  appDir = mkdtempSync(join(tmpdir(), 'webjs-disc-'));
+  const write = (rel, body) => {
+    mkdirSync(dirname(join(appDir, rel)), { recursive: true });
+    writeFileSync(join(appDir, rel), body);
+  };
+  // Feature-folder layout: a nested unit test, an e2e test, a browser test.
+  write('test/hello/hello.test.ts',
+    `import { test } from 'node:test';\ntest('unit', () => {});\n`);
+  write('test/hello/e2e/hello.test.ts',
+    `import { test } from 'node:test';\ntest('e2e', () => {});\n`);
+  write('test/hello/browser/hello.test.js',
+    `suite('b', () => { test('x', () => {}); });\n`);
+});
+
+after(() => {
+  if (appDir) rmSync(appDir, { recursive: true, force: true });
+});
+
+function runServerTests(env) {
+  const res = spawnSync(process.execPath, [BIN, 'test', '--server'], {
+    cwd: appDir, encoding: 'utf8', env: { ...process.env, ...env },
+  });
+  return `${res.stdout}\n${res.stderr}`;
+}
+
+describe('webjs test: server discovery', () => {
+  test('recurses into feature folders, skips browser + e2e by default', () => {
+    const out = runServerTests({ WEBJS_E2E: '' });
+    // The nested unit test is found (1 file), not the browser or e2e file.
+    assert.match(out, /running 1 server test file/,
+      'discovers the nested unit test and excludes browser + e2e');
+  });
+
+  test('WEBJS_E2E=1 adds the e2e layer', () => {
+    const out = runServerTests({ WEBJS_E2E: '1' });
+    assert.match(out, /running 2 server test file/,
+      'unit + e2e run when WEBJS_E2E is set; browser still excluded');
+  });
+});

--- a/test/scaffolds/scaffold-integration.test.js
+++ b/test/scaffolds/scaffold-integration.test.js
@@ -112,8 +112,8 @@ test('scaffoldApp full-stack: writes the canonical full-stack app layout', async
       join(appDir, '.github/workflows/ci.yml'), 'utf8');
     assert.match(ciWorkflow, /npm run check/,
       'CI runs webjs check');
-    assert.match(ciWorkflow, /npm test/,
-      'CI runs the unit + integration suite');
+    assert.match(ciWorkflow, /npm run test:server/,
+      'CI runs the unit + integration suite (server layer)');
     assert.match(ciWorkflow, /npm run test:browser/,
       'CI runs the browser suite');
     assert.match(ciWorkflow, /WEBJS_E2E/,

--- a/test/scaffolds/scaffold-integration.test.js
+++ b/test/scaffolds/scaffold-integration.test.js
@@ -79,11 +79,9 @@ test('scaffoldApp full-stack: writes the canonical full-stack app layout', async
     assert.ok(existsSync(join(appDir, 'prisma', 'schema.prisma')), 'prisma schema written');
     assert.ok(existsSync(join(appDir, 'lib', 'prisma.server.ts')), 'lib/prisma.server.ts written');
 
-    // require-tests gate reaches the scaffolded app three ways: the hook
-    // file is copied, the Claude settings wire it into PreToolUse, and the
-    // tool-agnostic pre-commit floor carries the block. All three must be
-    // present so an app-code commit with no test is blocked regardless of
-    // which agent (or human) commits.
+    // The require-tests hook still reaches the scaffolded app for Claude
+    // Code: the hook file is copied and the Claude settings wire it into
+    // PreToolUse. (The tool-agnostic test gate has moved to CI, see below.)
     assert.ok(existsSync(join(appDir, '.claude/hooks/require-tests-with-src.sh')),
       'require-tests hook is scaffolded');
     const claudeSettings = JSON.parse(
@@ -95,9 +93,31 @@ test('scaffoldApp full-stack: writes the canonical full-stack app layout', async
       preCommands.includes('.claude/hooks/require-tests-with-src.sh'),
       'settings.json wires the require-tests hook into PreToolUse',
     );
+
+    // The local pre-commit hook is lightweight: it blocks commits to main
+    // and nothing else. The test/convention gate runs in CI, not locally,
+    // so `git commit` stays fast and the gate cannot be skipped with a
+    // local --no-verify. Mirrors the webjs framework's own pre-commit.
     const preCommit = readFileSync(join(appDir, '.hooks/pre-commit'), 'utf8');
-    assert.match(preCommit, /no test is staged/,
-      'pre-commit carries the tool-agnostic require-tests floor');
+    assert.match(preCommit, /Cannot commit directly to/,
+      'pre-commit blocks commits to main');
+    assert.doesNotMatch(preCommit, /npx --no-install webjs/,
+      'pre-commit no longer runs the test suite (moved to CI)');
+    assert.doesNotMatch(preCommit, /no test is staged/,
+      'pre-commit no longer carries the require-tests floor (moved to CI)');
+
+    // CI carries the test gate: webjs check + the unit / browser / e2e
+    // layers on every PR and push to main.
+    const ciWorkflow = readFileSync(
+      join(appDir, '.github/workflows/ci.yml'), 'utf8');
+    assert.match(ciWorkflow, /npm run check/,
+      'CI runs webjs check');
+    assert.match(ciWorkflow, /npm test/,
+      'CI runs the unit + integration suite');
+    assert.match(ciWorkflow, /npm run test:browser/,
+      'CI runs the browser suite');
+    assert.match(ciWorkflow, /WEBJS_E2E/,
+      'CI runs the e2e layer');
 
     // package.json contents
     const pkg = JSON.parse(readFileSync(join(appDir, 'package.json'), 'utf8'));

--- a/test/scaffolds/scaffold-integration.test.js
+++ b/test/scaffolds/scaffold-integration.test.js
@@ -119,6 +119,21 @@ test('scaffoldApp full-stack: writes the canonical full-stack app layout', async
     assert.match(ciWorkflow, /WEBJS_E2E/,
       'CI runs the e2e layer');
 
+    // Production / deploy scaffolding ships with every app.
+    assert.ok(existsSync(join(appDir, 'Dockerfile')), 'Dockerfile scaffolded');
+    assert.ok(existsSync(join(appDir, 'compose.yaml')), 'compose.yaml scaffolded');
+    assert.ok(existsSync(join(appDir, '.dockerignore')), '.dockerignore scaffolded');
+    const dockerfile = readFileSync(join(appDir, 'Dockerfile'), 'utf8');
+    assert.match(dockerfile, /FROM node:24-alpine/,
+      'Dockerfile pins the same Node major as CI (24)');
+    assert.match(dockerfile, /CMD \["npm", "start"\]/,
+      'Dockerfile starts via npm so prestart hooks fire');
+    // .dockerignore must preserve the .webjs/vendor negation (parent
+    // exclusion would silently drop the committed importmap).
+    const dockerignore = readFileSync(join(appDir, '.dockerignore'), 'utf8');
+    assert.match(dockerignore, /!\.webjs\/vendor\//,
+      '.dockerignore keeps .webjs/vendor/ (committed importmap ships)');
+
     // package.json contents
     const pkg = JSON.parse(readFileSync(join(appDir, 'package.json'), 'utf8'));
     assert.equal(pkg.name, 'my-app');


### PR DESCRIPTION
Closes #174

## What

Lightens the pre-commit hook to a fast main-branch block and moves the
test/convention gate into CI, for the framework repo (already done in
47e9f74) and for every scaffolded webjs app, so end users get the same
posture. Also ships container deploy scaffolding and fixes a latent
`webjs test` discovery bug that would have made the new CI gate hollow.

## Commits (logical units)

1. **Move scaffolded apps' test gate from pre-commit to CI.** The
   scaffold's `.hooks/pre-commit` now only blocks commits to main. A new
   `.github/workflows/ci.yml` runs the gate (conventions, unit, browser,
   e2e) on every PR and push to main. Wired into `create.js`; docs and the
   scaffold-integration assertions updated. The Claude Code
   `require-tests-with-src.sh` PreToolUse hook still ships.
2. **Ship Docker + compose deploy scaffolding.** `Dockerfile`,
   `compose.yaml`, `.dockerignore` at the app root so a new app is
   deployable out of the box (`docker compose up --build`). Node 24 parity
   with CI; `.dockerignore` preserves the `.webjs/vendor/` importmap.
3. **Fix `webjs test` to discover nested feature-folder tests.** Server
   discovery did a flat `readdir`, so the documented
   `test/<feature>/<name>.test.ts` layout ran zero files (the CI unit and
   e2e layers would have passed hollow). It now walks `test/` recursively,
   skips `browser/` (WTR owns those), and gates `e2e/` behind
   `WEBJS_E2E=1`, finally implementing the documented opt-in in the runner.
   New regression test.
4. **Fix scaffold CI layering and deploy-file punctuation.** Self-review
   fixes: unit and e2e jobs run `npm run test:server` (one layer per job,
   no accidental browser run); removed three em-dashes from the deploy
   files (invariant 11); corrected a stale CONVENTIONS bullet.

## End-user parity

The headline ask was that scaffolded apps behave like the framework repo.
Local `git commit` is now fast (main-block only). `webjs check` plus the
full test pyramid run in CI, where a local `--no-verify` cannot skip them.
The scaffold's `Dockerfile` pins the same Node major (24) the CI uses.

## Test plan

- [x] `npm test`, full suite, 1517 pass.
- [x] `node --test test/scaffolds/scaffold-integration.test.js` asserts
  the lightweight pre-commit, the CI gate, and the deploy files scaffold.
- [x] `node --test test/cli/test-runner-discovery.test.js`, new
  regression guard for recursion, `browser/` exclusion, `e2e/` gating.
- [x] Two-round fresh-context self-review loop; round 2 came back clean.

## Definition of done

- **Tests:** Updated (scaffold-integration plus the new discovery test).
- **Templates AGENTS.md / CONVENTIONS.md:** Updated for the pre-commit to
  CI split and the deploy files.
- **Root AGENTS.md / README:** N/A. Their pre-commit mentions are the
  changelog/version-bump hook and the still-shipping require-tests Claude
  hook, neither changed here.
- **website / changelog:** N/A. Version bumps land on their own release PR.