### PR TITLE
fix: surface a missing webjs-frame instead of a silent full-page swap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,7 +288,7 @@ The bare `@webjsdev/core` specifier resolves to a BROWSER bundle that drops serv
 | `richFetch<T>(url, init?)` | Content-negotiated fetch with rich-type encoding. |
 | `navigate(url, opts?)` | Programmatic client-router nav. `{replace}` swaps in place. |
 | `revalidate(url?)` | Evict snapshot-cache for one URL or all. Call after mutations. |
-| `WebjsFrame` (`<webjs-frame id="...">`) | Escape-hatch partial-swap region. |
+| `WebjsFrame` (`<webjs-frame id="...">`) | Escape-hatch partial-swap region. A frame nav whose response lacks the frame fires a cancelable, bubbling `webjs:frame-missing` event (detail `{ frameId, url, document }`) and leaves the frame unchanged instead of full-swapping; `preventDefault()` hands the outcome to the listener. |
 | `Metadata` / `MetadataContext` (type-only) | Types the `metadata` / `generateMetadata(ctx)` return + context. `import type { Metadata } from '@webjsdev/core'`. |
 | `PageProps<R>` / `LayoutProps<R>` / `RouteHandlerContext<R>` (type-only) | Types the page / layout / route-handler args (`{ params, searchParams, url, actionData }`; layouts add `children`). `R` is an optional route literal that narrows `params` against the generated route union. `Route` / `RouteParams<R>` are the href + params helpers. Run `webjs types` to generate the union (see CLI reference). `import type { PageProps } from '@webjsdev/core'`. |
 
@@ -667,7 +667,7 @@ Wire-byte optimization is automatic: the router sends `X-Webjs-Have` listing mar
 
 **Production benefits from HTTP/2 at the edge.** Per-file ESM rides HTTP/2 multiplex to be competitive with bundling. PaaS edges (Railway, Fly, Render, Vercel, Cloudflare, Heroku) serve HTTP/2 automatically. Bare-VM self-hosters put nginx / Caddy / Traefik in front. The production server (`npm run start`) speaks plain HTTP/1.1.
 
-For partial-swap NOT tied to a folder layout, wrap in `<webjs-frame id="...">`. See `agent-docs/advanced.md` for the full mechanism.
+For partial-swap NOT tied to a folder layout, wrap in `<webjs-frame id="...">`. A frame nav whose response lacks the frame fires a cancelable `webjs:frame-missing` event and leaves the frame unchanged (no silent full-page swap). See `agent-docs/advanced.md` for the full mechanism.
 
 ---
 

--- a/agent-docs/advanced.md
+++ b/agent-docs/advanced.md
@@ -550,8 +550,36 @@ html`<webjs-frame id="activity">…contents…</webjs-frame>`
 On click, the router walks `closest('webjs-frame')` from the click
 target. If a frame is found AND the response contains a matching
 `<webjs-frame id="...">`, the swap is scoped to that frame's children,
-which takes precedence over the layout-marker mechanism. Otherwise the
-router falls through to the layout-marker path.
+which takes precedence over the layout-marker mechanism.
+
+#### `webjs:frame-missing` (response lacks the requested frame)
+
+When a frame-scoped navigation's response does NOT carry a matching
+`<webjs-frame id="...">` (e.g. an auth gate returns a login page without
+the frame), the router does NOT fall through to a full-page swap, because
+that would silently destroy the page. Instead it dispatches a cancelable,
+bubbling `webjs:frame-missing` CustomEvent on the frame element (so a
+document-level listener catches it) and returns.
+
+- **Default (not prevented):** the router emits a one-line `console.warn`
+  and leaves the frame UNCHANGED (its current content stays, now stale).
+  No full-page swap ever happens.
+- **`preventDefault()`:** the framework stays silent and does nothing
+  further. The listener owns the outcome, e.g. it may call `navigate(url)`
+  for a deliberate full swap, or `location.assign(url)` for a hard load.
+
+`event.detail` is `{ frameId, url, document }`, where `frameId` is the
+requested frame id, `url` is the navigation target, and `document` is the
+parsed response document (so a listener can inspect what came back).
+
+```ts
+document.addEventListener('webjs:frame-missing', (e) => {
+  // The frame wasn't in the response (auth redirect, say). Take over
+  // with a deliberate full navigation to the URL the server returned.
+  e.preventDefault();
+  location.assign(e.detail.url);
+});
+```
 
 ### Opt out per link
 

--- a/agent-docs/advanced.md
+++ b/agent-docs/advanced.md
@@ -564,7 +564,7 @@ document-level listener catches it) and returns.
 - **Default (not prevented):** the router emits a one-line `console.warn`
   and leaves the frame UNCHANGED (its current content stays, now stale).
   No full-page swap ever happens.
