### PR TITLE
Revert the blog vendor pin that broke the #170 elision e2e

### DIFF
--- a/examples/blog/.webjs/vendor/importmap.json
+++ b/examples/blog/.webjs/vendor/importmap.json
@@ -1,8 +1,0 @@
-{
-  "imports": {
-    "dayjs": "https://ga.jspm.io/npm:dayjs@1.11.21/dayjs.min.js"
-  },
-  "integrity": {
-    "https://ga.jspm.io/npm:dayjs@1.11.21/dayjs.min.js": "sha384-XFWkZWcQLB8xNT7bYSAjwHRjTg6esPTolseu0+AjqHGKkP+fqTc5/7pe1lEqB0Mp"
-  }
-}

--- a/examples/blog/railway.json
+++ b/examples/blog/railway.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://railway.com/railway.schema.json",
-  "deploy": {
-    "healthcheckPath": "/__webjs/ready"
-  }
-}


### PR DESCRIPTION
## Summary

My #190 vendor pin broke the blog's elision e2e ("vendor package used only by a display-only component is never fetched", #170), which had been failing on `main` (intermittently masked by the flaky prefetch e2e #180).

The blog is the **fixture** for that probe: `vendor-badge` is display-only and its only non-core dep is `dayjs`, so elision strips the component and prunes `dayjs` from the importmap when the map is resolved live. The test asserts the served importmap has **no** `dayjs` entry. My #190 pin committed `examples/blog/.webjs/vendor/importmap.json` with `dayjs`, which the framework serves **as-is** (a committed pin is not pruned), so the entry reappeared and `hasDayjsEntry` flipped true.

The pin was also **pointless**: `dayjs` is elided, so it is never fetched and never needs resolving. The #190 framework fix (serve the core runtime before `ensureReady`) is what actually fixed the cold-start stall; the pin was an unnecessary extra.

## What changed

- Removed `examples/blog/.webjs/vendor/importmap.json` (the harmful pin).
- Removed `examples/blog/railway.json` (redundant: all four services deploy from the repo root via the shared `Dockerfile`, so Railway reads the **root** `railway.json`; the per-app file was never consulted).

## Test plan

- [x] `WEBJS_E2E=1 node --test --test-name-pattern="never fetched"` now **passes** (was failing with the pin).
- [x] Verified the served importmap has zero `dayjs` occurrences without the pin (pruned via live resolve); with the pin it had `dayjs@1.11.21`.

## Definition of done

- **Tests:** the #170 e2e is the regression guard; it passes again.
- **Docs:** N/A. Reverts an extra; no surface change.
- **Lesson:** the elision-fixture apps must not pin vendor deps that the fixture asserts are pruned.