### PR TITLE
Isomorphic-globals lint rule + actionable SSR errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -420,7 +420,7 @@ Rules:
 - **Server-known data** (session, accept-language, theme cookie, URL) goes through the page function and is passed as a prop/attribute.
 - **For unacceptable flicker** (theme color, RTL), use a synchronous inline `<script>` in the root layout's `<head>` to set `document.documentElement` before custom elements upgrade.
 
-**Anti-pattern:** a component whose first paint is empty/placeholder because real data is fetched in `connectedCallback`/`firstUpdated`. Fetch on the server in the page function instead. See `agent-docs/components.md` for SSR mechanics in depth, and `agent-docs/lit-muscle-memory-gotchas.md` for the full catalog of lit patterns that produce broken SSR or silent reactivity failures in webjs.
+**Anti-pattern:** a component whose first paint is empty/placeholder because real data is fetched in `connectedCallback`/`firstUpdated`. Fetch on the server in the page function instead. See `agent-docs/components.md` for SSR mechanics in depth, and `agent-docs/lit-muscle-memory-gotchas.md` for the full catalog of lit patterns that produce broken SSR or silent reactivity failures in webjs. A browser global or `HTMLElement` member (`document`, `window`, `localStorage`, `this.setAttribute`, `this.classList`, ...) touched in the constructor or `render()` throws during SSR; `webjs check`'s `no-browser-globals-in-render` rule flags it, and an SSR crash on one now names the member and the fix.
 
 ### Light DOM (default) vs Shadow DOM (opt-in)
 

