### PR TITLE
refactor: finish lit-style kit conversions and re-vendor the blog ui

### DIFF
--- a/examples/blog/components/ui/alert.ts
+++ b/examples/blog/components/ui/alert.ts
@@ -1,8 +1,11 @@
 /**
- * Alert: informational banner. Composition of three class helpers.
+ * Alert: informational banner. Tier-1 class helpers; compose with a
+ * native `<div role="alert">` (or `role="status"` for non-urgent updates).
  *
  * shadcn parity:
- *   Alert (variant: default | destructive), AlertTitle, AlertDescription.
+ *   Alert (variant: default | destructive)  → alertClass({ variant })
+ *   AlertTitle                              → alertTitleClass()
+ *   AlertDescription                        → alertDescriptionClass()
  *
  * Usage:
  *   <div role="alert" class=${alertClass()}>

--- a/examples/blog/components/ui/badge.ts
+++ b/examples/blog/components/ui/badge.ts
@@ -1,15 +1,18 @@
 /**
- * Badge: small visual label. Pure class helper.
+ * Badge: small visual label. Tier-1 class helper; compose with any
+ * inline element (commonly `<span>` or `<a>` for linked badges).
  *
  * shadcn parity:
- *   variants: default | secondary | destructive | outline | ghost | link
+ *   Badge (variant: default | secondary | destructive | outline | ghost | link)
+ *                                  → badgeClass({ variant })
  *
  * Usage:
  *   <span class=${badgeClass()}>New</span>
  *   <span class=${badgeClass({ variant: 'destructive' })}>Error</span>
  *   <a    class=${badgeClass({ variant: 'link' })} href="/profile">@vivek</a>
  *
- * The `[a&]:hover:...` hover styles only apply when the element is an `<a>`.
+ * The `[a&]:hover:...` hover styles only apply when the element is an `<a>`,
+ * so a static `<span>` doesn't pick up an unwanted hover.
  *
  * Design tokens used: --primary, --secondary, --destructive, --foreground,
  * --accent, --border, --ring.

--- a/examples/blog/components/ui/button.ts
+++ b/examples/blog/components/ui/button.ts
@@ -1,11 +1,12 @@
 /**
- * Button: styled `<button>` via a class-helper function. Use with a real
- * native element so form submission, focus, keyboard activation, screen-reader
- * semantics all "just work".
+ * Button: styled native `<button>`. Tier-1 class helper. Compose with a
+ * real `<button>` (or `<a>` for link-styled buttons) so form submission,
+ * focus, keyboard activation, and screen-reader semantics all "just work".
  *
  * shadcn parity:
- *   variants: default | destructive | outline | secondary | ghost | link
- *   sizes:    default | xs | sm | lg | icon | icon-xs | icon-sm | icon-lg
+ *   Button (variant: default | destructive | outline | secondary | ghost | link)
+ *         (size:    default | xs | sm | lg | icon | icon-xs | icon-sm | icon-lg)
+ *                                            → buttonClass({ variant, size })
  *
  * Usage:
  *   <button class=${buttonClass()} type="submit">Save</button>
@@ -13,9 +14,8 @@
  *   <button class=${buttonClass({ size: 'icon' })} aria-label="Settings">⚙</button>
  *   <a       class=${buttonClass({ variant: 'link' })} href="/about">About</a>
  *
- * The shadcn React component supports `asChild` to apply Button styles to a
- * different element. The web equivalent is just calling buttonClass() and
- * spreading the classes onto whatever element you want: no Slot needed.
+ * shadcn React's `asChild` (Slot) prop has no equivalent here: just call
+ * `buttonClass(...)` and spread the classes onto whatever element you want.
  *
  * Design tokens used: --primary, --primary-foreground, --destructive,
  * --secondary, --secondary-foreground, --accent, --accent-foreground,
@@ -23,8 +23,16 @@
  */
 import { cn } from '../../lib/utils/cn.ts';
 
+// cursor-pointer is on the BASE so every variant (default, outline,
+// ghost, link, …) gets the right hover affordance. Native <button>
+// defaults to the OS arrow cursor in Chromium and Firefox: fine for
+// native chrome but unusual for app buttons; shadcn's modern Button
+// has long since gravitated toward an explicit cursor-pointer in the
+// real world (see the open issue shadcn-ui/ui#1791). disabled:pointer-
+// events-none below already suppresses cursor on disabled buttons by
+// virtue of the element not receiving pointer events at all.
 const BASE =