-- **`preventDefault()`:** the framework stays silent and does nothing
+- **Calling `preventDefault()`** keeps the framework silent and doing nothing
   further. The listener owns the outcome, e.g. it may call `navigate(url)`
   for a deliberate full swap, or `location.assign(url)` for a hard load.
 

--- a/packages/cli/templates/AGENTS.md
+++ b/packages/cli/templates/AGENTS.md
@@ -731,8 +731,13 @@ return html`
 ```
 
 The router's `closest('webjs-frame')` detection takes precedence over
-layout markers. Only the frame's content swaps. Use this sparingly -
-folder-based layouts handle 99% of cases.
+layout markers. Only the frame's content swaps. Use this sparingly,
+folder-based layouts handle 99% of cases. When a frame nav's response
+lacks the matching `<webjs-frame id>` (e.g. an auth redirect), the router
+fires a cancelable, bubbling `webjs:frame-missing` event (detail
+`{ frameId, url, document }`) and leaves the frame unchanged rather than
+silently swapping the whole page; call `preventDefault()` to take over
+the outcome (e.g. `location.assign(e.detail.url)`).
 
 ### 5. `loading.ts` for per-segment skeletons
 

--- a/packages/core/src/router-client.js
+++ b/packages/core/src/router-client.js
@@ -1473,6 +1473,23 @@ function applySwap(doc, frameId, revalidating, href, incomingBuild) {
       blurOutgoingFocus();
       return;
     }
+    // The response did not carry the requested frame (source null), or the
+    // target frame is gone from the live DOM (target null). Falling through
+    // would wholesale-replace the document, a silent full-page swap that
+    // destroys the page (e.g. an auth redirect returning a login page without
+    // the frame). Surface the contract violation with a cancelable event
+    // instead. Default: warn and leave the frame unchanged. A listener that
+    // calls preventDefault owns the outcome.
+    const evt = new CustomEvent('webjs:frame-missing', {
+      bubbles: true,
+      cancelable: true,
+      detail: { frameId, url: href || (typeof location !== 'undefined' ? location.href : null), document: doc },
+    });
+    (target || document).dispatchEvent(evt);
+    if (!evt.defaultPrevented) {
+      console.warn(`[webjs] frame "${frameId}" was not in the navigation response, leaving it unchanged. Handle "webjs:frame-missing" (preventDefault) to override.`);
+    }
+    return;
   }
 
   // 2. Auto-derived layout-marker swap.

