### PR TITLE
Release @webjsdev/server 0.8.6 and @webjsdev/cli 0.10.3

### DIFF
--- a/changelog/cli/0.10.3.md
+++ b/changelog/cli/0.10.3.md
@@ -1,0 +1,17 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.3
+date: 2026-06-02T10:00:00+05:30
+commit_count: 1
+---
+## Features
+
+- **scaffolded apps ship a platform-neutral readiness gate** ([#195](https://github.com/webjsdev/webjs/pull/195)) [`8385001`](https://github.com/webjsdev/webjs/commit/8385001)
+  A new app's `Dockerfile` and `compose.yaml` now carry a `HEALTHCHECK` that
+  probes the framework's `/__webjs/ready` endpoint (503 until the instance is
+  fully warm, then 200). Docker, compose, and most Docker-based platforms honour
+  it, so a cold deploy holds traffic until the app is warm without any
+  per-platform config. The probe is dependency-free (Node 24's built-in `fetch`).
+  The scaffold `AGENTS.md` documents `/__webjs/ready` and the per-platform knob
+  for platforms that read their own config (Railway `healthcheckPath`, Render
+  `healthCheckPath`, Fly `[checks]`, k8s `readinessProbe`).

--- a/changelog/server/0.8.6.md
+++ b/changelog/server/0.8.6.md
@@ -1,0 +1,20 @@
+---
+package: "@webjsdev/server"
+version: 0.8.6
+date: 2026-06-02T10:00:00+05:30
+commit_count: 1
+---
+## Fixes
+
+- **a committed vendor pin now prunes elided deps, so pinned == unpinned** ([#198](https://github.com/webjsdev/webjs/pull/198)) [`97583d5`](https://github.com/webjsdev/webjs/commit/97583d5)
+  A committed `.webjs/vendor/importmap.json` was served verbatim, skipping the
+  elision-aware pruning the live-resolve path applies. So a vendor package whose
+  only importer is a display-only (elided) component stayed in the served
+  importmap when pinned but was pruned when resolved live, meaning a pinned app
+  and an unpinned app served different maps for the same source. The pin is now
+  applied verbatim at boot (for a stable build id) and then pruned in
+  `ensureReady`, once elision is known, to the specifiers still reachable from
+  non-elided modules (`prunePinToReachable`), so both serve the same map. The
+  build id stays the boot-published hash of the committed pin, so the served map
+  shrinks with no warmup-time build-id drift, and the prune re-runs after every
+  dev rebuild rather than regrowing the full pin.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7001,7 +7001,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/server": "^0.8.0",
@@ -7037,7 +7037,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
## Summary

Release the two packages with unreleased changes since their last changelog.

- **@webjsdev/server 0.8.6** (patch): the pinned-importmap elision prune from
  #198. A committed vendor pin now prunes its elided-only deps in `ensureReady`,
  so a pinned app and an unpinned app serve the same importmap. The build id
  stays the boot hash of the pin (no warmup drift), and the prune survives dev
  rebuilds.
- **@webjsdev/cli 0.10.3** (patch): the platform-neutral scaffold readiness gate
  from #195. A new app's `Dockerfile` / `compose.yaml` carry a `HEALTHCHECK` on
  `/__webjs/ready`, with per-platform docs.

core / ui / ts-plugin are current (no unreleased commits in their trees).

## Dependent ranges

Both patch bumps. Every dependent pins `@webjsdev/server` at `^0.8.0` (0.8.6
satisfies) and `@webjsdev/cli` at `^0.10.0` / `^0.8.0` (0.10.3 satisfies
`^0.10.0`), so no range edits. `package-lock.json` regenerated (server 0.8.6,
cli 0.10.3).

## What merging does

Adding `changelog/server/0.8.6.md` and `changelog/cli/0.10.3.md` to `main`
triggers `release.yml`, which `npm publish`es each not-yet-published version and
cuts a GitHub Release per new changelog file. Both steps are idempotent.

## Test plan

- [x] `package-lock.json` regenerated and consistent (server 0.8.6, cli 0.10.3).
- [x] Patch bumps verified within every dependent's caret range.
- [x] Changelog entries hand-written (squash subjects carry no conventional
  prefix) matching the existing frontmatter shape.