### PR TITLE
docs: document the production secrets posture

### DIFF
--- a/docs/app/docs/deployment/page.ts
+++ b/docs/app/docs/deployment/page.ts
@@ -278,9 +278,28 @@ SESSION_SECRET="change-me"
 API_KEY="sk-..."</pre>
     <p>webjs auto-loads <code>&lt;appDir&gt;/.env</code> into <code>process.env</code> on boot via Node 24+'s built-in <code>process.loadEnvFile</code>. No <code>dotenv</code> dependency. Shell-exported values take precedence over the file, so production platforms (Railway, Fly, Render, Docker, systemd) keep injecting secrets the same way they already do. See <a href="/docs/configuration">Configuration</a> for the full precedence rules.</p>
 
+    <h2>Secrets: platform injection, not a committed file</h2>
+    <p>webjs deliberately stays out of secret management. There is no encrypted credentials file and no bespoke crypto subsystem. Secrets are plain environment variables, the 12-factor way, and the safe production posture is the standard one your platform already supports.</p>
+    <div role="note" style="border-left:4px solid var(--accent,#3b82f6);padding:1rem 1.25rem;background:var(--bg-elev);border-radius:.25rem;margin:1.25rem 0">
+      <p style="margin:0 0 .5rem;font-weight:600">Never commit <code>.env</code></p>
+      <p style="margin:0">The scaffold gitignores <code>.env</code> for you. Keep it that way. A committed <code>.env</code> leaks every secret to anyone with repo access and into your git history forever. Commit <code>.env.example</code> (keys with placeholder values) instead, so a new contributor knows what to set without seeing real values.</p>
+    </div>
+    <p><strong><code>.env</code> is for local development only.</strong> It is the convenient way to set <code>DATABASE_URL</code>, <code>AUTH_SECRET</code>, and the rest on your own machine. It is NOT how production secrets should reach a deployed app.</p>
+    <p><strong>Inject production secrets through the host platform's secret store.</strong> Because a shell-exported or platform-injected value takes precedence over the <code>.env</code> file (and you do not ship <code>.env</code> to production at all), every platform's native mechanism works with no webjs-specific step:</p>
+    <ul>
+      <li><strong>Railway / Fly / Render / Vercel / Heroku:</strong> set variables in the project's environment settings (or their CLI / dashboard secret store). They arrive as <code>process.env</code> at runtime.</li>
+      <li><strong>Docker / Compose:</strong> pass <code>--env-file</code> at run time (a file that lives on the host, never in the image), or use Docker / Compose <code>secrets</code> for files mounted at <code>/run/secrets</code>. Do not <code>COPY</code> a <code>.env</code> into the image, and keep <code>.env</code> in <code>.dockerignore</code> (the scaffold does).</li>
+      <li><strong>Kubernetes:</strong> a <code>Secret</code> surfaced as env vars (or a mounted file) via the pod spec.</li>
+      <li><strong>systemd / bare VM:</strong> an <code>EnvironmentFile=</code> directive pointing at a root-owned, <code>0600</code> file outside the repo.</li>
+    </ul>
+    <p>Server-side code reads these with <code>process.env.X</code>. They never reach the browser: only names prefixed <code>WEBJS_PUBLIC_</code> are exposed client-side, and the boundary is fail-closed, so a secret cannot leak by a typo. See <a href="/docs/security">Security</a> for the full env boundary.</p>
+    <h3>Rotate <code>AUTH_SECRET</code></h3>
+    <p><code>AUTH_SECRET</code> signs session cookies and auth tokens, so treat it like any signing key: use 32 or more random characters, keep it only in the platform secret store, and rotate it periodically and immediately on any suspected exposure. Rotating it invalidates existing sessions and tokens (everyone is signed out), which is the point. For a zero-downtime rotation, deploy the new value during a low-traffic window and accept that active sessions end. The same applies to any <code>SESSION_SECRET</code> and to OAuth provider secrets.</p>
+    <p>See the <a href="/docs/configuration">Configuration</a> page for the precedence rules and the optional <code>env.{js,ts}</code> boot-time validation that fails fast on a missing or malformed secret.</p>
+
     <h2>Docker / Containerisation</h2>
     <p>A minimal Dockerfile for a webjs app:</p>
