### PR TITLE
Repin in-repo apps' @webjsdev/cli to ^0.10.0 (link the workspace)

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,7 @@
     "css:build": "tailwindcss -i ./public/input.css -o ./public/tailwind.css --minify"
   },
   "dependencies": {
-    "@webjsdev/cli": "^0.8.0",
+    "@webjsdev/cli": "^0.10.0",
     "@webjsdev/core": "^0.7.0",
     "@webjsdev/server": "^0.8.0"
   },

--- a/examples/blog/package.json
+++ b/examples/blog/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",
-    "@webjsdev/cli": "^0.8.0",
+    "@webjsdev/cli": "^0.10.0",
     "@webjsdev/core": "^0.7.0",
     "@webjsdev/server": "^0.8.0",
     "dayjs": "^1.11.21"

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,25 +32,9 @@
       "name": "@webjsdev/docs",
       "version": "0.1.0",
       "dependencies": {
-        "@webjsdev/cli": "^0.8.0",
+        "@webjsdev/cli": "^0.10.0",
         "@webjsdev/core": "^0.7.0",
         "@webjsdev/server": "^0.8.0"
-      },
-      "engines": {
-        "node": ">=24.0.0"
-      }
-    },
-    "docs/node_modules/@webjsdev/cli": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/@webjsdev/cli/-/cli-0.8.6.tgz",
-      "integrity": "sha512-lawM8SRZN6X2a2qAbugUg4tZYNEjkr9Paao+qtZ84mNCHgkjsmlJtsybOs1o5siaTIaRSjIGTohAzogAsjEH+g==",
-      "license": "MIT",
-      "dependencies": {
-        "@webjsdev/server": "^0.7.2",
-        "@webjsdev/ui": "^0.3.1"
-      },
-      "bin": {
-        "webjs": "bin/webjs.js"
       },
       "engines": {
         "node": ">=24.0.0"
@@ -61,7 +45,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@prisma/client": "^5.22.0",
-        "@webjsdev/cli": "^0.8.0",
+        "@webjsdev/cli": "^0.10.0",
         "@webjsdev/core": "^0.7.0",
         "@webjsdev/server": "^0.8.0",
         "dayjs": "^1.11.21"
@@ -71,22 +55,6 @@
         "@webjsdev/ui": "^0.3.0",
         "prisma": "^5.22.0",
         "typescript": "^6.0.3"
-      },
-      "engines": {
-        "node": ">=24.0.0"
-      }
-    },
-    "examples/blog/node_modules/@webjsdev/cli": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/@webjsdev/cli/-/cli-0.8.6.tgz",
-      "integrity": "sha512-lawM8SRZN6X2a2qAbugUg4tZYNEjkr9Paao+qtZ84mNCHgkjsmlJtsybOs1o5siaTIaRSjIGTohAzogAsjEH+g==",
-      "license": "MIT",
-      "dependencies": {
-        "@webjsdev/server": "^0.7.2",
-        "@webjsdev/ui": "^0.3.1"
-      },
-      "bin": {
-        "webjs": "bin/webjs.js"
       },
       "engines": {
         "node": ">=24.0.0"
@@ -7093,22 +7061,6 @@
         "webjsui": "bin/webjsui.js"
       }
     },