-  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4";
+  "inline-flex shrink-0 cursor-pointer items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4";
 
 const VARIANTS = {
   default: 'bg-primary text-primary-foreground hover:bg-primary/90',

--- a/examples/blog/components/ui/card.ts
+++ b/examples/blog/components/ui/card.ts
@@ -1,9 +1,15 @@
 /**
- * Card: visual container. Pure class-helper functions; compose with any
- * element you like (most commonly `<div>`).
+ * Card: visual container. Tier-1 class helpers; compose with `<div>`
+ * (or any element) for each subpart.
  *
  * shadcn parity:
- *   Card, CardHeader, CardTitle, CardDescription, CardAction, CardContent, CardFooter.
+ *   Card (size: default | sm)  → cardClass({ size })
+ *   CardHeader                 → cardHeaderClass()
+ *   CardTitle                  → cardTitleClass()
+ *   CardDescription            → cardDescriptionClass()
+ *   CardAction                 → cardActionClass()
+ *   CardContent                → cardContentClass()
+ *   CardFooter                 → cardFooterClass()
  *
  * Usage:
  *   <div class=${cardClass()}>
@@ -23,16 +29,46 @@
  * Design tokens used: --card, --card-foreground, --muted-foreground, --border.
  */
 
-/** Card root. `data-slot="card"` recommended on the host. */
-export const cardClass = (): string =>
-  'flex flex-col gap-6 rounded-xl border bg-card py-6 text-card-foreground shadow-sm';
+export type CardSize = 'default' | 'sm';
 
-/** Card header: supports an optional `CardAction` slot via grid layout. */
+/**
+ * Card root. shadcn ships `size?: "default" | "sm"` on Card across
+ * 14/15 style families (only new-york-v4 omits it). The class string
+ * uses `group/card` so the header / title / content / footer helpers
+ * can read the parent card's data-size and adjust their own padding
+ * + gap.
+ *
+ * USAGE: pass size to cardClass AND set data-size="<size>" on the
+ * same host element so the group-data-[size=...]/card child rules
+ * fire. Set `data-slot="card"` for shadcn parity.
+ *
+ *   <div class=${cardClass({ size: 'sm' })} data-slot="card" data-size="sm">
+ *     <div class=${cardHeaderClass()}>...</div>
+ *     ...
+ *   </div>
+ *
+ * Sizes:
+ *   default: gap-6 / py-6 (shadcn new-york-v4 default)
+ *   sm:     gap-3 / py-3 (shadcn radix-nova + base-* defaults)
+ */
+export const cardClass = (opts: { size?: CardSize } = {}): string => {
+  const size = opts.size ?? 'default';
+  const base =
+    'group/card flex flex-col rounded-xl border bg-card text-card-foreground shadow-sm';
+  return size === 'sm' ? base + ' gap-3 py-3' : base + ' gap-6 py-6';
+};
+
+/**
+ * Card header: supports an optional `CardAction` slot via grid layout.
+ * group-data-[size=sm]/card rules pick up the compact layout when the
+ * root card carries data-size="sm".
+ */
 export const cardHeaderClass = (): string =>
-  '@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6';
+  '@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6 group-data-[size=sm]/card:px-4 group-data-[size=sm]/card:gap-1 group-data-[size=sm]/card:[.border-b]:pb-3';
 
-/** Card title: heading text within the header. */
-export const cardTitleClass = (): string => 'leading-none font-semibold';
+/** Card title: heading text within the header. Smaller when card is data-size="sm". */
+export const cardTitleClass = (): string =>
+  'leading-none font-semibold group-data-[size=sm]/card:text-sm';
 
 /** Card description: subdued caption beneath the title. */
 export const cardDescriptionClass = (): string => 'text-sm text-muted-foreground';
@@ -41,8 +77,10 @@ export const cardDescriptionClass = (): string => 'text-sm text-muted-foreground
 export const cardActionClass = (): string =>
   'col-start-2 row-span-2 row-start-1 self-start justify-self-end';
 
-/** Card content: the main body region. */
-export const cardContentClass = (): string => 'px-6';
+/** Card content: the main body region. Tighter padding when card is data-size="sm". */
+export const cardContentClass = (): string =>
+  'px-6 group-data-[size=sm]/card:px-4';
 
-/** Card footer: trailing controls or actions. */
-export const cardFooterClass = (): string => 'flex items-center px-6 [.border-t]:pt-6';
+/** Card footer: trailing controls or actions. Tighter padding when card is data-size="sm". */
+export const cardFooterClass = (): string =>
+  'flex items-center px-6 [.border-t]:pt-6 group-data-[size=sm]/card:px-4 group-data-[size=sm]/card:[.border-t]:pt-3';

--- a/examples/blog/components/ui/dialog.ts
+++ b/examples/blog/components/ui/dialog.ts
@@ -1,96 +1,116 @@
 /**
- * Dialog: modal dialog with focus trap, Escape-to-close, and overlay click.
+ * Dialog: modal dialog built on the native `<dialog>` element. Tier-2.
+ * The custom element is a thin decorator over `HTMLDialogElement.showModal()`,
+ * which gives us top-layer rendering (no z-index wars), the `::backdrop`
+ * pseudo, focus trap with initial-focus + restore-on-close, Escape-to-close
+ * via the cancel event, and background-inert for free.
  *
- * APG pattern: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/
+ * Composition: `<ui-dialog-content>` owns the native `<dialog>` element
+ * (its render() emits the `<dialog>` wrapper around its slotted content),
+ * while `<ui-dialog>` just tracks open state and asks the content child
+ * to `showModal()` / `close()`. Every <slot> is a default slot, which
+ * avoids the SSR pitfall where slot="..." set in connectedCallback never
+ * runs server-side (linkedom has no upgrade lifecycle).
  *
  * shadcn parity:
- *   <Dialog>            → <ui-dialog open>
- *   <DialogTrigger>     → <ui-dialog-trigger>
- *   <DialogContent>     → <ui-dialog-content>
- *   <DialogClose>       → <ui-dialog-close>
- *   <DialogHeader>      → div with dialogHeaderClass()
- *   <DialogTitle>       → h2/div with dialogTitleClass()
- *   <DialogDescription> → p with dialogDescriptionClass()
- *   <DialogFooter>      → div with dialogFooterClass()
+ *   Dialog             → <ui-dialog open>
+ *   DialogTrigger      → <ui-dialog-trigger>
+ *   DialogContent      → <ui-dialog-content show-close-button>
+ *   DialogClose        → <ui-dialog-close>
+ *   DialogHeader       → <div class=${dialogHeaderClass()}>
+ *   DialogTitle        → <h2 class=${dialogTitleClass()}>
+ *   DialogDescription  → <p class=${dialogDescriptionClass()}>
+ *   DialogFooter       → <div class=${dialogFooterClass()}>
  *
  * Usage:
  *   <ui-dialog>
  *     <ui-dialog-trigger>
- *       <button class=${buttonClass({ variant: 'outline' })}>Open</button>
+ *       <button class=${buttonClass({ variant: 'outline' })}>Edit profile</button>
  *     </ui-dialog-trigger>
  *     <ui-dialog-content>
  *       <div class=${dialogHeaderClass()}>
  *         <h2 class=${dialogTitleClass()}>Edit profile</h2>
- *         <p class=${dialogDescriptionClass()}>Make changes here.</p>
+ *         <p class=${dialogDescriptionClass()}>Make changes and click save.</p>
+ *       </div>
+ *       <div class="grid gap-3">
+ *         <label class=${labelClass()} for="dlg-name">Name</label>
+ *         <input class=${inputClass()} id="dlg-name" placeholder="Your name">
  *       </div>
  *       <div class=${dialogFooterClass()}>
- *         <ui-dialog-close>
- *           <button class=${buttonClass({ variant: 'outline' })}>Cancel</button>
- *         </ui-dialog-close>
- *         <button class=${buttonClass()} type="submit">Save</button>
+ *         <ui-dialog-close><button class=${buttonClass({ variant: 'outline' })}>Cancel</button></ui-dialog-close>
+ *         <button class=${buttonClass()}>Save</button>
  *       </div>
  *     </ui-dialog-content>
  *   </ui-dialog>
  *
+ *   <!-- Suppress the auto-injected top-right X close: -->
+ *   <ui-dialog-content show-close-button="false">…</ui-dialog-content>
+ *
  * Attributes on <ui-dialog>:
- *   `open`: boolean (reflected). Presence ⇒ dialog is shown.
+ *   `open`:  boolean (reflected). Presence shows the dialog.
  *
- * Events fired on <ui-dialog>:
- *   `ui-open-change`: `{ detail: { open: boolean } }`: fires after the
- *     element transitions between open / closed states.
+ * Attributes on <ui-dialog-content>:
+ *   `show-close-button`: "false" suppresses the auto-injected top-right X
+ *                        close button (default: shown).
  *
- * Keyboard:
- *   Escape           close
- *   Tab / Shift-Tab  cycle focusable elements within the dialog content
+ * Events:
+ *   `ui-open-change` on <ui-dialog>: `{ detail: { open } }` after a transition.
  *
- * Programmatic API on <ui-dialog>:
- *   .show()   .hide()   .toggle()
+ * Programmatic API on <ui-dialog>: `.show()` · `.hide()` · `.toggle()`.
  *
- * Design tokens used: --background, --border, --muted-foreground, --foreground.
+ * Keyboard: Escape closes (native `cancel` event); Tab cycles trapped
+ * within the dialog (native focus trap).
+ *
+ * Design tokens used: --background, --border, --muted-foreground.
  */
-
-import { cn, Base, defineElement } from '../../lib/utils/cn.ts';
+import { WebComponent, html, unsafeHTML } from '@webjsdev/core';
+import { ref, createRef } from '@webjsdev/core/directives';
+import { buttonClass } from './button.ts';
 
 // --------------------------------------------------------------------------
-// Class helpers for static subparts. Compose with plain elements.
+// Class helpers for subparts.
 // --------------------------------------------------------------------------
 
-/** Dialog header: flex column for title + description, stacks on mobile. */
 export const dialogHeaderClass = (): string =>
   'flex flex-col gap-2 text-center sm:text-left';
 
-/** Dialog title: large semibold heading. */
 export const dialogTitleClass = (): string =>
   'text-lg leading-none font-semibold';
 
-/** Dialog description: subdued caption below the title. */
 export const dialogDescriptionClass = (): string =>
   'text-sm text-muted-foreground';
 
-/** Dialog footer: right-aligned actions on desktop, reverse-stacked on mobile. */
 export const dialogFooterClass = (): string =>
   'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end';
 
-/** Dialog content panel: centered, fixed-position box with shadow + border. */
 export const dialogContentClass = (): string =>
   'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none sm:max-w-lg';
 
-/** Dialog backdrop: fixed full-viewport translucent overlay. */
-export const dialogOverlayClass = (): string => 'fixed inset-0 z-50 bg-black/50';
+export const dialogCloseButtonClass = (): string =>
+  "absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4";
+
+const DIALOG_CLOSE_X_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 6 6 18M6 6l12 12"></path></svg>';
 
 // --------------------------------------------------------------------------
-// Visibility CSS: installed once. Hides content + overlay when the host
-// <ui-dialog> doesn't have the `open` attribute. This works at SSR time too:
-// because SSR includes no `open` attribute by default, content is invisible
-// until JS hydrates and the user opens the dialog.
+// Pre-hydration paint fallback. Before the script upgrades the custom
+// elements, <ui-dialog-content> sits in normal flow and would flash
+// visible. The selector-based rules hide it until JS marks the host as
+// `[open]`. Once upgraded, the native <dialog> wrapper takes over:
+// closed `<dialog>` is UA `display: none`; opened via showModal() is
+// `display: block` in the top layer.
 // --------------------------------------------------------------------------
 
 const STYLES = `
-ui-dialog:not([open]) ui-dialog-content,
-ui-dialog:not([open]) ui-dialog-overlay { display: none !important; }
+ui-dialog:not([open]) ui-dialog-content { display: none !important; }
 ui-dialog[open] { display: contents; }
 ui-dialog-content { display: grid; }
 `;
+
+// Clears the UA defaults on <dialog> so it becomes an invisible top-layer
+// host. The visible box is rendered by <ui-dialog-content>. The
+// backdrop: variant styles the ::backdrop pseudo-element.
+const NATIVE_DIALOG_CLASS = 'border-0 bg-transparent p-0 m-0 w-0 h-0 max-w-none max-h-none overflow-visible text-inherit backdrop:bg-black/50';
 
 function installStyles(): void {
   if (typeof document === 'undefined') return;
@@ -102,244 +122,264 @@ function installStyles(): void {
 }
 
 // --------------------------------------------------------------------------
-// Body scroll lock: refcounted so multiple open dialogs nest correctly.
+// Body scroll lock. Refcounted so nested dialogs unlock in order. Native
+// <dialog> does not lock body scroll, only inert-ifies the background.
 // --------------------------------------------------------------------------
 
 let scrollLockCount = 0;
 let savedOverflow = '';
+let savedPaddingRight = '';
 
 function lockScroll(): void {
   if (scrollLockCount === 0) {
+    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
     savedOverflow = document.body.style.overflow;
+    savedPaddingRight = document.body.style.paddingRight;
     document.body.style.overflow = 'hidden';
+    if (scrollbarWidth > 0) document.body.style.paddingRight = `${scrollbarWidth}px`;
   }
   scrollLockCount++;
 }
 
 function unlockScroll(): void {
   scrollLockCount = Math.max(0, scrollLockCount - 1);
-  if (scrollLockCount === 0) document.body.style.overflow = savedOverflow;
-}
-
-// --------------------------------------------------------------------------
-// Focus management: find focusables, trap Tab, restore focus on close.
-// --------------------------------------------------------------------------
-
-const FOCUSABLE_SELECTOR = [
-  'a[href]',
-  'button:not([disabled])',
-  'input:not([disabled])',
-  'textarea:not([disabled])',
-  'select:not([disabled])',
-  '[tabindex]:not([tabindex="-1"])',
-  '[contenteditable="true"]',
-].join(',');
-
-function getFocusables(root: HTMLElement): HTMLElement[] {
-  return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
-    (el) => !el.hasAttribute('aria-hidden') && el.offsetParent !== null,
-  );
-}
-
-// --------------------------------------------------------------------------
-// <ui-dialog> owns open state, focus trap, escape, scroll lock.
-// --------------------------------------------------------------------------
-
-export class UiDialog extends Base {
-  static get observedAttributes(): string[] {
-    return ['open'];
+  if (scrollLockCount === 0) {
+    document.body.style.overflow = savedOverflow;
+    document.body.style.paddingRight = savedPaddingRight;
   }
+}
 
-  private _previouslyFocused: HTMLElement | null = null;
-  private _keyHandler = (e: KeyboardEvent): void => this._onKeyDown(e);
+// --------------------------------------------------------------------------
+// <ui-dialog>
+// Owns the open state. Defers the actual <dialog> element to the child
+// <ui-dialog-content> (so no named slot is needed, which avoids the
+// SSR routing problem). On open transitions, asks the content child
+// to showModal() / close() its inner <dialog>.
+// --------------------------------------------------------------------------
+
+export class UiDialog extends WebComponent {
+  static properties = {
+    open: { type: Boolean, reflect: true },
+  };
+  declare open: boolean;
+
+  constructor() {
+    super();
+    this.open = false;
+  }
 
   connectedCallback(): void {
     installStyles();
-    this.setAttribute('data-slot', 'dialog');
-    // Auto-ensure an overlay element exists inside the dialog so styles work
-    // even if the author forgot to write <ui-dialog-overlay>.
-    if (!this.querySelector(':scope > ui-dialog-overlay')) {
-      const overlay = document.createElement('ui-dialog-overlay');
-      this.insertBefore(overlay, this.firstChild);
-    }
-    this._reflect();
+    // Legacy <ui-dialog-overlay> isn't supported anymore; the native
+    // ::backdrop pseudo replaces it. Strip it if a stale doc uses it.
+    this.querySelector<HTMLElement>(':scope > ui-dialog-overlay')?.remove();
+    super.connectedCallback?.();
   }
 
   disconnectedCallback(): void {
-    if (this.isOpen) {
-      this._teardown();
-    }
+    if (this.open) this._teardown();
+    super.disconnectedCallback?.();
   }
 
-  attributeChangedCallback(name: string, oldVal: string | null, newVal: string | null): void {
-    if (name === 'open' && oldVal !== newVal) {
-      this._reflect();
-      if (newVal !== null) this._setup();
+  show(): void { this.open = true; }
+  hide(): void { this.open = false; }
+  toggle(): void { this.open = !this.open; }
+
+  // Back-compat getter alongside the reactive `open` prop.
+  get isOpen(): boolean { return this.open; }
+
+  render() {
+    return html`<div data-slot="dialog" data-state=${this.open ? 'open' : 'closed'}>
+      <slot></slot>
+    </div>`;
+  }
+
+  updated(changedProperties: Map<string, unknown>): void {
+    if (!changedProperties.has('open')) return;
+    // Constructor sets open=false, which records a (undefined -> false)
+    // transition in the first update. Skip it so the dialog doesn't
+    // emit a teardown + ui-open-change for the initial state.
+    if (changedProperties.get('open') === undefined) return;
+    // Defer one microtask so the content child has committed its own
+    // render (the native <dialog> element lives in the content's template).
+    queueMicrotask(() => {
+      if (this.open) this._setup();
       else this._teardown();
       this.dispatchEvent(
-        new CustomEvent('ui-open-change', { detail: { open: this.isOpen }, bubbles: true }),
+        new CustomEvent('ui-open-change', { detail: { open: this.open }, bubbles: true }),
       );
-    }
-  }
-
-  get isOpen(): boolean {
-    return this.hasAttribute('open');
-  }
-
-  set isOpen(v: boolean) {
-    if (v) this.setAttribute('open', '');
-    else this.removeAttribute('open');
-  }
-
-  show(): void {
-    this.isOpen = true;
-  }
-
-  hide(): void {
-    this.isOpen = false;
-  }
-
-  toggle(): void {
-    this.isOpen = !this.isOpen;
-  }
-
-  private _reflect(): void {
-    this.setAttribute('data-state', this.isOpen ? 'open' : 'closed');
-    const content = this.querySelector<HTMLElement>(':scope > ui-dialog-content');
-    if (content) {
-      content.setAttribute('data-state', this.isOpen ? 'open' : 'closed');
-      content.setAttribute('role', 'dialog');
-      content.setAttribute('aria-modal', 'true');
-    }
-  }
-
-  private _setup(): void {
-    this._previouslyFocused = document.activeElement as HTMLElement | null;
-    lockScroll();
-    document.addEventListener('keydown', this._keyHandler);
-    // Focus first focusable inside the content after a microtask so DOM is settled.
-    queueMicrotask(() => {
-      const content = this.querySelector<HTMLElement>(':scope > ui-dialog-content');
-      if (!content) return;
-      const focusables = getFocusables(content);
-      (focusables[0] ?? content).focus({ preventScroll: true });
     });
   }
 
-  private _teardown(): void {
+  get _content(): UiDialogContent | null {
+    return this.querySelector('ui-dialog-content') as UiDialogContent | null;
+  }
+
+  _setup(): void {
+    const content = this._content;
+    if (!content) return;
+    lockScroll();
+    content.showModal();
+  }
+
+  _teardown(): void {
     unlockScroll();
-    document.removeEventListener('keydown', this._keyHandler);
-    if (this._previouslyFocused) {
-      this._previouslyFocused.focus({ preventScroll: true });
-      this._previouslyFocused = null;
-    }
-  }
-
-  private _onKeyDown(e: KeyboardEvent): void {
-    if (!this.isOpen) return;
-    if (e.key === 'Escape') {
-      e.preventDefault();
-      this.hide();
-      return;
-    }
-    if (e.key === 'Tab') {
-      const content = this.querySelector<HTMLElement>(':scope > ui-dialog-content');
-      if (!content) return;
-      const focusables = getFocusables(content);
-      if (focusables.length === 0) {
-        e.preventDefault();
-        content.focus();
-        return;
-      }
-      const first = focusables[0];
-      const last = focusables[focusables.length - 1];
-      const active = document.activeElement as HTMLElement | null;
-      if (e.shiftKey && active === first) {
-        e.preventDefault();
-        last.focus();
-      } else if (!e.shiftKey && active === last) {
-        e.preventDefault();
-        first.focus();
-      }
-    }
+    this._content?.close();
   }
 }
-defineElement('ui-dialog', UiDialog);
+UiDialog.register('ui-dialog');
 
 // --------------------------------------------------------------------------
-// <ui-dialog-trigger> clicks on this (or any element inside) open the
-// enclosing <ui-dialog>. Decorator only: does not render anything.
+// <ui-dialog-trigger>
 // --------------------------------------------------------------------------
 
-export class UiDialogTrigger extends Base {
-  connectedCallback(): void {
-    this.setAttribute('data-slot', 'dialog-trigger');
-    this.addEventListener('click', this._onClick);
+export class UiDialogTrigger extends WebComponent {
+  render() {
+    return html`<div
+      data-slot="dialog-trigger"
+      @click=${this._onClick}
+    ><slot></slot></div>`;
   }
-  disconnectedCallback(): void {
-    this.removeEventListener('click', this._onClick);
-  }
-  private _onClick = (): void => {
-    const dialog = this.closest('ui-dialog') as UiDialog | null;
-    dialog?.show();
+
+  _onClick = (): void => {
+    (this.closest('ui-dialog') as UiDialog | null)?.show();
   };
 }
-defineElement('ui-dialog-trigger', UiDialogTrigger);
+UiDialogTrigger.register('ui-dialog-trigger');
 
 // --------------------------------------------------------------------------
-// <ui-dialog-content> is the centered panel. Applies the visual classes from
-// dialogContentClass() to its host, merging with any user-provided class.
+// <ui-dialog-content>
+// Auto-injects an X close button (top-right) unless show-close-button="false".
 // --------------------------------------------------------------------------
 
-export class UiDialogContent extends Base {
-  connectedCallback(): void {
-    this.setAttribute('data-slot', 'dialog-content');
-    this.setAttribute('tabindex', '-1');
-    const userClass = this.getAttribute('class') ?? '';
-    this.className = cn(dialogContentClass(), userClass);
+// <ui-dialog-content> owns the native <dialog> element. Renders a native
+// <dialog> wrapper around its slotted content, plus the auto-injected X
+// close button. Exposes showModal() / close() so the parent <ui-dialog>
+// can drive the open state imperatively without a named slot.
+
+export class UiDialogContent extends WebComponent {
+  static properties = {
+    showCloseButton: { type: String, reflect: true, attribute: 'show-close-button' },
+  };
+  declare showCloseButton: string;
+
+  // ref to the own-rendered native <dialog>. render() creates it, so a
+  // ref() binding is the lit-idiomatic handle (no querySelector against
+  // a string selector into the component's own output).
+  #dialog = createRef<HTMLDialogElement>();
+
+  constructor() {
+    super();
+    this.showCloseButton = 'true';
+  }
+
+  showModal(): void {
+    const native = this.#dialog.value;
+    if (native && !native.open) native.showModal();
+  }
+
+  close(): void {
+    const native = this.#dialog.value;
+    if (native?.open) native.close();
+  }
+
+  render() {
+    const wantClose = this.showCloseButton !== 'false';
+    const parentOpen = !!this._parent()?.open;
+    return html`<dialog
+      data-slot="dialog-native"
+      class=${NATIVE_DIALOG_CLASS}
+      ${ref(this.#dialog)}
+      @close=${this._onNativeClose}
+      @click=${this._onNativeBackdropClick}
+    ><div
+      data-slot="dialog-content"
+      role="dialog"
+      aria-modal="true"
+      tabindex="-1"
+      data-state=${parentOpen ? 'open' : 'closed'}
+      class=${dialogContentClass()}
+    >
+      <slot></slot>
+      ${wantClose
+        ? html`<button
+            type="button"
+            aria-label="Close"
+            data-slot="dialog-close"
+            class=${dialogCloseButtonClass()}
+            @click=${this._onAutoCloseClick}
+          >${unsafeHTML(DIALOG_CLOSE_X_SVG)}</button>`
+        : ''}
+    </div></dialog>`;
+  }
+
+  _onAutoCloseClick = (): void => {
+    this._parent()?.hide();
+  };
+
+  _onNativeClose = (): void => {
+    const p = this._parent();
+    if (p?.open) p.open = false;
+  };
+
+  // Backdrop-click closes the dialog: the click target on the backdrop is
+  // the <dialog> element itself (the inner content panel catches its own
+  // clicks).
+  _onNativeBackdropClick = (e: MouseEvent): void => {
+    if (e.target === e.currentTarget) this._parent()?.hide();
+  };
+
+  // SSR-safe: linkedom doesn't implement closest() on custom elements.
+  _parent(): UiDialog | null {
+    if (typeof this.closest !== 'function') return null;
+    return this.closest('ui-dialog') as UiDialog | null;
   }
 }
-defineElement('ui-dialog-content', UiDialogContent);
+UiDialogContent.register('ui-dialog-content');
 
 // --------------------------------------------------------------------------
-// <ui-dialog-overlay> is the translucent backdrop. Clicks here close the
-// enclosing dialog (matches shadcn's modal-close-on-overlay behavior).
+// <ui-dialog-close>
 // --------------------------------------------------------------------------
 
-export class UiDialogOverlay extends Base {
-  connectedCallback(): void {
-    this.setAttribute('data-slot', 'dialog-overlay');
-    this.setAttribute('aria-hidden', 'true');
-    const userClass = this.getAttribute('class') ?? '';
-    this.className = cn(dialogOverlayClass(), userClass);
-    this.addEventListener('click', this._onClick);
+export class UiDialogClose extends WebComponent {
+  render() {
+    return html`<div
+      data-slot="dialog-close"
+      @click=${this._onClick}
+    ><slot></slot></div>`;
   }
-  disconnectedCallback(): void {
-    this.removeEventListener('click', this._onClick);
-  }
-  private _onClick = (): void => {
-    const dialog = this.closest('ui-dialog') as UiDialog | null;
-    dialog?.hide();
+
+  _onClick = (): void => {
+    (this.closest('ui-dialog') as UiDialog | null)?.hide();
   };
 }
-defineElement('ui-dialog-overlay', UiDialogOverlay);
+UiDialogClose.register('ui-dialog-close');
 
 // --------------------------------------------------------------------------
-// <ui-dialog-close> clicks on this (or any element inside) close the
-// enclosing dialog.
+// <ui-dialog-footer>
 // --------------------------------------------------------------------------
 
-export class UiDialogClose extends Base {
-  connectedCallback(): void {
-    this.setAttribute('data-slot', 'dialog-close');
-    this.addEventListener('click', this._onClick);
-  }
-  disconnectedCallback(): void {
-    this.removeEventListener('click', this._onClick);
-  }
-  private _onClick = (): void => {
-    const dialog = this.closest('ui-dialog') as UiDialog | null;
-    dialog?.hide();
+export class UiDialogFooter extends WebComponent {
+  static properties = {
+    showCloseButton: { type: String, attribute: 'show-close-button' },
   };
+  declare showCloseButton: string | null;
+
+  constructor() {
+    super();
+    this.showCloseButton = null;
+  }
+
+  render() {
+    const wantClose = this.showCloseButton !== null && this.showCloseButton !== 'false';
+    return html`<div data-slot="dialog-footer" class=${dialogFooterClass()}>
+      <slot></slot>
+      ${wantClose
+        ? html`<ui-dialog-close>
+            <button class=${buttonClass({ variant: 'outline' })} type="button">Close</button>
+          </ui-dialog-close>`
+        : ''}
+    </div>`;
+  }
 }
-defineElement('ui-dialog-close', UiDialogClose);
+UiDialogFooter.register('ui-dialog-footer');

--- a/examples/blog/components/ui/input.ts
+++ b/examples/blog/components/ui/input.ts
@@ -1,8 +1,12 @@
 /**
- * Input: styled native `<input>` via a class-helper function. Works with
- * every native input type (text, email, password, number, search, tel, url,
- * date, time, file, color, …). Form submission, autocomplete, browser
- * validation, and password managers all work because it IS the native input.
+ * Input: styled native `<input>`. Tier-1 class helper. Works with every
+ * input type (text, email, password, number, search, tel, url, date,
+ * time, file, color, …). Form submission, autocomplete, browser
+ * validation, and password managers all work because it IS the native
+ * input.
+ *
+ * shadcn parity:
+ *   Input  → inputClass()
  *
  * Usage:
  *   <input class=${inputClass()} type="email" name="email" id="email" required

--- a/examples/blog/components/ui/label.ts
+++ b/examples/blog/components/ui/label.ts
@@ -1,17 +1,18 @@
 /**
- * Label: styled native `<label>` via a class-helper function. Use with a real
- * `<label for="...">` so click-to-focus, `htmlFor`/`for` linking, and screen
- * reader association all work natively.
+ * Label: styled native `<label>`. Tier-1 class helper. Compose with a
+ * real `<label for="...">` so click-to-focus, `htmlFor` / `for` linking,
+ * and screen-reader association all work natively (no Radix Label needed).
  *
- * shadcn parity: matches shadcn's Label component (which wraps Radix Label).
+ * shadcn parity:
+ *   Label  → labelClass()
  *
  * Usage:
  *   <label class=${labelClass()} for="email">Email</label>
  *   <input class=${inputClass()} id="email" name="email" type="email">
  *
- * Disabled-state inheritance: when a label is inside a container with
- * `data-disabled="true"` (the "field" pattern), it dims automatically.
- * When a label sits next to a peer-disabled control, same effect.
+ * Disabled-state inheritance: when the label is inside a container with
+ * `data-disabled="true"` (the "field" pattern), or next to a peer-disabled
+ * control, it dims automatically.
  *
  * Design tokens used: none (typography only).
  */

--- a/examples/blog/components/ui/separator.ts
+++ b/examples/blog/components/ui/separator.ts
@@ -1,11 +1,11 @@
 /**
- * Separator: horizontal or vertical divider. Pure class helper. For
- * accessibility, set `role="separator"` (or `role="none"` for purely
- * decorative use) and `aria-orientation` on the element.
+ * Separator: horizontal or vertical divider. Tier-1 class helper. For
+ * accessibility, set `role="separator"` + `aria-orientation` on the
+ * element (or `role="none"` for purely decorative use).
  *
  * shadcn parity:
- *   orientation: horizontal (default) | vertical
- *   decorative: true (default: uses `role="none"`)
+ *   Separator (orientation: horizontal | vertical, decorative: bool)
+ *                          → separatorClass({ orientation }) + role + data-orientation
  *
  * Usage:
  *   <div role="none" class=${separatorClass()} data-orientation="horizontal"></div>

--- a/packages/ui/packages/registry/components/alert-dialog.ts
+++ b/packages/ui/packages/registry/components/alert-dialog.ts
@@ -64,6 +64,7 @@
  * Design tokens used: --background, --border, --muted-foreground.
  */
 import { WebComponent, html } from '@webjsdev/core';
+import { ref, createRef } from '@webjsdev/core/directives';
 import { buttonClass, type ButtonVariant, type ButtonSize } from './button.ts';
 
 export const alertDialogContentClass = (): string =>
@@ -228,18 +229,23 @@ export class UiAlertDialogContent extends WebComponent {
   };
   declare size: 'default' | 'sm';
 
+  // ref to the own-rendered native <dialog>. render() creates it, so a
+  // ref() binding is the lit-idiomatic handle (no querySelector against
+  // a string selector into the component's own output).
+  #dialog = createRef<HTMLDialogElement>();
+
   constructor() {
     super();
     this.size = 'default';
   }
 
   showModal(): void {
-    const native = this.querySelector<HTMLDialogElement>('dialog[data-slot="alert-dialog-native"]');
+    const native = this.#dialog.value;
     if (native && !native.open) native.showModal();
   }
 
   close(): void {
-    const native = this.querySelector<HTMLDialogElement>('dialog[data-slot="alert-dialog-native"]');
+    const native = this.#dialog.value;
     if (native?.open) native.close();
   }
 
@@ -248,6 +254,7 @@ export class UiAlertDialogContent extends WebComponent {
     return html`<dialog
       data-slot="alert-dialog-native"
       class=${NATIVE_DIALOG_CLASS}
+      ${ref(this.#dialog)}
       @cancel=${this._onNativeCancel}
       @close=${this._onNativeClose}
     ><div

--- a/packages/ui/packages/registry/components/dialog.ts
+++ b/packages/ui/packages/registry/components/dialog.ts
@@ -64,6 +64,7 @@
  * Design tokens used: --background, --border, --muted-foreground.
  */
 import { WebComponent, html, unsafeHTML } from '@webjsdev/core';
+import { ref, createRef } from '@webjsdev/core/directives';
 import { buttonClass } from './button.ts';
 
 // --------------------------------------------------------------------------
@@ -262,18 +263,23 @@ export class UiDialogContent extends WebComponent {
   };
   declare showCloseButton: string;
 
+  // ref to the own-rendered native <dialog>. render() creates it, so a
+  // ref() binding is the lit-idiomatic handle (no querySelector against
+  // a string selector into the component's own output).
+  #dialog = createRef<HTMLDialogElement>();
+
   constructor() {
     super();
     this.showCloseButton = 'true';
   }
 
   showModal(): void {
-    const native = this.querySelector<HTMLDialogElement>('dialog[data-slot="dialog-native"]');
+    const native = this.#dialog.value;
     if (native && !native.open) native.showModal();
   }
 
   close(): void {
-    const native = this.querySelector<HTMLDialogElement>('dialog[data-slot="dialog-native"]');
+    const native = this.#dialog.value;
     if (native?.open) native.close();
   }
 
@@ -283,6 +289,7 @@ export class UiDialogContent extends WebComponent {
     return html`<dialog
       data-slot="dialog-native"
       class=${NATIVE_DIALOG_CLASS}
+      ${ref(this.#dialog)}
       @close=${this._onNativeClose}
       @click=${this._onNativeBackdropClick}
     ><div

--- a/packages/ui/packages/registry/components/dropdown-menu.ts
+++ b/packages/ui/packages/registry/components/dropdown-menu.ts
@@ -74,7 +74,7 @@
  * Design tokens used: --popover, --popover-foreground, --accent,
  * --accent-foreground, --destructive, --muted-foreground, --border.
  */
-import { WebComponent, html, unsafeHTML } from '@webjsdev/core';
+import { WebComponent, html, unsafeHTML, signal } from '@webjsdev/core';
 import { positionFloating, type PopoverSide, type PopoverAlign } from './popover.ts';
 
 // --------------------------------------------------------------------------
@@ -348,6 +348,12 @@ export class UiDropdownMenuItem extends WebComponent {
   declare variant: 'default' | 'destructive';
   declare inset: boolean;
 
+  // Keyboard / pointer highlight state for the own-rendered menuitem. A
+  // local signal bound with ?data-highlighted keeps the highlight in the
+  // declarative template instead of an imperative setAttribute on
+  // e.currentTarget (the lit-idiomatic form).
+  #highlighted = signal(false);
+
   constructor() {
     super();
     this.variant = 'default';
@@ -361,6 +367,7 @@ export class UiDropdownMenuItem extends WebComponent {
       tabindex="-1"
       data-variant=${this.variant}
       ?data-inset=${this.inset}
+      ?data-highlighted=${this.#highlighted.get()}
       class=${dropdownMenuItemClass()}
       @click=${this._onClick}
       @pointerenter=${this._onPointerEnter}
@@ -381,12 +388,12 @@ export class UiDropdownMenuItem extends WebComponent {
     el.focus();
   };
 
-  _onFocus = (e: Event): void => {
-    (e.currentTarget as HTMLElement).setAttribute('data-highlighted', '');
+  _onFocus = (): void => {
+    this.#highlighted.set(true);
   };
 
-  _onBlur = (e: Event): void => {
-    (e.currentTarget as HTMLElement).removeAttribute('data-highlighted');
+  _onBlur = (): void => {
+    this.#highlighted.set(false);
   };
 }
 UiDropdownMenuItem.register('ui-dropdown-menu-item');

--- a/packages/ui/test/components/browser/ui-overlay.test.js
+++ b/packages/ui/test/components/browser/ui-overlay.test.js
@@ -258,6 +258,36 @@ suite('ui-dropdown-menu', () => {
     root.remove();
   });
 
+  test('focus highlights the item (signal-backed data-highlighted), blur clears it', async () => {
+    const root = await mount(html`
+      <ui-dropdown-menu>
+        <ui-dropdown-menu-trigger><button>Open</button></ui-dropdown-menu-trigger>
+        <ui-dropdown-menu-content>
+          <ui-dropdown-menu-item>One</ui-dropdown-menu-item>
+          <ui-dropdown-menu-item>Two</ui-dropdown-menu-item>
+        </ui-dropdown-menu-content>
+      </ui-dropdown-menu>
+    `);
+    const dm = root.querySelector('ui-dropdown-menu');
+    dm.show();
+    await tick();
+    const items = root.querySelectorAll('ui-dropdown-menu-item [role="menuitem"]');
+    assert.ok(items.length >= 2);
+    // Highlight rides a local signal -> ?data-highlighted re-render, so it
+    // applies after the microtask tick, not synchronously on focus.
+    items[0].focus();
+    await tick();
+    assert.equal(items[0].hasAttribute('data-highlighted'), true, 'focused item is highlighted');
+    assert.equal(items[1].hasAttribute('data-highlighted'), false, 'unfocused item is not highlighted');
+    // Moving focus to the next item blurs the first and highlights the second.
+    items[1].focus();
+    await tick();
+    assert.equal(items[0].hasAttribute('data-highlighted'), false, 'blurred item clears highlight');
+    assert.equal(items[1].hasAttribute('data-highlighted'), true, 'newly focused item is highlighted');
+    dm.hide();
+    root.remove();
+  });
+
   test('escape closes the dropdown', async () => {
     const root = await mount(html`
       <ui-dropdown-menu>
@@ -337,6 +367,10 @@ suite('ui-alert-dialog', () => {
     assert.ok(ad.hasAttribute('open'), 'host gets [open] attribute');
     const inner = ad.querySelector('ui-alert-dialog-content [role="alertdialog"]');
     assert.ok(inner, 'inner alertdialog rendered');
+    // showModal() reaches the own-rendered native <dialog> through the
+    // ref()/createRef() handle, so the native element is actually open.
+    const native = ad.querySelector('dialog[data-slot="alert-dialog-native"]');
+    assert.ok(native && native.open, 'ref()-driven showModal opened the native <dialog>');
     ad.hide();
     root.remove();
   });


### PR DESCRIPTION
Closes #223

Re-opened against `main` after #222 (#227) merged (the original stacked PR #229 auto-closed when its base branch was deleted; this is the same three commits rebased onto main).

## What

The last vanilla-style slips in the monorepo WebComponents, plus refreshing the blog's stale vendored copies. Guided by the lit-style convention in `agent-docs/lit-muscle-memory-gotchas.md`.

1. **dropdown-menu**: `ui-dropdown-menu-item` toggled `data-highlighted` via `e.currentTarget.setAttribute` on focus/blur. Now a local `signal` bound `?data-highlighted=${this.#highlighted.get()}`.
2. **dialog / alert-dialog**: reached their own-rendered native `<dialog>` via `querySelector('dialog[data-slot="...-native"]')`. Now a `ref()` / `createRef()` handle (relies on the `/directives` browser-bundle export restored in #222).
3. **Re-vendored `examples/blog/components/ui/*`** (8 files) from the registry. The blog's copies predated the registry's lit-idiomatic versions (`dialog.ts` was full vanilla style). Only the `cn` import path is rewritten to the blog's layout.

## Tests

- Browser (`packages/ui/test/components/browser/ui-overlay.test.js`): a dropdown case asserting focus -> `data-highlighted` (signal re-render) and blur clears it; the alert-dialog open test strengthened to assert the `ref()`-driven `showModal()` opens the native `<dialog>`. 34 kit browser tests pass.
- Full unit suite 1618/1618. dropdown/dialog/alert-dialog stay interactive (signal / ref imports), so the elision verdict is unchanged.

## Dogfood (4-app gate)

- blog e2e dist mode: 65/65. website / docs / ui-website boot 200 (ui-website's dialog + dropdown component pages serve the converted kit, zero broken preloads). `webjs check` clean in the blog.

## Docs

N/A: internal refactor, no public-API or inventory change.