--- a/packages/core/test/routing/browser/frame-missing.test.js
+++ b/packages/core/test/routing/browser/frame-missing.test.js
@@ -1,0 +1,196 @@
+/**
+ * Real-browser regression tests for the <webjs-frame> "frame missing"
+ * contract (#251).
+ *
+ * The client router's frame escape hatch (applySwap branch 1) swaps only
+ * the inside of a matching `<webjs-frame id>`. Before the fix, when a
+ * frame-scoped navigation's response did NOT carry the requested frame,
+ * control fell through to the full-body swap, silently replacing the
+ * ENTIRE document (an auth redirect returning a login page without the
+ * frame thus destroyed the page).
+ *
+ * The fix dispatches a cancelable, bubbling `webjs:frame-missing` event
+ * and returns: default behaviour warns and leaves the frame unchanged
+ * (never a full-body swap); a listener calling preventDefault owns the
+ * outcome.
+ *
+ * This MUST run in a real browser. The headline behaviour (a CustomEvent
+ * fired, the document NOT wholesale-replaced, a stale-but-intact frame)
+ * is browser-observable: linkedom does not model the real swap + event
+ * dispatch path that drives it. We stub `window.fetch` to return the
+ * navigation response, then drive a real link click so `activeFrameId`,
+ * `performNavigation`, `fetchAndApply`, and `applySwap` all run exactly
+ * as in production.
+ */
+import { enableClientRouter } from '../../../src/router-client.js';
+
+const assert = {
+  ok: (v, msg) => { if (!v) throw new Error(msg || `Expected truthy, got ${v}`); },
+  equal: (a, b, msg) => { if (a !== b) throw new Error(msg || `Expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}`); },
+};
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+/** Wait for the router's async navigation pipeline to settle. */
+async function settle() { await tick(); await tick(); await tick(); }
+
+const htmlResponse = (body) => Promise.resolve(new Response(body, {
+  headers: { 'content-type': 'text/html', 'x-webjs-build': '' },
+}));
+
+suite('Client router: <webjs-frame> frame-missing contract (#251)', () => {
+  let container, origFetch, origWarn, warnings;
+
+  function setup() {
+    enableClientRouter(); // idempotent; ensures the document listeners are attached
+    container = document.createElement('div');
+    // Sibling content that lives OUTSIDE the frame. If the document is
+    // wholesale-replaced this node is destroyed: its survival is the
+    // proof that no full-body swap happened.
+    const sibling = document.createElement('div');
+    sibling.id = 'sibling-outside-frame';
+    sibling.textContent = 'OUTSIDE';
+    document.body.appendChild(sibling);
+    // The frame, with a link inside it (so activeFrameId resolves "main")
+    // and identifiable content.
+    container.innerHTML =
+      '<webjs-frame id="main">' +
+        '<span id="frame-content">ORIGINAL</span>' +
+        '<a id="frame-link" href="/no-frame-here">go</a>' +
+      '</webjs-frame>' +
+      '<a id="plain-link" href="/plain-target">plain</a>';
+    document.body.appendChild(container);
+
+    origFetch = window.fetch;
+    origWarn = console.warn;
+    warnings = [];
+    console.warn = (...a) => { warnings.push(a.join(' ')); };
+  }
+  function teardown() {
+    window.fetch = origFetch;
+    console.warn = origWarn;
+    container.remove();
+    const s = document.getElementById('sibling-outside-frame');
+    if (s) s.remove();
+  }
+
+  test('a frameless response fires webjs:frame-missing and does NOT wholesale-replace the document', async () => {
+    setup();
+    try {
+      // The navigation response lacks <webjs-frame id="main"> entirely.
+      window.fetch = () => htmlResponse(
+        '<!doctype html><html><head></head><body>' +
+        '<h1 id="login">Please log in</h1>' +
+        '</body></html>'
+      );
+
+      let evt = null;
+      const onMissing = (e) => { evt = e; };
+      document.addEventListener('webjs:frame-missing', onMissing);
+
+      document.getElementById('frame-link').click();
+      await settle();
+      document.removeEventListener('webjs:frame-missing', onMissing);
+
+      // (a) the event fired on document (it bubbles), with the frame id.
+      assert.ok(evt, 'webjs:frame-missing must fire when the response lacks the frame');
+      assert.equal(evt.detail.frameId, 'main', 'detail.frameId names the requested frame');
+      assert.ok(evt.detail.document, 'detail.document carries the parsed response document');
+      assert.ok(evt.bubbles, 'event bubbles so a document-level listener catches it');
+      assert.ok(evt.cancelable, 'event is cancelable so a listener can preventDefault');
+
+      // (b) the document was NOT wholesale-replaced: the sibling-outside
+      // content and the original frame content both survive.
+      assert.ok(document.getElementById('sibling-outside-frame'),
+        'sibling-outside-frame must survive (no full-body swap)');
+      assert.equal(document.getElementById('sibling-outside-frame').textContent, 'OUTSIDE',
+        'outside content is untouched');
+      assert.ok(document.getElementById('frame-content'),
+        'the original frame content stays (frame left unchanged, stale)');
+      assert.equal(document.getElementById('frame-content').textContent, 'ORIGINAL',
+        'frame content is the original, not the login page');
+      assert.ok(!document.getElementById('login'),
+        'the frameless response body must NOT have been spliced into the document');
+
+      // default (not prevented): a warning was emitted.
+      assert.ok(warnings.some((w) => w.includes('frame "main"') && w.includes('frame-missing')),
+        'default behaviour warns about the missing frame');
+    } finally { teardown(); }
+  });
+
+  test('preventDefault suppresses the warning and still performs no full swap', async () => {
+    setup();
+    try {
+      window.fetch = () => htmlResponse(
+        '<!doctype html><html><head></head><body><h1 id="login">Login</h1></body></html>'
+      );
+
+      let fired = false;
+      const onMissing = (e) => { fired = true; e.preventDefault(); };
+      document.addEventListener('webjs:frame-missing', onMissing);
+
+      document.getElementById('frame-link').click();
+      await settle();
+      document.removeEventListener('webjs:frame-missing', onMissing);
+
+      assert.ok(fired, 'listener ran');
+      assert.equal(warnings.length, 0,
+        'preventDefault suppresses the framework warning (listener owns the outcome)');
+      // Still no full-body swap: the framework returns after dispatch.
+      assert.ok(document.getElementById('sibling-outside-frame'),
+        'no full-body swap even when prevented');
+      assert.ok(document.getElementById('frame-content'),
+        'frame untouched when prevented');
+      assert.ok(!document.getElementById('login'),
+        'frameless response body not spliced in');
+    } finally { teardown(); }
+  });
+
+  test('counterfactual: a response WITH the frame still swaps the frame (happy path intact)', async () => {
+    setup();
+    try {
+      // The response DOES carry <webjs-frame id="main"> with new content.
+      window.fetch = () => htmlResponse(
+        '<!doctype html><html><head></head><body>' +
+        '<webjs-frame id="main"><span id="frame-content">UPDATED</span></webjs-frame>' +
+        '</body></html>'
+      );
+
+      let fired = false;
+      document.addEventListener('webjs:frame-missing', () => { fired = true; }, { once: true });
+
+      document.getElementById('frame-link').click();
+      await settle();
+
+      assert.ok(!fired, 'frame-missing must NOT fire when the frame is present');
+      assert.equal(document.getElementById('frame-content').textContent, 'UPDATED',
+        'the frame content swapped to the response content');
+      assert.ok(document.getElementById('sibling-outside-frame'),
+        'outside-frame content preserved by the frame swap (no full swap)');
+    } finally { teardown(); }
+  });
+
+  test('counterfactual: a NON-frame nav (frameId null) never fires frame-missing', async () => {
+    setup();
+    try {
+      // The new guard is scoped to frameId only. A plain link (outside any
+      // frame) must NOT trigger frame-missing even when the response lacks
+      // any frame: it just falls through to the normal layout/full swap.
+      // (The "still swaps normally" guarantee is covered by the positive
+      // control in router-js-handled.test.js; here we prove the new early
+      // return is scoped to frameId and never over-triggers.)
+      window.fetch = () => htmlResponse(
+        '<!doctype html><html><head></head><body>' +
+        '<h1 id="plain-swapped">Plain target</h1>' +
+        '</body></html>'
+      );
+
+      let fired = false;
+      document.addEventListener('webjs:frame-missing', () => { fired = true; }, { once: true });
+
+      document.getElementById('plain-link').click();
+      await settle();
+
+      assert.ok(!fired, 'a non-frame nav must NOT fire frame-missing (guard is scoped to frameId)');
+    } finally { teardown(); }
+  });
+});


