### PR TITLE
Add source-fidelity assertion (served equals authored line/column)

### DIFF
--- a/test/source-fidelity/fixture/app/page.ts
+++ b/test/source-fidelity/fixture/app/page.ts
@@ -1,0 +1,12 @@
+import { html } from '@webjsdev/core';
+import '../components/typed.ts';
+import '../components/plain.ts';
+import '../components/badge.ts';
+
+export default function Page() {
+  return html`
+    <typed-comp count="1"></typed-comp>
+    <plain-comp></plain-comp>
+    <display-badge></display-badge>
+  `;
+}

--- a/test/source-fidelity/fixture/components/badge.ts
+++ b/test/source-fidelity/fixture/components/badge.ts
@@ -1,0 +1,10 @@
+import { WebComponent, html } from '@webjsdev/core';
+
+// Display-only (no interactivity signal), so the framework elides it: the
+// side-effect import in app/page.ts is swapped for a same-line comment.
+export class DisplayBadge extends WebComponent {
+  render() {
+    return html`<span>badge</span>`;
+  }
+}
+DisplayBadge.register('display-badge');

--- a/test/source-fidelity/fixture/components/plain.ts
+++ b/test/source-fidelity/fixture/components/plain.ts
@@ -1,0 +1,10 @@
+import { WebComponent, html } from '@webjsdev/core';
+
+// Interactive (@click) so it ships, and carries NO type annotations, so the
+// strip is a no-op and the served bytes must equal the authored file exactly.
+export class PlainComp extends WebComponent {
+  render() {
+    return html`<button @click=${() => this.dispatchEvent(new CustomEvent('ping'))}>plain</button>`;
+  }
+}
+PlainComp.register('plain-comp');

--- a/test/source-fidelity/fixture/components/typed.ts
+++ b/test/source-fidelity/fixture/components/typed.ts
@@ -1,0 +1,22 @@
+import { WebComponent, html } from '@webjsdev/core';
+
+// Interactive (@click) so it ships, and carries TypeScript type
+// annotations so the served bytes exercise the position-preserving strip.
+export class TypedComp extends WebComponent {
+  static properties = { count: { type: Number } };
+  declare count: number;
+
+  constructor() {
+    super();
+    this.count = 0;
+  }
+
+  _inc(by: number): void {
+    this.count = this.count + by;
+  }
+
+  render() {
+    return html`<button @click=${() => this._inc(1)}>${this.count}</button>`;
+  }
+}
+TypedComp.register('typed-comp');

--- a/test/source-fidelity/fixture/package.json
+++ b/test/source-fidelity/fixture/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "source-fidelity-fixture",
+  "version": "0.0.0",
+  "type": "module",
+  "private": true
+}

