### PR TITLE
docs: add the schema-first recipe and a Prisma connection-pool section

### DIFF
--- a/agent-docs/recipes.md
+++ b/agent-docs/recipes.md
@@ -4,6 +4,88 @@ Copy-paste patterns for the most common webjs tasks. Each recipe is the
 canonical shape, follow it rather than inventing a variant. The full API
 reference lives in the root `AGENTS.md`.
 
+## Schema-first: from scaffold to product (do this FIRST)
+
+A freshly scaffolded app ships an EXAMPLE `User` model, an example
+`app/page.ts`, and an example component. They are starting-point references,
+not the product. The first thing to do for a real app is replace the example
+schema with the real domain models, then build features on top. This is the
+transition agents most often get wrong, so it is the first recipe.
+
+> **Two non-negotiables.** NEVER leave the example `User` model in
+> `schema.prisma` if the app does not actually have users (delete or replace
+> it). NEVER persist app data in JSON files (`data/todos.json`, `db.json`), in
+> a module-scope array or `Map`, or in `localStorage`. Those reset on every
+> reload and cannot scale. Every piece of stored data is a Prisma model.
+
+1. **Edit `prisma/schema.prisma`** to the real domain. Replace the example
+   `User` model with the models the app needs.
+
+   ```prisma
+   // prisma/schema.prisma
+   model Post {
+     id        String   @id @default(cuid())
+     title     String
+     body      String
+     published Boolean  @default(false)
+     createdAt DateTime @default(now())
+   }
+   ```
+
+2. **Migrate.** Run the npm script (not the `webjs`/`prisma` binary directly,
+   so the `predev` / `db:*` hooks fire):
+
+   ```sh
+   npm run db:migrate -- --name add_post
+   ```
+
+   This creates the migration, applies it to the dev SQLite database, and
+   regenerates the Prisma client.
+
+3. **Generate one query and one action per operation**, one exported function
+   per file, named after the file, under the feature module. Reads go in
+   `queries/`, mutations in `actions/`. Both are `.server.ts` with
+   `'use server'`, so their browser imports become typed RPC stubs.
+
+   ```ts
+   // modules/posts/queries/list-posts.server.ts
+   'use server';
+   import { prisma } from '../../../lib/prisma.server.ts';
+   export async function listPosts() {
+     return prisma.post.findMany({ where: { published: true }, orderBy: { createdAt: 'desc' } });
+   }
+   ```
+
+   ```ts
+   // modules/posts/actions/create-post.server.ts
+   'use server';
+   import { prisma } from '../../../lib/prisma.server.ts';
+   export async function createPost(input: { title: string; body: string }) {
+     const title = String(input?.title || '').trim();
+     if (!title) return { success: false, error: 'title required', status: 400 };
+     const post = await prisma.post.create({ data: { title, body: String(input?.body || '') } });
+     return { success: true, data: post };
+   }
+   ```
+
+4. **Wire it into a page** by calling the query (the page runs on the server,
+   so it imports the `.server` query directly and awaits it). Never import
+   `@prisma/client` into a page; reach the database through the query.
+
+   ```ts
+   // app/posts/page.ts
+   import { html } from '@webjsdev/core';
+   import { listPosts } from '../../modules/posts/queries/list-posts.server.ts';
+   export default async function Posts() {
+     const posts = await listPosts();
+     return html`<ul>${posts.map((p) => html`<li>${p.title}</li>`)}</ul>`;
+   }
+   ```
+
+For the write path, pair `create-post.server.ts` with a `<form>` plus a page
+`action` or a `route.ts` POST handler (see the form-mutation recipe below), so
+it works without JavaScript and the client router upgrades it automatically.
+
 ## Add a page
 
 ```ts

--- a/docs/app/docs/deployment/page.ts
+++ b/docs/app/docs/deployment/page.ts
@@ -297,6 +297,24 @@ API_KEY="sk-..."</pre>
     <p><code>AUTH_SECRET</code> signs session cookies and auth tokens, so treat it like any signing key: use 32 or more random characters, keep it only in the platform secret store, and rotate it periodically and immediately on any suspected exposure. Rotating it invalidates existing sessions and tokens (everyone is signed out), which is the point. For a zero-downtime rotation, deploy the new value during a low-traffic window and accept that active sessions end. The same applies to any <code>SESSION_SECRET</code> and to OAuth provider secrets.</p>
     <p>See the <a href="/docs/configuration">Configuration</a> page for the precedence rules and the optional <code>env.{js,ts}</code> boot-time validation that fails fast on a missing or malformed secret.</p>
 
+    <h2>Database connections (Prisma + Postgres)</h2>
+    <p>SQLite needs no pool tuning. When you move to Postgres in production, size the connection pool, because connection exhaustion is the most common scaling surprise and webjs gives no prior signal in dev (SQLite has no pool).</p>
+    <p>A webjs server is ONE Node process per instance, and Prisma opens its own connection pool inside that process. The default pool size is <code>num_cpus * 2 + 1</code>, which is fine for a single instance but multiplies as you scale: with <strong>N</strong> instances the database sees up to <strong>N times the per-instance pool</strong> connections at once. Postgres caps total connections (often 100 on a small managed plan), so a few instances on the default pool can exhaust it.</p>
+    <p><strong>Bound the per-instance pool with <code>connection_limit</code> in the <code>DATABASE_URL</code></strong>, sized so <code>instances * connection_limit</code> stays comfortably under the database's <code>max_connections</code> (leave headroom for migrations and admin tools):</p>
+    <pre># One pool of at most 10 connections per instance.
+DATABASE_URL="postgresql://user:pass@db.example.com:5432/app?connection_limit=10"</pre>
+    <p><strong>Front Postgres with a pooler when instance count is high or variable</strong> (autoscaling, many small instances, or a low <code>max_connections</code> plan). Point <code>DATABASE_URL</code> at a transaction-mode pooler (PgBouncer, or a managed pooler like Supabase, Neon, or PlanetScale) so many app connections share a small set of real database connections. With PgBouncer in transaction mode, tell Prisma so it disables prepared statements, and give migrations a DIRECT connection (the pooler does not support the session features migrations need):</p>
+    <pre># App traffic goes through the pooler (port 6543), migrations go direct (5432).
+DATABASE_URL="postgresql://user:pass@pooler.example.com:6543/app?pgbouncer=true&amp;connection_limit=1"
+DIRECT_URL="postgresql://user:pass@db.example.com:5432/app"</pre>
+    <pre>// prisma/schema.prisma
+datasource db {
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
+}</pre>
+    <p>Behind a transaction pooler, set <code>connection_limit=1</code> per instance (the pooler does the multiplexing). Without a pooler, set <code>connection_limit</code> to a per-instance budget and keep the instance count bounded. Either way, always import the Prisma client from the scaffolded <code>lib/prisma.server.ts</code> singleton, never <code>new PrismaClient()</code> per request, so a process opens one pool, not one per call.</p>
+
     <h2>Docker / Containerisation</h2>
     <p>A minimal Dockerfile for a webjs app:</p>
     <pre>FROM node:24-slim

--- a/test/docs/recipes-and-pooling.test.mjs
+++ b/test/docs/recipes-and-pooling.test.mjs
@@ -1,0 +1,52 @@
+/**
+ * Tests for #272: the agent-docs/recipes.md restore (the schema-first recipe +
+ * the anti-pattern warnings + the common recipes the root AGENTS.md references)
+ * and the deployment-doc Prisma connection-pool section.
+ */
+import { test, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { createRequestHandler } from '@webjsdev/server';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..', '..');
+const DOCS_DIR = resolve(ROOT, 'docs');
+
+test('agent-docs/recipes.md exists so the AGENTS.md references resolve', async () => {
+  const path = resolve(ROOT, 'agent-docs', 'recipes.md');
+  assert.ok(existsSync(path), 'agent-docs/recipes.md must exist');
+  // The root AGENTS.md references it; that link must point at a real file.
+  const agents = await readFile(resolve(ROOT, 'AGENTS.md'), 'utf8');
+  assert.ok(agents.includes('agent-docs/recipes.md'), 'AGENTS.md references recipes.md');
+});
+
+test('recipes.md has the schema-first recipe, the anti-pattern warnings, and the common recipes', async () => {
+  const md = await readFile(resolve(ROOT, 'agent-docs', 'recipes.md'), 'utf8');
+  // Schema-first recipe + its steps.
+  assert.ok(/Schema-first/i.test(md), 'has the schema-first recipe');
+  assert.ok(md.includes('db:migrate'), 'covers the migrate step');
+  assert.ok(/queries\/|actions\//.test(md), 'covers one-file-per query/action');
+  // The two non-negotiable anti-patterns are called out explicitly.
+  assert.ok(/NEVER leave the example/i.test(md), 'warns against the example User model');
+  assert.ok(/NEVER persist app data|JSON files/i.test(md), 'warns against JSON-file persistence');
+  // The common recipes the AGENTS.md recipes section points at are present.
+  for (const recipe of ['Add a page', 'Add a dynamic route', 'Add a server action', 'Add a component']) {
+    assert.ok(md.includes(recipe), `recipes.md must include "${recipe}"`);
+  }
+});
+
+test('the deployment doc documents Prisma connection pooling for Postgres', async () => {
+  const app = await createRequestHandler({ appDir: DOCS_DIR, dev: false });
+  if (app.warmup) await app.warmup();
+  const res = await app.handle(new Request('http://localhost/docs/deployment'));
+  assert.equal(res.status, 200);
+  const html = await res.text();
+  assert.ok(html.includes('connection_limit'), 'documents connection_limit');
+  assert.ok(/pooler|PgBouncer/i.test(html), 'documents when to use a pooler');
+  assert.ok(/max_connections/.test(html), 'explains the max_connections constraint');
+  assert.ok(/DATABASE_URL="postgresql:/.test(html), 'gives a concrete DATABASE_URL example');
+  assert.ok(/single|one Node process|per instance/i.test(html), 'sizes it for the single-process server');
+});


### PR DESCRIPTION
Closes #272

## What

The root AGENTS.md references `agent-docs/recipes.md`, which existed but lacked the canonical scaffold-to-product recipe, the transition agents most often get wrong (leaving the example `User` model, or reaching for JSON-file persistence). Separately, the scaffold endorses Postgres in production but documented no connection-pool guidance, so a team moving from SQLite hits connection exhaustion under load with no prior signal in dev.

- **Schema-first recipe** (now the first entry in `recipes.md`): edit `schema.prisma`, `npm run db:migrate`, generate one-file-per query/action under the feature module, wire into a page through the query. Two non-negotiables called out: never leave the example `User` model, never persist app data in JSON files / arrays / localStorage.
- **Database connections section** (deployment doc): a webjs server is one process per instance, so the per-instance Prisma pool multiplies by instance count. Bound it with `connection_limit` sized under the database `max_connections`, and front Postgres with a transaction-mode pooler (with a `directUrl` for migrations) when instance count is high, with concrete `DATABASE_URL` examples.

## Tests

`test/docs/recipes-and-pooling.test.mjs`: `recipes.md` exists (so the AGENTS.md reference resolves) and contains the schema-first recipe, both anti-pattern warnings, and the common recipes; the deployment doc documents `connection_limit`, the pooler guidance, `max_connections`, a concrete `DATABASE_URL`, and the single-process sizing.

## Scope

Docs only (`agent-docs/recipes.md`, the deployment page, a test). No framework code. No version bump.
