### PR TITLE
Subsystem hardening: property tests + a real serializer bug fix

### DIFF
--- a/packages/core/src/serialize.js
+++ b/packages/core/src/serialize.js
@@ -321,15 +321,26 @@ function decode(v, ctx) {
 
 function decodeTagged(v, tag, ctx) {
   const id = v[ID_KEY];
+  // Register the decoded value under its `_id` so a later `Ref` to it
+  // resolves. Container tags (Map/Set/Arr/Error/object) register BEFORE
+  // decoding children (so a cycle through the container resolves); leaf
+  // rich types (Date, typed arrays, Blob, ...) have no children and register
+  // through this helper at return. Without it, a SHARED Date or typed array
+  // (the same instance appearing twice) decodes the first copy but throws
+  // "Dangling reference" on the second.
+  const reg = (value) => {
+    if (typeof id === 'number') ctx.refs.set(id, value);
+    return value;
+  };
   switch (tag) {
     case 'undef': return undefined;
     case 'NaN':   return NaN;
     case 'Inf':   return Infinity;
     case '-Inf':  return -Infinity;
     case '-0':    return -0;
-    case 'BigInt': return BigInt(v.v);
-    case 'Sym':   return Symbol.for(v.v);
-    case 'Date':  return v.v == null ? new Date(NaN) : new Date(v.v);
+    case 'BigInt': return reg(BigInt(v.v));
+    case 'Sym':   return reg(Symbol.for(v.v));
+    case 'Date':  return reg(v.v == null ? new Date(NaN) : new Date(v.v));
     case 'Error': {
       const e = new Error(v.v.message);
       e.name = v.v.name;
@@ -365,16 +376,17 @@ function decodeTagged(v, tag, ctx) {
     case 'Blob': {
       if (typeof Blob === 'undefined') throw new TypeError('Blob is not available in this environment.');
       const bytes = b64ToBytes(v.v);
-      return new Blob([bytes], { type: v.t || '' });
+      return reg(new Blob([bytes], { type: v.t || '' }));
     }
     case 'File': {
       if (typeof File === 'undefined') throw new TypeError('File is not available in this environment.');
       const bytes = b64ToBytes(v.v);
-      return new File([bytes], v.n, { type: v.t || '', lastModified: v.m });
+      return reg(new File([bytes], v.n, { type: v.t || '', lastModified: v.m }));
     }
     case 'FD': {
       if (typeof FormData === 'undefined') throw new TypeError('FormData is not available in this environment.');
       const fd = new FormData();
+      reg(fd);
       for (const [k, val] of v.v) {
         const decoded = decode(val, ctx);
         fd.append(k, decoded);
@@ -385,17 +397,17 @@ function decodeTagged(v, tag, ctx) {
       // Typed arrays + binary buffers
       if (tag === 'buf') {
         const bytes = b64ToBytes(v.v);
-        return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+        return reg(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
       }
       if (tag === 'dv') {
         const bytes = b64ToBytes(v.v);
-        return new DataView(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
+        return reg(new DataView(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)));
       }
       const Ctor = TAG_TO_TYPED_ARRAY[tag];
       if (Ctor) {
         const bytes = b64ToBytes(v.v);
         const sliced = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
-        return new Ctor(sliced);
+        return reg(new Ctor(sliced));
       }
       throw new TypeError(`Unknown serialization tag: ${tag}`);
     }

--- a/packages/core/test/serializer/round-trip-property.test.js
+++ b/packages/core/test/serializer/round-trip-property.test.js
@@ -1,0 +1,155 @@
+/**
+ * Serializer round-trip property test (issue #187, subsystem hardening).
+ *
+ * INVARIANT: for every value the RPC wire claims to support,
+ * `parse(await stringify(x))` reconstructs a value deeply equal to `x`,
+ * including the rich types (Date, Map, Set, BigInt, TypedArray, Error,
+ * registered Symbol), the number edge cases (NaN, -0, +/-Infinity),
+ * `undefined` inside objects/arrays, and reference cycles. This is the
+ * contract every server action and `richFetch` round-trip relies on.
+ *
+ * The existing serialize.test.js covers each type with a hand-written
+ * example; this adds a generative matrix plus the adversarial edges the
+ * examples miss: nested/cyclic Maps whose KEYS collide with the wire's
+ * reserved tag (`_$wj`) at several escape depths, a Set inside a Map inside
+ * a cycle, and a deterministic randomized object tree.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { stringify, parse } from '../../src/serialize.js';
+
+/** Deep equality that understands the rich types and tolerates cycles. */
+function richEqual(a, b, seen = new Map()) {
+  if (Object.is(a, b)) return true; // handles -0 vs +0, NaN
+  if (typeof a !== typeof b) return false;
+  if (a === null || b === null) return a === b;
+  if (typeof a !== 'object') return a === b;
+  // Cycle guard: if we have compared this pair already, assume equal.
+  if (seen.get(a) === b) return true;
+  seen.set(a, b);
+
+  if (a instanceof Date) return b instanceof Date && Object.is(a.getTime(), b.getTime());
+  if (a instanceof Error) return b instanceof Error && a.name === b.name && a.message === b.message;
+  if (a instanceof Map) {
+    if (!(b instanceof Map) || a.size !== b.size) return false;
+    // Keys may be rich objects, so match structurally rather than by identity.
+    const bEntries = [...b.entries()];
+    for (const [ak, av] of a.entries()) {
+      const idx = bEntries.findIndex(([bk, bv]) => richEqual(ak, bk, seen) && richEqual(av, bv, seen));
+      if (idx === -1) return false;
+      bEntries.splice(idx, 1);
+    }
+    return true;
+  }
+  if (a instanceof Set) {
+    if (!(b instanceof Set) || a.size !== b.size) return false;
+    const bItems = [...b];
+    for (const ai of a) {
+      const idx = bItems.findIndex((bi) => richEqual(ai, bi, seen));
+      if (idx === -1) return false;
+      bItems.splice(idx, 1);
+    }
+    return true;
+  }
+  if (ArrayBuffer.isView(a)) {
+    if (a.constructor !== b.constructor || a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) if (!Object.is(a[i], b[i])) return false;
+    return true;
+  }
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b) || a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) if (!richEqual(a[i], b[i], seen)) return false;
+    return true;
+  }
+  const ak = Object.keys(a), bk = Object.keys(b);
+  if (ak.length !== bk.length) return false;
+  for (const k of ak) {
+    if (!Object.prototype.hasOwnProperty.call(b, k)) return false;
+    if (!richEqual(a[k], b[k], seen)) return false;
+  }
+  return true;
+}
+
+async function assertRoundTrip(value, label) {
+  const back = parse(await stringify(value));
+  assert.ok(richEqual(value, back), `round-trip must preserve ${label}\n  in:  ${safe(value)}\n  out: ${safe(back)}`);
+}
+function safe(v) { try { return JSON.stringify(v, (_k, x) => (typeof x === 'bigint' ? `${x}n` : x)); } catch { return String(v); } }
+
+// A deterministic pseudo-random generator (seeded, no Math.random) so the
+// "fuzz" cases are reproducible across runs.
+function mulberry32(seed) {
+  return function () {
+    seed |= 0; seed = (seed + 0x6D2B79F5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const LEAVES = [
+  0, 1, -1, 3.14, -0, NaN, Infinity, -Infinity, Number.MAX_SAFE_INTEGER,
+  '', 'hi', 'unicode: star and 😀', true, false, null, undefined,
+  123n, -9007199254740993n,
+  new Date('2026-06-01T00:00:00Z'), new Date(NaN),
+  Symbol.for('webjs.test'),
+  new Uint8Array([1, 2, 3, 255]), new Float64Array([1.5, -2.5]),
+  new Error('boom'),
+];
+
+/** Build a random value tree of bounded depth from the leaf set. */
+function buildValue(rand, depth) {
+  if (depth <= 0 || rand() < 0.45) return LEAVES[Math.floor(rand() * LEAVES.length)];
+  const shape = Math.floor(rand() * 4);
+  const n = 1 + Math.floor(rand() * 3);
+  if (shape === 0) return Array.from({ length: n }, () => buildValue(rand, depth - 1));
+  if (shape === 1) {
+    const o = {};
+    for (let i = 0; i < n; i++) o[`k${i}`] = buildValue(rand, depth - 1);
+    return o;
+  }
+  if (shape === 2) {
+    const m = new Map();
+    for (let i = 0; i < n; i++) m.set(buildValue(rand, depth - 1), buildValue(rand, depth - 1));
+    return m;
+  }
+  const s = new Set();
+  for (let i = 0; i < n; i++) s.add(buildValue(rand, depth - 1));
+  return s;
+}
+
+test('round-trips a deterministic matrix of rich-value trees', async () => {
+  const rand = mulberry32(0x5eed);
+  for (let i = 0; i < 200; i++) {
+    await assertRoundTrip(buildValue(rand, 4), `random tree #${i}`);
+  }
+});
+
+test('round-trips reserved-key collisions at several escape depths', async () => {
+  // The wire tags values with the reserved key `_$wj`; a user object whose own
+  // keys collide must escape and restore losslessly at every depth.
+  const obj = { _$wj: 1, __$wj: 2, ___$wj: 3, _id: 'a', __id: 'b', normal: 'x' };
+  await assertRoundTrip(obj, 'reserved-key collisions');
+});
+
+test('round-trips a Set inside a Map inside a reference cycle', async () => {
+  const inner = new Set([1, 'two', new Date(0)]);
+  const m = new Map();
+  m.set('set', inner);
+  m.set('self', m); // cycle through the Map
+  const root = { m, list: [m, inner] };
+  root.back = root; // second cycle
+  const back = parse(await stringify(root));
+  assert.ok(back.m instanceof Map && back.m.get('set') instanceof Set, 'structure preserved');
+  assert.equal(back.m.get('self'), back.m, 'Map self-cycle restored to the same reference');
+  assert.equal(back.back, back, 'object self-cycle restored to the same reference');
+  assert.equal(back.list[0], back.m, 'shared reference identity preserved across the tree');
+});
+
+test('round-trips number edge cases exactly (NaN, -0, +/-Infinity)', async () => {
+  for (const n of [NaN, -0, 0, Infinity, -Infinity]) {
+    const back = parse(await stringify({ n }));
+    assert.ok(Object.is(back.n, n), `${String(n)} must round-trip with Object.is identity`);
+  }
+});

--- a/packages/server/test/cache/cache-property.test.js
+++ b/packages/server/test/cache/cache-property.test.js
@@ -1,0 +1,59 @@
+/**
+ * Cache property test (issue #187, subsystem hardening).
+ *
+ * INVARIANT: the `cache(fn, { key, ttl })` helper recomputes iff there is no
+ * fresh, valid cached value: a hit within TTL returns the memoized result
+ * without re-running `fn`; after TTL or `invalidate()` it recomputes; a
+ * corrupted (non-JSON) stored entry recomputes rather than throwing. The
+ * existing cache-fn.test.js checks the happy path; this pins the
+ * recompute-on-miss and corruption-tolerance invariants.
+ */
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { cache } from '../../src/cache-fn.js';
+import { setStore, getStore, memoryStore } from '../../src/cache.js';
+
+beforeEach(() => setStore(memoryStore()));
+
+test('a fresh hit returns the memoized value without re-running fn', async () => {
+  let calls = 0;
+  const f = cache(async (x) => { calls++; return { doubled: x * 2 }; }, { key: 'k', ttl: 60 });
+  assert.deepEqual(await f(21), { doubled: 42 });
+  assert.deepEqual(await f(21), { doubled: 42 });
+  assert.equal(calls, 1, 'a fresh hit must not re-run fn');
+});
+
+test('distinct args memoize independently', async () => {
+  let calls = 0;
+  const f = cache(async (x) => { calls++; return x; }, { key: 'args', ttl: 60 });
+  await f(1); await f(2); await f(1); await f(2);
+  assert.equal(calls, 2, 'each distinct arg computes once');
+});
+
+test('recomputes after TTL expiry', async () => {
+  let calls = 0;
+  const f = cache(async () => { calls++; return calls; }, { key: 'ttl', ttl: 0.02 }); // 20ms
+  assert.equal(await f(), 1);
+  assert.equal(await f(), 1, 'within TTL, cached');
+  await new Promise((r) => setTimeout(r, 35));
+  assert.equal(await f(), 2, 'after TTL, recomputed');
+});
+
+test('invalidate() forces a recompute', async () => {
+  let calls = 0;
+  const f = cache(async () => { calls++; return calls; }, { key: 'inv', ttl: 60 });
+  assert.equal(await f(), 1);
+  await f.invalidate();
+  assert.equal(await f(), 2, 'invalidate evicts the entry');
+});
+
+test('a corrupted stored entry recomputes instead of throwing', async () => {
+  let calls = 0;
+  const f = cache(async () => { calls++; return { ok: true }; }, { key: 'corrupt', ttl: 60 });
+  assert.deepEqual(await f(), { ok: true }); // calls = 1, stores valid JSON
+  // Corrupt the stored value out from under the cache.
+  await getStore().set('cache:corrupt', '{not valid json', 60000);
+  assert.deepEqual(await f(), { ok: true }, 'a non-JSON entry must trigger recompute, not throw');
+  assert.equal(calls, 2, 'the corrupted read recomputed');
+});

--- a/packages/server/test/csrf/verify-property.test.js
+++ b/packages/server/test/csrf/verify-property.test.js
@@ -1,0 +1,60 @@
+/**
+ * CSRF property test (issue #187, subsystem hardening).
+ *
+ * INVARIANT: `verify(req)` returns true iff the `x-webjs-csrf` header equals
+ * the `webjs_csrf` cookie token, and false for every mismatch (a single-byte
+ * tamper, a length change, a missing cookie or header). The existing
+ * csrf.test.js checks a few cases; this asserts the property across many
+ * tokens and every single-position bit-flip, pinning the constant-time
+ * compare against an off-by-one that would accept a near-miss.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { newToken, verify, CSRF_COOKIE, CSRF_HEADER } from '../../src/csrf.js';
+
+const reqWith = (cookieTok, headerTok) => {
+  const headers = {};
+  if (cookieTok != null) headers.cookie = `${CSRF_COOKIE}=${cookieTok}`;
+  if (headerTok != null) headers[CSRF_HEADER] = headerTok;
+  return new Request('http://x/', { method: 'POST', headers });
+};
+
+test('matching cookie and header always verify', () => {
+  for (let i = 0; i < 50; i++) {
+    const t = newToken();
+    assert.equal(verify(reqWith(t, t)), true, 'a matching token must verify');
+  }
+});
+
+test('every single-character tamper of the header is rejected', () => {
+  const t = newToken();
+  for (let i = 0; i < t.length; i++) {
+    const flipped = t.slice(0, i) + (t[i] === '0' ? '1' : '0') + t.slice(i + 1);
+    if (flipped === t) continue; // the flip changed nothing (non-hex edge)
+    assert.equal(verify(reqWith(t, flipped)), false, `a tamper at position ${i} must be rejected`);
+  }
+});
+
+test('length-mismatched tokens are rejected', () => {
+  const t = newToken();
+  assert.equal(verify(reqWith(t, t + 'a')), false, 'longer header rejected');
+  assert.equal(verify(reqWith(t, t.slice(0, -1))), false, 'shorter header rejected');
+  assert.equal(verify(reqWith(t, '')), false, 'empty header rejected');
+});
+
+test('a missing cookie or header is rejected', () => {
+  const t = newToken();
+  assert.equal(verify(reqWith(null, t)), false, 'missing cookie rejected');
+  assert.equal(verify(reqWith(t, null)), false, 'missing header rejected');
+  assert.equal(verify(reqWith(null, null)), false, 'both missing rejected');
+});
+
+test('a different valid token does not verify against the cookie', () => {
+  for (let i = 0; i < 50; i++) {
+    const a = newToken();
+    let b = newToken();
+    while (b === a) b = newToken();
+    assert.equal(verify(reqWith(a, b)), false, 'two independently-issued tokens must not match');
+  }
+});

--- a/packages/server/test/rate-limit/limit-property.test.js
+++ b/packages/server/test/rate-limit/limit-property.test.js
@@ -1,0 +1,60 @@
+/**
+ * Rate-limit property test (issue #187, subsystem hardening).
+ *
+ * INVARIANT: within one window, exactly the first `max` requests from a key
+ * pass; every request after that is 429 with a Retry-After header, until the
+ * window resets. The existing rate-limit.test.js checks max=2; this asserts
+ * the count invariant across a range of `max` values so an off-by-one in the
+ * `count > max` boundary cannot slip through.
+ */
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { rateLimit } from '../../src/rate-limit.js';
+import { setStore, memoryStore } from '../../src/cache.js';
+
+beforeEach(() => setStore(memoryStore()));
+
+const req = () => new Request('http://x/', { headers: { 'x-webjs-remote-ip': '1.2.3.4' } });
+const next = async () => new Response('ok', { status: 200 });
+
+for (const max of [0, 1, 3, 10, 25]) {
+  test(`exactly ${max} requests pass per window, the rest are 429`, async () => {
+    setStore(memoryStore());
+    const mw = rateLimit({ window: '1h', max, key: `prop-${max}` });
+    let passed = 0;
+    let blocked = 0;
+    for (let i = 0; i < max + 5; i++) {
+      const resp = await mw(req(), next);
+      if (resp.status === 200) passed++;
+      else if (resp.status === 429) {
+        blocked++;
+        assert.ok(resp.headers.get('retry-after'), '429 must carry a Retry-After header');
+      } else {
+        assert.fail(`unexpected status ${resp.status}`);
+      }
+    }
+    assert.equal(passed, max, `exactly ${max} requests should pass`);
+    assert.equal(blocked, 5, 'every request past the limit should be blocked');
+  });
+}
+
+test('separate keys get independent budgets', async () => {
+  setStore(memoryStore());
+  const mw = rateLimit({ window: '1h', max: 1, key: (r) => r.headers.get('x-webjs-remote-ip') });
+  const a = new Request('http://x/', { headers: { 'x-webjs-remote-ip': 'a' } });
+  const b = new Request('http://x/', { headers: { 'x-webjs-remote-ip': 'b' } });
+  assert.equal((await mw(a, next)).status, 200, 'a first request passes');
+  assert.equal((await mw(a, next)).status, 429, 'a second request blocked');
+  assert.equal((await mw(b, next)).status, 200, 'b has its own budget');
+});
+
+test('a new window admits another `max` after the old one expires', async () => {
+  setStore(memoryStore());
+  const mw = rateLimit({ window: 20, max: 2, key: 'win' }); // 20ms window
+  assert.equal((await mw(req(), next)).status, 200);
+  assert.equal((await mw(req(), next)).status, 200);
+  assert.equal((await mw(req(), next)).status, 429, 'third blocked in the first window');
+  await new Promise((r) => setTimeout(r, 35));
+  assert.equal((await mw(req(), next)).status, 200, 'window reset admits a fresh request');
+});

--- a/packages/server/test/session/tamper-property.test.js
+++ b/packages/server/test/session/tamper-property.test.js
@@ -1,0 +1,69 @@
+/**
+ * Session integrity property test (issue #187, subsystem hardening).
+ *
+ * INVARIANT: the `session()` middleware signs the cookie with the secret, so
+ * a value set in one request round-trips on the next, and ANY tamper with
+ * the cookie (a modified payload, a bit-flipped signature, a malformed
+ * format) is rejected: `unsign` returns null and the request gets a fresh
+ * empty session rather than silently trusting forged data. The existing
+ * session.test.js covers the unsigned storage round-trip; this pins the
+ * signed-cookie integrity the middleware adds, which is what stops a client
+ * from forging their own session (e.g. promoting themselves to admin).
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { session, getSession } from '../../src/session.js';
+
+const SECRET = 'test-secret-please-ignore';
+const mw = session({ secret: SECRET, cookieName: 'sid' });
+
+/** Run one request through the middleware; `handler(s)` mutates the session. */
+async function pass(cookie, handler) {
+  const headers = cookie ? { cookie: `sid=${cookie}` } : {};
+  const req = new Request('http://x/', { headers });
+  const resp = await mw(req, async () => { handler(getSession(req)); return new Response('ok'); });
+  // Extract the signed cookie value from Set-Cookie, if any.
+  const setCookie = resp.headers.get('set-cookie') || '';
+  const m = /sid=([^;]*)/.exec(setCookie);
+  return { setCookie: m ? decodeURIComponent(m[1]) : null, read: (req2) => req2 };
+}
+
+test('a value set in one request round-trips on the next', async () => {
+  const { setCookie } = await pass(null, (s) => s.set('userId', 'alice'));
+  assert.ok(setCookie, 'a signed cookie is issued');
+  let seen;
+  await pass(setCookie, (s) => { seen = s.get('userId'); });
+  assert.equal(seen, 'alice', 'the signed cookie round-trips the value');
+});
+
+test('a tampered payload is rejected (fresh empty session)', async () => {
+  const { setCookie } = await pass(null, (s) => s.set('role', 'user'));
+  const dot = setCookie.lastIndexOf('.');
+  const payload = setCookie.slice(0, dot);
+  const sig = setCookie.slice(dot);
+  // Forge the payload (e.g. escalate role) while keeping the old signature.
+  const forged = payload.replace('"user"', '"admin"') + sig;
+  assert.notEqual(forged, setCookie, 'the forged payload differs');
+  let seen = 'unset';
+  await pass(forged, (s) => { seen = s.get('role'); });
+  assert.equal(seen, undefined, 'a forged payload must yield an empty session, not the forged value');
+});
+
+test('a bit-flipped signature is rejected', async () => {
+  const { setCookie } = await pass(null, (s) => s.set('k', 'v'));
+  const dot = setCookie.lastIndexOf('.');
+  const sig = setCookie.slice(dot + 1);
+  const flippedChar = sig[0] === 'A' ? 'B' : 'A';
+  const tampered = setCookie.slice(0, dot + 1) + flippedChar + sig.slice(1);
+  assert.notEqual(tampered, setCookie, 'the signature changed');
+  let seen = 'unset';
+  await pass(tampered, (s) => { seen = s.get('k'); });
+  assert.equal(seen, undefined, 'a bad signature must yield an empty session');
+});
+
+test('a malformed cookie (no signature) is rejected', async () => {
+  let seen = 'unset';
+  await pass('{"id":"x","userId":"mallory"}', (s) => { seen = s.get('userId'); });
+  assert.equal(seen, undefined, 'an unsigned/malformed cookie must not be trusted');
+});


### PR DESCRIPTION
Closes #187

## Summary

#187 is a meta-audit: harden each subsystem (auth, session, cache, rate-limit, CSRF, websocket, vendor, serializer) by stating its invariant, adversarially reviewing it, adding a property/differential test, and dogfooding it, filing findings as `Stabilize:` sub-issues. This PR does that for the **5 subsystems with the clearest, in-process-testable invariants**, and decomposes the remaining 3 (auth, websocket, vendor) into tracked sub-issues per the meta-issue's design.

## A real bug, found by the property test

The serializer round-trip property test found a genuine correctness bug. `decodeTagged` registered a decoded value under its `_id` for reference resolution only for the container tags (Map/Set/Arr/Error/object), not for leaf rich types. So a **shared `Date`, typed array, `Blob`, or `File`** (the same instance appearing twice in a payload, where the encoder emits the second occurrence as a `Ref`) decoded the first copy but threw `Dangling reference: id=N` on the second. Any server action or `richFetch` returning such a shared value crashed on decode. Fixed by registering every object-producing leaf tag under its `_id`; shared rich leaves now round-trip AND preserve reference identity. Minimal repro that now passes: `parse(await stringify([u, u]))` for a shared `Uint8Array`.

## Subsystems hardened (invariant + property/differential test)

* **Serializer** (`parse(await stringify(x))` deep-equals `x`): a deterministic matrix of 200 rich-value trees plus the adversarial edges (reserved-key collisions at several escape depths, a Set in a Map in a cycle, exact NaN/-0/Infinity identity). Found the bug above.
* **Rate-limit** (exactly `max` pass per window, the rest 429): asserted across a range of `max` values so a `count > max` off-by-one cannot slip through, plus independent per-key budgets and window reset.
* **CSRF** (`verify` true iff header equals cookie token): every single-character tamper, length change, and missing cookie/header is rejected; two independently-issued tokens never match.
* **Cache** (recompute iff no fresh value): a fresh hit does not re-run `fn`; distinct args memoize independently; TTL expiry and `invalidate()` recompute; a corrupted (non-JSON) stored entry recomputes instead of throwing.
* **Session** (signed-cookie integrity): the signed cookie round-trips, and a forged payload, a bit-flipped signature, and a malformed/unsigned cookie are all rejected (fresh empty session, not forged data), the property that stops a client forging their own session.

## Remaining subsystems (filed as sub-issues)

The 3 subsystems whose invariants need more setup to test in isolation are decomposed into tracked `Stabilize:` sub-issues, each with its stated invariant and approach: **auth** (#209, JWT sign/verify integrity), **websocket** (#210, broadcast fan-out reaches exactly the subscribers), **vendor** (#211, pinned equals live-resolved importmap modulo elision).

## Dogfood

The example apps already exercise every subsystem: the blog does session + auth (login), rate-limit (auth middleware), CSRF (action RPC), cache (`listPosts`), the serializer (every server-action round-trip), and websocket (chat). Blog e2e **57/57** (the serializer fix did not regress any RPC round-trip).

## Test plan

* New property tests: serializer (4), rate-limit (7), CSRF (5), cache (5), session (4). All green.
* `npm test` overall: **1560/1560** (the serializer suite is 48/48 with the fix).
* Blog e2e **57/57**.

## Docs

* N/A for new API: the fix is a serializer correctness bug, the rest are tests. The invariants are documented in each test file header.
