### PR TITLE
Add JS-disabled progressive-enhancement e2e layer

### DIFF
--- a/examples/blog/AGENTS.md
+++ b/examples/blog/AGENTS.md
@@ -37,6 +37,7 @@ app/                         thin route adapters
   error.ts                   error boundary
   not-found.ts               404
   login/page.ts              /login (auth-forms component)
+  search/page.ts             /search (progressive no-JS GET search form)
   blog/[slug]/page.ts        /blog/:slug (post + live comments)
   dashboard/
     middleware.ts             auth gate (302 → /login if no session)

--- a/examples/blog/app/layout.ts
+++ b/examples/blog/app/layout.ts
@@ -215,6 +215,7 @@ export default function RootLayout({ children }: { children: unknown }) {
       <!-- Inline nav, sm and up. -->
       <nav class="hidden sm:flex gap-4 items-center">
         ${navLink('/', 'Posts')}
+        ${navLink('/search', 'Search')}
         ${navLink('/about', 'About')}
         ${navLink('/dashboard', 'Dashboard')}
         <a href="https://github.com/webjsdev/webjs/tree/main/examples/blog" target="_blank" rel="noopener" class="text-fg-muted no-underline font-medium text-[13px] leading-none tracking-[0.005em] transition-colors duration-fast hover:text-fg">GitHub</a>
@@ -236,6 +237,7 @@ export default function RootLayout({ children }: { children: unknown }) {
           </summary>
           <nav class="absolute right-0 top-[calc(100%+8px)] min-w-[200px] flex flex-col gap-1 bg-bg-elev border border-border rounded-lg shadow-lg p-2 z-50">
             <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="/">Posts</a>
+            <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="/search">Search</a>
             <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="/about">About</a>
             <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="/dashboard">Dashboard</a>
             <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="https://github.com/webjsdev/webjs/tree/main/examples/blog" target="_blank" rel="noopener">GitHub</a>

--- a/examples/blog/app/search/page.ts
+++ b/examples/blog/app/search/page.ts
@@ -1,0 +1,46 @@
+import { html } from '@webjsdev/core';
+import { listPosts } from '../../modules/posts/queries/list-posts.server.ts';
+
+export const metadata = { title: 'Search posts' };
+
+/**
+ * Progressive-enhancement search. A plain native GET form: with JavaScript
+ * the client router promotes it to a fragment swap, and with JavaScript
+ * disabled the browser does a full navigation to `/search?q=...` and this
+ * server-rendered page shows the results. It has no interactivity, so it
+ * reads and works identically either way, which is exactly the no-JS
+ * baseline the framework promises. The JS-disabled e2e layer (#183)
+ * exercises this form as the canonical "a form submits and the server
+ * renders the response with JS off" case.
+ */
+export default async function Search(
+  { searchParams }: { searchParams?: { q?: string } },
+) {
+  const q = String(searchParams?.q || '').trim();
+  const all = await listPosts();
+  const results = q
+    ? all.filter((p) => p.title.toLowerCase().includes(q.toLowerCase()))
+    : [];
+  return html`
+    <section class="grid gap-6 max-w-2xl">
+      <h1 class="text-2xl font-semibold tracking-tight">Search posts</h1>
+      <form action="/search" method="get" class="flex gap-2">
+        <input
+          type="search"
+          name="q"
+          value=${q}
+          placeholder="Search by title"
+          aria-label="Search posts"
+          class="flex-1 px-3 py-2 rounded-md border border-border bg-bg-elev text-fg"
+        >
+        <button type="submit" class="px-4 py-2 rounded-md bg-accent text-bg font-medium">Search</button>
+      </form>
+      ${q
+        ? html`<p data-search-summary class="text-fg-muted text-sm">Found ${results.length} result${results.length === 1 ? '' : 's'} for "${q}".</p>`
+        : html`<p data-search-summary class="text-fg-muted text-sm">Type a query and submit to search post titles.</p>`}
+      <ul class="grid gap-2">
+        ${results.map((p) => html`<li class="search-result"><a href="/blog/${p.slug}" class="text-accent no-underline hover:underline">${p.title}</a></li>`)}
+      </ul>
+    </section>
+  `;
+}

--- a/test/e2e/e2e.test.mjs
+++ b/test/e2e/e2e.test.mjs
@@ -1626,6 +1626,92 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
     const path = await page.evaluate(() => location.pathname);
     assert.equal(path, '/', 'must stay on the home page after sending a chat message');
   });
