### PR TITLE
Release @webjsdev/server 0.8.5 and @webjsdev/cli 0.10.2

### DIFF
--- a/changelog/cli/0.10.2.md
+++ b/changelog/cli/0.10.2.md
@@ -1,0 +1,19 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.2
+date: 2026-06-01T22:45:00+05:30
+commit_count: 1
+---
+## Fixes
+
+- **`webjs test` discovers the documented feature-folder layout; the scaffold test gate moves to CI** ([#188](https://github.com/webjsdev/webjs/pull/188)) [`bc8e67c`](https://github.com/webjsdev/webjs/commit/bc8e67c)
+  `webjs test` (server layer) did a flat `readdir` of `test/`, so the documented
+  `test/<feature>/<name>.test.ts` layout ran zero files and a scaffolded app's
+  starter test never ran. It now walks `test/` recursively, skips `browser/`
+  subfolders (web-test-runner owns those), and gates `e2e/` behind `WEBJS_E2E=1`,
+  finally implementing the documented opt-in in the runner. Scaffolded apps also
+  ship a lighter `.hooks/pre-commit` (it only blocks commits to `main`; the test
+  and convention gate runs in a generated `.github/workflows/ci.yml` instead, so
+  `git commit` stays fast and the gate cannot be skipped with a local
+  `--no-verify`), plus a `Dockerfile`, `compose.yaml`, and `.dockerignore` so a
+  new app is deployable out of the box.

--- a/changelog/server/0.8.5.md
+++ b/changelog/server/0.8.5.md
@@ -1,0 +1,20 @@
+---
+package: "@webjsdev/server"
+version: 0.8.5
+date: 2026-06-01T22:45:00+05:30
+commit_count: 1
+---
+## Fixes
+
+- **the core runtime and other static assets no longer wait on the first vendor resolve** ([#191](https://github.com/webjsdev/webjs/pull/191)) [`aa3eb43`](https://github.com/webjsdev/webjs/commit/aa3eb43)
+  `/__webjs/core/*` (the `@webjsdev/core` runtime every page boots from), the
+  dev reload client, and downloaded `/__webjs/vendor/*` bundles were served
+  after the per-request `ensureReady()` analysis, so on a cold instance they
+  blocked on the first vendor resolve (an unpinned app's `api.jspm.io` call, a
+  10s timeout with transient retries stacking toward ~30s). Because the core
+  bundle is on every page's boot path, that stalled first interactivity
+  site-wide whenever an instance was cold. They are now served before
+  `ensureReady()`, like the health and readiness probes, since they depend on
+  neither the analysis nor the vendor importmap. The `/__webjs/core/` path guard
+  also moves from a raw prefix check to a trailing-separator boundary, closing
+  an encoded-slash (`..%2f`) escape to an `@webjsdev/core`-prefixed sibling.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7001,7 +7001,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/server": "^0.8.0",
@@ -7037,7 +7037,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
## Summary

Release the two packages that carry unreleased fixes since their last changelog.

- **@webjsdev/server 0.8.5** (patch): the cold-start fix from #191. The core
  runtime (`/__webjs/core/*`, on every page's boot path), the dev reload client,
  and downloaded vendor bundles now serve before the per-request `ensureReady()`
  vendor resolve, so a cold instance no longer stalls them behind the jspm call.
  Includes the encoded-slash path-guard hardening.
- **@webjsdev/cli 0.10.2** (patch): the `webjs test` feature-folder discovery fix
  and the scaffold gate-to-CI move with Docker/compose templates, from #188.

core / ui / ts-plugin are current (no unreleased commits in their trees).

## Dependent ranges

Both are patch bumps. Every in-repo dependent and `@webjsdev/cli` itself pin
`@webjsdev/server` at `^0.8.0` (0.8.5 satisfies it), and the published shims pin
`@webjsdev/cli` at `^0.10.0` (0.10.2 satisfies it), so no range edits are needed.
`package-lock.json` is regenerated.

## What merging does

Adding `changelog/server/0.8.5.md` and `changelog/cli/0.10.2.md` to `main`
triggers `.github/workflows/release.yml`, which `npm publish`es each package
whose version is not yet on the registry and cuts a GitHub Release per new
changelog file. Both steps are idempotent.

## Test plan

- [x] `package-lock.json` regenerated and consistent (server 0.8.5, cli 0.10.2);
  `npm ci` would not desync.
- [x] Patch bumps verified to stay within every dependent's caret range.
- [x] Changelog entries hand-written (squash-merge subjects carry no
  conventional prefix, so the generator emits nothing) and match the existing
  frontmatter shape.