### PR TITLE
feat: add a cors() middleware primitive for route handlers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -517,8 +517,20 @@ Two markers describe server-side files. The combination determines behaviour:
 1. Authenticate every mutating endpoint (bearer/API key, explicit CSRF, or origin allow-list).
 2. Use `validate`. Never trust merged `{...query, ...params, ...body}`.
 3. Log responsibly. No user input or secrets in errors.
-4. Configure CORS narrowly.
+4. Configure CORS narrowly. For a route handler (or app-wide), use the `cors()` middleware (see below); for an `expose()`d endpoint use a tight `origin` allow-list. Never combine `origin: '*'` with `credentials: true` (the CORS spec forbids it; `cors()` narrows the wildcard to the reflected origin instead of serving an invalid `*`).
 5. Rate-limit at the edge (`rateLimit()` middleware, see `agent-docs/advanced.md`).
+
+### CORS for route handlers (`cors()` middleware)
+
+`cors()` from `@webjsdev/server` returns a webjs middleware `(req, next) => Response`, usable in `middleware.{js,ts}` (root or per-segment) OR wrapped around a `route.{js,ts}` handler. It handles origin reflection, the `OPTIONS` preflight (`204` short-circuit), `Vary: Origin` (append, not clobber), and the credentials rule. The `--template api` scaffold ships a root `middleware.ts` demonstrating it.
+
+```js
+// middleware.js
+import { cors } from '@webjsdev/server';
+export default cors({ origin: ['https://app.example.com'], credentials: true });
+```
+
+`origin` accepts a string (exact), `string[]` allow-list, a `RegExp`, a function `(origin) => boolean`, or `'*'` / `true` (any). A disallowed origin gets no `Access-Control-Allow-Origin` (the browser blocks the read) but the actual request is still served, since CORS is browser-enforced. **`credentials: true` + a wildcard origin is invalid per the CORS spec; `cors()` narrows the wildcard to the reflected request origin (and adds `Vary: Origin`) rather than emitting `*`.** See `agent-docs/advanced.md` for the full option reference.
 
 ### Components (`components/*.{js,ts}`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -517,7 +517,7 @@ Two markers describe server-side files. The combination determines behaviour:
 1. Authenticate every mutating endpoint (bearer/API key, explicit CSRF, or origin allow-list).
 2. Use `validate`. Never trust merged `{...query, ...params, ...body}`.
 3. Log responsibly. No user input or secrets in errors.
-4. Configure CORS narrowly. For a route handler (or app-wide), use the `cors()` middleware (see below); for an `expose()`d endpoint use a tight `origin` allow-list. Never combine `origin: '*'` with `credentials: true` (the CORS spec forbids it; `cors()` narrows the wildcard to the reflected origin instead of serving an invalid `*`).
+4. Configure CORS narrowly. For a route handler (or app-wide), use the `cors()` middleware (see below); for an `expose()`d endpoint use a tight `origin` allow-list. **A credentialed endpoint (`credentials: true`) REQUIRES an explicit `origin` allowlist; never combine it with a wildcard `'*'`.** The CORS spec forbids the pair, and reflecting under credentials grants any origin credentialed access. `cors()` narrows the wildcard to the reflected origin to keep the request working but emits a one-time `console.warn`; do not rely on that fallback for a real allowlist.
 5. Rate-limit at the edge (`rateLimit()` middleware, see `agent-docs/advanced.md`).
 
 ### CORS for route handlers (`cors()` middleware)