--- a/test/source-fidelity/source-fidelity.test.mjs
+++ b/test/source-fidelity/source-fidelity.test.mjs
@@ -1,0 +1,115 @@
+/**
+ * Source-fidelity assertion (issue #185).
+ *
+ * "Source is the runtime, served verbatim with identical line and column
+ * numbers" is a core webjs promise: you debug the served file with no
+ * sourcemap because every (line, column) maps to itself in the authored
+ * source. That rests on two position-preserving transforms, and nothing
+ * asserted the property until now:
+ *   - TypeScript type-strip blanks type syntax to whitespace IN PLACE, so the
+ *     served bytes have the same length and every code character keeps its
+ *     exact (line, column).
+ *   - Elision swaps an elidable component's side-effect import for a comment
+ *     on the SAME line (no newline added or removed), so line numbers are
+ *     preserved for every token; only the import's own line changes.
+ *   - A `.server.*` file is served as a stub (out of scope here).
+ *
+ * This requests source files through the in-process handler and asserts the
+ * served bytes match the authored file's line/column structure. The
+ * counterfactual proves a line-shifting transform would fail.
+ */
+import { test, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createRequestHandler } from '@webjsdev/server';
+
+const FIXTURE = resolve(dirname(fileURLToPath(import.meta.url)), 'fixture');
+
+let handler;
+before(async () => {
+  handler = await createRequestHandler({ appDir: FIXTURE, dev: false });
+  if (handler.warmup) await handler.warmup();
+});
+
+async function served(rel) {
+  const r = await handler.handle(new Request('http://localhost/' + rel));
+  assert.ok(r.status < 400, `${rel} should be servable (got ${r.status})`);
+  return r.text();
+}
+const authored = (rel) => readFile(resolve(FIXTURE, rel), 'utf8');
+
+/** Line numbers are preserved: same number of lines. */
+function sameLineCount(a, b) {
+  return a.split('\n').length === b.split('\n').length;
+}
+
+/**
+ * Full position preservation: identical byte length, identical per-line
+ * length, and every served character is either the authored character or a
+ * space that replaced stripped type syntax (the strip never moves code).
+ */
+function positionPreserved(servedSrc, authoredSrc) {
+  if (servedSrc.length !== authoredSrc.length) return false;
+  for (let i = 0; i < authoredSrc.length; i++) {
+    if (servedSrc[i] !== authoredSrc[i] && servedSrc[i] !== ' ') return false;
+  }
+  return true;
+}
+
+test('TS type-strip is position-preserving: served line/column equals authored', async () => {
+  const s = await served('components/typed.ts');
+  const a = await authored('components/typed.ts');
+  assert.ok(sameLineCount(s, a), `line count must match (served ${s.split('\n').length}, authored ${a.split('\n').length})`);
+  assert.equal(s.length, a.length, 'type-strip must preserve total byte length (blank in place)');
+  const sl = s.split('\n'), al = a.split('\n');
+  for (let i = 0; i < al.length; i++) {
+    assert.equal(sl[i].length, al[i].length, `line ${i + 1} length must be preserved`);
+  }
+  assert.ok(positionPreserved(s, a), 'every code character must keep its exact position (types blanked to spaces)');
+  // Sampled column fidelity: a code line with no types is byte-identical and
+  // at the same line index.
+  const idx = al.findIndex((l) => l.includes("TypedComp.register('typed-comp');"));
+  assert.ok(idx >= 0, 'sample line present in authored');
+  assert.equal(sl[idx], al[idx], 'a non-type line must be served byte-identical at the same line');
+  // The type-bearing lines ARE transformed (so the test is not vacuous).
+  assert.notEqual(s, a, 'the file does carry types, so served must differ from authored (blanked)');
+});
+
+test('a file with no types is served verbatim (byte-for-byte)', async () => {
+  const s = await served('components/plain.ts');
+  const a = await authored('components/plain.ts');
+  assert.equal(s, a, 'a file with nothing to transform must be served byte-identical to its source');
+});
+
+test('elision preserves line numbers: only the elided import line changes', async () => {
+  const s = await served('app/page.ts');
+  const a = await authored('app/page.ts');
+  assert.ok(sameLineCount(s, a), `elision must not shift line numbers (served ${s.split('\n').length}, authored ${a.split('\n').length})`);
+  const sl = s.split('\n'), al = a.split('\n');
+  const changed = [];
+  for (let i = 0; i < al.length; i++) if (sl[i] !== al[i]) changed.push(i);
+  assert.equal(changed.length, 1, `exactly one line should change (the elided import); changed lines: ${changed.map((i) => i + 1)}`);
+  const i = changed[0];
+  assert.match(al[i], /^import .*badge\.ts/, 'the changed authored line is the badge import');
+  assert.match(sl[i], /webjs: elided display-only component/, 'the served line is the elision comment');
+  // Every OTHER line is byte-identical, so a breakpoint on any of them maps
+  // straight through.
+  for (let j = 0; j < al.length; j++) {
+    if (j !== i) assert.equal(sl[j], al[j], `non-elided line ${j + 1} must be byte-identical`);
+  }
+});
+
+test('counterfactual: a line-shifting transform fails the fidelity assertion', async () => {
+  // A transform that strips a type by DELETING it (collapsing) instead of
+  // blanking it in place would shift every following column on that line and,
+  // if it removed a newline, shift every following line. Simulate both and
+  // assert the fidelity checks catch them.
+  const a = await authored('components/typed.ts');
+  const columnShifted = a.replace(': number', '');      // deletes, shifting columns
+  const lineShifted = a.replace('\n  constructor() {', '  constructor() {'); // removes a newline
+  assert.ok(!positionPreserved(columnShifted, a), 'a column-shifting (delete-not-blank) transform must fail position preservation');
+  assert.ok(!sameLineCount(lineShifted, a), 'a line-removing transform must fail the line-count check');
+});

--- a/test/source-fidelity/source-fidelity.test.mjs
+++ b/test/source-fidelity/source-fidelity.test.mjs
@@ -23,6 +23,7 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { stripTypeScriptTypes } from 'node:module';
 
 import { createRequestHandler } from '@webjsdev/server';
 
