### PR TITLE
Serve the core runtime and other static assets before ensureReady

### DIFF
--- a/examples/blog/.webjs/vendor/importmap.json
+++ b/examples/blog/.webjs/vendor/importmap.json
@@ -1,0 +1,8 @@
+{
+  "imports": {
+    "dayjs": "https://ga.jspm.io/npm:dayjs@1.11.21/dayjs.min.js"
+  },
+  "integrity": {
+    "https://ga.jspm.io/npm:dayjs@1.11.21/dayjs.min.js": "sha384-XFWkZWcQLB8xNT7bYSAjwHRjTg6esPTolseu0+AjqHGKkP+fqTc5/7pe1lEqB0Mp"
+  }
+}

--- a/examples/blog/railway.json
+++ b/examples/blog/railway.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "deploy": {
+    "healthcheckPath": "/__webjs/ready"
+  }
+}

--- a/packages/server/AGENTS.md
+++ b/packages/server/AGENTS.md
@@ -179,6 +179,18 @@ can load it without booting the full server.
    health (e.g. a DB ping) that the static analysis cannot see. Both are
    answered in `handle()` BEFORE `ensureReady`, so a probe never blocks on the
    analysis.
+   **Framework-internal static assets are also served before `ensureReady`.**
+   `tryServeFrameworkStatic` (called in `handle()` right after the probes)
+   serves `/__webjs/core/*` (the `@webjsdev/core` runtime, resolved from the
+   boot-set `coreDir`), `/__webjs/reload.js`, and downloaded `/__webjs/vendor/*`
+   bundles without awaiting the analysis or the vendor importmap, because they
+   depend on neither. Otherwise a cold instance gated the core runtime (on every
+   page's boot path) behind the first vendor resolve, stalling first
+   interactivity site-wide for up to the jspm timeout (#190). Like the probes,
+   these bypass app middleware (`state.middleware` is not even loaded until
+   `ensureReady` completes); that is correct, since they are framework
+   infrastructure the app needs to function, not app routes. `handleCore` keeps
+   a fallback call so it stays correct if entered directly.
 4. **One pluggable cache store, four built-in consumers.** `cache.js`
    is shared by `cache-fn.js`, `session.js` (store-backed), and
    `rate-limit.js`. A single `setStore(redisStore({…}))` call at

--- a/packages/server/src/dev.js
+++ b/packages/server/src/dev.js
@@ -830,7 +830,13 @@ async function tryServeFrameworkStatic(path, method, ctx) {
   if (path.startsWith('/__webjs/core/')) {
     const rel = path.slice('/__webjs/core/'.length);
     const abs = resolve(coreDir, rel);
-    if (!abs.startsWith(coreDir)) return new Response('forbidden', { status: 403 });
+    // Trailing-separator boundary check, not a raw string prefix: a raw
+    // `startsWith(coreDir)` would admit a sibling like `@webjsdev/core-evil`,
+    // reachable via an encoded slash (`..%2f`, which survives URL normalization
+    // and then decodes to `../`). Match the public-root branch's guard.
+    if (abs !== coreDir && !abs.startsWith(coreDir + sep)) {
+      return new Response('forbidden', { status: 403 });
+    }
     return fileResponse(abs, { dev, immutable: false });
   }
 

--- a/packages/server/src/dev.js
+++ b/packages/server/src/dev.js
@@ -549,6 +549,16 @@ export async function createRequestHandler(opts) {
         }
         return Response.json({ status: 'ok' }, { headers: noStore });
       }
+      // Framework-internal static assets (the @webjsdev/core runtime, the dev
+      // reload client, downloaded vendor bundles) depend on neither the analysis
+      // nor the vendor importmap, so serve them BEFORE ensureReady(). Otherwise a
+      // cold instance blocks them behind the first vendor resolve (issue #190),
+      // and the core bundle is on every page's boot path, so that stalled first
+      // interactivity site-wide. Matched on the decoded path, like handleCore.
+      let assetPath = probePath;
+      try { assetPath = decodeURIComponent(probePath); } catch { /* keep raw on malformed escape */ }
+      const staticResp = await tryServeFrameworkStatic(assetPath, req.method.toUpperCase(), { coreDir, appDir, dev });
+      if (staticResp) return staticResp;
       // Build all whole-app analysis on the first request (memoized), before
       // any SSR, module serve, gate check, action dispatch, or middleware runs.
       await ensureReady();
@@ -775,23 +785,29 @@ export async function startServer(opts) {
  * @param {Request} req
  * @param {{state: any, appDir: string, coreDir: string, dev: boolean}} ctx
  */
-async function handleCore(req, ctx) {
-  const { state, appDir, coreDir, dev } = ctx;
-  const url = new URL(req.url);
-  // Decode percent-encoded characters so filesystem lookups match real
-  // filenames. Dynamic route segments like `[slug]` and route groups like
-  // `(marketing)` contain chars that browsers percent-encode in URLs
-  // (`%5B`, `%5D`, `%28`, `%29`). Without decoding, the server joins the
-  // encoded path with the app directory → file not found → 404 → no JS
-  // loads → no interactivity.
-  let path;
-  try { path = decodeURIComponent(url.pathname); } catch { path = url.pathname; }
-  const method = req.method.toUpperCase();
+/**
+ * Serve framework-internal static assets that depend on NEITHER the whole-app
+ * analysis NOR the vendor importmap: the `@webjsdev/core` runtime files, the
+ * dev reload client, and (in `--download` pin mode) the committed vendor
+ * bundles. `handle()` calls this BEFORE `ensureReady()`, so a cold instance
+ * returns them immediately instead of blocking on the first vendor resolve
+ * (issue #190). The core bundle is on every page's boot path, so coupling it
+ * to the jspm resolve stalled first interactivity site-wide on a cold instance.
+ *
+ * Like the health / readiness probes (also answered pre-`ensureReady`), these
+ * bypass app middleware. That is correct: they are framework infrastructure the
+ * app needs to function, not app routes, and `state.middleware` is not even
+ * loaded until `ensureReady()` completes.
+ *
+ * @param {string} path decoded pathname
+ * @param {string} method upper-cased HTTP method
+ * @param {{ coreDir: string, appDir: string, dev: boolean }} ctx
+ * @returns {Promise<Response|null>} a Response, or null when path is not one of these assets
+ */
+async function tryServeFrameworkStatic(path, method, ctx) {
+  const { coreDir, appDir, dev } = ctx;
 
-  // Health / readiness probes (`/__webjs/health`, `/__webjs/ready`) are handled
-  // in `handle()` BEFORE ensureReady, so they are not repeated here.
-
-  // Dev live-reload client
+  // Dev live-reload client.
   if (path === '/__webjs/reload.js') {
     if (!dev) return new Response('Not found', { status: 404 });
     return new Response(RELOAD_CLIENT_JS, {
@@ -802,13 +818,12 @@ async function handleCore(req, ctx) {
   // Core module: /__webjs/core/*
   //
   // ETag + ~1h max-age, NOT immutable. The URL path is un-versioned
-  // (`/__webjs/core/src/render-client.js` etc.), so bumping
-  // `@webjsdev/core` ships different bytes at the same URL. An
-  // `immutable` cache-control directive at an edge CDN (Cloudflare,
-  // Vercel, Fly) keeps the prior bytes pinned for up to a year, which
-  // silently bricks the next deploy: browsers load the old client
-  // renderer against a server emitting the new SSR shape, and any
-  // exports added in the bump (e.g., the slot.js entry points landed
+  // (`/__webjs/core/src/render-client.js` etc.), so bumping `@webjsdev/core`
+  // ships different bytes at the same URL. An `immutable` cache-control
+  // directive at an edge CDN (Cloudflare, Vercel, Fly) keeps the prior bytes
+  // pinned for up to a year, which silently bricks the next deploy: browsers
+  // load the old client renderer against a server emitting the new SSR shape,
+  // and any exports added in the bump (e.g., the slot.js entry points landed
   // for 0.6.0) resolve to undefined in the cached file.
   // Regression: 2026-05-20, ui.webjs.dev tier-2 components after
   // @webjsdev/core 0.5.0 -> 0.6.0 republish.
@@ -819,18 +834,16 @@ async function handleCore(req, ctx) {
     return fileResponse(abs, { dev, immutable: false });
   }
 
-  // Vendor URL handler for `webjs vendor pin --download` mode only.
-  // In default pin mode (or no-pin mode) the importmap routes bare
-  // imports straight to ga.jspm.io URLs and the browser bypasses this
-  // server entirely. When the user ran `webjs vendor pin --download`,
-  // the importmap has local `/__webjs/vendor/<file>.js` URLs and this
-  // handler serves the committed bundle files from `.webjs/vendor/`.
+  // Vendor URL handler for `webjs vendor pin --download` mode only. In default
+  // pin mode (or no-pin mode) the importmap routes bare imports straight to
+  // ga.jspm.io URLs and the browser bypasses this server entirely. When the
+  // user ran `webjs vendor pin --download`, the importmap has local
+  // `/__webjs/vendor/<file>.js` URLs and this serves the committed bundle files
+  // from `.webjs/vendor/`. These are read-only static content: allow GET/HEAD
+  // for the normal fetch, OPTIONS for any cross-origin preflight (204 with the
+  // same Allow header rather than 405, which some intermediaries treat as a
+  // hard failure even for a CORS probe), and 405 everything else.
   if (path.startsWith('/__webjs/vendor/') && path.endsWith('.js')) {
-    // Vendor bundles are read-only static content. Allow GET/HEAD for
-    // the normal fetch, OPTIONS for any cross-origin preflight (we
-    // return 204 with the same Allow header rather than 405, which
-    // some intermediaries treat as a hard failure even for a CORS
-    // probe), and 405 everything else.
     if (method === 'OPTIONS') {
       return new Response(null, { status: 204, headers: { allow: 'GET, HEAD, OPTIONS' } });
     }
@@ -845,6 +858,31 @@ async function handleCore(req, ctx) {
     }
     return resp;
   }
+
+  return null;
+}
+
+async function handleCore(req, ctx) {
+  const { state, appDir, coreDir, dev } = ctx;
+  const url = new URL(req.url);
+  // Decode percent-encoded characters so filesystem lookups match real
+  // filenames. Dynamic route segments like `[slug]` and route groups like
+  // `(marketing)` contain chars that browsers percent-encode in URLs
+  // (`%5B`, `%5D`, `%28`, `%29`). Without decoding, the server joins the
+  // encoded path with the app directory → file not found → 404 → no JS
+  // loads → no interactivity.
+  let path;
+  try { path = decodeURIComponent(url.pathname); } catch { path = url.pathname; }
+  const method = req.method.toUpperCase();
+
+  // Health / readiness probes (`/__webjs/health`, `/__webjs/ready`) and the
+  // framework-internal static assets (`/__webjs/core/*`, `/__webjs/reload.js`,
+  // downloaded `/__webjs/vendor/*`) are served in `handle()` BEFORE ensureReady,
+  // so they are not repeated here. This fallback covers the (currently
+  // unreachable) case of handleCore being entered for one of those assets, so
+  // the routing stays correct if a future caller bypasses the early path.
+  const frameworkStatic = await tryServeFrameworkStatic(path, method, { coreDir, appDir, dev });
+  if (frameworkStatic) return frameworkStatic;
 
   // Internal server-action RPC endpoint
   const actMatch = /^\/__webjs\/action\/([a-f0-9]+)\/([A-Za-z0-9_$]+)$/.exec(path);

--- a/packages/server/test/dev/dev-handler.test.js
+++ b/packages/server/test/dev/dev-handler.test.js
@@ -239,6 +239,16 @@ test('handle: /__webjs/core/ refuses path traversal → 403', async () => {
   assert.ok(resp.status === 403 || resp.status === 404, `expected 403/404, got ${resp.status}`);
 });
 
+test('handle: /__webjs/core/ refuses an encoded-slash sibling escape → 403', async () => {
+  // `..%2f` survives URL normalization (the slash is encoded) and then decodes
+  // to `../`, so a raw startsWith(coreDir) prefix check would admit a sibling
+  // package like @webjsdev/core-evil. The trailing-separator boundary blocks it.
+  const appDir = makeApp({ 'app/page.ts': `export default () => 'ok';` });
+  const app = await createRequestHandler({ appDir, dev: true });
+  const resp = await app.handle(new Request('http://x/__webjs/core/..%2fcore-evil/secret.js'));
+  assert.equal(resp.status, 403, `expected 403, got ${resp.status}`);
+});
+
 /* ------------ vendor URLs: --download mode handler ------------ */
 //
 // In the default jspm.io mode, the importmap routes bare imports to

--- a/packages/server/test/dev/dev-handler.test.js
+++ b/packages/server/test/dev/dev-handler.test.js
@@ -208,6 +208,29 @@ test('handle: /__webjs/core/* serves core source files', async () => {
   assert.ok(resp.headers.get('content-type').includes('javascript'));
 });
 
+test('handle: /__webjs/core/* and reload.js serve BEFORE ensureReady (cold instance)', async () => {
+  // #190: the core runtime bundle is on every page's boot path, so it must not
+  // be gated behind the first-request vendor resolve (a cold instance stalled it
+  // for up to ~30s while jspm resolved). Proven by serving it on a handler that
+  // is never warmed and then checking readiness is STILL pending: serving the
+  // asset did not run the whole-app analysis. On the pre-#190 ordering the core
+  // branch sat after `await ensureReady()`, so this request would have flipped
+  // readiness to ready here.
+  const appDir = makeApp({ 'app/page.ts': `export default () => 'ok';` });
+  const app = await createRequestHandler({ appDir, dev: true }); // no warmup()
+
+  const core = await app.handle(new Request('http://x/__webjs/core/index.js'));
+  assert.equal(core.status, 200, 'core asset serves on a cold handler');
+  const reload = await app.handle(new Request('http://x/__webjs/reload.js'));
+  assert.equal(reload.status, 200, 'reload client serves on a cold handler');
+
+  // Neither request ran ensureReady, so readiness is still pending. (This probe
+  // returns 503 from the synchronous not-ready check before its own background
+  // warm kicks in.)
+  const ready = await app.handle(new Request('http://x/__webjs/ready'));
+  assert.equal(ready.status, 503, 'serving a static asset must not trigger ensureReady');
+});
+
 test('handle: /__webjs/core/ refuses path traversal → 403', async () => {
   const appDir = makeApp({ 'app/page.ts': `export default () => 'ok';` });
   const app = await createRequestHandler({ appDir, dev: true });


### PR DESCRIPTION
## Summary

Closes #190

On a cold instance, the first request for the core browser bundle
(`/__webjs/core/dist/webjs-core-browser.js`) stalled up to ~30s before
serving, then ~200ms once warm. Observed live on example-blog.webjs.dev.

Root cause: that static, dependency-free asset sat after the blanket
`await ensureReady()` in `dev.js handle()`, so it blocked on the whole-app
analysis AND the vendor stage. For an unpinned app (the blog imports
`dayjs`) the vendor stage calls `api.jspm.io` (10s timeout, transient
retries stacking toward ~30s). `ensureReady()` is memoized, so a warm
instance is fast; a freshly deployed / recycled instance pays the full
wait on its first requests. The blog had no `railway.json`, so Railway
routed traffic the moment the port opened, before warmup completed. The
core bundle is on every page's boot path, so this delayed first
interactivity site-wide whenever an instance was cold.

This is not caused by runtime-first boot (deferring analysis to the first
request), and reverting to boot-time analysis would be worse: the jspm
call would then block startup and a jspm outage would stop the process
from booting. The bug is that a static asset needing neither the analysis
nor the importmap was coupled to the vendor resolve.

## What changed

- **Framework (the fix):** `tryServeFrameworkStatic()` serves
  `/__webjs/core/*`, `/__webjs/reload.js`, and downloaded
  `/__webjs/vendor/*` bundles in `handle()` BEFORE `ensureReady()`, exactly
  like the health / readiness probes. They depend on neither the analysis
  nor the vendor importmap. Like the probes they bypass app middleware
  (which is not even loaded until `ensureReady` completes); correct, since
  these are framework infrastructure the app needs to function.
- **Blog deploy hardening:** `examples/blog/railway.json` sets
  `healthcheckPath: /__webjs/ready` so Railway holds traffic until warm,
  and the blog vendor is pinned (`.webjs/vendor/importmap.json`) so the
  vendor stage reads a local file instead of calling jspm.

## Test plan

- [x] Unit (counterfactual): a cold handler serves the core asset and
  reload client while `/__webjs/ready` is still 503, proving the request
  did not run `ensureReady`. Verified it goes red when the early call is
  removed.
- [x] Locally testable without prod or network: `node --test
  packages/server/test/dev/dev-handler.test.js`. Also confirmed via a live
  local boot (core asset served in ~3.6ms).
- [x] `npm test` full server dev/elision/vendor suites pass.
- [x] Dogfood: blog e2e 54/57 (the 3 failures are the pre-existing #180
  prefetch flake, which fails identically on clean `main`, proof captured);
  website / docs / ui-website boot 200 in prod mode with the core asset 200
  and no broken modulepreloads.

## Definition of done

- **Tests:** Updated (new ordering counterfactual in dev-handler).
- **packages/server/AGENTS.md:** Updated (invariant 3 static-asset carve-out).
- **Scaffold templates:** N/A. The scaffold's `railway.json` guidance
  already documents `healthcheckPath: /__webjs/ready`; this changes the
  framework's own request handler, not generated code.
- **Version bump:** owed (a `fix` to `@webjsdev/server`); I will open the
  release PR after merge.