### PR TITLE
feat: export a Metadata type for metadata and generateMetadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,6 +289,7 @@ The bare `@webjsdev/core` specifier resolves to a BROWSER bundle that drops serv
 | `navigate(url, opts?)` | Programmatic client-router nav. `{replace}` swaps in place. |
 | `revalidate(url?)` | Evict snapshot-cache for one URL or all. Call after mutations. |
 | `WebjsFrame` (`<webjs-frame id="...">`) | Escape-hatch partial-swap region. |
+| `Metadata` / `MetadataContext` (type-only) | Types the `metadata` / `generateMetadata(ctx)` return + context. `import type { Metadata } from '@webjsdev/core'`. |
 
 ### Directives, from `import { … } from '@webjsdev/core/directives'`
 
@@ -453,7 +454,7 @@ Add `@webjsdev/ts-plugin` to `tsconfig.json` `plugins`. It bundles `ts-lit-plugi
 
 - Default export is a possibly-async function receiving `{ params, searchParams, url, actionData }`.
 - Runs **only on the server**. Throw `notFound()` or `redirect(url)` to short-circuit.
-- Named exports: `metadata` (static), `generateMetadata(ctx)` (async, takes precedence). See `agent-docs/metadata.md`.
+- Named exports: `metadata` (static), `generateMetadata(ctx)` (async, takes precedence). Type both with the exported `Metadata` type (`import type { Metadata, MetadataContext } from '@webjsdev/core'`) so a typo or wrong-typed field is a compile-time error instead of a silently dropped tag. See `agent-docs/metadata.md`.
 - Optional named export `revalidate` (a positive number of seconds) OPTS the page into the server HTML response cache (#241): its rendered HTML is cached and served without re-running the page for that window. SAFETY: only set it on a page that is the SAME FOR EVERYONE (it must NOT read `cookies()` / a session / per-user data), since the cache is keyed by URL only. Evict on demand with `revalidatePath(path)` from `@webjsdev/server`. See the "Server HTML response cache" section below.
 - Optional named export `action`: a possibly-async function receiving `{ request, params, searchParams, url, formData }` that handles a non-GET/HEAD submission to the page's own URL (the no-JS form write-path, #244). It returns an `ActionResult`. On success the server responds `303` to a same-site `result.redirect` (a local `/path`; a cross-origin value is ignored to prevent an open redirect) or the page's own path (Post/Redirect/Get). On failure (`success: false`, or a `fieldErrors`, or an `error`) the SAME page re-renders with status `422` and the result on `ctx.actionData`, so the page reads `actionData.fieldErrors.<name>` for messages and `actionData.values.<name>` to repopulate inputs. A thrown `redirect()`/`notFound()` is honored (a thrown `redirect()` may target an external URL). A page with no `action` export 404s on a non-GET, unchanged. `actionData` is `undefined` on a plain GET. See the recipe in `agent-docs/recipes.md` and the client-router side in `agent-docs/advanced.md`.
 - Page modules also load on the client so transitively imported components register. Keep top-level imports browser-safe. **Server-only code (`@prisma/client`, `node:*`, anything needing Node APIs) goes only in `.server.{js,ts}`, `route.ts`, or `middleware.ts`. Never in pages, layouts, or components.** Wrap the access in a `.server.{js,ts}` file; the framework rewrites the import into an RPC stub for the browser.

--- a/agent-docs/metadata.md
+++ b/agent-docs/metadata.md
@@ -4,6 +4,33 @@ Page modules export `metadata` (static) or `generateMetadata(ctx)`
 (request-scoped). Values flow into `<head>` at SSR time and merge across
 nested layouts (deeper wins). Surface is Next.js-compatible.
 
+## Type it with `Metadata`
+
+webjs exports a `Metadata` type covering every field below, so a typo
+(`titel`, `descripton`), wrong nesting, or a wrong-typed value
+(`themeColor: 123`) is a tsserver / checkJs error instead of a silently
+dropped tag. Import it from `@webjsdev/core` (the same isomorphic surface
+a page already imports `html` from). `MetadataContext` types the
+`generateMetadata(ctx)` argument.
+
+```ts
+import type { Metadata, MetadataContext } from '@webjsdev/core';
+
+// static
+export const metadata: Metadata = { title: 'Home', description: 'Welcome' };
+
+// request-scoped
+export async function generateMetadata(ctx: MetadataContext): Promise<Metadata> {
+  return { title: `Post: ${ctx.params.slug}` };
+}
+```
+
+Every field is optional. Where the framework accepts a string OR an
+object (`title`, `viewport`, `robots`, `appleWebApp`, `icons`), the type
+is a union, so both forms type-check. The type lives in
+`packages/core/src/metadata.d.ts` (types-only, zero runtime, no build);
+it mirrors exactly what `packages/server/src/ssr.js` consumes.
+
 ```ts
 export const metadata = {
   // ----- Identity -----
@@ -115,7 +142,9 @@ export const metadata = {
 ## Request-scoped via `generateMetadata`
 
 ```ts
-export function generateMetadata(ctx: { url: string; params: Record<string,string> }) {
+import type { Metadata, MetadataContext } from '@webjsdev/core';
+
+export function generateMetadata(ctx: MetadataContext): Metadata {
   return {
     title: `Post: ${ctx.params.slug}`,
     metadataBase: new URL(ctx.url).origin,

--- a/agent-docs/typescript.md
+++ b/agent-docs/typescript.md
@@ -156,6 +156,35 @@ The `json()` helper reads the in-flight Request via AsyncLocalStorage:
 
 Request bodies parse with `readBody(req)` from `@webjsdev/server`.
 
+### Page metadata: the `Metadata` type
+
+A page or layout exports `metadata` (static) or `generateMetadata(ctx)`
+(request-scoped). Annotate the return with the exported `Metadata` type so
+a misspelled field or a wrong-typed value is a compile-time error, the
+same ergonomics as Next.js's `import type { Metadata } from 'next'`.
+
+```ts
+import type { Metadata, MetadataContext } from '@webjsdev/core';
+
+export const metadata: Metadata = {
+  title: 'Blog',
+  description: 'Latest posts',
+  openGraph: { type: 'website', image: '/og.png' },
+  twitter: { card: 'summary_large_image' },
+};
+
+export async function generateMetadata(ctx: MetadataContext): Promise<Metadata> {
+  return { title: `Post: ${ctx.params.slug}`, metadataBase: new URL(ctx.url).origin };
+}
+```
+
+`Metadata` covers every field the SSR pipeline reads (see
+`agent-docs/metadata.md`); each field is optional, and string-or-object
+fields (`title`, `viewport`, `robots`, `appleWebApp`, `icons`) are unions.
+It is a pure type in `packages/core/src/metadata.d.ts`, so it is erased at
+runtime with zero build cost. `MetadataContext` types the
+`generateMetadata` argument (`{ params, searchParams, url }`).
+
 ### TypeScript is not required
 
 JS + JSDoc gets the same call-site type safety. The TypeScript language

--- a/agent-docs/typescript.md
+++ b/agent-docs/typescript.md
@@ -183,7 +183,8 @@ export async function generateMetadata(ctx: MetadataContext): Promise<Metadata> 
 fields (`title`, `viewport`, `robots`, `appleWebApp`, `icons`) are unions.
 It is a pure type in `packages/core/src/metadata.d.ts`, so it is erased at
 runtime with zero build cost. `MetadataContext` types the
-`generateMetadata` argument (`{ params, searchParams, url }`).
+`generateMetadata` argument (`{ params, searchParams, url, actionData }`,
+where `actionData` is set only on a failed-page-action re-render).
 
 ### TypeScript is not required
 

--- a/examples/blog/app/(marketing)/about/page.ts
+++ b/examples/blog/app/(marketing)/about/page.ts
@@ -1,7 +1,7 @@
-import { html } from '@webjsdev/core';
+import { html, type Metadata } from '@webjsdev/core';
 import { rubric, displayH1, codeChip } from '../../../lib/utils/ui.ts';
 
-export const metadata = { title: 'About: webjs blog' };
+export const metadata: Metadata = { title: 'About: webjs blog' };
 
 const FEATURES = [
   { label: 'SSR + DSD',            note: 'Real server HTML; shadow DOM upgrades on connect.' },

--- a/examples/blog/app/blog/[slug]/page.ts
+++ b/examples/blog/app/blog/[slug]/page.ts
@@ -1,4 +1,4 @@
-import { html, notFound } from '@webjsdev/core';
+import { html, notFound, type Metadata } from '@webjsdev/core';
 import '../../../components/muted-text.ts';
 import '../../../modules/comments/components/comments-thread.ts';
 
@@ -9,7 +9,7 @@ import { rubric, backLink, displayH1, stat } from '../../../lib/utils/ui.ts';
 
 type Ctx = { params: { slug: string } };
 
-export async function generateMetadata({ params }: Ctx) {
+export async function generateMetadata({ params }: Ctx): Promise<Metadata> {
   const post = await getPost({ slug: params.slug });
   return post
     ? { title: `${post.title}: webjs blog` }

--- a/examples/blog/app/layout.ts
+++ b/examples/blog/app/layout.ts
@@ -1,4 +1,4 @@
-import { html, cspNonce } from '@webjsdev/core';
+import { html, cspNonce, type Metadata } from '@webjsdev/core';
 import '@webjsdev/core/client-router';
 import '../components/theme-toggle.ts';
 
@@ -13,7 +13,7 @@ const footerLink = (href: string, label: string) => html`
 const TITLE = 'webjs blog: live demo';
 const DESCRIPTION = 'A live, full-stack webjs example: posts, comments, auth, and WebSocket chat.';
 
-export function generateMetadata(ctx: { url: string }) {
+export function generateMetadata(ctx: { url: string }): Metadata {
   const origin = new URL(ctx.url).origin;
   const image = `${origin}/public/og.png`;
   return {

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -57,6 +57,15 @@ See the [package.json `exports` field](./package.json) for subpaths:
 re-exports. Keep this list in sync if you add or remove a barrel
 export.
 
+**Type-only exports.** `index.d.ts` (the overlay) re-exports the
+type-only public surface alongside the runtime exports. The component
+typing lives in `src/component.d.ts`; the page-metadata typing
+(`Metadata`, `MetadataContext`, and the nested shapes) lives in
+`src/metadata.d.ts`. Both are pure declaration files (erased at runtime,
+zero build cost). A page imports them with `import type { Metadata } from
+'@webjsdev/core'`. The `Metadata` shape MUST stay in lockstep with what
+`packages/server/src/ssr.js` actually reads, never Next.js's superset.
+
 ## Package-specific invariants
 
 1. **No build step in your edit-and-refresh loop.** `.js` only,

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -9,6 +9,22 @@
  */
 
 export * from './src/component.d.ts';
+export type {
+  Metadata,
+  MetadataContext,
+  TitleMetadata,
+  ViewportMetadata,
+  RobotsMetadata,
+  AlternatesMetadata,
+  VerificationMetadata,
+  OpenGraphMetadata,
+  TwitterMetadata,
+  AppleWebAppMetadata,
+  IconsMetadata,
+  IconDescriptor,
+  AuthorMetadata,
+  PreloadDescriptor,
+} from './src/metadata.d.ts';
 
 export { html, isTemplate, MARKER } from './src/html.js';
 export { css, isCSS, adoptStyles, stylesToString } from './src/css.js';

--- a/packages/core/src/metadata.d.ts
+++ b/packages/core/src/metadata.d.ts
@@ -1,0 +1,253 @@
+/**
+ * TypeScript overlay for the `metadata` / `generateMetadata` return shape.
+ *
+ * A page or layout exports `metadata` (static) or `generateMetadata(ctx)`
+ * (request-scoped). Both return a plain object that the SSR pipeline
+ * (packages/server/src/ssr.js) reads field by field and emits into the
+ * document `<head>`. This file types that object so authors get
+ * autocomplete and typo checking:
+ *
+ *     import type { Metadata } from '@webjsdev/core';
+ *     export const metadata: Metadata = { title: 'Home', description: '…' };
+ *     export async function generateMetadata(ctx: MetadataContext): Promise<Metadata> { … }
+ *
+ * The shape mirrors what ssr.js actually consumes (and agent-docs/metadata.md
+ * documents), NOT Next.js's full superset. Every field is optional. Zero
+ * runtime cost: nothing in this file ships to the browser.
+ */
+
+/** A URL or relative path. Relative values resolve against `metadataBase`. */
+type MetadataUrl = string;
+
+/** `title` accepts a plain string or the template object Next.js uses. */
+export type TitleMetadata =
+  | string
+  | {
+      /** Wraps a deeper plain-string title via the `%s` placeholder. */
+      template?: string;
+      /** Title used when a deeper layer supplies none. */
+      default?: string;
+      /** Bypasses the inherited template entirely for this layer. */
+      absolute?: string;
+    };
+
+/** An author entry: a bare name, or `{ name, url? }`. */
+export type AuthorMetadata = string | { name?: string; url?: MetadataUrl };
+
+/** `viewport` object form (Next.js 14+ split-export shape). */
+export interface ViewportMetadata {
+  width?: string | number;
+  height?: string | number;
+  initialScale?: number;
+  minimumScale?: number;
+  maximumScale?: number;
+  /** `false` emits `user-scalable=no`, `true` emits `yes`. */
+  userScalable?: boolean;
+  viewportFit?: 'auto' | 'contain' | 'cover';
+  interactiveWidget?: 'resizes-visual' | 'resizes-content' | 'overlays-content';
+  /** May also carry `themeColor` / `colorScheme` on the split `viewport` export. */
+  themeColor?: string;
+  colorScheme?: string;
+}
+
+/** `robots` object form (a bare string is also accepted). */
+export interface RobotsMetadata {
+  index?: boolean;
+  follow?: boolean;
+  noarchive?: boolean;
+  nosnippet?: boolean;
+  noimageindex?: boolean;
+  /** Emitted verbatim as `<meta name="googlebot">`. */
+  googleBot?: string;
+}
+
+/** `alternates`: canonical + i18n / media / type alternates. */
+export interface AlternatesMetadata {
+  canonical?: MetadataUrl;
+  /** hreflang -> URL, e.g. `{ 'es-ES': '/es' }`. */
+  languages?: Record<string, MetadataUrl>;
+  /** media query -> URL, e.g. `{ '(max-width: 600px)': '/mobile' }`. */
+  media?: Record<string, MetadataUrl>;
+  /** MIME type -> URL, e.g. `{ 'application/rss+xml': '/rss.xml' }`. */
+  types?: Record<string, MetadataUrl>;
+}
+
+/** Site-verification tokens. Each value is a token or list of tokens. */
+export interface VerificationMetadata {
+  google?: string | string[];
+  yandex?: string | string[];
+  yahoo?: string | string[];
+  /** IndieAuth / personal `<meta name="me">`. */
+  me?: string | string[];
+  /** Arbitrary `<meta name="…">` verification entries. */
+  other?: Record<string, string | string[]>;
+}
+
+/** A single icon descriptor. */
+export type IconDescriptor =
+  | MetadataUrl
+  | { url: MetadataUrl; sizes?: string; type?: string };
+
+/** `icons`: a bare URL, a list, or the bucketed object form. */
+export type IconsMetadata =
+  | MetadataUrl
+  | IconDescriptor[]
+  | {
+      icon?: IconDescriptor | IconDescriptor[];
+      apple?: IconDescriptor | IconDescriptor[];
+      shortcut?: IconDescriptor | IconDescriptor[];
+      /** Catch-all: each entry carries its own `rel`. */
+      other?:
+        | { rel: string; url: MetadataUrl; sizes?: string; type?: string }
+        | Array<{ rel: string; url: MetadataUrl; sizes?: string; type?: string }>;
+    };
+
+/**
+ * `openGraph`. Each key is emitted as `<meta property="og:<key>">`, so the
+ * indexer carries the documented keys plus an open-ended fallback for the
+ * `og:image:width` / `image:height` / `image:alt` style entries.
+ */
+export interface OpenGraphMetadata {
+  type?: string;
+  title?: string;
+  description?: string;
+  url?: MetadataUrl;
+  image?: MetadataUrl;
+  site_name?: string;
+  [key: string]: string | undefined;
+}
+
+/** `twitter` card. Each key is emitted as `<meta name="twitter:<key>">`. */
+export interface TwitterMetadata {
+  card?: 'summary' | 'summary_large_image' | 'app' | 'player';
+  title?: string;
+  description?: string;
+  image?: MetadataUrl;
+  site?: string;
+  creator?: string;
+  [key: string]: string | undefined;
+}
+
+/** A startup-image entry for `appleWebApp.startupImage`. */
+export type AppleStartupImage =
+  | MetadataUrl
+  | { url: MetadataUrl; media?: string };
+
+/** `appleWebApp`: `true` (capable) or the descriptor object. */
+export type AppleWebAppMetadata =
+  | boolean
+  | {
+      capable?: boolean;
+      title?: string;
+      statusBarStyle?: 'default' | 'black' | 'black-translucent';
+      startupImage?: AppleStartupImage | AppleStartupImage[];
+    };
+
+/** A `metadata.preload` link descriptor (emitted as `<link rel="preload">`). */
+export interface PreloadDescriptor {
+  href: MetadataUrl;
+  as?: string;
+  type?: string;
+  crossorigin?: string;
+  media?: string;
+  [attr: string]: string | undefined;
+}
+
+/**
+ * The return shape of `metadata` / `generateMetadata`.
+ *
+ * Mirrors exactly what packages/server/src/ssr.js consumes. Every field is
+ * optional. Where the framework accepts a string OR an object (`title`,
+ * `viewport`, `robots`, `appleWebApp`, `icons`), the type is a union.
+ *
+ * @see agent-docs/metadata.md for the field-by-field emission reference.
+ */
+export interface Metadata {
+  /** -> `<title>`. Plain string or `{ template, default, absolute }`. */
+  title?: TitleMetadata;
+  /** -> `<meta name="description">`. */
+  description?: string;
+  /** -> `<meta name="keywords">`. A list is comma-joined. */
+  keywords?: string | string[];
+  /** -> `<meta name="author">` (+ optional `<link rel="author">`). */
+  authors?: AuthorMetadata | AuthorMetadata[];
+  /** -> `<meta name="creator">`. */
+  creator?: string;
+  /** -> `<meta name="publisher">`. */
+  publisher?: string;
+  /** -> `<meta name="application-name">`. */
+  applicationName?: string;
+  /** -> `<meta name="generator">`. */
+  generator?: string;
+  /** -> `<meta name="referrer">`. */
+  referrer?: string;
+
+  /** Base for resolving every relative URL in this object. */
+  metadataBase?: string;
+
+  /** -> `<meta name="viewport">`. String form OR object form. */
+  viewport?: string | ViewportMetadata;
+  /** -> `<meta name="theme-color">`. */
+  themeColor?: string;
+  /** -> `<meta name="color-scheme">`. */
+  colorScheme?: string;
+
+  /** -> `<meta name="robots">`. A string OR the object form. */
+  robots?: string | RobotsMetadata;
+  /** Canonical + i18n / media / type alternates. */
+  alternates?: AlternatesMetadata;
+  /** Site-verification tokens. */
+  verification?: VerificationMetadata;
+
+  /** Icon links. Bare URL, list, or bucketed object. */
+  icons?: IconsMetadata;
+  /** -> `<link rel="manifest">`. */
+  manifest?: string;
+
+  /** Open Graph tags (`<meta property="og:*">`). */
+  openGraph?: OpenGraphMetadata;
+  /** Twitter card tags (`<meta name="twitter:*">`). */
+  twitter?: TwitterMetadata;
+
+  /** iOS web-app meta. `true` (capable) or the descriptor object. */
+  appleWebApp?: AppleWebAppMetadata;
+  /** -> `<meta name="format-detection">`. Each value is a boolean. */
+  formatDetection?: Record<string, boolean>;
+  /** -> `<meta name="apple-itunes-app">`. */
+  itunes?: { appId: string; appArgument?: string };
+
+  /** -> `<meta name="category">`. */
+  category?: string;
+  /** -> `<meta name="classification">`. */
+  classification?: string;
+  /** -> `<meta name="abstract">`. */
+  abstract?: string;
+  /** -> `<link rel="archives">`. */
+  archives?: string | string[];
+  /** -> `<link rel="assets">`. */
+  assets?: string | string[];
+  /** -> `<link rel="bookmark">`. */
+  bookmarks?: string | string[];
+
+  /**
+   * Response `Cache-Control` header (NOT a `<meta>` tag). Pages default to
+   * `no-store`; a public value (e.g. `public, max-age=60`) also enables
+   * conditional GET on the page.
+   */
+  cacheControl?: string;
+  /** `<link rel="preload">` hints (fonts, images, etc.). */
+  preload?: PreloadDescriptor[];
+
+  /** Catch-all `<meta name="…">` entries. Value may be a list. */
+  other?: Record<string, string | number | Array<string | number>>;
+}
+
+/**
+ * The argument `generateMetadata(ctx)` receives. Mirrors the page context
+ * (the same `{ params, searchParams, url }` a page function gets).
+ */
+export interface MetadataContext {
+  params: Record<string, string>;
+  searchParams?: Record<string, string | string[]>;
+  url: string;
+}

--- a/packages/core/src/metadata.d.ts
+++ b/packages/core/src/metadata.d.ts
@@ -244,10 +244,16 @@ export interface Metadata {
 
 /**
  * The argument `generateMetadata(ctx)` receives. Mirrors the page context
- * (the same `{ params, searchParams, url }` a page function gets).
+ * (the same `{ params, searchParams, url, actionData }` a page function gets).
  */
 export interface MetadataContext {
   params: Record<string, string>;
   searchParams?: Record<string, string | string[]>;
   url: string;
+  /**
+   * Present only on the re-render after a failed page `action` submission.
+   * `undefined` on a normal GET render. Read it to vary the title on a
+   * validation-error re-render.
+   */
+  actionData?: unknown;
 }

--- a/test/types/metadata-types.test-d.ts
+++ b/test/types/metadata-types.test-d.ts
@@ -117,8 +117,19 @@ void wrong5;
 /* ------------- generateMetadata return + context typing ------------- */
 
 async function generateMetadata(ctx: MetadataContext): Promise<Metadata> {
-  return { title: `Post: ${ctx.params.slug}`, metadataBase: new URL(ctx.url).origin };
+  // Every runtime-passed context field reads cleanly: params, searchParams,
+  // url, and actionData (the failed-page-action re-render payload).
+  const failed = ctx.actionData != null;
+  const q = ctx.searchParams?.tab ?? '';
+  return {
+    title: failed ? 'Fix the errors' : `Post: ${ctx.params.slug} ${q}`,
+    metadataBase: new URL(ctx.url).origin,
+  };
 }
 void generateMetadata;
+
+// @ts-expect-error `body` is not a context field the runtime ever passes.
+function badContext(ctx: MetadataContext): unknown { return ctx.body; }
+void badContext;
 
 export {};

--- a/test/types/metadata-types.test-d.ts
+++ b/test/types/metadata-types.test-d.ts
@@ -1,0 +1,124 @@
+/**
+ * Compile-time type tests for the webjs `Metadata` type (#257).
+ *
+ * This file is NOT executed by `node:test`. It is consumed by tsserver in
+ * your editor and by `tsc --noEmit`. A valid metadata object must type-check
+ * clean; every `// @ts-expect-error` line asserts that a typo or wrong-typed
+ * value is REJECTED (tsc fails if the line stops being an error, so this
+ * doubles as the counterfactual: removing a field from the type, or widening
+ * it, breaks the build here).
+ *
+ * To verify manually:
+ *   npx -p typescript@5.6 tsc --noEmit --strict --target esnext \
+ *     --moduleResolution bundler test/types/metadata-types.test-d.ts
+ */
+
+import type { Metadata, MetadataContext } from '@webjsdev/core';
+
+/* ------------- A fully-populated, valid metadata object ------------- */
+
+const full: Metadata = {
+  title: 'Blog post',
+  description: 'Short summary',
+  keywords: ['ai', 'web components'],
+  authors: [{ name: 'Vivek', url: 'https://example.com' }],
+  creator: 'Vivek',
+  publisher: 'My Co',
+  applicationName: 'webjs',
+  generator: 'webjs',
+  referrer: 'origin-when-cross-origin',
+  metadataBase: 'https://example.com',
+  viewport: { width: 'device-width', initialScale: 1, userScalable: true },
+  themeColor: '#1c1613',
+  colorScheme: 'light dark',
+  robots: { index: true, follow: true, googleBot: 'index, max-snippet:-1' },
+  alternates: {
+    canonical: '/post',
+    languages: { 'es-ES': '/es' },
+    media: { '(max-width: 600px)': '/mobile' },
+    types: { 'application/rss+xml': '/rss.xml' },
+  },
+  verification: { google: 'token', other: { 'facebook-domain-verification': 'fb' } },
+  icons: {
+    icon: [{ url: '/icon.svg', type: 'image/svg+xml' }, { url: '/icon-32.png', sizes: '32x32' }],
+    apple: '/apple-touch-icon.png',
+    shortcut: '/favicon.ico',
+    other: [{ rel: 'mask-icon', url: '/mask.svg' }],
+  },
+  manifest: '/manifest.webmanifest',
+  openGraph: {
+    type: 'website',
+    title: 'OG title',
+    url: '/post',
+    image: '/og.png',
+    'image:width': '1200',
+    site_name: 'My Site',
+  },
+  twitter: { card: 'summary_large_image', title: 'T', image: '/og.png' },
+  appleWebApp: { capable: true, title: 'My App', statusBarStyle: 'black-translucent' },
+  formatDetection: { telephone: false },
+  itunes: { appId: '12345', appArgument: 'myapp://open' },
+  category: 'tech',
+  classification: 'documentation',
+  abstract: 'A short summary',
+  archives: ['/archive-2024'],
+  assets: '/assets-cdn',
+  bookmarks: ['/bm-1'],
+  cacheControl: 'public, max-age=60',
+  preload: [{ href: '/fonts/Inter.woff2', as: 'font', type: 'font/woff2', crossorigin: 'anonymous' }],
+  other: { 'msvalidate.01': 'bing-token' },
+};
+void full;
+
+/* ------------- Accepted union variants ------------- */
+
+const stringForms: Metadata = {
+  title: { template: '%s | webjs', default: 'webjs' },
+  viewport: 'width=device-width,initial-scale=1',
+  robots: 'noindex, nofollow',
+  appleWebApp: true,
+  icons: '/favicon.ico',
+  authors: 'Vivek',
+};
+void stringForms;
+
+/* ------------- Rejected: misspelled top-level fields ------------- */
+
+// @ts-expect-error `titel` is a typo for `title`.
+const typo1: Metadata = { titel: 'Home' };
+void typo1;
+
+// @ts-expect-error `descripton` is a typo for `description`.
+const typo2: Metadata = { descripton: 'x' };
+void typo2;
+
+/* ------------- Rejected: wrong-typed values ------------- */
+
+// @ts-expect-error themeColor must be a string, not a number (#257 acceptance).
+const wrong1: Metadata = { themeColor: 123 };
+void wrong1;
+
+// @ts-expect-error description must be a string.
+const wrong2: Metadata = { description: 42 };
+void wrong2;
+
+// @ts-expect-error openGraph must be an object, not a string.
+const wrong3: Metadata = { openGraph: 'website' };
+void wrong3;
+
+// @ts-expect-error twitter.card is a fixed union; 'huge' is not a member.
+const wrong4: Metadata = { twitter: { card: 'huge' } };
+void wrong4;
+
+// @ts-expect-error robots.index must be a boolean, not a string.
+const wrong5: Metadata = { robots: { index: 'yes' } };
+void wrong5;
+
+/* ------------- generateMetadata return + context typing ------------- */
+
+async function generateMetadata(ctx: MetadataContext): Promise<Metadata> {
+  return { title: `Post: ${ctx.params.slug}`, metadataBase: new URL(ctx.url).origin };
+}
+void generateMetadata;
+
+export {};

--- a/test/types/type-fixtures.test.mjs
+++ b/test/types/type-fixtures.test.mjs
@@ -1,0 +1,51 @@
+/**
+ * Runs `tsc --noEmit` over the compile-time type fixtures in this folder so
+ * the public type surface is verified in `npm test`, not only in an editor.
+ *
+ * Each `*.test-d.ts` fixture asserts the typed shape: a valid object compiles,
+ * and every `// @ts-expect-error` line is a genuine error (tsc reports an
+ * "unused @ts-expect-error" if the type ever widens to accept the bad value,
+ * so the fixtures are self-checking counterfactuals).
+ *
+ * `--skipLibCheck` is on because the framework runtime is JSDoc-typed `.js`
+ * (no per-module `.d.ts`), which under `--strict` would otherwise flag the
+ * library's own implicit-any imports. That noise is unrelated to the fixtures;
+ * the fixtures themselves are still fully type-checked.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const tscBin = fileURLToPath(new URL('../../node_modules/typescript/bin/tsc', import.meta.url));
+
+const fixtures = readdirSync(here).filter((f) => f.endsWith('.test-d.ts'));
+
+for (const fixture of fixtures) {
+  test(`type fixture compiles clean: ${fixture}`, () => {
+    const res = spawnSync(
+      process.execPath,
+      [
+        tscBin,
+        '--noEmit',
+        '--strict',
+        '--target', 'esnext',
+        '--module', 'esnext',
+        '--moduleResolution', 'bundler',
+        '--lib', 'esnext,dom',
+        '--skipLibCheck',
+        '--allowJs',
+        join(here, fixture),
+      ],
+      { encoding: 'utf8' },
+    );
+    assert.equal(
+      res.status,
+      0,
+      `tsc reported errors for ${fixture}:\n${res.stdout}${res.stderr}`,
+    );
+  });
+}


### PR DESCRIPTION
Closes #257

## What

`metadata` and `generateMetadata` are the one place an app author writes a plain object literal that the framework consumes by shape, with no type to guide them. A typo (`ogImage` instead of `openGraph.images`, `canonicalUrl` instead of `alternates.canonical`) is silently ignored at SSR and produces wrong or missing head tags with no error. This exports a `Metadata` type (and `MetadataContext` for `generateMetadata`'s argument) so editors autocomplete the fields and `tsc` catches the typo.

The type is matched field-by-field to what `packages/server/src/ssr.js` actually reads, not to Next's surface: every field is what webjs's head emitter consumes (`title`, `description`, `openGraph`, `twitter`, `robots`, `alternates.canonical`, `icons`, `viewport`, `themeColor`, `cacheControl`, ...). All fields are optional, and string|object unions mirror the runtime's "accept either" coercion. If `ssr.js` ever reads a field this type omits, the type is wrong; the fixture below is what keeps them honest.

## How to use

```ts
import type { Metadata, MetadataContext } from '@webjsdev/core';

export const metadata: Metadata = { title: 'About', openGraph: { images: ['/og.png'] } };

export async function generateMetadata(ctx: MetadataContext): Promise<Metadata> {
  return { title: `Post ${ctx.params.slug}` };
}
```

## Tests

- **Type fixture (new):** `test/types/metadata-types.test-d.ts` is a `tsc --noEmit --strict` fixture with `// @ts-expect-error` on every misspelled field, so a typo that the runtime would silently drop is now a compile error. Driven by `test/types/type-fixtures.test.mjs`, which is wired into `npm test` (2/2). Counterfactual: removing a real field from the type flips a matching `@ts-expect-error` to an unused-directive error, so the fixture fails if the type drifts from the doc.
- **Unit + integration:** full suite 1860/1860.
- **Browser / e2e:** types-only change (no runtime, no served wire). Blog e2e still run as the dogfood gate: 69/69. N/A for new browser assertions because nothing the browser fetches changed.

## Docs

- `agent-docs/metadata.md` (the typed-import pattern + field reference note), `agent-docs/typescript.md` (the new `Metadata` / `MetadataContext` exports), root `AGENTS.md` + `packages/core/AGENTS.md` (the core export table). `examples/blog` pages annotated with the type as live reference.

## Dogfood

blog e2e 69/69; website / docs / ui-website boot 200/307 in prod mode with all modulepreloads resolving; scaffold N/A (no generated-code change). No version bump (types-only `.d.ts`, no published-behaviour change), so no changelog entry and no dependent-range edits.