@@ -69,6 +70,14 @@ test('TS type-strip is position-preserving: served line/column equals authored',
     assert.equal(sl[i].length, al[i].length, `line ${i + 1} length must be preserved`);
   }
   assert.ok(positionPreserved(s, a), 'every code character must keep its exact position (types blanked to spaces)');
+  // The strongest pin: the served bytes are EXACTLY Node's position-preserving
+  // strip of the authored source, with no extra transform layered on top
+  // (no banner, no sourcemap comment, no import rewrite, nothing that could
+  // shift a line or column). This also closes the gap where positionPreserved
+  // alone would tolerate a real code character being blanked to a space: only
+  // genuine type syntax is blanked here.
+  assert.equal(s, stripTypeScriptTypes(a),
+    'served bytes must equal the position-preserving type-strip of the authored source, nothing more');
   // Sampled column fidelity: a code line with no types is byte-identical and
   // at the same line index.
   const idx = al.findIndex((l) => l.includes("TypedComp.register('typed-comp');"));
@@ -108,7 +117,7 @@ test('counterfactual: a line-shifting transform fails the fidelity assertion', a
   // if it removed a newline, shift every following line. Simulate both and
   // assert the fidelity checks catch them.
   const a = await authored('components/typed.ts');
-  const columnShifted = a.replace(': number', '');      // deletes, shifting columns
+  const columnShifted = a.replace('(by: number)', '(by)');      // deletes a type, shifting that line's columns
   const lineShifted = a.replace('\n  constructor() {', '  constructor() {'); // removes a newline
   assert.ok(!positionPreserved(columnShifted, a), 'a column-shifting (delete-not-blank) transform must fail position preservation');
   assert.ok(!sameLineCount(lineShifted, a), 'a line-removing transform must fail the line-count check');


### PR DESCRIPTION
Closes #185

## Summary

"Source is the runtime, served verbatim with identical line and column numbers" is a core webjs promise (you debug the served file with no sourcemap because every position maps to itself). It rests on two position-preserving transforms, but nothing asserted the property, so a future transform could silently break it. This adds the guard.

## What changed

A fixture app (`test/source-fidelity/fixture/`) plus an integration test (`test/source-fidelity/source-fidelity.test.mjs`) that requests source files through the in-process `createRequestHandler` and checks the served bytes against the authored file:

* **`components/typed.ts`** (TypeScript type-strip): asserts full position preservation. Same line count, same total byte length, same per-line length, and every served character is either the authored character or a space that replaced stripped type syntax (the strip blanks types IN PLACE and never moves code). Verified against the real served output: the file is 570 bytes and 23 lines both authored and served, differing only on the two type-bearing lines where `: number` / `: void` / `declare ...` are blanked to equal-length whitespace.
* **`components/plain.ts`** (no types): asserts the served bytes are byte-for-byte identical to the source (the strip is a no-op).
* **`app/page.ts`** (elided import): asserts elision preserves line numbers. Exactly one line changes (the display-only `badge.ts` side-effect import, swapped for a same-line `/* webjs: elided display-only component */` comment, which adds no newline), and every other line is byte-identical, so a breakpoint on any non-elided line maps straight through.

## Counterfactual

A transform that strips a type by DELETING it (collapsing) instead of blanking it in place would shift the following columns, and one that removes a newline would shift every following line. The test simulates both and asserts the fidelity checks catch them (position-preservation fails the column-shift, line-count fails the newline-removal).

## Acceptance criteria

* Asserts served `.ts` line count and column positions equal the authored source: done (line count + per-line length + per-character position).
* Covers a TS file (type strip), a file with an elided import, and a normal file: done (typed.ts, page.ts, plain.ts).
* Counterfactual: a line-shifting transform fails: done.

## Test plan

* `node --test test/source-fidelity/source-fidelity.test.mjs`: 4/4.
* `npm test` overall: **1539/1539** (the fixture's `.ts` files are not `*.test.*`, so node:test never executes them; they are only loaded through the handler, which strips their types).
* Test-only (a fixture app + a test, no `src` change), so the four dogfood apps are unaffected.

## Docs

* N/A: this guards an existing documented promise (`AGENTS.md` invariant 10 and the no-build docs already state the position-preserving strip), no API or behaviour change.
