### PR TITLE
Fix: root prepare must not fail npm install in a build context

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "node": ">=24.0.0"
   },
   "scripts": {
-    "prepare": "node scripts/git-worktree-safe.mjs",
+    "prepare": "node scripts/git-worktree-safe.mjs 2>/dev/null || true",
     "fix:git": "node scripts/git-worktree-safe.mjs",
     "check:git": "node scripts/git-worktree-safe.mjs --check",
     "dev": "node scripts/dev-all.js",

--- a/test/repo-health/prepare-build-safe.test.mjs
+++ b/test/repo-health/prepare-build-safe.test.mjs
@@ -1,0 +1,38 @@
+// Regression guard: the root `prepare` script must NOT fail `npm install` when
+// scripts/git-worktree-safe.mjs is absent.
+//
+// In a Docker / Nixpacks build, `npm install` runs after `COPY package.json`
+// but before the rest of the repo is copied, so `scripts/` is not in the image
+// yet. A bare `node scripts/git-worktree-safe.mjs` then exits 1 (module not
+// found) and fails the build. This broke all four deployed services. The
+// prepare command must tolerate the script being absent (exit 0).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execSync } from 'node:child_process';
+import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+test('root prepare script tolerates a missing scripts/ dir (build context)', () => {
+  const prepare = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8')).scripts.prepare;
+  assert.ok(prepare, 'root package.json defines a prepare script');
+
+  // Run the EXACT prepare command in a temp dir that does NOT contain
+  // scripts/git-worktree-safe.mjs, the way a Docker build runs it before the
+  // repo is fully copied. It must exit 0 so `npm install` does not fail.
+  const dir = mkdtempSync(join(tmpdir(), 'webjs-prepare-'));
+  try {
+    execSync(prepare, { cwd: dir, stdio: 'ignore' }); // throws on non-zero exit
+  } catch (err) {
+    assert.fail(
+      `prepare command "${prepare}" failed when scripts/ is absent (exit ${err.status}); ` +
+      `it must end in a guard like "|| true" so a build context cannot break npm install`,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Hotfix for a production outage: **all four Railway services (example-blog, website, docs, ui-website) fail to deploy.** They build from the monorepo root, and the build dies at `npm install`:

```
[16/26] RUN npm install --no-audit --no-fund
Error: Cannot find module '/app/scripts/git-worktree-safe.mjs'
npm error command sh -c node scripts/git-worktree-safe.mjs
Build Failed
```

Root cause: #189 changed the root `prepare` to a bare `node scripts/git-worktree-safe.mjs`. In a Docker / Nixpacks build, `npm install` runs after `COPY package.json` but **before the repo is fully copied**, so `scripts/` is not in the image yet. `node` exits 1 (module not found) and the build fails. The previous `prepare` ended in `|| true`, so it never failed the install.

## Fix

Restore the guard:

```
"prepare": "node scripts/git-worktree-safe.mjs 2>/dev/null || true"
```

A missing script (build context) or any git error is now a no-op that exits 0, so `npm install` never fails. The dev-machine self-heal still runs when the script is present.

## Test plan

- [x] New regression test runs the ACTUAL prepare command in a scriptless temp dir and asserts exit 0 (`test/repo-health/prepare-build-safe.test.mjs`).
- [x] Counterfactual confirmed: the unguarded command exits 1 ("Cannot find module") in a scriptless dir, which is the exact build failure; the guarded command exits 0.
- [x] Verified the script still heals + exits 0 when present (dev).

## Definition of done

- **Tests:** Updated (new build-context regression test).
- **Docs:** N/A. One-line restoration of the prior resilient pattern; no surface change.
- **Version bump:** N/A. Root monorepo package.json (private, not published).

Expedited review given the live outage (one-line restoration of a known-good pattern with a proven counterfactual).