@@ -530,7 +530,11 @@ import { cors } from '@webjsdev/server';
 export default cors({ origin: ['https://app.example.com'], credentials: true });
 ```
 
-`origin` accepts a string (exact), `string[]` allow-list, a `RegExp`, a function `(origin) => boolean`, or `'*'` / `true` (any). A disallowed origin gets no `Access-Control-Allow-Origin` (the browser blocks the read) but the actual request is still served, since CORS is browser-enforced. **`credentials: true` + a wildcard origin is invalid per the CORS spec; `cors()` narrows the wildcard to the reflected request origin (and adds `Vary: Origin`) rather than emitting `*`.** See `agent-docs/advanced.md` for the full option reference.
+`origin` accepts a string (exact), `string[]` allow-list, a `RegExp`, a function `(origin) => boolean`, or `'*'` / `true` (any). A disallowed origin gets no `Access-Control-Allow-Origin` (the browser blocks the read) but the actual request is still served, since CORS is browser-enforced.
+
+> **`credentials: true` REQUIRES an explicit origin allowlist.** A wildcard origin (`'*'` / `true`) with `credentials: true` is invalid per the CORS spec, and combining them effectively grants credentialed access to EVERY origin (cookies, `Authorization`). `cors()` keeps the request working by narrowing the wildcard to the reflected request origin (and adds `Vary: Origin`) rather than emitting an invalid `*`, BUT it emits a one-time `console.warn` flagging the footgun. For any credentialed endpoint, pass an explicit `origin` list (string / array / RegExp / function), never `'*'`.
+
+See `agent-docs/advanced.md` for the full option reference.
 
 ### Components (`components/*.{js,ts}`)
 

--- a/agent-docs/advanced.md
+++ b/agent-docs/advanced.md
@@ -178,6 +178,54 @@ the host actually provides. The default rate-limit collapsing to
 
 **Scaling:** in-memory by default. `setStore(redisStore({ url: process.env.REDIS_URL }))` shares limits across instances.
 
+## CORS via `cors()`
+
+`cors()` is a middleware factory (same `(req, next) => Response` contract as `rateLimit()`), usable in `middleware.js` (root or per-segment) or wrapped around a `route.js` handler. It handles origin reflection, the `OPTIONS` preflight, `Vary: Origin`, and the credentials rule, so route handlers do not hand-roll any of it. The `--template api` scaffold ships a root `middleware.ts` demonstrating it.
+
+```js
+// middleware.js (applies to every request)
+import { cors } from '@webjsdev/server';
+export default cors({
+  origin: ['https://app.example.com', 'http://localhost:3000'],
+  credentials: true,
+  methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
+  allowedHeaders: ['content-type', 'authorization'],
+  maxAge: 86400,
+});
+```
+
+Wrap a single handler instead of going app-wide:
+
+```js
+// app/api/widgets/route.js
+import { cors } from '@webjsdev/server';
+const corsMw = cors({ origin: '*' });
+export async function GET(req) {
+  return corsMw(req, async () => Response.json({ widgets: [] }));
+}
+```
+
+### Options
+
+| Option | Meaning |
+|---|---|
+| `origin` | A string (exact), `string[]` allow-list, a `RegExp`, a function `(origin) => boolean`, or `'*'` / `true` (any). Entries in an array may mix strings and RegExps. Defaults to `'*'`. |
+| `credentials` | Sets `Access-Control-Allow-Credentials: true` for an allowed specific origin. |
+| `methods` | Advertised on a preflight (`Access-Control-Allow-Methods`). |
+| `allowedHeaders` | Advertised on a preflight; defaults to reflecting `Access-Control-Request-Headers`. |
+| `exposedHeaders` | `Access-Control-Expose-Headers` on the actual response. |
+| `maxAge` | Preflight cache lifetime in seconds. |
+
+### Behavior
+
+- **Preflight.** An `OPTIONS` request carrying `Access-Control-Request-Method` short-circuits with a `204` carrying the Allow-Methods / Allow-Headers / Max-Age headers. `next()` is NOT called. A disallowed-origin preflight returns a bare `204` with no CORS headers, so the browser blocks the follow-up.
+- **Actual request.** `next()` runs, then `Access-Control-Allow-Origin` (plus credentials / exposed headers) is attached. A disallowed origin gets NO `Access-Control-Allow-Origin`, and the browser blocks the cross-origin read, but the server still serves the response (CORS is browser-enforced, not a server gate; this matches the `expose()` path, which never 403s a mismatched actual request).
+- **`Vary: Origin`.** Appended (never clobbering an existing `Vary`) whenever the allowed origin is dynamic (a reflected, per-origin value), so a shared cache keys on `Origin` and cannot poison one origin's response onto another. A constant `*` (no credentials) does not vary, so no `Vary` is added.
+
+### The credentials + wildcard rule (spec, enforced)
+
+`Access-Control-Allow-Origin: *` is INVALID together with `Access-Control-Allow-Credentials: true`, and the browser rejects the pair. So when `credentials: true` is combined with a wildcard `origin`, `cors()` NARROWS to the reflected request origin instead of sending `*` (and appends `Vary: Origin`). With no `Origin` header under that combination it refuses entirely (no ACAO). To allow credentialed cross-origin requests, list explicit origins; never rely on `'*'` + credentials.
+
 ## Client router: nested-layout-aware partial swap
 
 `import '@webjsdev/core/client-router'` enables SPA-style navigation that

--- a/agent-docs/advanced.md
+++ b/agent-docs/advanced.md
@@ -222,9 +222,20 @@ export async function GET(req) {
 - **Actual request.** `next()` runs, then `Access-Control-Allow-Origin` (plus credentials / exposed headers) is attached. A disallowed origin gets NO `Access-Control-Allow-Origin`, and the browser blocks the cross-origin read, but the server still serves the response (CORS is browser-enforced, not a server gate; this matches the `expose()` path, which never 403s a mismatched actual request).
 - **`Vary: Origin`.** Appended (never clobbering an existing `Vary`) whenever the allowed origin is dynamic (a reflected, per-origin value), so a shared cache keys on `Origin` and cannot poison one origin's response onto another. A constant `*` (no credentials) does not vary, so no `Vary` is added.
 
-### The credentials + wildcard rule (spec, enforced)
+### `credentials: true` requires an explicit origin allowlist (spec, enforced, warned)
 
-`Access-Control-Allow-Origin: *` is INVALID together with `Access-Control-Allow-Credentials: true`, and the browser rejects the pair. So when `credentials: true` is combined with a wildcard `origin`, `cors()` NARROWS to the reflected request origin instead of sending `*` (and appends `Vary: Origin`). With no `Origin` header under that combination it refuses entirely (no ACAO). To allow credentialed cross-origin requests, list explicit origins; never rely on `'*'` + credentials.
+**For any credentialed endpoint, pass an explicit `origin` allowlist (string / array / RegExp / function). Never combine `credentials: true` with a wildcard `origin` (`'*'` / `true`).**
+
+`Access-Control-Allow-Origin: *` is INVALID together with `Access-Control-Allow-Credentials: true`, and the browser rejects the pair. Worse, the usual workaround (reflecting the request origin) under credentials effectively grants credentialed access (cookies, `Authorization`) to EVERY origin, a real footgun.
+
+`cors()` keeps the request working rather than failing it: when `credentials: true` meets a wildcard `origin` it NARROWS to the reflected request origin instead of sending `*` (and appends `Vary: Origin`). With no `Origin` header under that combination it refuses entirely (no ACAO). Because that reflects any origin with credentials, it ALSO emits a one-time `console.warn` (deduped, not per-request):
+
+```
+cors(): credentials with a wildcard origin reflects ANY origin with credentials.
+Use an explicit origin allowlist for credentialed requests.
+```
+
+The warning is informational; the request still proceeds. Treat it as a prompt to replace the wildcard with a real allowlist. An explicit allowlist with `credentials: true` is the safe, silent path.
 
 ## Client router: nested-layout-aware partial swap
 

--- a/packages/cli/lib/create.js
+++ b/packages/cli/lib/create.js
@@ -494,6 +494,27 @@ if (process.env.NODE_ENV !== 'production') g.__prisma = prisma;
   if (isApi) {
     // API-only template: no layout, no page, no components.
     // Just a health route and an example module with route wrapper.
+
+    // Root middleware applying CORS to every route. An API consumed by a
+    // browser from another origin needs this; the `cors()` primitive
+    // handles origin reflection, the OPTIONS preflight, Vary: Origin, and
+    // the credentials rule, so route handlers stay focused on data.
+    await writeFile(join(appDir, 'middleware.ts'), `import { cors } from '@webjsdev/server';
+
+/**
+ * App-wide CORS policy. Replace the allow-list with your real frontend
+ * origins. With \`credentials: true\` a wildcard origin is invalid per the
+ * CORS spec, so list explicit origins (never \`'*'\` + credentials).
+ */
+export default cors({
+  origin: ['http://localhost:3000', 'https://app.example.com'],
+  credentials: true,
+  methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
+  allowedHeaders: ['content-type', 'authorization'],
+  maxAge: 86400,
+});
+`);
+
     await mkdir(join(appDir, 'app', 'api', 'health'), { recursive: true });
     await mkdir(join(appDir, 'app', 'api', 'users'), { recursive: true });
     await writeFile(join(appDir, 'app', 'api', 'health', 'route.ts'), `export async function GET() {

--- a/packages/cli/templates/AGENTS.md
+++ b/packages/cli/templates/AGENTS.md
@@ -440,7 +440,7 @@ import { createContext } from '@webjsdev/core/context';
 import { Task } from '@webjsdev/core/task';
 import { fixture, waitForUpdate } from '@webjsdev/core/testing';
 
-import { rateLimit, cache, createAuth, Credentials, Session } from '@webjsdev/server';
+import { rateLimit, cors, cache, createAuth, Credentials, Session } from '@webjsdev/server';
 ```
 
 ## Environment variables (server vs browser)

--- a/packages/server/AGENTS.md
+++ b/packages/server/AGENTS.md
@@ -41,6 +41,7 @@ with metadata, Suspense, streaming) for HTML, or `api.js` /
 | `cache.js` | Pluggable cache store: `memoryStore` / `redisStore`; `setStore` / `getStore` |
 | `cache-fn.js` | `cache(key, fn, { ttl })` query-caching helper + `invalidate()` |
 | `rate-limit.js` | `rateLimit({ window, max })` middleware factory |
+| `cors.js` | `cors({ origin, credentials, methods, allowedHeaders, exposedHeaders, maxAge })` middleware factory for route handlers / `middleware.js`. Shared origin-resolution + header-building core (`resolveOrigin` / `applyCorsHeaders`) reused by the `expose()` REST path in `actions.js`. Enforces the CORS-spec rule that `credentials: true` forbids a wildcard ACAO (narrows `*` to the reflected origin). |
 | `csrf.js` | Double-submit CSRF protection (server-action endpoints) |
 | `websocket.js` | WS upgrade handling: invokes `WS` export from `route.ts` |
 | `broadcast.js` | `broadcast(topic, msg)` for fan-out messaging |

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -35,6 +35,7 @@ export { scanComponents, primeComponentRegistry, extractComponents, findOrphanCo
 export { headers, cookies, getRequest, withRequest, cspNonce } from './src/context.js';
 export { defaultLogger } from './src/logger.js';
 export { rateLimit, parseWindow, clientIp, stampRemoteIp } from './src/rate-limit.js';
+export { cors, resolveOrigin, applyCorsHeaders } from './src/cors.js';
 export { memoryStore, redisStore, getStore, setStore } from './src/cache.js';
 export { cache } from './src/cache-fn.js';
 export { Session, session, cookieSessionStorage, storeSessionStorage, cookieSession, storeSession, getSession } from './src/session.js';

--- a/packages/server/src/actions.js
+++ b/packages/server/src/actions.js
@@ -6,6 +6,7 @@ import { getExposed } from '@webjsdev/core';
 import { walk } from './fs-walk.js';
 import { verify as verifyCsrf, CSRF_COOKIE, CSRF_HEADER } from './csrf.js';
 import { getSerializer } from './serializer.js';
+import { resolveOrigin } from './cors.js';
 
 /**
  * Internal RPC wire-format content type. Distinguishes webjs action
@@ -388,11 +389,23 @@ export function withCors(resp, route, req) {
   return new Response(resp.body, { status: resp.status, statusText: resp.statusText, headers: newHeaders });
 }
 
-/** @param {string|string[]} configured @param {string} origin */
+/**
+ * Match a route's configured origin policy against the request origin,
+ * preserving the expose() path's historical contract: `*` returns `true`
+ * (literal wildcard), an allowed concrete origin echoes back, and a
+ * mismatch returns `null`. Delegates the per-rule decision to the shared
+ * cors.js resolver (so RegExp + function policies work here too) but keeps
+ * the wildcard-as-`true` and echo-vs-null shape this caller expects.
+ *
+ * @param {string|string[]|RegExp|((origin: string) => boolean)} configured
+ * @param {string} origin
+ * @returns {true | string | null}
+ */
 function matchOrigin(configured, origin) {
   if (configured === '*') return true;
-  if (Array.isArray(configured)) return configured.includes(origin) ? origin : null;
-  return configured === origin ? origin : null;
+  const resolved = resolveOrigin(configured, origin, false);
+  if (!resolved) return null;
+  return resolved.allowOrigin === '*' ? true : resolved.allowOrigin;
 }
 
 /**

--- a/packages/server/src/cors.js
+++ b/packages/server/src/cors.js
@@ -1,0 +1,219 @@
+/**
+ * Reusable CORS primitive for webjs.
+ *
+ * Two surfaces share one origin-resolution + header-building core:
+ *
+ * 1. `cors(options)` returns a webjs MIDDLEWARE `(req, next) => Response`,
+ *    usable in `middleware.js` (root or per-segment) or wrapped around a
+ *    `route.js` handler. This is the public app-facing API.
+ * 2. The `expose()` REST path (`actions.js`) reuses `resolveOrigin` and
+ *    `applyCorsHeaders` so a route's `cors` config and a standalone
+ *    `cors()` middleware compute identical headers.
+ *
+ * Web-standards-first: the option shape mirrors the well-trodden
+ * `cors` npm package and the Fetch CORS protocol. We reflect the
+ * request `Origin` ONLY when the policy allows it, never blanket-reflect
+ * with credentials, and always append (never clobber) `Vary: Origin`
+ * when the allowed origin is dynamic, to keep shared caches correct.
+ *
+ * The one hard CORS-spec rule we enforce: a wildcard origin (`*`) is
+ * incompatible with `credentials: true`. The browser rejects
+ * `Access-Control-Allow-Origin: *` together with
+ * `Access-Control-Allow-Credentials: true`, so when both are configured
+ * we NARROW to the reflected request origin instead of sending `*`
+ * (and append `Vary: Origin`, since the response now varies by origin).
+ *
+ * ```js
+ * // middleware.js
+ * import { cors } from '@webjsdev/server';
+ * export default cors({ origin: ['https://app.example.com'], credentials: true });
+ * ```
+ *
+ * @module cors
+ */
+
+/**
+ * @typedef {string | RegExp | ((origin: string) => boolean)} OriginRule
+ *   A single origin rule. A function receives the request `Origin` and
+ *   returns whether it is allowed.
+ */
+
+/**
+ * @typedef {Object} CorsOptions
+ * @property {'*' | true | OriginRule | OriginRule[]} [origin]
+ *   Allowed origin policy. `'*'` / `true` allows any origin. A string is
+ *   an exact match. A `RegExp` tests the origin. A function returns a
+ *   boolean. An array is an allow-list of any of the above (matches if
+ *   ANY entry matches). Defaults to `'*'`.
+ * @property {boolean} [credentials]
+ *   Send `Access-Control-Allow-Credentials: true`. Forces a wildcard
+ *   origin to narrow to the reflected request origin (spec requirement).
+ * @property {string[] | string} [methods]
+ *   Methods advertised on a preflight. Defaults to the common verb set.
+ * @property {string[] | string} [allowedHeaders]
+ *   Request headers advertised on a preflight. Defaults to reflecting
+ *   the preflight's `Access-Control-Request-Headers`.
+ * @property {string[] | string} [exposedHeaders]
+ *   Response headers exposed to client JS via
+ *   `Access-Control-Expose-Headers`.
+ * @property {number} [maxAge]
+ *   Preflight cache lifetime in seconds (`Access-Control-Max-Age`).
+ */
+
+const DEFAULT_METHODS = ['GET', 'HEAD', 'PUT', 'PATCH', 'POST', 'DELETE'];
+
+/** @param {string[] | string | undefined} v @returns {string | undefined} */
+function csv(v) {
+  if (v == null) return undefined;
+  return Array.isArray(v) ? v.join(', ') : String(v);
+}
+
+/**
+ * Decide whether `origin` is allowed by a single rule.
+ *
+ * @param {OriginRule | '*' | true} rule
+ * @param {string} origin
+ * @returns {boolean}
+ */
+function ruleAllows(rule, origin) {
+  if (rule === '*' || rule === true) return true;
+  if (typeof rule === 'string') return rule === origin;
+  if (rule instanceof RegExp) return rule.test(origin);
+  if (typeof rule === 'function') return rule(origin) === true;
+  return false;
+}
+
+/**
+ * Resolve a CORS origin policy against a request `Origin` header.
+ *
+ * Returns the value to send in `Access-Control-Allow-Origin`, or `null`
+ * when the origin is NOT allowed (the caller then omits the header so the
+ * browser blocks the cross-origin read). The shape:
+ *
+ * - `{ allowOrigin: '*', dynamic: false }`  any origin, no credentials.
+ * - `{ allowOrigin: '<origin>', dynamic: true }`  reflected, varies by origin.
+ * - `null`  disallowed.
+ *
+ * `credentials: true` forces a wildcard to narrow: `*` is invalid with
+ * credentials, so we reflect the concrete request origin (and mark the
+ * result dynamic so `Vary: Origin` is appended). With no `Origin` header
+ * a wildcard policy still resolves to `*` (or, under credentials, yields
+ * no reflected value), matching same-origin / server-to-server traffic.
+ *
+ * @param {'*' | true | OriginRule | OriginRule[]} policy
+ * @param {string} origin  request `Origin` header (`''` if absent)
+ * @param {boolean} credentials
+ * @returns {{ allowOrigin: string, dynamic: boolean } | null}
+ */
+export function resolveOrigin(policy, origin, credentials) {
+  const rules = Array.isArray(policy) ? policy : [policy];
+  const isWildcard = rules.some((r) => r === '*' || r === true);
+
+  if (isWildcard) {
+    // Wildcard + credentials is invalid per the CORS spec: a literal `*`
+    // ACAO can never be combined with `Allow-Credentials: true`. Narrow
+    // to the reflected origin (dynamic), or refuse if no origin is given.
+    if (credentials) {
+      if (!origin) return null;
+      return { allowOrigin: origin, dynamic: true };
+    }
+    return { allowOrigin: '*', dynamic: false };
+  }
+
+  if (!origin) return null;
+  const allowed = rules.some((r) => ruleAllows(r, origin));
+  if (!allowed) return null;
+  return { allowOrigin: origin, dynamic: true };
+}
+
+/** @param {Headers} headers append `Vary: Origin` without clobbering existing Vary */
+function appendVaryOrigin(headers) {
+  const existing = headers.get('vary');
+  if (!existing) {
+    headers.set('vary', 'Origin');
+    return;
+  }
+  const parts = existing.split(',').map((s) => s.trim().toLowerCase());
+  if (parts.includes('*') || parts.includes('origin')) return;
+  headers.append('vary', 'Origin');
+}
+
+/**
+ * Mutate `headers` in place to carry the actual-request CORS headers for
+ * a resolved origin: `Access-Control-Allow-Origin`, optional
+ * `Allow-Credentials`, optional `Expose-Headers`, and `Vary: Origin`
+ * when the origin is dynamic.
+ *
+ * @param {Headers} headers
+ * @param {{ allowOrigin: string, dynamic: boolean }} resolved
+ * @param {{ credentials?: boolean, exposedHeaders?: string[] | string }} cfg
+ */
+export function applyCorsHeaders(headers, resolved, cfg) {
+  headers.set('access-control-allow-origin', resolved.allowOrigin);
+  if (cfg.credentials && resolved.allowOrigin !== '*') {
+    headers.set('access-control-allow-credentials', 'true');
+  }
+  const exposed = csv(cfg.exposedHeaders);
+  if (exposed) headers.set('access-control-expose-headers', exposed);
+  if (resolved.dynamic) appendVaryOrigin(headers);
+}
+
+/**
+ * Build a CORS middleware `(req, next) => Response`.
+ *
+ * Behavior:
+ * - On an OPTIONS preflight (carries `Access-Control-Request-Method`),
+ *   short-circuit with a 204 carrying Allow-Methods / Allow-Headers /
+ *   Max-Age. `next()` is NOT called.
+ * - On an actual request, call `next()` then attach the actual-request
+ *   CORS headers to the response.
+ * - A disallowed origin gets NO `Access-Control-Allow-Origin` (the
+ *   browser blocks the read). The server still serves the actual request
+ *   (CORS is browser-enforced); a disallowed PREFLIGHT returns a bare 204
+ *   with no CORS headers, so the browser blocks the follow-up.
+ *
+ * @param {CorsOptions} [options]
+ * @returns {(req: Request, next: () => Promise<Response>) => Promise<Response>}
+ */
+export function cors(options = {}) {
+  const policy = options.origin ?? '*';
+  const credentials = options.credentials === true;
+  const methods = csv(options.methods) || DEFAULT_METHODS.join(', ');
+  const allowedHeaders = csv(options.allowedHeaders);
+  const exposedHeaders = options.exposedHeaders;
+  const maxAge = options.maxAge;
+
+  return async function corsMiddleware(req, next) {
+    const origin = req.headers.get('origin') || '';
+    const resolved = resolveOrigin(policy, origin, credentials);
+    const isPreflight =
+      req.method === 'OPTIONS' && req.headers.has('access-control-request-method');
+
+    if (isPreflight) {
+      const headers = new Headers();
+      // Disallowed preflight: bare 204, no CORS headers. The browser then
+      // blocks the actual request, which is the correct CORS posture.
+      if (resolved) {
+        applyCorsHeaders(headers, resolved, { credentials, exposedHeaders });
+        headers.set('access-control-allow-methods', methods);
+        const reqHeaders =
+          allowedHeaders || req.headers.get('access-control-request-headers') || 'content-type';
+        headers.set('access-control-allow-headers', reqHeaders);
+        if (maxAge != null) headers.set('access-control-max-age', String(maxAge));
+      }
+      return new Response(null, { status: 204, headers });
+    }
+
+    const resp = await next();
+    if (!resolved) return resp;
+    // Some synthetic Responses have immutable headers; fall back to a copy.
+    try {
+      applyCorsHeaders(resp.headers, resolved, { credentials, exposedHeaders });
+      return resp;
+    } catch {
+      const headers = new Headers(resp.headers);
+      applyCorsHeaders(headers, resolved, { credentials, exposedHeaders });
+      return new Response(resp.body, { status: resp.status, statusText: resp.statusText, headers });
+    }
+  };
+}

--- a/packages/server/src/cors.js
+++ b/packages/server/src/cors.js
@@ -62,6 +62,29 @@
 
 const DEFAULT_METHODS = ['GET', 'HEAD', 'PUT', 'PATCH', 'POST', 'DELETE'];
 
+/**
+ * Module-level dedupe flag for the credentials+wildcard warning. Reflecting
+ * the request origin under `credentials: true` grants credentialed access to
+ * EVERY origin, a real footgun, so we warn ONCE (not per request) to keep
+ * logs readable while still surfacing it. The request still proceeds.
+ */
+let warnedCredentialedWildcard = false;
+
+/** Emit the one-time credentials+wildcard warning (deduped across requests). */
+function warnCredentialedWildcard() {
+  if (warnedCredentialedWildcard) return;
+  warnedCredentialedWildcard = true;
+  console.warn(
+    'cors(): credentials with a wildcard origin reflects ANY origin with credentials. ' +
+      'Use an explicit origin allowlist for credentialed requests.',
+  );
+}
+
+/** Testing hook: reset the one-time warning dedupe flag. */
+export function _resetCorsWarnings() {
+  warnedCredentialedWildcard = false;
+}
+
 /** @param {string[] | string | undefined} v @returns {string | undefined} */
 function csv(v) {
   if (v == null) return undefined;
@@ -113,7 +136,10 @@ export function resolveOrigin(policy, origin, credentials) {
     // Wildcard + credentials is invalid per the CORS spec: a literal `*`
     // ACAO can never be combined with `Allow-Credentials: true`. Narrow
     // to the reflected origin (dynamic), or refuse if no origin is given.
+    // Reflecting under credentials effectively allows EVERY origin, so warn
+    // once (the request still proceeds) to flag the footgun.
     if (credentials) {
+      warnCredentialedWildcard();
       if (!origin) return null;
       return { allowOrigin: origin, dynamic: true };
     }

--- a/packages/server/test/cors/cors-middleware.test.js
+++ b/packages/server/test/cors/cors-middleware.test.js
@@ -11,7 +11,27 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { cors, resolveOrigin, applyCorsHeaders } from '../../src/cors.js';
+import { cors, resolveOrigin, applyCorsHeaders, _resetCorsWarnings } from '../../src/cors.js';
+
+/**
+ * Run `fn` capturing console.warn calls, then restore. Returns the array
+ * of warning strings emitted during `fn`.
+ *
+ * @param {() => unknown | Promise<unknown>} fn
+ * @returns {Promise<string[]>}
+ */
+async function captureWarnings(fn) {
+  const original = console.warn;
+  /** @type {string[]} */
+  const warnings = [];
+  console.warn = (...args) => warnings.push(args.join(' '));
+  try {
+    await fn();
+  } finally {
+    console.warn = original;
+  }
+  return warnings;
+}
 
 /** @param {string|null} origin @param {string} [method] @param {Record<string,string>} [extra] */
 function req(origin, method = 'GET', extra = {}) {
@@ -177,7 +197,10 @@ test('COUNTERFACTUAL: credentials + wildcard NEVER emits ACAO: * with ACAC', asy
   // (resolveOrigin returning `{ allowOrigin: '*' }` under credentials),
   // this assertion fails.
   const mw = cors({ origin: '*', credentials: true });
-  const resp = await mw(req('https://a.com'), nextOk());
+  let resp;
+  await captureWarnings(async () => {
+    resp = await mw(req('https://a.com'), nextOk());
+  });
   const acao = resp.headers.get('access-control-allow-origin');
   assert.notEqual(acao, '*', 'must not send wildcard ACAO with credentials');
   assert.equal(acao, 'https://a.com', 'wildcard narrows to the reflected origin');
@@ -188,13 +211,19 @@ test('COUNTERFACTUAL: credentials + wildcard NEVER emits ACAO: * with ACAC', asy
 
 test('credentials + wildcard with NO origin header refuses (no ACAO at all)', async () => {
   const mw = cors({ origin: '*', credentials: true });
-  const resp = await mw(req(null), nextOk());
+  let resp;
+  await captureWarnings(async () => {
+    resp = await mw(req(null), nextOk());
+  });
   assert.equal(resp.headers.get('access-control-allow-origin'), null);
   assert.equal(resp.headers.get('access-control-allow-credentials'), null);
 });
 
-test('resolveOrigin counterfactual at the unit level: wildcard+credentials never yields *', () => {
-  const r = resolveOrigin('*', 'https://a.com', true);
+test('resolveOrigin counterfactual at the unit level: wildcard+credentials never yields *', async () => {
+  let r;
+  await captureWarnings(() => {
+    r = resolveOrigin('*', 'https://a.com', true);
+  });
   assert.ok(r);
   assert.notEqual(r.allowOrigin, '*');
   assert.equal(r.allowOrigin, 'https://a.com');
@@ -254,4 +283,55 @@ test('cors() wraps a route.js handler: compose middleware + handler', async () =
   assert.equal(resp.headers.get('access-control-allow-origin'), 'https://app.example.com');
   assert.equal(resp.headers.get('access-control-allow-credentials'), 'true');
   assert.deepEqual(await resp.json(), { users: [] });
+});
+
+// --- credentials + wildcard footgun warning ---
+
+test('credentials + wildcard warns LOUDLY (the dangerous any-origin reflection)', async () => {
+  _resetCorsWarnings();
+  const mw = cors({ origin: '*', credentials: true });
+  const warnings = await captureWarnings(() => mw(req('https://a.com'), nextOk()));
+  assert.equal(warnings.length, 1, 'exactly one warning for the credentials+wildcard combo');
+  assert.match(warnings[0], /credentials/i);
+  assert.match(warnings[0], /wildcard|any origin/i);
+  assert.match(warnings[0], /allowlist/i, 'points the user at the explicit-allowlist fix');
+});
+
+test('credentials + wildcard warning is deduped to ONCE across many requests', async () => {
+  _resetCorsWarnings();
+  const mw = cors({ origin: true, credentials: true });
+  const warnings = await captureWarnings(async () => {
+    await mw(req('https://a.com'), nextOk());
+    await mw(req('https://b.com'), nextOk());
+    await mw(req('https://c.com'), nextOk());
+  });
+  assert.equal(warnings.length, 1, 'one-time, not per-request');
+});
+
+test('explicit allowlist with credentials does NOT warn (the safe path)', async () => {
+  _resetCorsWarnings();
+  const mw = cors({ origin: ['https://a.com', 'https://b.com'], credentials: true });
+  const warnings = await captureWarnings(async () => {
+    await mw(req('https://a.com'), nextOk());
+    await mw(req('https://b.com'), nextOk());
+  });
+  assert.equal(warnings.length, 0, 'an explicit allowlist is safe and silent');
+});
+
+test('wildcard WITHOUT credentials does not warn (no footgun, plain ACAO: *)', async () => {
+  _resetCorsWarnings();
+  const mw = cors({ origin: '*' });
+  const warnings = await captureWarnings(() => mw(req('https://a.com'), nextOk()));
+  assert.equal(warnings.length, 0);
+});
+
+test('the warning still serves the request (warn, not error)', async () => {
+  _resetCorsWarnings();
+  const mw = cors({ origin: '*', credentials: true });
+  let resp;
+  await captureWarnings(async () => {
+    resp = await mw(req('https://a.com'), nextOk());
+  });
+  assert.equal(resp.status, 200, 'request proceeds despite the warning');
+  assert.equal(resp.headers.get('access-control-allow-origin'), 'https://a.com');
 });

--- a/packages/server/test/cors/cors-middleware.test.js
+++ b/packages/server/test/cors/cors-middleware.test.js
@@ -1,0 +1,257 @@
+/**
+ * Unit + integration tests for the standalone `cors()` middleware
+ * primitive (`src/cors.js`), the app-facing surface usable in
+ * `middleware.js` or wrapped around a `route.js` handler.
+ *
+ * Covers: allowed-origin reflection, disallowed-origin (no ACAO),
+ * OPTIONS preflight short-circuit, credentialed specific origin,
+ * the credentials+wildcard guard (COUNTERFACTUAL), Vary: Origin
+ * append-not-clobber, and RegExp / function / array origin policies.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { cors, resolveOrigin, applyCorsHeaders } from '../../src/cors.js';
+
+/** @param {string|null} origin @param {string} [method] @param {Record<string,string>} [extra] */
+function req(origin, method = 'GET', extra = {}) {
+  const headers = new Headers();
+  if (origin) headers.set('origin', origin);
+  for (const [k, v] of Object.entries(extra)) headers.set(k, v);
+  return new Request('http://localhost/api', { method, headers });
+}
+
+/** A next() that returns a plain JSON 200, optionally with seeded headers. */
+function nextOk(seed = {}) {
+  return async () => new Response(JSON.stringify({ ok: true }), { status: 200, headers: seed });
+}
+
+// --- allowed / disallowed origin on the actual request ---
+
+test('allowed exact-string origin reflects ACAO on the actual response', async () => {
+  const mw = cors({ origin: 'https://a.com' });
+  const resp = await mw(req('https://a.com'), nextOk());
+  assert.equal(resp.headers.get('access-control-allow-origin'), 'https://a.com');
+  assert.equal(resp.status, 200);
+  assert.deepEqual(await resp.json(), { ok: true });
+});
+
+test('disallowed origin gets NO ACAO but the request is still served', async () => {
+  const mw = cors({ origin: 'https://a.com' });
+  const resp = await mw(req('https://evil.com'), nextOk());
+  assert.equal(resp.headers.get('access-control-allow-origin'), null);
+  // CORS is browser-enforced: the server still serves the body.
+  assert.equal(resp.status, 200);
+  assert.deepEqual(await resp.json(), { ok: true });
+});
+
+test('wildcard origin sends ACAO: * (no credentials)', async () => {
+  const mw = cors({ origin: '*' });
+  const resp = await mw(req('https://anything.com'), nextOk());
+  assert.equal(resp.headers.get('access-control-allow-origin'), '*');
+});
+
+test('default policy (no origin option) is wildcard', async () => {
+  const mw = cors();
+  const resp = await mw(req('https://anything.com'), nextOk());
+  assert.equal(resp.headers.get('access-control-allow-origin'), '*');
+});
+
+// --- array / RegExp / function policies ---
+
+test('array allow-list reflects an included origin, omits a non-member', async () => {
+  const mw = cors({ origin: ['https://a.com', 'https://b.com'] });
+  const ok = await mw(req('https://b.com'), nextOk());
+  assert.equal(ok.headers.get('access-control-allow-origin'), 'https://b.com');
+  const no = await mw(req('https://c.com'), nextOk());
+  assert.equal(no.headers.get('access-control-allow-origin'), null);
+});
+
+test('RegExp origin policy matches by pattern', async () => {
+  const mw = cors({ origin: /\.example\.com$/ });
+  const ok = await mw(req('https://app.example.com'), nextOk());
+  assert.equal(ok.headers.get('access-control-allow-origin'), 'https://app.example.com');
+  const no = await mw(req('https://example.com.evil.net'), nextOk());
+  assert.equal(no.headers.get('access-control-allow-origin'), null);
+});
+
+test('function origin policy decides dynamically', async () => {
+  const mw = cors({ origin: (o) => o.startsWith('https://trusted-') });
+  const ok = await mw(req('https://trusted-1.io'), nextOk());
+  assert.equal(ok.headers.get('access-control-allow-origin'), 'https://trusted-1.io');
+  const no = await mw(req('https://hostile.io'), nextOk());
+  assert.equal(no.headers.get('access-control-allow-origin'), null);
+});
+
+test('mixed array of RegExp + string entries matches either', async () => {
+  const mw = cors({ origin: ['https://a.com', /\.b\.com$/] });
+  const a = await mw(req('https://a.com'), nextOk());
+  assert.equal(a.headers.get('access-control-allow-origin'), 'https://a.com');
+  const b = await mw(req('https://x.b.com'), nextOk());
+  assert.equal(b.headers.get('access-control-allow-origin'), 'https://x.b.com');
+});
+
+// --- OPTIONS preflight short-circuit ---
+
+test('OPTIONS preflight short-circuits 204 with Allow-Methods/Headers and does NOT call next', async () => {
+  let nextCalled = false;
+  const mw = cors({ origin: 'https://a.com', methods: ['GET', 'POST'], maxAge: 600 });
+  const resp = await mw(
+    req('https://a.com', 'OPTIONS', {
+      'access-control-request-method': 'POST',
+      'access-control-request-headers': 'content-type,authorization',
+    }),
+    async () => {
+      nextCalled = true;
+      return new Response('should not happen');
+    },
+  );
+  assert.equal(nextCalled, false, 'next() must not run on a preflight');
+  assert.equal(resp.status, 204);
+  assert.equal(resp.headers.get('access-control-allow-origin'), 'https://a.com');
+  assert.equal(resp.headers.get('access-control-allow-methods'), 'GET, POST');
+  assert.equal(resp.headers.get('access-control-allow-headers'), 'content-type,authorization');
+  assert.equal(resp.headers.get('access-control-max-age'), '600');
+});
+
+test('preflight reflects Access-Control-Request-Headers when allowedHeaders unset', async () => {
+  const mw = cors({ origin: '*' });
+  const resp = await mw(
+    req('https://a.com', 'OPTIONS', {
+      'access-control-request-method': 'GET',
+      'access-control-request-headers': 'x-custom-header',
+    }),
+    nextOk(),
+  );
+  assert.equal(resp.headers.get('access-control-allow-headers'), 'x-custom-header');
+});
+
+test('preflight uses configured allowedHeaders over the request header', async () => {
+  const mw = cors({ origin: '*', allowedHeaders: ['x-only-this'] });
+  const resp = await mw(
+    req('https://a.com', 'OPTIONS', {
+      'access-control-request-method': 'GET',
+      'access-control-request-headers': 'content-type',
+    }),
+    nextOk(),
+  );
+  assert.equal(resp.headers.get('access-control-allow-headers'), 'x-only-this');
+});
+
+test('disallowed preflight returns a bare 204 with no CORS headers', async () => {
+  const mw = cors({ origin: 'https://a.com' });
+  const resp = await mw(
+    req('https://evil.com', 'OPTIONS', { 'access-control-request-method': 'POST' }),
+    nextOk(),
+  );
+  assert.equal(resp.status, 204);
+  assert.equal(resp.headers.get('access-control-allow-origin'), null);
+  assert.equal(resp.headers.get('access-control-allow-methods'), null);
+});
+
+test('OPTIONS without Access-Control-Request-Method is NOT a preflight (passes to next)', async () => {
+  let nextCalled = false;
+  const mw = cors({ origin: '*' });
+  const resp = await mw(req('https://a.com', 'OPTIONS'), async () => {
+    nextCalled = true;
+    return new Response(null, { status: 204 });
+  });
+  assert.equal(nextCalled, true);
+  // It is an actual request, so ACAO is still applied.
+  assert.equal(resp.headers.get('access-control-allow-origin'), '*');
+});
+
+// --- credentials ---
+
+test('credentialed request with a specific allowed origin sets ACAC: true', async () => {
+  const mw = cors({ origin: 'https://a.com', credentials: true });
+  const resp = await mw(req('https://a.com'), nextOk());
+  assert.equal(resp.headers.get('access-control-allow-origin'), 'https://a.com');
+  assert.equal(resp.headers.get('access-control-allow-credentials'), 'true');
+});
+
+test('COUNTERFACTUAL: credentials + wildcard NEVER emits ACAO: * with ACAC', async () => {
+  // The CORS spec forbids `Access-Control-Allow-Origin: *` together with
+  // `Access-Control-Allow-Credentials: true`. The guard narrows the
+  // wildcard to the reflected request origin. If the guard were removed
+  // (resolveOrigin returning `{ allowOrigin: '*' }` under credentials),
+  // this assertion fails.
+  const mw = cors({ origin: '*', credentials: true });
+  const resp = await mw(req('https://a.com'), nextOk());
+  const acao = resp.headers.get('access-control-allow-origin');
+  assert.notEqual(acao, '*', 'must not send wildcard ACAO with credentials');
+  assert.equal(acao, 'https://a.com', 'wildcard narrows to the reflected origin');
+  assert.equal(resp.headers.get('access-control-allow-credentials'), 'true');
+  // And it varies by origin, so caches must key on Origin.
+  assert.equal(resp.headers.get('vary'), 'Origin');
+});
+
+test('credentials + wildcard with NO origin header refuses (no ACAO at all)', async () => {
+  const mw = cors({ origin: '*', credentials: true });
+  const resp = await mw(req(null), nextOk());
+  assert.equal(resp.headers.get('access-control-allow-origin'), null);
+  assert.equal(resp.headers.get('access-control-allow-credentials'), null);
+});
+
+test('resolveOrigin counterfactual at the unit level: wildcard+credentials never yields *', () => {
+  const r = resolveOrigin('*', 'https://a.com', true);
+  assert.ok(r);
+  assert.notEqual(r.allowOrigin, '*');
+  assert.equal(r.allowOrigin, 'https://a.com');
+  assert.equal(r.dynamic, true);
+  // Without credentials it is a plain static wildcard.
+  const w = resolveOrigin('*', 'https://a.com', false);
+  assert.deepEqual(w, { allowOrigin: '*', dynamic: false });
+});
+
+// --- Vary: Origin ---
+
+test('Vary: Origin is set for a dynamic (reflected) origin', async () => {
+  const mw = cors({ origin: ['https://a.com'] });
+  const resp = await mw(req('https://a.com'), nextOk());
+  assert.equal(resp.headers.get('vary'), 'Origin');
+});
+
+test('static wildcard (no credentials) does NOT add Vary: Origin', async () => {
+  const mw = cors({ origin: '*' });
+  const resp = await mw(req('https://a.com'), nextOk());
+  // No Origin variance for a constant `*`.
+  assert.equal(resp.headers.get('vary'), null);
+});
+
+test('Vary: Origin appends and does NOT clobber an existing Vary', async () => {
+  const mw = cors({ origin: 'https://a.com' });
+  const resp = await mw(req('https://a.com'), nextOk({ vary: 'Accept-Encoding' }));
+  const vary = resp.headers.get('vary');
+  const parts = vary.split(',').map((s) => s.trim().toLowerCase());
+  assert.ok(parts.includes('accept-encoding'), 'existing Vary preserved');
+  assert.ok(parts.includes('origin'), 'Origin appended');
+});
+
+test('Vary: Origin not duplicated when already present', () => {
+  const headers = new Headers({ vary: 'Origin' });
+  applyCorsHeaders(headers, { allowOrigin: 'https://a.com', dynamic: true }, {});
+  assert.equal(headers.get('vary'), 'Origin');
+});
+
+// --- exposedHeaders ---
+
+test('exposedHeaders sets Access-Control-Expose-Headers on the actual response', async () => {
+  const mw = cors({ origin: '*', exposedHeaders: ['x-total-count', 'x-page'] });
+  const resp = await mw(req('https://a.com'), nextOk());
+  assert.equal(resp.headers.get('access-control-expose-headers'), 'x-total-count, x-page');
+});
+
+// --- usable wrapped around a route handler ---
+
+test('cors() wraps a route.js handler: compose middleware + handler', async () => {
+  const mw = cors({ origin: 'https://app.example.com', credentials: true });
+  /** A toy route handler. */
+  const GET = async () => Response.json({ users: [] });
+  const handler = (request) => mw(request, () => GET(request));
+
+  const resp = await handler(req('https://app.example.com'));
+  assert.equal(resp.headers.get('access-control-allow-origin'), 'https://app.example.com');
+  assert.equal(resp.headers.get('access-control-allow-credentials'), 'true');
+  assert.deepEqual(await resp.json(), { users: [] });
+});

--- a/test/scaffolds/scaffold-integration.test.js
+++ b/test/scaffolds/scaffold-integration.test.js
@@ -190,6 +190,15 @@ test('scaffoldApp api: writes API-only template (no layout, no components)', asy
     assert.ok(existsSync(join(appDir, 'app', 'api', 'health', 'route.ts')), 'health route');
     assert.ok(existsSync(join(appDir, 'app', 'api', 'users', 'route.ts')), 'users route');
 
+    // Root CORS middleware demonstrating the cors() primitive
+    const mwPath = join(appDir, 'middleware.ts');
+    assert.ok(existsSync(mwPath), 'api template ships a root middleware.ts');
+    const mw = readFileSync(mwPath, 'utf8');
+    assert.match(mw, /import \{ cors \} from '@webjsdev\/server'/, 'imports cors()');
+    assert.match(mw, /export default cors\(/, 'default-exports the cors() middleware');
+    // Never demonstrate the invalid wildcard + credentials combination.
+    assert.doesNotMatch(mw, /origin:\s*'\*'/, 'no wildcard origin with credentials');
+
     // Module skeleton
     assert.ok(existsSync(join(appDir, 'modules', 'users', 'queries', 'list-users.server.ts')));
     assert.ok(existsSync(join(appDir, 'modules', 'users', 'actions', 'create-user.server.ts')));


### PR DESCRIPTION
## Summary

Closes #234

CORS was baked only into the `expose()` action path, so a plain `app/**/route.js` handler (the `--template api` shape) had to hand-roll origin reflection, OPTIONS preflight, `Vary: Origin`, and credential rules, a recurring source of CORS bugs. This adds a reusable `cors()` primitive.

`cors({ origin, credentials, methods, allowedHeaders, exposedHeaders, maxAge })` is exported from `@webjsdev/server` and returns a webjs middleware `(req, next) => Response`, usable in `middleware.js` (root or per-segment) or wrapped around a `route.js` handler. `origin` accepts a string, an array (entries may mix strings and RegExps), a RegExp, a predicate `(origin) => boolean`, or `'*'` / `true`. An OPTIONS preflight short-circuits a 204 with the Allow-Methods/Headers/Max-Age headers; an actual request reflects an allowed `Access-Control-Allow-Origin` and appends `Vary: Origin` for dynamic origins (never clobbering an existing Vary). A disallowed origin gets no ACAO but is still served (CORS is browser-enforced). `credentials: true` never emits a wildcard ACAO (the browser rejects `*` with credentials); it narrows to the reflected origin. The shared origin resolver also backs the `expose()` path (no behavior change there), so RegExp/predicate policies now work in both.

## Test plan

- **Unit/integration** (`packages/server/test/cors/cors-middleware.test.js`, new, 24): allowed-origin reflected; disallowed gets no ACAO; OPTIONS preflight short-circuits 204 with Allow headers; credentialed + specific origin sets ACAC; credentialed + wildcard never emits `*` (counterfactual: removing the guard reds this); Vary appended not clobbered; RegExp / function / array origin policies. The existing 17 `expose()` cors tests still pass (no regression from the shared resolver).
- Full unit suite 1691/1691; a freshly-scaffolded api app has zero `webjs check` violations.

## Definition of done

- **Docs:** root `AGENTS.md` (cors() helper + the expose() checklist CORS item + the credentials/wildcard rule), `agent-docs/advanced.md`, `packages/server/AGENTS.md` (module map), `packages/cli/templates/AGENTS.md`.
- **Scaffold:** `--template api` now writes a root `middleware.ts` demonstrating `cors()` with an explicit allow-list (never `*` + credentials); scaffold integration test updated.
- **Dogfood:** blog e2e 69/69; website / docs / ui-website boot 200 in prod mode, zero broken modulepreloads; `cors` export confirmed.
- **Version bump:** N/A in this PR (release PR after merge).

The `cors.js` and `actions.js` preflight builders stay distinct (expose 403s on mismatch, the middleware serves a bare 204), since only the origin/header core was worth sharing.