### PR TITLE
chore: release @webjsdev/core 0.7.7

### DIFF
--- a/changelog/core/0.7.7.md
+++ b/changelog/core/0.7.7.md
@@ -1,0 +1,17 @@
+---
+package: "@webjsdev/core"
+version: 0.7.7
+date: 2026-06-02T20:04:29.145Z
+commit_count: 2
+---
+## Features
+
+- **support `closest()` and host IDL reflections in the SSR shim** ([#228](https://github.com/webjsdev/webjs/pull/228)) [`a9c26ea7`](https://github.com/webjsdev/webjs/commit/a9c26ea7)
+
+  The server element shim now implements `closest()` (tag-name selectors, resolved against an ancestor chain the SSR walker threads through each instance) plus the host IDL reflections a `render()` mutates on `this` (`dataset`, `className`, `hidden`, `id`/`title`/`slot`/`role`/`tabIndex`, and the `aria*` mixin), each reflecting to its content attribute. So a compound child (a tabs trigger, a toggle-group item) resolves its parent and marks active/pressed state in the first server paint, with no hydration flash, and a light-DOM item that sets host attributes inside `render()` no longer crashes SSR on an undefined `dataset`. Only tag-name selectors resolve at SSR; class / attribute / descendant selectors stay client-only.
+
+## Fixes
+
+- **re-export the full directive set from the core browser entry** ([#227](https://github.com/webjsdev/webjs/pull/227)) [`993d629f`](https://github.com/webjsdev/webjs/commit/993d629f)
+
+  The `@webjsdev/core/directives` subpath collapses onto the dist browser bundle (built from `index-browser.js`), which only re-exported `unsafeHTML` / `live`, so a built app importing `ref` / `createRef` / `keyed` / `guard` / `cache` / `until` / `templateContent` / `asyncAppend` / `asyncReplace` / `watch` got "does not provide an export". Both index entries now re-export the full lit-parity directive set so the bundle carries every directive, and `repeat` is exposed on the `/directives` subpath in src mode too, matching the documented table in both modes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6984,7 +6984,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.24.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",


### PR DESCRIPTION
Releases **@webjsdev/core 0.7.7** (patch), covering the two core changes merged since the last release (#226).

- **feat #228**: `closest()` + host IDL reflections in the SSR shim (compound components mark active/pressed state in the first server paint).
- **fix #227**: re-export the full directive set from the core browser entry, so `ref`/`createRef`/`keyed`/etc. resolve from `@webjsdev/core/directives` in dist, plus `repeat` on the `/directives` subpath in src mode.

Patch bump: every in-repo dependent pins `^0.7` (server `^0.7.1`, website / docs / blog `^0.7.0`), so `0.7.7` satisfies them with no range changes. `package-lock.json` regenerated.

No other package needs a release: #230 was a `refactor:` (no changelog entry), and the only `src` changes since #226 are in `packages/core`. server / cli / ui / ts-plugin are unchanged.

On merge, `release.yml` publishes `@webjsdev/core@0.7.7` to npm and creates the `core@0.7.7` GitHub Release from `changelog/core/0.7.7.md`.