+
+  // --- Progressive enhancement: the no-JS baseline must hold (#183) ---
+  //
+  // "Progressive enhancement by default" is the foundational claim: with
+  // JavaScript disabled the page must still read, <a> links must navigate,
+  // a <form> server action must submit, and display-only components must
+  // render. This layer loads the blog with JS OFF and asserts each.
+  //
+  // setJavaScriptEnabled(false) disables ALL page script execution,
+  // including page.evaluate, so this block reads the DOM via page.content()
+  // (HTML serialization, no page JS) and interacts via CDP-level type/click
+  // (real input/mouse events the browser handles natively), never evaluate.
+  describe('progressive enhancement (JS disabled) (#183)', () => {
+    let noJs;
+
+    before(async () => {
+      noJs = await browser.newPage();
+      await noJs.setJavaScriptEnabled(false);
+      await noJs.setViewport({ width: 1024, height: 768 }); // show the desktop nav
+    });
+
+    after(async () => {
+      if (noJs) await noJs.close();
+    });
+
+    test('content reads and a display-only component renders with JS off', async () => {
+      await noJs.goto(`${baseUrl}/`, { waitUntil: 'domcontentloaded', timeout: 15000 });
+      const html = await noJs.content();
+      // Real post content from the SSR'd HTML (seeded posts).
+      assert.match(html, /Hello, webjs|Zero build steps|Web components first/,
+        'post content must be server-rendered and readable with JS off');
+      // The display-only build-stamp renders its SSR markup even though its
+      // module never ships (criterion: a display-only component renders).
+      assert.match(html, /zero JS shipped for this badge/,
+        'a display-only component must render its SSR markup with JS off');
+    });
+
+    test('an <a> link performs a full navigation with JS off', async () => {
+      await noJs.goto(`${baseUrl}/`, { waitUntil: 'domcontentloaded', timeout: 15000 });
+      // With JS off the client router never attaches, so clicking a same-origin
+      // <a> is a native full-page navigation. Click the desktop nav About link.
+      await Promise.all([
+        noJs.waitForNavigation({ waitUntil: 'domcontentloaded', timeout: 15000 }),
+        noJs.click('nav a[href="/about"]'),
+      ]);
+      assert.ok(noJs.url().endsWith('/about'), `link should navigate to /about, got ${noJs.url()}`);
+      const html = await noJs.content();
+      assert.match(html, /about/i, '/about content must render after a no-JS navigation');
+    });
+
+    test('a server-rendered form submits and the response renders with JS off', async () => {
+      await noJs.goto(`${baseUrl}/search`, { waitUntil: 'domcontentloaded', timeout: 15000 });
+      // Type a query and submit the native GET form. Both are CDP-level
+      // browser events, so they work with page JS disabled. The submission is
+      // a real navigation to /search?q=web that the SERVER renders.
+      await noJs.type('input[name="q"]', 'web');
+      await Promise.all([
+        noJs.waitForNavigation({ waitUntil: 'domcontentloaded', timeout: 15000 }),
+        noJs.click('form button[type="submit"]'),
+      ]);
+      assert.match(noJs.url(), /\/search\?q=web/, `form should GET-navigate to /search?q=web, got ${noJs.url()}`);
+      const html = await noJs.content();
+      assert.match(html, /Found 2 results for "web"/,
+        'the server must render the search results for the no-JS form submission');
+      assert.match(html, /class="search-result"/, 'result items must render');
+    });
+
+    test('counterfactual: a JS-dependent interaction does NOT work with JS off', async () => {
+      // The interactive counter needs JS to increment. With JS off, clicking
+      // the increment button must do nothing: the seeded value stays put. This
+      // proves the harness genuinely disabled JS, so any feature whose first
+      // paint or core behaviour depended on JS would render broken and fail
+      // the assertions above rather than passing on a secretly-live page.
+      await noJs.goto(`${baseUrl}/`, { waitUntil: 'domcontentloaded', timeout: 15000 });
+      const countOf = (html) => {
+        const m = html.match(/<my-counter[^>]*>[\s\S]*?<output[^>]*>(\d+)<\/output>/);
+        return m ? Number(m[1]) : NaN;
+      };
+      const before = countOf(await noJs.content());
+      assert.equal(before, 3, `counter SSRs its seeded value (got ${before})`);
+      await noJs.click('my-counter button[aria-label="Increment"]');
+      await sleep(300);
+      const after = countOf(await noJs.content());
+      assert.equal(after, 3, `with JS off the counter must NOT increment (got ${after})`);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/e2e/e2e.test.mjs
+++ b/test/e2e/e2e.test.mjs
@@ -1673,7 +1673,9 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
       ]);
       assert.ok(noJs.url().endsWith('/about'), `link should navigate to /about, got ${noJs.url()}`);
       const html = await noJs.content();
-      assert.match(html, /about/i, '/about content must render after a no-JS navigation');
+      // Match a phrase unique to the about page body, not the nav word
+      // "About" that appears on every page.
+      assert.match(html, /What's on display/, '/about page body must render after a no-JS navigation');
     });
 
     test('a server-rendered form submits and the response renders with JS off', async () => {


### PR DESCRIPTION
Closes #183

## Summary

"Progressive enhancement by default" is webjs's foundational claim, but it was never continuously verified. This adds an e2e layer that loads the blog with JavaScript DISABLED and asserts the no-JS baseline: content reads, an `<a>` link navigates, a `<form>` submits and the server renders the response, and a display-only component renders. A counterfactual proves the harness genuinely disabled JS.

## What changed

1. **A progressive (no-JS) search form on the blog** (`examples/blog/app/search/page.ts` + a `/search` nav link). The blog's existing forms (auth, comments, chat, new-post) are all JS-driven (`@submit` + `fetch`), so the app had no native `<form action method>` to exercise the framework's promise that forms submit with JS off. `/search` is a plain GET form over post titles: with JS the client router fragment-swaps it, with JS off the browser does a full navigation to `/search?q=...` and the server renders the results. This is the canonical no-JS form the test asserts on, and a genuinely useful blog feature.

2. **The JS-disabled e2e layer** (`progressive enhancement (JS disabled) (#183)` in `test/e2e/e2e.test.mjs`). A nested describe runs a second page with `setJavaScriptEnabled(false)`. Because that also disables `page.evaluate`, the block reads the DOM via `page.content()` (HTML serialization, no page JS) and interacts via CDP-level `type`/`click` (real browser input/mouse events). It asserts:
   * Content reads (seeded posts render) AND a display-only component renders its SSR markup (`zero JS shipped for this badge`).
   * An `<a>` nav link performs a full native navigation to `/about`.
   * The `/search` GET form submits (type + click) and the server renders `Found 2 results for "web"`.
   * **Counterfactual**: clicking the interactive counter does NOT increment it with JS off, proving JS is genuinely disabled (so a feature whose first paint or behaviour needed JS would render broken and fail the assertions above rather than passing on a secretly-live page).

## Acceptance criteria

* JS-disabled e2e asserts content reads, links navigate, and a server-rendered form submits on the blog: done (4 tests).
* At least one display-only component renders correct markup with JS off: done (the build-stamp badge).
* Counterfactual: a feature whose first paint depends on JS fails the test: the counter counterfactual proves the harness fails JS-dependent behaviour.

## Test plan

* JS-disabled describe: 4/4 green.
* Full blog e2e suite: **61/61** (the 4 new tests plus the pre-existing 57; the added `/search` nav link in the shared layout does not disturb any other test).
* `npm test` overall: **1535/1535** (includes the blog smoke + scaffold suites).
* `webjs check` on the blog: all conventions pass.
* Dogfood: only the blog changed; website / docs / ui-website are untouched. Extending the no-JS layer to docs is a sensible follow-up but is beyond this issue's blog-scoped acceptance.

## Docs

* N/A for framework docs: this adds a blog example feature + a test, no framework API change. The progressive-enhancement claim it verifies is already documented in `AGENTS.md`.
