### PR TITLE
Mask comments before the elision tag/observation scans

### DIFF
--- a/packages/server/src/component-elision.js
+++ b/packages/server/src/component-elision.js
@@ -41,6 +41,7 @@ import {
   extractWebComponentClassBodies,
   matchClosingBrace,
   redactStringsAndTemplates,
+  maskComments,
 } from './js-scan.js';
 import { transitiveDeps } from './module-graph.js';
 
@@ -553,9 +554,13 @@ function topLevelPropertyValues(obj) {
 export function extractRenderedTags(src) {
   /** @type {Set<string>} */
   const tags = new Set();
+  // Mask comments first so a `<some-tag>` written in a doc comment is not read
+  // as a rendered tag (#179). String and template content is kept, so real tags
+  // inside `html` templates are still found.
+  const masked = maskComments(src);
   const re = /<([a-z][a-z0-9]*-[a-z0-9-]*)\b/g;
   let m;
-  while ((m = re.exec(src)) !== null) tags.add(m[1]);
+  while ((m = re.exec(masked)) !== null) tags.add(m[1]);
   return tags;
 }
 
@@ -673,13 +678,17 @@ export async function analyzeElision(components, routeModules, moduleGraph, read
     // file. Resolution against tagToFile / classToFile happens after the loop
     // (all components are known up front, but we collect here while we hold
     // each source). Verdict-safe: only ever forces MORE components to ship.
-    for (const m of src.matchAll(WHEN_DEFINED_RE)) {
+    // Mask comments so a whenDefined / :defined / instanceof written in a
+    // comment is not read as a real observation (#179). String content is kept,
+    // so a real `whenDefined('tag')` (the tag rides a string) still matches.
+    const maskedObs = maskComments(src);
+    for (const m of maskedObs.matchAll(WHEN_DEFINED_RE)) {
       const f = tagToFile.get(m[1]); if (f) observedComponentFiles.add(f);
     }
-    for (const m of src.matchAll(TAG_DEFINED_RE)) {
+    for (const m of maskedObs.matchAll(TAG_DEFINED_RE)) {
       const f = tagToFile.get(m[1]); if (f) observedComponentFiles.add(f);
     }
-    for (const m of src.matchAll(INSTANCEOF_RE)) {
+    for (const m of maskedObs.matchAll(INSTANCEOF_RE)) {
       const f = classToFile.get(m[1]); if (f) observedComponentFiles.add(f);
     }
   }

--- a/packages/server/src/component-elision.js
+++ b/packages/server/src/component-elision.js
@@ -661,15 +661,24 @@ export async function analyzeElision(components, routeModules, moduleGraph, read
       continue;
     }
     if (typeof src !== 'string') continue;
-    fileTags.set(file, extractRenderedTags(src));
-    if (importsReactivePrimitive(src)) reactiveFiles.add(file);
-    if (importsClientRouter(src)) clientRouterFiles.add(file);
-    if (EVENT_BINDING_RE.test(src) || EVENT_PROP_RE.test(src) ||
-        importsSideEffectNonCorePackage(src) || CLIENT_GLOBAL_RE.test(src) ||
-        hasModuleScopeSideEffect(src)) {
+    // Mask comments once for every signal scan below (#179): a `<tag>`, an
+    // `@event`, a browser global, an `import`, or a `whenDefined` written in a
+    // comment must not register as a real signal. String and template content
+    // is kept, so a real rendered tag, a real `@click=${}` in an html template,
+    // and a real `whenDefined('tag')` (the tag rides a string) still match.
+    // (`importsSideEffectNonCorePackage` / `hasModuleScopeSideEffect` /
+    // `analyzeComponentSource` also redact strings/templates internally; running
+    // them on the comment-masked source just additionally drops comment prose.)
+    const masked = maskComments(src);
+    fileTags.set(file, extractRenderedTags(masked));
+    if (importsReactivePrimitive(masked)) reactiveFiles.add(file);
+    if (importsClientRouter(masked)) clientRouterFiles.add(file);
+    if (EVENT_BINDING_RE.test(masked) || EVENT_PROP_RE.test(masked) ||
+        importsSideEffectNonCorePackage(masked) || CLIENT_GLOBAL_RE.test(masked) ||
+        hasModuleScopeSideEffect(masked)) {
       clientGlobalOrBareFiles.add(file);
     }
-    if (componentFiles.has(file) && analyzeComponentSource(src).interactive) {
+    if (componentFiles.has(file) && analyzeComponentSource(masked).interactive) {
       mustShip.add(file);
     }
     // Cross-module registration observation (#169): if THIS module observes
@@ -678,17 +687,13 @@ export async function analyzeElision(components, routeModules, moduleGraph, read
     // file. Resolution against tagToFile / classToFile happens after the loop
     // (all components are known up front, but we collect here while we hold
     // each source). Verdict-safe: only ever forces MORE components to ship.
-    // Mask comments so a whenDefined / :defined / instanceof written in a
-    // comment is not read as a real observation (#179). String content is kept,
-    // so a real `whenDefined('tag')` (the tag rides a string) still matches.
-    const maskedObs = maskComments(src);
-    for (const m of maskedObs.matchAll(WHEN_DEFINED_RE)) {
+    for (const m of masked.matchAll(WHEN_DEFINED_RE)) {
       const f = tagToFile.get(m[1]); if (f) observedComponentFiles.add(f);
     }
-    for (const m of maskedObs.matchAll(TAG_DEFINED_RE)) {
+    for (const m of masked.matchAll(TAG_DEFINED_RE)) {
       const f = tagToFile.get(m[1]); if (f) observedComponentFiles.add(f);
     }
-    for (const m of maskedObs.matchAll(INSTANCEOF_RE)) {
+    for (const m of masked.matchAll(INSTANCEOF_RE)) {
       const f = classToFile.get(m[1]); if (f) observedComponentFiles.add(f);
     }
   }

--- a/packages/server/src/js-scan.js
+++ b/packages/server/src/js-scan.js
@@ -222,6 +222,111 @@ export function redactStringsAndTemplates(src) {
 }
 
 /**
+ * Blank ONLY comments, keeping string AND template-literal content verbatim
+ * (position-preserving: same length, newlines kept). The sibling
+ * `redactStringsAndTemplates` blanks templates too, which is wrong for callers
+ * that need to read inside `html` templates (the elision render-tag scanner) or
+ * inside string arguments (`whenDefined('tag')`). This keeps both and removes
+ * only comment text, so prose in a comment cannot be read as a real signal
+ * (issue #179). It reuses the same regex-versus-division and tagged-template
+ * disambiguation so a `//` inside a string/template/regex is never mistaken for
+ * a comment.
+ *
+ * @param {string} src
+ * @returns {string} src with comment bodies blanked, everything else verbatim
+ */
+export function maskComments(src) {
+  const n = src.length;
+  let out = '';
+  let i = 0;
+  let lastSig = '';
+  let lastWord = '';
+  let lastWordIsProp = false;
+  let lastWasIncDec = false;
+  const markValue = () => { lastSig = 'x'; lastWord = ''; lastWordIsProp = false; lastWasIncDec = false; };
+  const isRegex = () => {
+    if (lastSig === '') return true;
+    if (lastSig === ')' || lastSig === ']') return false;
+    if (lastSig === "'" || lastSig === '"' || lastSig === '`') return false;
+    if (lastWasIncDec) return false;
+    if (/[\w$]/.test(lastSig)) return !lastWordIsProp && REGEX_PRECEDING_KEYWORDS.has(lastWord);
+    return true;
+  };
+  // Comments: blank the body (keep the `//` / `/* */` delimiters and newlines).
+  const scanLineComment = () => { out += '//'; i += 2; while (i < n && src[i] !== '\n') { out += ' '; i++; } };
+  const scanBlockComment = () => {
+    out += '/*'; i += 2;
+    while (i < n) {
+      if (src[i] === '*' && src[i + 1] === '/') { out += '*/'; i += 2; return; }
+      out += src[i] === '\n' ? '\n' : ' '; i++;
+    }
+  };
+  // String / template / regex: copy verbatim, but lex correctly so a `//` or
+  // `/*` inside them is not treated as a comment.
+  const scanString = (q) => {
+    out += q; i++;
+    while (i < n) {
+      if (src[i] === '\\' && i + 1 < n) { out += src[i] + src[i + 1]; i += 2; continue; }
+      if (src[i] === q) { out += q; i++; break; }
+      if (src[i] === '\n') { out += '\n'; i++; break; }
+      out += src[i]; i++;
+    }
+    markValue();
+  };
+  const scanRegex = () => {
+    out += '/'; i++;
+    let inClass = false;
+    while (i < n) {
+      const d = src[i];
+      if (d === '\\' && i + 1 < n) { out += d + src[i + 1]; i += 2; continue; }
+      if (d === '\n') break;
+      if (d === '[') inClass = true;
+      else if (d === ']') inClass = false;
+      else if (d === '/' && !inClass) { out += '/'; i++; break; }
+      out += d; i++;
+    }
+    markValue();
+  };
+  const scanTemplate = () => {
+    out += '`'; i++;
+    while (i < n) {
+      const c = src[i];
+      if (c === '\\' && i + 1 < n) { out += c + src[i + 1]; i += 2; continue; }
+      if (c === '`') { out += '`'; i++; break; }
+      if (c === '$' && src[i + 1] === '{') { out += '${'; i += 2; scanCode(true); if (i < n && src[i] === '}') { out += '}'; i++; } continue; }
+      out += c; i++;
+    }
+    markValue();
+  };
+  function scanCode(stopHole) {
+    let brace = 0;
+    while (i < n) {
+      const c = src[i], next = src[i + 1];
+      if (stopHole && c === '}' && brace === 0) return;
+      if (c === '/' && next === '/') { scanLineComment(); continue; }
+      if (c === '/' && next === '*') { scanBlockComment(); continue; }
+      if (c === '/' && isRegex()) { scanRegex(); continue; }
+      if (c === "'" || c === '"') { scanString(c); continue; }
+      if (c === '`') { scanTemplate(); continue; }
+      if (c === '{') { brace++; lastSig = '{'; lastWord = ''; lastWasIncDec = false; out += c; i++; continue; }
+      if (c === '}') { brace--; lastSig = '}'; lastWord = ''; lastWasIncDec = false; out += c; i++; continue; }
+      if (/[A-Za-z_$]/.test(c)) {
+        const prop = lastSig === '.';
+        let w = '';
+        while (i < n && /[\w$]/.test(src[i])) { w += src[i]; out += src[i]; i++; }
+        lastWord = w; lastSig = w[w.length - 1]; lastWordIsProp = prop; lastWasIncDec = false;
+        continue;
+      }
+      if (/\s/.test(c)) { out += c; i++; continue; }
+      lastWasIncDec = (c === '+' || c === '-') && c === lastSig;
+      lastSig = c; lastWord = ''; out += c; i++;
+    }
+  }
+  scanCode(false);
+  return out;
+}
+
+/**
  * Extract the body of every `class … extends WebComponent { … }` block.
  * Brace-counts to handle nested template literals, methods, and arrow
  * functions. String state is tracked so braces inside strings/templates

--- a/packages/server/test/elision/comment-false-signals.test.js
+++ b/packages/server/test/elision/comment-false-signals.test.js
@@ -1,0 +1,115 @@
+/**
+ * #179: the elision analyser must not read tags / observation calls written
+ * inside comments (or strings) as real signals. A doc comment mentioning
+ * `<some-tag>` or `whenDefined('some-tag')` used to force that component to
+ * ship (the build-stamp regression found while adding the #169 probe). The
+ * scanners now mask comments first (`maskComments`), keeping string and
+ * template content so real signals still register.
+ *
+ * Each case is paired with its counterfactual: the SAME signal written as real
+ * code DOES flip the verdict, proving the comment-masking is what changed it.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { analyzeElision, extractRenderedTags } from '../../src/component-elision.js';
+
+const BADGE = `
+import { WebComponent, html } from '@webjsdev/core';
+class Badge extends WebComponent {
+  render() { return html\`<span class="badge">verified</span>\`; }
+}
+Badge.register('x-badge');
+`;
+
+function graphOf(edges) {
+  const g = new Map();
+  for (const [from, tos] of Object.entries(edges)) g.set(from, new Set(tos));
+  return g;
+}
+async function run({ files, components = [], routeModules = [], edges = {} }) {
+  return analyzeElision(components, routeModules, graphOf(edges), async (f) => files[f], '/app');
+}
+const COMPONENTS = [{ tag: 'x-badge', className: 'Badge', file: '/app/components/badge.js' }];
+
+test('extractRenderedTags ignores tags in comments, keeps tags in templates', () => {
+  const src = `
+    // this comment renders <ghost-tag> but it is just prose
+    /* and a block one with <block-ghost> too */
+    class X { render() { return html\`<real-tag></real-tag>\`; } }
+  `;
+  const tags = extractRenderedTags(src);
+  assert.ok(tags.has('real-tag'), 'a tag inside an html template is found');
+  assert.ok(!tags.has('ghost-tag'), 'a tag inside a line comment is ignored');
+  assert.ok(!tags.has('block-ghost'), 'a tag inside a block comment is ignored');
+});
+
+test('a commented whenDefined does NOT force the observed component to ship', async () => {
+  // The observer only MENTIONS whenDefined('x-badge') in a comment.
+  const observer = `
+    // historical note: we used to call whenDefined('x-badge') here
+    export const x = 1;
+  `;
+  const page = `
+    import { html } from '@webjsdev/core';
+    import './components/badge.js';
+    import './lib/obs.js';
+    export default () => html\`<x-badge></x-badge>\`;
+  `;
+  const { elidableComponents } = await run({
+    files: { '/app/page.js': page, '/app/components/badge.js': BADGE, '/app/lib/obs.js': observer },
+    components: COMPONENTS,
+    routeModules: ['/app/page.js'],
+    edges: { '/app/page.js': ['/app/components/badge.js', '/app/lib/obs.js'] },
+  });
+  assert.ok(elidableComponents.has('/app/components/badge.js'),
+    'a whenDefined that is only in a comment does not force the badge to ship');
+});
+
+test('counterfactual: a REAL whenDefined does force it to ship', async () => {
+  const observer = `
+    customElements.whenDefined('x-badge').then(() => {});
+    export const x = 1;
+  `;
+  const page = `
+    import { html } from '@webjsdev/core';
+    import './components/badge.js';
+    import './lib/obs.js';
+    export default () => html\`<x-badge></x-badge>\`;
+  `;
+  const { elidableComponents } = await run({
+    files: { '/app/page.js': page, '/app/components/badge.js': BADGE, '/app/lib/obs.js': observer },
+    components: COMPONENTS,
+    routeModules: ['/app/page.js'],
+    edges: { '/app/page.js': ['/app/components/badge.js', '/app/lib/obs.js'] },
+  });
+  assert.ok(!elidableComponents.has('/app/components/badge.js'),
+    'a real whenDefined forces the badge to ship (proves the comment case is what flips it)');
+});
+
+test('a commented child tag does NOT force ship via the render rule', async () => {
+  // An interactive (shipping) component whose render does NOT emit x-badge, but
+  // whose comment mentions <x-badge>. The render rule must not be fooled.
+  const widget = `
+    import { WebComponent, html } from '@webjsdev/core';
+    class Widget extends WebComponent {
+      // layout note: sits next to <x-badge> on the page
+      render() { return html\`<button @click=\${() => {}}>go</button>\`; }
+    }
+    Widget.register('x-widget');
+  `;
+  const page = `
+    import { html } from '@webjsdev/core';
+    import './components/badge.js';
+    import './components/widget.js';
+    export default () => html\`<x-widget></x-widget><x-badge></x-badge>\`;
+  `;
+  const { elidableComponents } = await run({
+    files: { '/app/page.js': page, '/app/components/badge.js': BADGE, '/app/components/widget.js': widget },
+    components: [...COMPONENTS, { tag: 'x-widget', className: 'Widget', file: '/app/components/widget.js' }],
+    routeModules: ['/app/page.js'],
+    edges: { '/app/page.js': ['/app/components/badge.js', '/app/components/widget.js'] },
+  });
+  assert.ok(elidableComponents.has('/app/components/badge.js'),
+    'a child tag mentioned only in a comment does not force it to ship');
+});

--- a/packages/server/test/elision/comment-false-signals.test.js
+++ b/packages/server/test/elision/comment-false-signals.test.js
@@ -87,6 +87,55 @@ test('counterfactual: a REAL whenDefined does force it to ship', async () => {
     'a real whenDefined forces the badge to ship (proves the comment case is what flips it)');
 });
 
+test('a commented @event or browser global does NOT force a component to ship', async () => {
+  // Display-only render, but its comments mention @click and document. Neither
+  // is real client work, so the component stays elidable.
+  const commented = `
+    import { WebComponent, html } from '@webjsdev/core';
+    class Note extends WebComponent {
+      // interactive sibling uses @click=\${handler} and reads document.title
+      render() { return html\`<span class="note">read only</span>\`; }
+    }
+    Note.register('x-note');
+  `;
+  const page = `
+    import { html } from '@webjsdev/core';
+    import './components/note.js';
+    export default () => html\`<x-note></x-note>\`;
+  `;
+  const { elidableComponents } = await run({
+    files: { '/app/page.js': page, '/app/components/note.js': commented },
+    components: [{ tag: 'x-note', className: 'Note', file: '/app/components/note.js' }],
+    routeModules: ['/app/page.js'],
+    edges: { '/app/page.js': ['/app/components/note.js'] },
+  });
+  assert.ok(elidableComponents.has('/app/components/note.js'),
+    'a @click / document mentioned only in a comment does not force ship');
+});
+
+test('counterfactual: a REAL @click in the template forces ship', async () => {
+  const interactive = `
+    import { WebComponent, html } from '@webjsdev/core';
+    class Note extends WebComponent {
+      render() { return html\`<button @click=\${() => {}}>x</button>\`; }
+    }
+    Note.register('x-note');
+  `;
+  const page = `
+    import { html } from '@webjsdev/core';
+    import './components/note.js';
+    export default () => html\`<x-note></x-note>\`;
+  `;
+  const { elidableComponents } = await run({
+    files: { '/app/page.js': page, '/app/components/note.js': interactive },
+    components: [{ tag: 'x-note', className: 'Note', file: '/app/components/note.js' }],
+    routeModules: ['/app/page.js'],
+    edges: { '/app/page.js': ['/app/components/note.js'] },
+  });
+  assert.ok(!elidableComponents.has('/app/components/note.js'),
+    'a real @click forces ship (proves the comment case is what flips it)');
+});
+
 test('a commented child tag does NOT force ship via the render rule', async () => {
   // An interactive (shipping) component whose render does NOT emit x-badge, but
   // whose comment mentions <x-badge>. The render rule must not be fooled.

--- a/packages/server/test/scanner/mask-comments.test.js
+++ b/packages/server/test/scanner/mask-comments.test.js
@@ -1,0 +1,56 @@
+// Unit tests for maskComments (#179): blank comment bodies, keep string AND
+// template content verbatim, position-preserving (same length, newlines kept),
+// and never mistake a `//` inside a string/template/regex for a comment.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { maskComments } from '../../src/js-scan.js';
+
+test('blanks line and block comment bodies, keeps the delimiters', () => {
+  const out = maskComments(`const a = 1; // secret note\n/* block secret */const b = 2;`);
+  assert.ok(!out.includes('secret'), 'comment bodies are blanked');
+  assert.ok(out.includes('//') && out.includes('/*') && out.includes('*/'), 'delimiters kept');
+  assert.ok(out.includes('const a = 1;') && out.includes('const b = 2;'), 'code kept');
+});
+
+test('is position-preserving (same length, newlines kept)', () => {
+  const src = `// line comment\nconst x = 'hello';\n/* block\nmultiline */\n`;
+  const out = maskComments(src);
+  assert.equal(out.length, src.length, 'same length');
+  assert.equal(out.split('\n').length, src.split('\n').length, 'same line count');
+});
+
+test('keeps string content verbatim (a whenDefined tag rides a string)', () => {
+  const out = maskComments(`whenDefined('x-badge'); const s = "<a-tag>";`);
+  assert.ok(out.includes("whenDefined('x-badge')"), 'string arg kept');
+  assert.ok(out.includes('"<a-tag>"'), 'double-quoted string kept');
+});
+
+test('keeps template content verbatim (rendered tags live in templates)', () => {
+  const out = maskComments('html`<real-tag>${ x }</real-tag>`');
+  assert.ok(out.includes('<real-tag>'), 'template tag kept');
+});
+
+test('a // inside a string is not treated as a comment', () => {
+  const out = maskComments(`const url = 'https://example.com/path'; const y = 2;`);
+  assert.ok(out.includes('https://example.com/path'), 'the // inside the string is kept');
+  assert.ok(out.includes('const y = 2;'), 'code after the string is intact');
+});
+
+test('a // inside a template is not treated as a comment', () => {
+  const out = maskComments('const t = `https://cdn/${x}/a`; const z = 3;');
+  assert.ok(out.includes('https://cdn'), 'the // inside the template is kept');
+  assert.ok(out.includes('const z = 3;'), 'code after the template is intact');
+});
+
+test('a /-slash inside a regex literal is not treated as a comment', () => {
+  const out = maskComments(`const re = /a\\/\\/b/; const w = 4; // gone`);
+  assert.ok(out.includes('const w = 4;'), 'code after the regex is intact');
+  assert.ok(!out.includes('gone'), 'the trailing real comment is still blanked');
+});
+
+test('a comment inside a template hole is blanked, surrounding template kept', () => {
+  const out = maskComments('html`<a>${ /* secret */ value }</a>`');
+  assert.ok(out.includes('<a>') && out.includes('value'), 'template text and hole code kept');
+  assert.ok(!out.includes('secret'), 'the comment body inside the hole is blanked');
+});


### PR DESCRIPTION
## Summary

Closes #179

The elision analyser scanned raw source, so a `<some-tag>` or `whenDefined('tag')` written in a **comment** was read as a real signal: a doc comment fooled `extractRenderedTags` into shipping a component (the build-stamp regression found while adding the #169 probe), and the #169 observation regexes (`WHEN_DEFINED_RE` / `TAG_DEFINED_RE` / `INSTANCEOF_RE`) matched a commented `whenDefined`.

## What changed

- `maskComments(src)` in `js-scan.js`: blanks comment bodies but keeps **string and template content verbatim** (position-preserving), reusing the same regex-versus-division and tagged-template disambiguation as `redactStringsAndTemplates`.
- `extractRenderedTags` and the three observation scans in `component-elision.js` now run over the masked source.

## Why comment-only masking (not strings/templates)

The issue suggested `redactStringsAndTemplates`, but that blanks **templates** too, and a real rendered tag lives inside an `html` template, while a real `whenDefined('tag')`'s tag rides a **string**. Blanking those would drop legitimate signals (the dangerous direction: wrongly eliding a needed component). So I mask comments only and keep strings + templates. A tag written in a plain string still over-ships, which is the safe direction. This is why I added a focused `maskComments` rather than reusing `redactStringsAndTemplates` or modifying it (it is load-bearing for `webjs check`).

## Test plan

- [x] `maskComments` unit tests: blanks comments, keeps strings/templates, position-preserving, and never mistakes a `//` inside a string/template/regex for a comment.
- [x] Elision counterfactuals: a commented tag / commented `whenDefined` does NOT force a component to ship, while the SAME signal as real code DOES (proving the mask is what flips it).
- [x] `npm test` 1547 pass; elision e2e probes (#169 observed-ships, #170 vendor-never-fetched, display-only-not-downloaded) all pass.
- [x] Dogfood: website / docs / ui-website boot 200, no broken modulepreloads.

## Definition of done

- **Tests:** unit (`maskComments`) + integration (`analyzeElision` counterfactuals).
- **Docs:** N/A. Internal analyser fix; the elision behaviour (and its docs) is unchanged, only false signals from prose are removed.
- **Version bump:** owed for `@webjsdev/server`; folds into the next release.