### PR DESCRIPTION
Closes #251

## The bug

A frame-scoped navigation whose response omits the requested `<webjs-frame id>` silently blew away the whole page. In `applySwap` the frame branch was gated on `if (target && source)`; when the response lacked a matching frame (`source` null) or the target frame was gone from the live DOM (`target` null), control fell through to the layout-marker swap and then the full-body `replaceChildren`, wholesale-replacing the document with no warning, no event, and no error. An auth redirect returning a login page without the frame thus destroyed the page.

## The fix

When `frameId` is set and the frame swap cannot complete, dispatch a cancelable, bubbling `webjs:frame-missing` CustomEvent (`detail: { frameId, url, document }`) and return, instead of falling through. Default behaviour: one `console.warn` and the frame is left UNCHANGED (stale), never a full-page swap. A listener that calls `preventDefault()` owns the outcome (e.g. a deliberate `navigate(url)` or `location.assign`). A guard plus one event, no new frame controller. Mirrors Turbo's `turbo:frame-missing`.

The guard is scoped strictly: it runs only inside `if (frameId)`, after the successful-swap early return, so a successful frame swap and every non-frame navigation are untouched. The revalidating/cache-restore path passes `frameId = null` (popstate), so it never enters the frame branch and can never emit a spurious warning.

## Tests

- **Browser (real Chromium, web-test-runner)** `packages/core/test/routing/browser/frame-missing.test.js`: drives a real frame-scoped nav through the client router with a stubbed fetch. Asserts (a) `webjs:frame-missing` fires on document with the right `detail.frameId`; (b) the document is NOT wholesale-replaced (content outside the frame and the original frame content both survive); (c) `preventDefault()` suppresses the warn and still no full swap. Counterfactuals: a response WITH the frame still swaps (happy path), and a non-frame nav never fires the event. Verified the test fails when the fix is reverted. 4/4 pass; full browser suite 286 pass.
- **Node suite** 1870/1870.
- **E2E** N/A: `examples/blog` has no `<webjs-frame>` usage, and the real-Chromium browser test already exercises the headline browser behaviour. Blog e2e still run as the dogfood gate (69/69, no nav regression).

## Docs

`agent-docs/advanced.md` (new `webjs:frame-missing` subsection under the `<webjs-frame>` escape hatch: when it fires, cancelable+bubbles, the `detail` shape, default warn/leave-stale, the `preventDefault` handoff, a listener example), root `AGENTS.md` (WebjsFrame row + client-nav mention), `packages/cli/templates/AGENTS.md` (scaffolded apps' frame section).

## Dogfood

blog e2e 69/69 (dist mode, reflects the fix); website / docs / ui-website boot 200/307 with all preloads resolving. No version bump (batched core/server release).
