### PR TITLE
chore: release @webjsdev/server 0.8.8

### DIFF
--- a/changelog/server/0.8.8.md
+++ b/changelog/server/0.8.8.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/server"
+version: 0.8.8
+date: 2026-06-02T09:15:13.538Z
+commit_count: 1
+---
+## Fixes
+
+- **harden auth and websocket against malformed input (DoS)** ([#215](https://github.com/webjsdev/webjs/pull/215)) [`fd2913a3`](https://github.com/webjsdev/webjs/commit/fd2913a3)
+  * fix: a malformed auth cookie reads as no session instead of crashing
+  
+  unsign() calls atob via unb64url, which throws a DOMException on non-base64
+  input, but unlike decodeJwt it had no try/catch. So a malformed or

--- a/package-lock.json
+++ b/package-lock.json
@@ -7005,7 +7005,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.7",
+      "version": "0.8.8",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
## Summary

Patch release of @webjsdev/server with the two security/robustness fixes from #215 (auth malformed-cookie DoS, websocket broadcast abort). Patch bump, so the cli/blog `^0.8.0` ranges stay satisfied.

The changelog `changelog/server/0.8.8.md` was **auto-generated** by the pre-commit hook from #215 conventional-commit subject (the process fix from the start-work skill, now validated end-to-end). No hand-writing.

Merging publishes @webjsdev/server 0.8.8 to npm + a GitHub Release via release.yml.