--- a/agent-docs/lit-muscle-memory-gotchas.md
+++ b/agent-docs/lit-muscle-memory-gotchas.md
@@ -139,6 +139,20 @@ connectedCallback() {
 }
 ```
 
+The same applies to HTMLElement instance members on `this`
+(`this.setAttribute(...)`, `this.classList`, `this.querySelector(...)`,
+`this.attachShadow(...)`, `this.hasAttribute(...)`): the SSR-time instance is
+a bare class with no DOM, so they throw. Read an attribute that drives render
+through a reactive property (`static properties` + `declare`) instead of
+`this.hasAttribute(...)`; the SSR walker applies the attribute to the property
+before calling render.
+
+Two guards catch this. `webjs check` flags browser globals and HTMLElement
+members used in a constructor or render body (the `no-browser-globals-in-render`
+rule). And if one slips through, the SSR crash is now actionable: the log names
+the offending member and tells you to move it to `connectedCallback` or a
+lifecycle hook, instead of a raw `document is not defined`.
+
 ### 4. Top-level imports of browser-only libraries
 
 `import * as d3 from 'd3'`, `import Chart from 'chart.js'`, or any

--- a/packages/core/src/render-server.js
+++ b/packages/core/src/render-server.js
@@ -314,6 +314,41 @@ async function renderTemplate(tr, ctx) {
   return out;
 }
 
+// Browser-only names whose absence during SSR produces a recognisable error.
+// Mirrors the `no-browser-globals-in-render` webjs check rule, which catches
+// these at edit time; this turns the runtime SSR crash into the same guidance.
+const SSR_BROWSER_GLOBALS = new Set([
+  'document', 'window', 'localStorage', 'sessionStorage', 'navigator',
+  'matchMedia', 'requestAnimationFrame', 'getComputedStyle',
+  'IntersectionObserver', 'MutationObserver', 'ResizeObserver',
+]);
+const SSR_HTMLELEMENT_METHODS = new Set([
+  'attachShadow', 'setAttribute', 'getAttribute', 'removeAttribute',
+  'hasAttribute', 'dispatchEvent', 'querySelector', 'querySelectorAll',
+  'getBoundingClientRect', 'focus', 'blur', 'scrollIntoView',
+]);
+
+/**
+ * If `e` is the recognisable failure of touching a browser-only API during
+ * SSR (a `ReferenceError` for a browser global, or a `TypeError` calling an
+ * HTMLElement method that does not exist on the bare server-side instance),
+ * return an actionable, member-naming hint; otherwise null.
+ * @param {unknown} e
+ * @returns {string | null}
+ */
+function browserMemberHint(e) {
+  const msg = e && typeof (/** @type any */ (e).message) === 'string' ? /** @type any */ (e).message : '';
+  let m = /^(\w+) is not defined$/.exec(msg);
+  if (e instanceof ReferenceError && m && SSR_BROWSER_GLOBALS.has(m[1])) {
+    return `\`${m[1]}\` is a browser-only global and is undefined during SSR.`;
+  }
+  m = /\.(\w+) is not a function$/.exec(msg);
+  if (e instanceof TypeError && m && SSR_HTMLELEMENT_METHODS.has(m[1])) {
+    return `\`${m[1]}\` is an HTMLElement method that does not exist on the server-side component instance during SSR.`;
+  }
+  return null;
+}
+
 /**
  * Scan an HTML string for registered custom elements and inject
  * Declarative Shadow DOM (`<template shadowrootmode="open">`).
@@ -443,7 +478,15 @@ async function injectDSD(html, ctx) {
         });
       }
     } catch (e) {
-      console.error(`[webjs] SSR failed for <${tag}>:`, e);
+      const hint = browserMemberHint(e);
+      if (hint) {
+        console.error(
+          `[webjs] SSR failed for <${tag}>: ${hint} It was touched in the component's constructor or render(), which run during SSR. Move browser-only work to connectedCallback() or a lifecycle hook (firstUpdated/updated), which SSR never calls; seed first-paint defaults in the constructor only from server-known inputs (attributes / props).`,
+          e,
+        );
+      } else {
+        console.error(`[webjs] SSR failed for <${tag}>:`, e);
+      }
     }
   }
   if (!edits.length) return html;

--- a/packages/core/test/rendering/ssr-browser-member-error.test.js
+++ b/packages/core/test/rendering/ssr-browser-member-error.test.js
@@ -1,0 +1,59 @@
+/**
+ * Actionable SSR errors for the isomorphic footgun (issue #186).
+ *
+ * The SSR pipeline runs a component's constructor and render() on a bare
+ * server-side class with no DOM. Touching a browser global or an HTMLElement
+ * method there throws. Instead of a raw, hard-to-trace crash, the SSR walker
+ * now logs a message that names the offending member and the fix (move it to
+ * connectedCallback / a lifecycle hook, which SSR never calls).
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { WebComponent } from '../../src/component.js';
+import { html } from '../../src/html.js';
+import { renderToString } from '../../src/render-server.js';
+
+/** Capture console.error output while running `fn`. */
+async function captureErrors(fn) {
+  const orig = console.error;
+  let captured = '';
+  console.error = (...a) => { captured += a.map(String).join(' ') + '\n'; };
+  try { await fn(); } finally { console.error = orig; }
+  return captured;
+}
+
+test('a browser global in render yields an actionable, member-naming SSR error', async () => {
+  class UsesDocument extends WebComponent {
+    render() { return html`<p>${document.title}</p>`; }
+  }
+  UsesDocument.register('ssr-uses-document');
+  const out = await captureErrors(() => renderToString(html`<ssr-uses-document></ssr-uses-document>`));
+  assert.match(out, /ssr-uses-document/, 'names the failing component');
+  assert.match(out, /`document`/, 'names the offending member');
+  assert.match(out, /browser-only global/, 'explains it is browser-only');
+  assert.match(out, /connectedCallback/, 'points at the fix');
+});
+
+test('an HTMLElement method in render yields an actionable, member-naming SSR error', async () => {
+  class UsesSetAttr extends WebComponent {
+    render() { this.setAttribute('x', '1'); return html`<p></p>`; }
+  }
+  UsesSetAttr.register('ssr-uses-setattr');
+  const out = await captureErrors(() => renderToString(html`<ssr-uses-setattr></ssr-uses-setattr>`));
+  assert.match(out, /`setAttribute`/, 'names the offending HTMLElement method');
+  assert.match(out, /HTMLElement method/, 'explains it is an HTMLElement method');
+  assert.match(out, /connectedCallback/, 'points at the fix');
+});
+
+test('an unrelated SSR error keeps the plain message (no false member hint)', async () => {
+  // A non-browser error (a thrown string-message Error) must NOT be dressed up
+  // with the browser-member guidance, so the hint is specific, not noise.
+  class ThrowsPlain extends WebComponent {
+    render() { throw new Error('something domain-specific broke'); }
+  }
+  ThrowsPlain.register('ssr-throws-plain');
+  const out = await captureErrors(() => renderToString(html`<ssr-throws-plain></ssr-throws-plain>`));
+  assert.match(out, /SSR failed for <ssr-throws-plain>/, 'still logs the failure');
+  assert.doesNotMatch(out, /browser-only global|HTMLElement method|connectedCallback/, 'no spurious browser-member hint');
+});

