### PR TITLE
fix: harden auth and websocket against malformed input (DoS)

### DIFF
--- a/packages/server/src/auth.js
+++ b/packages/server/src/auth.js
@@ -49,8 +49,13 @@ async function unsign(input, secret) {
   const idx = input.lastIndexOf('.');
   if (idx < 1) return null;
   const value = input.slice(0, idx);
-  const ok = await crypto.subtle.verify('HMAC', await hmacKey(secret), unb64url(input.slice(idx + 1)), enc.encode(value));
-  return ok ? value : null;
+  // `unb64url` -> `atob` throws on non-base64 input. A malformed signature
+  // (a corrupted or attacker-supplied cookie) must read as "not signed by
+  // us", not crash the request. Mirrors the guard in `decodeJwt`.
+  try {
+    const ok = await crypto.subtle.verify('HMAC', await hmacKey(secret), unb64url(input.slice(idx + 1)), enc.encode(value));
+    return ok ? value : null;
+  } catch { return null; }
 }
 
 function randomId() {

--- a/packages/server/src/broadcast.js
+++ b/packages/server/src/broadcast.js
@@ -55,7 +55,11 @@ export function broadcast(path, data, opts) {
   const msg = typeof data === 'string' ? data : data.toString();
   for (const ws of clients) {
     if (opts?.except && ws === opts.except) continue;
-    if (ws.readyState === 1) ws.send(msg);
+    if (ws.readyState !== 1) continue;
+    // A socket can die between the readyState check and the send (or send
+    // can throw for other reasons). Isolate each send so one dead client
+    // cannot abort the fan-out to everyone after it in the set.
+    try { ws.send(msg); } catch { /* drop this client's frame; close handler removes it */ }
   }
 }
 

--- a/packages/server/test/auth/malformed-cookie.test.js
+++ b/packages/server/test/auth/malformed-cookie.test.js
@@ -1,0 +1,62 @@
+/**
+ * Regression: a malformed auth cookie must read as "no session", never crash
+ * the request (#209 hardening). `unsign` (and `decodeJwt`) call `atob`, which
+ * throws on non-base64 input; an attacker or a corrupted cookie must not be
+ * able to turn that into an uncaught exception (a 500 / DoS). Both the
+ * database-strategy session cookie and the JWT cookie are covered.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createAuth, Credentials } from '../../src/auth.js';
+import { setStore, memoryStore } from '../../src/cache.js';
+
+const SECRET = 'x'.repeat(32);
+const MALFORMED = [
+  'webjs.auth=sid.@@@notbase64@@@',
+  'webjs.auth=nodotatall',
+  'webjs.auth=a.b.c.d.e',
+  'webjs.auth=.onlydot',
+  'webjs.auth=value.',
+  'webjs.auth=' + 'A'.repeat(50),
+];
+
+test('database strategy: a malformed signed cookie returns null, never throws', async () => {
+  setStore(memoryStore());
+  const auth = createAuth({
+    secret: SECRET,
+    session: { strategy: 'database' },
+    providers: [Credentials({ authorize: async () => ({ id: '1' }) })],
+  });
+  for (const cookie of MALFORMED) {
+    const req = new Request('http://x/', { headers: { cookie } });
+    const session = await auth.auth(req); // must not throw
+    assert.equal(session, null, `malformed cookie ${JSON.stringify(cookie)} must read as no session`);
+  }
+});
+
+test('jwt strategy: a malformed token cookie returns null, never throws', async () => {
+  const auth = createAuth({
+    secret: SECRET,
+    providers: [Credentials({ authorize: async () => ({ id: '1' }) })],
+  });
+  for (const cookie of MALFORMED) {
+    const req = new Request('http://x/', { headers: { cookie } });
+    assert.equal(await auth.auth(req), null, `malformed JWT cookie ${JSON.stringify(cookie)} must read as no session`);
+  }
+});
+
+test('a genuinely-signed database session still round-trips (the guard did not break the happy path)', async () => {
+  setStore(memoryStore());
+  const auth = createAuth({
+    secret: SECRET,
+    session: { strategy: 'database' },
+    providers: [Credentials({ authorize: async () => ({ id: '42', name: 'Ada' }) })],
+  });
+  const resp = await auth.signIn('credentials', {});
+  const setCookie = resp.headers.get('set-cookie');
+  const m = /webjs\.auth=([^;]+)/.exec(setCookie);
+  assert.ok(m, 'sign-in issues a signed session cookie');
+  const session = await auth.auth(new Request('http://x/', { headers: { cookie: `webjs.auth=${m[1]}` } }));
+  assert.equal(session?.user?.id, '42', 'a valid signed cookie still resolves the session');
+});

--- a/packages/server/test/broadcast/fanout-property.test.js
+++ b/packages/server/test/broadcast/fanout-property.test.js
@@ -50,6 +50,22 @@ test('a closed subscriber auto-deregisters and stops receiving', async () => {
   assert.deepEqual(b.sent, ['after-close'], 'the remaining subscriber still receives');
 });
 
+test('one client whose send throws does not abort delivery to the rest', () => {
+  // Regression (#210 hardening): a socket can die between the readyState
+  // check and the send. If that send throws, every client AFTER it in the
+  // set must still receive the message.
+  const before = mockWs();
+  const dead = mockWs();
+  dead.send = () => { throw new Error('socket gone'); };
+  const after = mockWs();
+  registerClient('/resilient', before);
+  registerClient('/resilient', dead);
+  registerClient('/resilient', after);
+  assert.doesNotThrow(() => broadcast('/resilient', 'msg'), 'a failing send must not throw out of broadcast');
+  assert.deepEqual(before.sent, ['msg'], 'a client before the dead one receives');
+  assert.deepEqual(after.sent, ['msg'], 'a client after the dead one still receives');
+});
+
 test('the `except` client is skipped', async () => {
   const sender = mockWs(), other = mockWs();
   registerClient('/c', sender);


### PR DESCRIPTION
Closes #209
Closes #210

## Summary

The adversarial-review half of the #187 subsystem hardening (the property tests landed in #213). I read the auth, websocket/broadcast, and vendor implementations hunting for real defects, the way the serializer property test surfaced the Dangling-reference bug. Two real robustness/DoS bugs found and fixed, each with a repro and a regression test. Vendor (`prunePinToReachable`, `readPinFile`) and the WS upgrade handler were reviewed and found already hardened (try/catch throughout, the pin reader even rejects `javascript:` / protocol-relative URLs), so no change there.

## Bugs fixed

* **auth (#209): a malformed cookie crashed the request instead of reading as no session.** `unsign()` calls `atob` via `unb64url`, which throws a `DOMException` on non-base64 input, but unlike `decodeJwt` it had no `try/catch`. So a malformed or attacker-supplied `webjs.auth` cookie (database strategy) or `webjs.auth.state` cookie (OAuth callback) produced an uncaught exception (a 500 / DoS) rather than being treated as unsigned. Repro: `auth.auth(req with cookie 'webjs.auth=sid.@@@')` threw `DOMException: Invalid character`. Fixed by guarding the verify in `try/catch` returning null, mirroring `decodeJwt`. (Swept every `atob`/`unb64url` call site: `session.js` was already guarded; this was the only gap.)

* **websocket (#210): one dead client aborted the whole broadcast.** `broadcast()` sent to each open client unguarded, but a socket can die between the `readyState` check and `send()`, and `ws.send()` then throws. The throw propagated out of the loop, so every client AFTER the dead one in the set received nothing. Repro: a 3-client set with a throwing middle socket left the third client with zero frames. Fixed by isolating each send in `try/catch`.

## Test plan

* Regression tests: `packages/server/test/auth/malformed-cookie.test.js` (malformed cookies return null for both strategies, never throw; a valid signed session still round-trips) and a new case in `packages/server/test/broadcast/fanout-property.test.js` (a throwing client does not abort delivery to the rest).
* `npm test`: **1628/1628**. Blog e2e (exercises auth login + chat broadcast): **64/64**.

## Docs

* N/A: these are internal robustness fixes, no public API or behaviour change beyond not-crashing. The invariants are documented in the test headers.