-    "packages/ui/node_modules/@webjsdev/cli": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/@webjsdev/cli/-/cli-0.8.6.tgz",
-      "integrity": "sha512-lawM8SRZN6X2a2qAbugUg4tZYNEjkr9Paao+qtZ84mNCHgkjsmlJtsybOs1o5siaTIaRSjIGTohAzogAsjEH+g==",
-      "license": "MIT",
-      "dependencies": {
-        "@webjsdev/server": "^0.7.2",
-        "@webjsdev/ui": "^0.3.1"
-      },
-      "bin": {
-        "webjs": "bin/webjs.js"
-      },
-      "engines": {
-        "node": ">=24.0.0"
-      }
-    },
     "packages/ui/packages/registry": {
       "name": "@webjsdev/ui-registry",
       "version": "0.1.0"
@@ -7117,7 +7069,7 @@
       "name": "@webjsdev/ui-website",
       "version": "0.1.0",
       "dependencies": {
-        "@webjsdev/cli": "^0.8.0",
+        "@webjsdev/cli": "^0.10.0",
         "@webjsdev/core": "^0.7.0",
         "@webjsdev/server": "^0.8.0",
         "@webjsdev/ui-registry": "*"
@@ -7144,25 +7096,9 @@
       "name": "@webjsdev/website",
       "version": "0.1.1",
       "dependencies": {
-        "@webjsdev/cli": "^0.8.0",
+        "@webjsdev/cli": "^0.10.0",
         "@webjsdev/core": "^0.7.0",
         "@webjsdev/server": "^0.8.0"
-      },
-      "engines": {
-        "node": ">=24.0.0"
-      }
-    },
-    "website/node_modules/@webjsdev/cli": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/@webjsdev/cli/-/cli-0.8.6.tgz",
-      "integrity": "sha512-lawM8SRZN6X2a2qAbugUg4tZYNEjkr9Paao+qtZ84mNCHgkjsmlJtsybOs1o5siaTIaRSjIGTohAzogAsjEH+g==",
-      "license": "MIT",
-      "dependencies": {
-        "@webjsdev/server": "^0.7.2",
-        "@webjsdev/ui": "^0.3.1"
-      },
-      "bin": {
-        "webjs": "bin/webjs.js"
       },
       "engines": {
         "node": ">=24.0.0"

--- a/packages/ui/packages/website/package.json
+++ b/packages/ui/packages/website/package.json
@@ -15,7 +15,7 @@
     "preview:build": "node scripts/copy-registry.js"
   },
   "dependencies": {
-    "@webjsdev/cli": "^0.8.0",
+    "@webjsdev/cli": "^0.10.0",
     "@webjsdev/core": "^0.7.0",
     "@webjsdev/server": "^0.8.0",
     "@webjsdev/ui-registry": "*"

--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,7 @@
     "css:build": "tailwindcss -i ./public/input.css -o ./public/tailwind.css --minify"
   },
   "dependencies": {
-    "@webjsdev/cli": "^0.8.0",
+    "@webjsdev/cli": "^0.10.0",
     "@webjsdev/core": "^0.7.0",
     "@webjsdev/server": "^0.8.0"
   },


### PR DESCRIPTION
## Summary

Closes #142

The in-repo apps (examples/blog, docs, website, packages/ui/packages/website) pinned `@webjsdev/cli: ^0.8.0`. The workspace cli is now `0.10.3`, which does not satisfy `^0.8.0`, so npm installed a **published 0.8.x cli** into each app instead of linking the workspace. That published cli declares `@webjsdev/server: ^0.7.2`, so the workspace `@webjsdev/server` (`0.8.6`) showed as `invalid` in `npm ls` and the apps did not actually exercise the workspace cli/server.

Bump the four apps to `@webjsdev/cli: ^0.10.0` so npm links the workspace cli (which transitively pins `@webjsdev/server ^0.8.0`, satisfied). The server/core pins (`^0.8.0` / `^0.7.0`) were already satisfied by the workspace and are unchanged.

## What changed

- `@webjsdev/cli` pin `^0.8.0` -> `^0.10.0` in `examples/blog`, `docs`, `website`, `packages/ui/packages/website`.
- `package-lock.json` regenerated (a full `npm install` re-linked the workspace cli, dropping the nested published `0.8.6`).

## Test plan

- [x] `npm ls @webjsdev/server` and `npm ls @webjsdev/cli` both report **0 invalid** (was 5 server-invalid before).
- [x] `npm test` full suite: 1535 pass (lockfile consistent, `npm ci` would not desync).
- [x] Dogfood: website / docs / ui-website boot 200 with no broken modulepreloads; blog #170 e2e passes.

## On the optional drift gate

The issue lists an optional CI check that fails on resolution drift. I left it out (you recently asked for no added guards). Recurrence is instead handled by the standing version-bump rule: a cli **minor** bump must widen the dependent ranges in the same release PR. Happy to add the `npm ls` gate if you want belt-and-suspenders.

## Definition of done

- **Tests:** the `npm ls` drift check is the regression evidence; full suite passes.
- **Docs:** N/A. App dependency-range fix; no public surface or behaviour change.
- **Version bump:** N/A. The in-repo apps are private (not published).