--- a/packages/server/src/check.js
+++ b/packages/server/src/check.js
@@ -448,14 +448,14 @@ function findBrowserMemberUses(code) {
   while ((m = gRe.exec(code)) !== null) {
     if (seen.has(m[1])) continue;
     seen.add(m[1]);
-    out.push({ member: m[1], kind: 'browser global' });
+    out.push({ member: m[1], kind: 'a browser global' });
   }
   const hRe = new RegExp(`\\bthis\\.(${HTMLELEMENT_MEMBERS.join('|')})\\b`, 'g');
   while ((m = hRe.exec(code)) !== null) {
     const key = `this.${m[1]}`;
     if (seen.has(key)) continue;
     seen.add(key);
-    out.push({ member: key, kind: 'HTMLElement member' });
+    out.push({ member: key, kind: 'an HTMLElement member' });
   }
   return out;
 }
@@ -644,7 +644,7 @@ export async function checkConventions(appDir, opts) {
             violations.push({
               rule: 'no-browser-globals-in-render',
               file: rel,
-              message: `\`${member}\` (a ${kind}) is used in ${method}(), which runs during SSR where it is not available, so it throws and the component fails to server-render.`,
+              message: `\`${member}\` (${kind}) is used in ${method}(), which runs during SSR where it is not available, so it throws and the component fails to server-render.`,
               fix: `Move browser-only work to connectedCallback() or a lifecycle hook (firstUpdated/updated), which SSR never calls. Seed first-paint defaults in the constructor only from server-known inputs (attributes / props), then refine in connectedCallback by writing to a signal.`,
             });
           }

--- a/packages/server/src/check.js
+++ b/packages/server/src/check.js
@@ -114,6 +114,11 @@ export const RULES = [
     description:
       'Verifies the `.gitignore` exception for `.webjs/vendor/` is structurally correct via `git check-ignore`. The intended pattern is `.webjs/*` (NOT `.webjs/`) plus `!.webjs/vendor/` plus `!.webjs/vendor/**`. The common-looking pattern `.webjs/` excludes the directory itself, after which git cannot re-include children (gitignore semantics: a parent exclusion blocks child negations). Without this rule, an AI agent or human editor would silently break `webjs vendor pin` by simplifying the pattern; the failure is invisible until production. Rule fires when the working directory is a git repo and a `.gitignore` exists; skipped when neither is true.',
   },
+  {
+    name: 'no-browser-globals-in-render',
+    description:
+      'Flags browser-only APIs used in a WebComponent constructor or render() method. The SSR pipeline instantiates the component (running the constructor) and calls render() to produce HTML, on a bare server-side class with no DOM. So a browser global (document, window, localStorage, sessionStorage, navigator, location, matchMedia, screen, history) or an HTMLElement instance member on `this` (attachShadow, shadowRoot, setAttribute, getAttribute, removeAttribute, dispatchEvent, classList, querySelector, querySelectorAll, getBoundingClientRect, focus, blur, scrollIntoView) touched there throws at SSR time (the isomorphic footgun). These belong in connectedCallback() or a lifecycle hook (firstUpdated/updated), which SSR never calls; seed first-paint defaults in the constructor only from server-known inputs (attributes, props). Conservative: only the constructor and render bodies are scanned (the methods SSR actually runs), and only direct references, so helper indirection is not flagged (the runtime SSR error covers that case).',
+  },
 ];
 
 /** Set of all known rule names for fast lookup. */
@@ -389,6 +394,72 @@ function findFieldInitializers(classBody, props) {
   return out;
 }
 