-    <pre>FROM node:23-slim
+    <pre>FROM node:24-slim
 
 WORKDIR /app
 

--- a/test/docs/deployment-secrets.test.mjs
+++ b/test/docs/deployment-secrets.test.mjs
@@ -1,0 +1,47 @@
+/**
+ * Integration test for the deployment-doc secrets posture (#270). Boots the
+ * docs app via createRequestHandler (prod) and asserts the /docs/deployment
+ * page documents the standard platform-injection posture the issue requires:
+ * never commit .env, inject production secrets via the host platform's secret
+ * store, .env is local-dev only, and rotate AUTH_SECRET. Also guards the
+ * Dockerfile Node-version fix (webjs needs Node 24+).
+ */
+import { test, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequestHandler } from '@webjsdev/server';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DOCS_DIR = resolve(__dirname, '..', '..', 'docs');
+
+/** @type {(path: string) => Promise<Response>} */
+let handle;
+
+before(async () => {
+  const app = await createRequestHandler({ appDir: DOCS_DIR, dev: false });
+  handle = (path) => app.handle(new Request('http://localhost' + path));
+});
+
+test('the deployment page documents the secrets posture', async () => {
+  const res = await handle('/docs/deployment');
+  assert.equal(res.status, 200);
+  const html = await res.text();
+
+  assert.ok(html.includes('Never commit'), 'states never to commit .env');
+  assert.ok(/secret store/i.test(html), 'documents platform secret-store injection');
+  assert.ok(/local development only/i.test(html), 'documents .env as local-dev only');
+  assert.ok(/[Rr]otate/.test(html) && html.includes('AUTH_SECRET'), 'documents AUTH_SECRET rotation');
+  // Platform examples are named.
+  assert.ok(/Railway|Fly|Render/.test(html), 'names platform secret stores');
+  assert.ok(/secrets/i.test(html) && /Docker/.test(html), 'covers Docker / Compose secrets');
+});
+
+test('the example Dockerfile pins a supported Node version (24+)', async () => {
+  const res = await handle('/docs/deployment');
+  const html = await res.text();
+  // webjs requires Node 24+ for the built-in TS strip; an older base image
+  // would fail at boot, so the doc must not show node:23.
+  assert.ok(!html.includes('node:23'), 'the Dockerfile must not pin node:23 (webjs needs 24+)');
+  assert.ok(/node:24/.test(html), 'the Dockerfile pins node:24');
+});


### PR DESCRIPTION
Closes #270

## What

Secrets load from a plaintext `.env` and there was no guidance on the safe production posture, so a team might commit `.env` or hand-copy secrets between environments. The Rails-style encrypted-credentials ask is a bespoke crypto subsystem with no web-standard primitive, so this documents the standard platform-injection approach instead (no framework code).

Add a **Secrets** section to `/docs/deployment`:

- Never commit `.env` (the scaffold gitignores it; commit `.env.example` instead).
- `.env` is for local development only.
- Inject production secrets through the host platform's secret store: Railway / Fly / Render / Vercel / Heroku env, Docker / Compose `secrets`, a Kubernetes `Secret`, or a systemd `EnvironmentFile`. A platform-injected value already takes precedence over `.env`, so no webjs-specific step is needed.
- Rotate `AUTH_SECRET` (32+ random chars, platform store only, rotate on suspected exposure; rotation invalidates existing sessions, which is the point).
- Links the Configuration and Security pages.

Also fixes a real bug in the same page: the example Dockerfile pinned `node:23-slim`, which would fail at boot because webjs requires Node 24+ for the built-in TypeScript strip.

## Tests

`test/docs/deployment-secrets.test.mjs`: asserts the page documents never-commit, platform-store injection (with named platforms), `.env` local-dev only, `AUTH_SECRET` rotation, Docker secrets, and that the Dockerfile no longer shows `node:23`.

## Scope

Touches only `docs/` + `test/docs/`. No framework code (a posture doc, not an encrypted-credentials feature). No version bump.
