### PR TITLE
chore: release core 0.7.5, server 0.8.7, ui 0.3.3

### DIFF
--- a/changelog/core/0.7.5.md
+++ b/changelog/core/0.7.5.md
@@ -1,0 +1,33 @@
+---
+package: "@webjsdev/core"
+version: 0.7.5
+date: 2026-06-02T12:00:00+05:30
+commit_count: 3
+---
+## Features
+
+- **`webjs:prefetch` event when a speculative fragment is cached** ([#202](https://github.com/webjsdev/webjs/pull/202)) [`651d407`](https://github.com/webjsdev/webjs/commit/651d407)
+  The client router now dispatches a `webjs:prefetch` event on `document` the
+  instant a prefetched page fragment lands in the cache and becomes
+  consumable (strictly later than the request going out). The detail is
+  `{ url, key, from: 'prefetch' }`, mirroring `webjs:navigate`, which now also
+  carries `from: 'navigate'`, so one listener can split the two. Use it to
+  instrument prefetch hit rate or gate work on a warm cache.
+
+- **Actionable SSR errors for browser-only APIs in a component** ([#208](https://github.com/webjsdev/webjs/pull/208)) [`54ffb02`](https://github.com/webjsdev/webjs/commit/54ffb02)
+  When a component touches a browser global (`document`, `window`, ...) or an
+  `HTMLElement` member on `this` (`setAttribute`, `classList`, ...) in its
+  constructor or `render()`, which the SSR pipeline runs on a bare server-side
+  class, the resulting crash now logs a message naming the offending member
+  and the fix (move it to `connectedCallback` or a lifecycle hook), instead of
+  a raw `document is not defined`.
+
+## Fixes
+
+- **shared rich values round-trip through the RPC serializer** ([#212](https://github.com/webjsdev/webjs/pull/212)) [`ff4332a`](https://github.com/webjsdev/webjs/commit/ff4332a)
+  A `Date`, typed array, `Blob`, or `File` that appears more than once in a
+  single payload (the same instance, which the encoder emits as a back
+  reference) decoded the first copy but threw `Dangling reference` on the
+  second, crashing any server action or `richFetch` that returned such a
+  shared value. The decoder now registers every leaf rich type under its id,
+  so shared rich values round-trip and preserve reference identity.

--- a/changelog/server/0.8.7.md
+++ b/changelog/server/0.8.7.md
@@ -1,0 +1,39 @@
+---
+package: "@webjsdev/server"
+version: 0.8.7
+date: 2026-06-02T12:00:00+05:30
+commit_count: 4
+---
+## Features
+
+- **`WEBJS_ELIDE` environment override for the elision switch** ([#203](https://github.com/webjsdev/webjs/pull/203)) [`444fb29`](https://github.com/webjsdev/webjs/commit/444fb29)
+  A `WEBJS_ELIDE` env var now overrides the `package.json` `webjs.elide`
+  switch: `0` / `false` / `off` / `no` force component elision off, `1` /
+  `true` / `on` / `yes` force it on, and any other value falls through. It is
+  the deploy-time escape hatch to rule elision out while debugging a suspected
+  wrong-strip, without editing committed code.
+
+- **`no-browser-globals-in-render` convention rule** ([#208](https://github.com/webjsdev/webjs/pull/208)) [`54ffb02`](https://github.com/webjsdev/webjs/commit/54ffb02)
+  `webjs check` now flags browser globals and `HTMLElement` members used in a
+  component's constructor or `render()`, which the SSR pipeline runs on a bare
+  server-side class with no DOM, so they throw at SSR time. The rule names the
+  member and the fix (move it to `connectedCallback` or a lifecycle hook). It
+  is conservative: only the constructor and render bodies are scanned, only
+  direct references, and string/template content is masked.
+
+## Fixes
+
+- **comments are masked before the elision tag and observation scans** ([#201](https://github.com/webjsdev/webjs/pull/201)) [`8b0c8d8`](https://github.com/webjsdev/webjs/commit/8b0c8d8)
+  A commented-out custom-element tag, `whenDefined`, or `@event` no longer
+  forces a display-only component to ship. The elision analyser now masks
+  comment bodies (keeping string and template content) before its tag,
+  observation, and interactivity scans, so dead code in a comment cannot
+  defeat the optimization.
+
+- **the transformed-source cache is per request handler** ([#203](https://github.com/webjsdev/webjs/pull/203)) [`444fb29`](https://github.com/webjsdev/webjs/commit/444fb29)
+  The stripped-TypeScript-plus-elision cache was module-global keyed only on
+  path and mtime, but the cached bytes bake in a handler's elision verdict, so
+  two `createRequestHandler` instances for the same app with different elision
+  settings (a multi-tenant embedder) served each other's elided source. The
+  cache now lives in per-handler state; single-handler production behaviour is
+  unchanged.

--- a/changelog/ui/0.3.3.md
+++ b/changelog/ui/0.3.3.md
@@ -1,0 +1,16 @@
+---
+package: "@webjsdev/ui"
+version: 0.3.3
+date: 2026-06-02T12:00:00+05:30
+commit_count: 1
+---
+## Fixes
+
+- **dropdown-menu `inset` is SSR-safe** ([#208](https://github.com/webjsdev/webjs/pull/208)) [`54ffb02`](https://github.com/webjsdev/webjs/commit/54ffb02)
+  `UiDropdownMenuItem`, `UiDropdownMenuLabel`, and `UiDropdownMenuSubTrigger`
+  read `this.hasAttribute('inset')` inside `render()`, which throws during SSR
+  (the server-side instance has no DOM), so the render was swallowed and the
+  items server-rendered empty, appearing only after client hydration. The
+  render-time attribute read is now a reactive `inset` boolean property the
+  SSR walker applies before render, so the items server-render their
+  `data-inset` state correctly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6984,7 +6984,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.24.0"
@@ -7005,7 +7005,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",
@@ -7049,7 +7049,7 @@
     },
     "packages/ui": {
       "name": "@webjsdev/ui",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/ui",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "description": "An AI-first component library - class-helper functions for visuals, custom elements only where state matters. Source-copied into your repo, you own it. Works with any Tailwind v4 project.",
   "bin": {


### PR DESCRIPTION
## Summary

Releases the user-facing changes from the 9 stabilize PRs merged today. Patch bumps, so every in-repo dependent's `^` range stays satisfied (no range updates needed). Merging this publishes to npm and creates the GitHub releases via the existing `release.yml` workflow.

## Versions

* **@webjsdev/core** 0.7.4 -> 0.7.5
* **@webjsdev/server** 0.8.6 -> 0.8.7
* **@webjsdev/ui** 0.3.2 -> 0.3.3

(@webjsdev/cli and @webjsdev/ts-plugin are unchanged this cycle.)

## Highlights

**core 0.7.5**
* feat: `webjs:prefetch` event when a prefetched fragment is cached (#202)
* feat: actionable SSR errors naming the browser-only member touched in a component (#208)
* fix: shared `Date` / typed array / `Blob` / `File` now round-trip through the RPC serializer instead of throwing `Dangling reference` (#212)

**server 0.8.7**
* feat: `WEBJS_ELIDE` env override for the elision switch (#203)
* feat: `no-browser-globals-in-render` convention rule (#208)
* fix: comments masked before the elision tag/observation scans (#201)
* fix: the transformed-source cache is per request handler, so two handlers with different elision settings no longer bleed (#203)

**ui 0.3.3**
* fix: dropdown-menu `inset` is SSR-safe (reads a reactive property instead of `this.hasAttribute` in render) (#208)

## Notes

Changelogs (`changelog/{core,server,ui}/*.md`) are hand-written because the squash-merge subjects are not conventional-commit prefixed, so the auto-generator had nothing to extract. `package-lock.json` is regenerated for the three bumps.