+// Browser-only globals that are undefined during SSR (the server-side
+// WebComponent base is a bare class with no DOM). High-confidence names only
+// (unlikely to be ordinary local variables), so the rule stays low-noise.
+const BROWSER_GLOBALS = [
+  'document', 'window', 'localStorage', 'sessionStorage', 'navigator',
+  'matchMedia', 'requestAnimationFrame', 'getComputedStyle',
+  'IntersectionObserver', 'MutationObserver', 'ResizeObserver',
+];
+// HTMLElement instance members that do not exist on the bare server class, so
+// `this.<member>` throws (a method call) or is `undefined` (a property) at SSR.
+const HTMLELEMENT_MEMBERS = [
+  'attachShadow', 'shadowRoot', 'setAttribute', 'getAttribute',
+  'removeAttribute', 'hasAttribute', 'dispatchEvent', 'classList',
+  'querySelector', 'querySelectorAll', 'getBoundingClientRect',
+  'focus', 'blur', 'scrollIntoView',
+];
+
+/**
+ * Extract the body text of a named method from a (redacted) class body, or
+ * '' if absent. Handles `async`, a TS return-type annotation, and params.
+ * @param {string} classBody
+ * @param {string} name
+ */
+function methodBodyOf(classBody, name) {
+  const re = new RegExp(`(?:^|[\\s;}])(?:async\\s+)?${name}\\s*\\([^)]*\\)\\s*(?::[^{]*)?\\{`, 'g');
+  const m = re.exec(classBody);
+  if (!m) return '';
+  const open = classBody.indexOf('{', m.index + m[0].length - 1);
+  if (open === -1) return '';
+  const close = matchClosingBrace(classBody, open + 1);
+  return close === -1 ? '' : classBody.slice(open + 1, close);
+}
+
+/**
+ * Find browser-only globals and HTMLElement `this.<member>` accesses in a
+ * (redacted) method body. Returns one entry per distinct member.
+ * @param {string} code
+ * @returns {{ member: string, kind: string }[]}
+ */
+function findBrowserMemberUses(code) {
+  // The class body arrives template-redacted, but `redactStringsAndTemplates`
+  // keeps single/double-quoted string CONTENT (real specifiers ride strings).
+  // Blank that too so a browser word inside a string literal (e.g. a label
+  // `'open the document'`) is not mistaken for a real global access.
+  code = code
+    .replace(/'(?:[^'\\]|\\.)*'/g, (s) => `'${' '.repeat(Math.max(0, s.length - 2))}'`)
+    .replace(/"(?:[^"\\]|\\.)*"/g, (s) => `"${' '.repeat(Math.max(0, s.length - 2))}"`);
+  const out = [];
+  const seen = new Set();
+  const gRe = new RegExp(`(?<![.\\w$])(${BROWSER_GLOBALS.join('|')})\\b`, 'g');
+  let m;
+  while ((m = gRe.exec(code)) !== null) {
+    if (seen.has(m[1])) continue;
+    seen.add(m[1]);
+    out.push({ member: m[1], kind: 'browser global' });
+  }
+  const hRe = new RegExp(`\\bthis\\.(${HTMLELEMENT_MEMBERS.join('|')})\\b`, 'g');
+  while ((m = hRe.exec(code)) !== null) {
+    const key = `this.${m[1]}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ member: key, kind: 'HTMLElement member' });
+  }
+  return out;
+}
+
 /**
  * Scan a webjs app directory and report convention violations.
  *
@@ -552,6 +623,31 @@ export async function checkConventions(appDir, opts) {
             message: `Reactive prop \`${bad}\` uses a class-field initializer; this clobbers the framework's reactive accessor under modern class-field semantics.`,
             fix: `Replace with \`declare ${bad}: <Type>;\` and set the default inside \`constructor()\` after \`super()\`.`,
           });
