### PR TITLE
Ship a platform-neutral readiness gate in the scaffold

### DIFF
--- a/packages/cli/templates/AGENTS.md
+++ b/packages/cli/templates/AGENTS.md
@@ -318,12 +318,17 @@ Fully warm means the deterministic analysis AND the first vendor attempt have
 both completed, so the importmap and its build id are settled. Point your
 platform's readiness check at `/__webjs/ready` so it holds traffic off a
 not-yet-warmed instance instead of routing the first user request into the cold
-analysis or the brief window where the importmap is still resolving. On
-Railway, set `"healthcheckPath": "/__webjs/ready"` under `deploy` in
-`railway.json`. For dependency-aware
-readiness (gate on a live DB ping), add an optional `readiness.{js,ts}` at the
-app root that default-exports an async check; `/__webjs/ready` runs it once warm
-and reports 503 if it returns `false` or throws.
+analysis or the brief window where the importmap is still resolving. The
+scaffolded `Dockerfile` and `compose.yaml` already wire this up with a
+`HEALTHCHECK` that probes `/__webjs/ready`, so any Docker-based deploy gets the
+gate with no extra config. On a platform that reads its own config instead,
+point its equivalent knob at the same path: Railway `"healthcheckPath":
+"/__webjs/ready"`, Render `healthCheckPath: /__webjs/ready`, Fly a
+`[[http_service.checks]]` on `/__webjs/ready`, or a Kubernetes `readinessProbe`
+with `httpGet.path: /__webjs/ready`. For dependency-aware readiness (gate on a
+live DB ping), add an optional `readiness.{js,ts}` at the app root that
+default-exports an async check; `/__webjs/ready` runs it once warm and reports
+503 if it returns `false` or throws.
 
 Scripts:
 

--- a/packages/cli/templates/Dockerfile
+++ b/packages/cli/templates/Dockerfile
@@ -33,6 +33,17 @@ ENV NODE_ENV=production
 ENV PORT=8080
 EXPOSE 8080
 
+# Platform-neutral readiness gate. webjs answers /__webjs/ready with 503 until
+# the instance is fully warm (analysis + first vendor attempt), then 200. This
+# HEALTHCHECK is honoured by Docker, compose, and most Docker-based platforms,
+# so the gate works the same everywhere instead of needing a per-platform file.
+# The probe is dependency-free (Node 24's built-in fetch, no curl/wget). For
+# platforms that read their own config, point the equivalent knob at the same
+# path (Railway healthcheckPath, Render healthCheckPath, Fly [checks], k8s
+# readinessProbe); see AGENTS.md "Health and readiness probes".
+HEALTHCHECK --interval=15s --timeout=3s --start-period=40s --retries=5 \
+  CMD ["node", "-e", "fetch('http://127.0.0.1:'+(process.env.PORT||8080)+'/__webjs/ready').then(r=>process.exit(r.ok?0:1),()=>process.exit(1))"]
+
 # `npm start` runs `prestart: prisma migrate deploy` (idempotent, a no-op when
 # there are no migrations yet) and then `webjs start`, which serves on $PORT.
 CMD ["npm", "start"]

--- a/packages/cli/templates/compose.yaml
+++ b/packages/cli/templates/compose.yaml
@@ -23,6 +23,14 @@ services:
       # REDIS_URL: redis://redis:6379
     volumes:
       - app-data:/data
+    # Readiness gate: hold the service "starting" until /__webjs/ready returns
+    # 200 (fully warm). Same probe as the Dockerfile HEALTHCHECK; dependency-free.
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:'+(process.env.PORT||8080)+'/__webjs/ready').then(r=>process.exit(r.ok?0:1),()=>process.exit(1))"]
+      interval: 15s
+      timeout: 3s
+      start_period: 40s
+      retries: 5
 
 volumes:
   app-data:

--- a/test/scaffolds/scaffold-integration.test.js
+++ b/test/scaffolds/scaffold-integration.test.js
@@ -128,6 +128,13 @@ test('scaffoldApp full-stack: writes the canonical full-stack app layout', async
       'Dockerfile pins the same Node major as CI (24)');
     assert.match(dockerfile, /CMD \["npm", "start"\]/,
       'Dockerfile starts via npm so prestart hooks fire');
+    // Platform-neutral readiness gate: a HEALTHCHECK probing /__webjs/ready, so
+    // the gate works on any Docker-based deploy without a per-platform file.
+    assert.match(dockerfile, /HEALTHCHECK[\s\S]*\/__webjs\/ready/,
+      'Dockerfile HEALTHCHECK probes /__webjs/ready');
+    const compose = readFileSync(join(appDir, 'compose.yaml'), 'utf8');
+    assert.match(compose, /healthcheck:[\s\S]*\/__webjs\/ready/,
+      'compose.yaml healthcheck probes /__webjs/ready');
     // .dockerignore must preserve the .webjs/vendor negation (parent
     // exclusion would silently drop the committed importmap).
     const dockerignore = readFileSync(join(appDir, '.dockerignore'), 'utf8');


### PR DESCRIPTION
## Summary

Closes #193

Newly scaffolded apps had no readiness gate, so a cold deploy could route traffic before the instance was warm. This ships one, but **platform-neutrally** rather than presuming Railway.

A scaffolded app may deploy to Railway, Render, Fly, a plain Docker host, or k8s. So instead of a Railway-only `railway.json`, the scaffold's `Dockerfile` and `compose.yaml` (the universal deploy artifacts it already ships) get a `HEALTHCHECK` that probes the framework's `/__webjs/ready` (503 until fully warm, then 200). Docker, compose, and most Docker-based platforms honour it, so the gate works the same everywhere with no per-platform file. The probe is dependency-free (Node 24's built-in `fetch`, no curl/wget).

### What I found while scoping this

The in-repo apps (website, docs, ui-website, blog) are **already gated**: all four Railway services deploy from the repo root via the shared root `Dockerfile`, so Railway reads the **root `railway.json`** (which already sets `healthcheckPath: /__webjs/ready`). Per-app files in those subdirs are never read, so this PR adds nothing there. The real gap was the scaffold.

### Not a `readiness.{js,ts}` file

`/__webjs/ready` is the framework's built-in readiness endpoint. The HEALTHCHECK points the platform at it. The optional `readiness.{js,ts}` (live DB-ping gating) is a separate feature, unchanged here.

## What changed

- `packages/cli/templates/Dockerfile`: `HEALTHCHECK` probing `/__webjs/ready`.
- `packages/cli/templates/compose.yaml`: matching `healthcheck:`.
- `packages/cli/templates/AGENTS.md`: documents `/__webjs/ready` + the per-platform knob (Railway `healthcheckPath`, Render `healthCheckPath`, Fly `[checks]`, k8s `readinessProbe`).
- `test/scaffolds/scaffold-integration.test.js`: asserts the Dockerfile + compose healthcheck.

## Test plan

- [x] Scaffold-integration asserts the Dockerfile `HEALTHCHECK` and compose `healthcheck` both probe `/__webjs/ready`.
- [x] The probe command is valid and exits 1 when the endpoint is unreachable/not-ready, 0 on 200.

## Definition of done

- **Tests:** Updated (scaffold-integration healthcheck assertions).
- **packages/cli/templates/AGENTS.md:** Updated (platform-neutral readiness docs).
- **In-repo apps:** N/A. Already gated via the root `railway.json`.
- **Version bump:** owed for `@webjsdev/cli` (scaffold Dockerfile/compose change); folds into the next cli release after merge.