### PR TITLE
chore: release core 0.7.6, server 0.8.9, cli 0.10.4, ui 0.3.4

### DIFF
--- a/changelog/cli/0.10.4.md
+++ b/changelog/cli/0.10.4.md
@@ -1,0 +1,11 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.4
+date: 2026-06-02T17:00:58.774Z
+commit_count: 1
+---
+## Features
+
+- **make webjs check correctness-only; move conventions to CONVENTIONS.md** ([#225](https://github.com/webjsdev/webjs/pull/225)) [`f9f13e48`](https://github.com/webjsdev/webjs/commit/f9f13e48)
+
+  `webjs check` now runs only correctness checks (a crash, a security leak, a build/type-strip failure), unconditionally. The four preference rules (`actions-in-modules`, `one-function-per-action`, `tests-exist`, `no-json-data-files`) and the `package.json` `webjs.conventions` override mechanism are removed; project conventions move to `CONVENTIONS.md` guidance. The `webjs check --rules` output and the success line are updated to match.

--- a/changelog/core/0.7.6.md
+++ b/changelog/core/0.7.6.md
@@ -1,0 +1,17 @@
+---
+package: "@webjsdev/core"
+version: 0.7.6
+date: 2026-06-02T17:00:58.729Z
+commit_count: 2
+---
+## Features
+
+- **run willUpdate/hostUpdate at SSR with a server element shim** ([#218](https://github.com/webjsdev/webjs/pull/218)) [`7857a731`](https://github.com/webjsdev/webjs/commit/7857a731)
+
+  The SSR walker now runs the pre-render lifecycle (`willUpdate`, controllers' `hostUpdate`) and reflects `reflect: true` properties before `render()`, and `WebComponent`'s server base is a DOM shim backing the attribute methods, no-op events, and an inert `attachInternals`. So lit muscle-memory patterns (deriving render state in `willUpdate`, reading attributes in `render`, reflecting a property) work server-side instead of crashing or producing a wrong first paint.
+
+## Fixes
+
+- **decode Object/Array attributes at SSR** ([#221](https://github.com/webjsdev/webjs/pull/221)) [`02e14621`](https://github.com/webjsdev/webjs/commit/02e14621)
+
+  `applyAttrsToInstance` JSON-parsed the raw entity-encoded attribute text, so a JSON value in an attribute (every `"` escaped to `&quot;`) failed to parse and silently became a string at SSR. It now decodes the entities first, so the attribute form of a rich `Object` / `Array` prop renders correctly server-side.

--- a/changelog/server/0.8.9.md
+++ b/changelog/server/0.8.9.md
@@ -1,0 +1,17 @@
+---
+package: "@webjsdev/server"
+version: 0.8.9
+date: 2026-06-02T17:00:58.750Z
+commit_count: 2
+---
+## Features
+
+- **make webjs check correctness-only; move conventions to CONVENTIONS.md** ([#225](https://github.com/webjsdev/webjs/pull/225)) [`f9f13e48`](https://github.com/webjsdev/webjs/commit/f9f13e48)
+
+  `checkConventions` now runs only correctness rules (a crash, a security leak, a build/type-strip failure), unconditionally. The four preference rules (`actions-in-modules`, `one-function-per-action`, `tests-exist`, `no-json-data-files`) and the `package.json` `webjs.conventions` override mechanism (`loadConventionOverrides`, the `opts.rules` param) are removed.
+
+## Fixes
+
+- **narrow no-browser-globals-in-render for the SSR shim** ([#218](https://github.com/webjsdev/webjs/pull/218)) [`7857a731`](https://github.com/webjsdev/webjs/commit/7857a731)
+
+  Now that the SSR server base shims the attribute / event / `attachInternals` methods, `no-browser-globals-in-render` no longer flags them, and it scans `willUpdate` (which now runs at SSR) in addition to the constructor and `render`.

--- a/changelog/ui/0.3.4.md
+++ b/changelog/ui/0.3.4.md
@@ -1,0 +1,11 @@
+---
+package: "@webjsdev/ui"
+version: 0.3.4
+date: 2026-06-02T17:00:58.824Z
+commit_count: 1
+---
+## Refactor
+
+- **tooltip / hover-card read delay config via reactive props** ([#221](https://github.com/webjsdev/webjs/pull/221)) [`02e14621`](https://github.com/webjsdev/webjs/commit/02e14621)
+
+  `ui-tooltip` and `ui-hover-card` now read their `delay-duration` / `skip-delay-duration` / `open-delay` / `close-delay` config through typed reactive properties (`delayDuration` etc.) instead of `this.getAttribute`. The attribute API is unchanged (shadcn parity); the property form is now also available.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6969,7 +6969,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/server": "^0.8.0",
@@ -6984,7 +6984,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.24.0"
@@ -7005,7 +7005,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.8",
+      "version": "0.8.9",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",
@@ -7049,7 +7049,7 @@
     },
     "packages/ui": {
       "name": "@webjsdev/ui",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/ui",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "type": "module",
   "description": "An AI-first component library - class-helper functions for visuals, custom elements only where state matters. Source-copied into your repo, you own it. Works with any Tailwind v4 project.",
   "bin": {


### PR DESCRIPTION
## Summary

Release the work merged this cycle. Patch bumps keep every package in its current minor line, so the in-repo dependents that pin `^0.x.0` keep resolving the workspace copy (a minor would fall out of range).

| Package | Bump | Carries |
|---|---|---|
| `@webjsdev/core` | 0.7.5 → **0.7.6** | feat: run willUpdate/hostUpdate at SSR + server element shim (#218); fix: decode Object/Array attributes at SSR (#221) |
| `@webjsdev/server` | 0.8.8 → **0.8.9** | feat: webjs check correctness-only (#225); fix: narrow no-browser-globals-in-render for the SSR shim (#218) |
| `@webjsdev/cli` | 0.10.3 → **0.10.4** | feat: webjs check correctness-only + CLI/help update (#225) |
| `@webjsdev/ui` | 0.3.3 → **0.3.4** | refactor: tooltip/hover-card read delay config via reactive props (#221) |

`@webjsdev/ts-plugin` has no unreleased functional change, so it is not bumped.

The per-package changelog files are committed under `changelog/<pkg>/<version>.md` (auto-generated by the pre-commit hook from the conventional squash subjects, then hand-edited so each package's entry describes its own change rather than the squash body's lead paragraph).

## What merging does

Merging this PR adds the four `changelog/**.md` files to `main`, which triggers `.github/workflows/release.yml`: for each new changelog file it `npm publish`es the package (skipping versions already on the registry) and cuts a GitHub Release. Both steps are idempotent.

## Test plan

- No code change beyond the `version` fields; `package-lock.json` regenerated so `npm ci` stays in sync.
- CI (unit/integration, browser, e2e, build, conventions) runs against the bump.

## Docs

N/A because this is a release bump; the changelogs are the docs.