+        }
+      }
+    }
+  }
+
+  // --- Rule: no-browser-globals-in-render ---
+  // The SSR pipeline runs the constructor (`new Cls()`) and calls `render()`
+  // on a bare server-side class with no DOM. A browser global or an
+  // HTMLElement member on `this` touched there throws at SSR time. Those
+  // belong in connectedCallback / lifecycle hooks, which SSR never calls.
+  if (isRuleEnabled('no-browser-globals-in-render', overrides)) {
+    for (const { rel, scan } of files) {
+      if (!/class\s+\w+\s+extends\s+WebComponent/.test(scan)) continue;
+      for (const body of extractWebComponentClassBodies(scan)) {
+        for (const method of ['constructor', 'render']) {
+          const code = methodBodyOf(body, method);
+          if (!code) continue;
+          for (const { member, kind } of findBrowserMemberUses(code)) {
+            violations.push({
+              rule: 'no-browser-globals-in-render',
+              file: rel,
+              message: `\`${member}\` (a ${kind}) is used in ${method}(), which runs during SSR where it is not available, so it throws and the component fails to server-render.`,
+              fix: `Move browser-only work to connectedCallback() or a lifecycle hook (firstUpdated/updated), which SSR never calls. Seed first-paint defaults in the constructor only from server-known inputs (attributes / props), then refine in connectedCallback by writing to a signal.`,
+            });
+          }
         }
       }
     }

--- a/packages/server/test/check/no-browser-globals-in-render.test.js
+++ b/packages/server/test/check/no-browser-globals-in-render.test.js
@@ -54,7 +54,7 @@ Ctor.register('ctor-el');
 `);
   try {
     const v = find(await checkConventions(dir), 'ctor.ts');
-    assert.ok(v.some((x) => x.member ? false : x.message.includes('matchMedia') && x.message.includes('constructor')), 'matchMedia in constructor flagged');
+    assert.ok(v.some((x) => x.message.includes('matchMedia') && x.message.includes('constructor')), 'matchMedia in constructor flagged');
   } finally { await rm(dir, { recursive: true, force: true }); }
 });
 

--- a/packages/server/test/check/no-browser-globals-in-render.test.js
+++ b/packages/server/test/check/no-browser-globals-in-render.test.js
@@ -1,0 +1,129 @@
+/**
+ * Tests for the no-browser-globals-in-render rule (issue #186). The SSR
+ * pipeline runs a component's constructor and render() on a bare server-side
+ * class with no DOM, so a browser global or an HTMLElement member touched
+ * there throws at SSR time. The rule flags those; it must NOT flag the same
+ * access in connectedCallback / lifecycle hooks (which SSR never calls).
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { checkConventions } from '../../src/check.js';
+
+async function appWith(rel, contents) {
+  const dir = await mkdtemp(join(tmpdir(), 'webjs-bg-'));
+  const filePath = join(dir, rel);
+  await mkdir(filePath.slice(0, filePath.lastIndexOf('/')), { recursive: true });
+  await writeFile(filePath, contents);
+  return dir;
+}
+const find = (vs, file) => vs.filter((v) => v.rule === 'no-browser-globals-in-render' && v.file.includes(file));
+
+test('flags document used in render()', async () => {
+  const dir = await appWith('components/bad.ts', `
+import { WebComponent, html } from '@webjsdev/core';
+export class Bad extends WebComponent {
+  render() {
+    const w = document.querySelector('x');
+    return html\`<p>\${w}</p>\`;
+  }
+}
+Bad.register('bad-el');
+`);
+  try {
+    const v = find(await checkConventions(dir), 'bad.ts');
+    assert.ok(v.length >= 1, 'document in render must be flagged');
+    assert.ok(v.some((x) => x.message.includes('document') && x.message.includes('render')), 'message names the member and method');
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('flags a browser global in the constructor', async () => {
+  const dir = await appWith('components/ctor.ts', `
+import { WebComponent, html } from '@webjsdev/core';
+export class Ctor extends WebComponent {
+  constructor() {
+    super();
+    this.dark = matchMedia('(prefers-color-scheme: dark)').matches;
+  }
+  render() { return html\`<p></p>\`; }
+}
+Ctor.register('ctor-el');
+`);
+  try {
+    const v = find(await checkConventions(dir), 'ctor.ts');
+    assert.ok(v.some((x) => x.member ? false : x.message.includes('matchMedia') && x.message.includes('constructor')), 'matchMedia in constructor flagged');
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('flags this.attachShadow (an HTMLElement member) in render', async () => {
+  const dir = await appWith('components/shadow.ts', `
+import { WebComponent, html } from '@webjsdev/core';
+export class Sh extends WebComponent {
+  render() {
+    this.attachShadow({ mode: 'open' });
+    return html\`<p></p>\`;
+  }
+}
+Sh.register('sh-el');
+`);
+  try {
+    const v = find(await checkConventions(dir), 'shadow.ts');
+    assert.ok(v.some((x) => x.message.includes('this.attachShadow')), 'this.attachShadow flagged');
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('does NOT flag document used in connectedCallback (SSR never calls it)', async () => {
+  const dir = await appWith('components/ok.ts', `
+import { WebComponent, html } from '@webjsdev/core';
+export class Ok extends WebComponent {
+  constructor() { super(); this.w = 0; }
+  connectedCallback() {
+    super.connectedCallback();
+    this.w = window.innerWidth;
+    document.title = 'x';
+  }
+  firstUpdated() { this.scrollIntoView(); }
+  render() { return html\`<p>\${this.w}</p>\`; }
+}
+Ok.register('ok-el');
+`);
+  try {
+    const v = find(await checkConventions(dir), 'ok.ts');
+    assert.equal(v.length, 0, `browser globals in connectedCallback/firstUpdated must NOT be flagged; got ${JSON.stringify(v.map((x) => x.message))}`);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('counterfactual control: a clean component is not flagged', async () => {
+  const dir = await appWith('components/clean.ts', `
+import { WebComponent, html } from '@webjsdev/core';
+export class Clean extends WebComponent {
+  static properties = { name: { type: String } };
+  declare name;
+  constructor() { super(); this.name = ''; }
+  render() { return html\`<p>hello \${this.name}</p>\`; }
+}
+Clean.register('clean-el');
+`);
+  try {
+    assert.equal(find(await checkConventions(dir), 'clean.ts').length, 0, 'a clean component must not be flagged');
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('does not match a browser word inside a string or template (redacted)', async () => {
+  const dir = await appWith('components/strs.ts', `
+import { WebComponent, html } from '@webjsdev/core';
+export class Strs extends WebComponent {
+  render() {
+    const label = 'open the document';
+    return html\`<p>window and document are fine here: \${label}</p>\`;
+  }
+}
+Strs.register('strs-el');
+`);
+  try {
+    assert.equal(find(await checkConventions(dir), 'strs.ts').length, 0, 'browser words inside strings/templates must not be flagged');
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});

--- a/packages/ui/packages/registry/components/dropdown-menu.ts
+++ b/packages/ui/packages/registry/components/dropdown-menu.ts
@@ -343,22 +343,24 @@ UiDropdownMenuContent.register('ui-dropdown-menu-content');
 export class UiDropdownMenuItem extends WebComponent {
   static properties = {
     variant: { type: String, reflect: true },
+    inset: { type: Boolean },
   };
   declare variant: 'default' | 'destructive';
+  declare inset: boolean;
 
   constructor() {
     super();
     this.variant = 'default';
+    this.inset = false;
   }
 
   render() {
-    const inset = this.hasAttribute('inset');
     return html`<div
       data-slot="dropdown-menu-item"
       role="menuitem"
       tabindex="-1"
       data-variant=${this.variant}
-      ?data-inset=${inset}
+      ?data-inset=${this.inset}
       class=${dropdownMenuItemClass()}
       @click=${this._onClick}
       @pointerenter=${this._onPointerEnter}
@@ -394,11 +396,18 @@ UiDropdownMenuItem.register('ui-dropdown-menu-item');
 // --------------------------------------------------------------------------
 
 export class UiDropdownMenuLabel extends WebComponent {
+  static properties = { inset: { type: Boolean } };
+  declare inset: boolean;
+
+  constructor() {
+    super();
+    this.inset = false;
+  }
+
   render() {
-    const inset = this.hasAttribute('inset');
     return html`<div
       data-slot="dropdown-menu-label"
-      ?data-inset=${inset}
+      ?data-inset=${this.inset}
       class=${dropdownMenuLabelClass()}
     ><slot></slot></div>`;
   }
@@ -540,6 +549,14 @@ export class UiDropdownMenuSub extends WebComponent {
 UiDropdownMenuSub.register('ui-dropdown-menu-sub');
 
 export class UiDropdownMenuSubTrigger extends WebComponent {
+  static properties = { inset: { type: Boolean } };
+  declare inset: boolean;
+
+  constructor() {
+    super();
+    this.inset = false;
+  }
+
   // SSR-safe: linkedom doesn't implement closest() on custom elements.
   _sub(): UiDropdownMenuSub | null {
     if (typeof this.closest !== 'function') return null;
@@ -547,7 +564,6 @@ export class UiDropdownMenuSubTrigger extends WebComponent {
   }
 
   render() {
-    const inset = this.hasAttribute('inset');
     const open = !!this._sub()?.open;
     return html`<div
       data-slot="dropdown-menu-sub-trigger"
@@ -556,7 +572,7 @@ export class UiDropdownMenuSubTrigger extends WebComponent {
       aria-haspopup="menu"
       aria-expanded=${String(open)}
       data-state=${open ? 'open' : 'closed'}
-      ?data-inset=${inset}
+      ?data-inset=${this.inset}
       class=${dropdownMenuSubTriggerClass()}
       @click=${this._onClick}
       @pointerenter=${this._onPointerEnter}


### PR DESCRIPTION
Closes #186

## Summary

The server-side `WebComponent` base is a bare class with no DOM, so any browser global (`document`, `window`, `localStorage`, `matchMedia`) or `HTMLElement` member on `this` (`attachShadow`, `setAttribute`, `classList`, `querySelector`) touched in the constructor or `render()` throws during SSR (the isomorphic footgun). It used to fail as a raw, hard-to-trace crash. This adds a static guard and makes the runtime crash actionable, and fixes the one real instance the new rule found.

## What changed

1. **`no-browser-globals-in-render` check rule** (`packages/server/src/check.js`). Flags browser globals and `HTMLElement` `this.<member>` accesses in a component's constructor or render body (the methods SSR runs), naming the member and the fix. Conservative and low-noise: high-confidence global names only, only the constructor and render bodies, only direct references (helper indirection is left to the runtime error), and string/template content is masked so a browser word inside a literal is not flagged.

2. **Actionable SSR crash** (`packages/core/src/render-server.js`). When instantiating or rendering a component throws because it touched a browser-only API, the `injectDSD` catch now detects the recognisable failure (a `ReferenceError` for a browser global, or a `TypeError` calling an `HTMLElement` method the bare server instance lacks) and logs a message naming the member and the fix (move to `connectedCallback` / a lifecycle hook). Unrelated errors keep their plain message, so the hint stays specific. This is the runtime companion covering the transitive-helper case the static rule does not see.

3. **Fixed the one real footgun the rule found** (`packages/ui/packages/registry/components/dropdown-menu.ts`). `UiDropdownMenuItem`, `UiDropdownMenuLabel`, and `UiDropdownMenuSubTrigger` read `this.hasAttribute('inset')` in render(), which threw at SSR (the render was swallowed and the items server-rendered empty, appearing only after hydration). Replaced the render-time attribute read with a reactive `inset` boolean property (the SSR walker applies the attribute to it before render), so the items now server-render their `data-inset` state. Verified the inset item now SSRs with `data-inset` present instead of throwing.

## Acceptance criteria

* `webjs check` flags `document`/`window`/`localStorage`/`HTMLElement`-method access in the constructor or render: done.
* SSR crash on a browser member yields an actionable message naming the member and the fix: done (both `ReferenceError` globals and `TypeError` methods).
* Counterfactual: a component touching `document` in render is flagged: done (and the negatives: the same access in `connectedCallback`/`firstUpdated`, a clean component, and a browser word inside a string are NOT flagged).

## Test plan

* **Unit**: `no-browser-globals-in-render` rule (6 cases: positives, the connectedCallback negative, a clean control, the string-redaction case) and the actionable-SSR-error (3 cases: a global, a method, and an unrelated error that keeps the plain message). `npm test` overall: **1544/1544**.
* **Dogfood**: `webjs check` on all four apps reports **0** browser-globals violations (the dropdown fix cleared ui-website, which had 3). Blog e2e **57/57**. website / docs / ui-website boot 200 (including ui-website's `/docs/components/dropdown-menu` page, 40 preloads all resolving). The ui kit browser tests **34/34** (the dropdown fix preserved behaviour).

## Docs

* `agent-docs/lit-muscle-memory-gotchas.md`: extended the "Browser-only APIs in constructor/render" section to `HTMLElement` members, with the reactive-property fix for attribute reads, plus the rule and actionable error.
* `AGENTS.md`: noted both guards in the SSR-safe-state anti-pattern.
* The rule itself is self-documenting via `webjs check --rules` (a metadata entry was added).
