### PR TITLE
feat: add a webjs doctor project-health command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -740,6 +740,7 @@ webjs dev    [--port N]                               # dev server with live rel
 webjs start  [--port N]                               # prod server. No build step, source IS the runtime. Speaks plain HTTP/1.1 (put a reverse proxy in front for TLS + HTTP/2)
 webjs test   [--server] [--browser] [--watch]         # unit + browser tests
 webjs check  [--fix]                                  # convention validator
+webjs doctor                                          # project-health checklist (Node, tsconfig, env drift, vendor pins, @webjsdev versions, git hook); non-zero exit on a hard fail so CI can gate
 webjs types                                           # generate .webjs/routes.d.ts (typed Route union + per-route params; #258). Opt-in; webjs dev emits it automatically
 webjs typecheck [tsc args...]                         # type-check the app with the project's own tsc --noEmit (non-zero on errors; needs typescript installed)
 webjs create <name> [--template api|saas]             # scaffold a new app

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -27,6 +27,14 @@ lib/
                          builtins) and would itself link-fail on old Node. So the
                          primary guard depends only on `process.versions.node`.
                          Tests: `test/node-preflight/`.
+  doctor.js              `webjs doctor` project-health checks (#266).
+                         `runDoctorChecks(appDir, opts?)` is PURE (reads files +
+                         optionally the network, never exits / prints) so each
+                         check is unit-testable. `opts.nodeVersion` overrides the
+                         running Node, `opts.vendor` injects the pin-freshness
+                         `{ hasVendorPin, findOutdated }` pair (offline tests).
+                         The bin renders + owns the non-zero exit on a hard fail.
+                         Tests: `test/cli/doctor.test.mjs`.
   create.js              `webjs create <name>` scaffold logic. Copies
                          `templates/` into the new app, writes
                          package.json + tsconfig + Prisma schema,
@@ -53,6 +61,7 @@ README.md                npm-facing package readme.
 | `webjs start` | `startServer({ dev: false })`, plain HTTP/1.1 (front a reverse proxy for TLS + HTTP/2) |
 | `webjs test [--server\|--browser]` | `node --test` for server tests, `wtr` for browser tests |
 | `webjs check [--rules\|--fix]` | `checkConventions()` from `@webjsdev/server/check` |
+| `webjs doctor` | `runDoctorChecks()` from `lib/doctor.js`. A project-health checklist over existing signals (Node major, tsconfig `erasableSyntaxOnly`, `.env` drift vs `.env.example`, vendor-pin freshness, `@webjsdev/*` version coherence, git pre-commit hook). PURE checks render with a `[pass]` / `[warn]` / `[fail]` marker; non-zero exit iff a HARD check fails (Node below the floor, or `erasableSyntaxOnly` missing in an existing tsconfig), so CI can gate. Warns (drift / staleness) never fail the exit. The only network touch (pin freshness) is best-effort: a fetch failure is a warn, never a hard fail. An onboarding/setup-verify tool, NOT a scaffold-CI hard gate. Tests: `test/cli/doctor.test.mjs` |
 | `webjs types` | `generateRouteTypes()` from `@webjsdev/server`, writes `.webjs/routes.d.ts` (typed `Route` union + per-route params, #258). Also auto-emitted at `webjs dev` startup |
 | `webjs typecheck [tsc args]` | Resolves the project's own `typescript/bin/tsc` (via `createRequire` from the app cwd) and spawns it with `--noEmit`, passing extra args through. Exits non-zero on a type error (a CI gate). A clear message + non-zero exit when typescript is not installed (#265). The framework runs the standard compiler, it does not embed one |
 | `webjs create <name> [--template …]` | `scaffoldApp()` from `lib/create.js` |

--- a/packages/cli/bin/webjs.js
+++ b/packages/cli/bin/webjs.js
@@ -42,6 +42,7 @@ const USAGE = `webjs commands:
   webjs start [--port 8080]                       Start production server (serves source directly, no build step)
   webjs test  [--server|--browser]                 Run server + browser tests
   webjs check                                     Run correctness checks on the app
+  webjs doctor                                    Verify project health (Node, tsconfig, env, vendor pins, @webjsdev versions, git hook)
   webjs types                                     Generate .webjs/routes.d.ts (typed Route union + per-route params)
   webjs typecheck [tsc args...]                   Type-check the app with the project's tsc --noEmit (non-zero on errors)
   webjs create <name> [--template full-stack|api|saas] [--no-install]  Scaffold a new webjs app
@@ -275,6 +276,38 @@ async function main() {
           if (v.fix) console.log(`    Fix: ${v.fix}`);
           console.log();
         }
+        process.exit(1);
+      }
+      break;
+    }
+    case 'doctor': {
+      // Project-health checklist (#266). The checks are PURE (in lib/doctor.js);
+      // this branch only renders them and owns the exit code: non-zero iff any
+      // HARD check FAILS, so CI can gate on it. Warns are informational and do
+      // NOT fail the exit (env drift / pin staleness / version drift are the
+      // app's concern, not a broken toolchain).
+      const { runDoctorChecks } = await import('../lib/doctor.js');
+      const results = await runDoctorChecks(process.cwd());
+      const marker = { pass: '[pass]', warn: '[warn]', fail: '[fail]' };
+      console.log('webjs doctor: project-health checklist\n');
+      for (const r of results) {
+        console.log(`  ${marker[r.status]} ${r.name}`);
+        console.log(`    ${r.message}`);
+        if (r.fix && r.status !== 'pass') console.log(`    Fix: ${r.fix}`);
+        console.log();
+      }
+      const counts = results.reduce((acc, r) => {
+        acc[r.status] = (acc[r.status] || 0) + 1;
+        return acc;
+      }, /** @type {Record<string, number>} */ ({}));
+      const pass = counts.pass || 0;
+      const warn = counts.warn || 0;
+      const fail = counts.fail || 0;
+      console.log(`  ${pass} passed, ${warn} warning(s), ${fail} failed.`);
+      if (fail > 0) {
+        console.error(
+          `\nwebjs doctor: ${fail} hard check(s) failed. Fix the toolchain issue(s) above.`,
+        );
         process.exit(1);
       }
       break;

--- a/packages/cli/lib/create.js
+++ b/packages/cli/lib/create.js
@@ -287,6 +287,11 @@ export async function scaffoldApp(name, cwd, opts = {}) {
       'test:browser': 'webjs test --browser',
       check: 'webjs check',
       typecheck: 'webjs typecheck',
+      // Onboarding/setup-verify: a contributor runs `npm run doctor` after
+      // cloning to assert the toolchain (Node floor, tsconfig flag, env drift,
+      // vendor pins, @webjsdev versions, git hook). Local tool, NOT a CI gate
+      // (its env-drift + network pin-freshness checks would make CI flaky).
+      doctor: 'webjs doctor',
       'db:migrate': 'prisma migrate dev',
       'db:generate': 'prisma generate',
       'db:studio': 'prisma studio',

--- a/packages/cli/lib/doctor.js
+++ b/packages/cli/lib/doctor.js
@@ -1,0 +1,534 @@
+/**
+ * `webjs doctor`: a project-health checklist runner (issue #266).
+ *
+ * webjs has unusually many fragile preconditions, each an independent failure
+ * mode a contributor onboarding to an existing repo only hits at runtime: the
+ * Node 24+ strip-types floor, the `erasableSyntaxOnly` TS flag, importmap pin
+ * freshness, env drift vs `.env.example`, `@webjsdev/*` version coherence, and
+ * the git pre-commit hook activation. `webjs doctor` verifies each one up front
+ * and prints pass/warn/fail with an actionable fix line.
+ *
+ * This module is PURE: `runDoctorChecks(appDir, opts?)` reads files (and, for
+ * the pin check, optionally the network), but NEVER calls `process.exit` and
+ * NEVER prints. The CLI (`bin/webjs.js`, `case 'doctor'`) renders the results
+ * and owns the exit code, which is what makes every check unit-testable in
+ * isolation against a tmp fixture appDir.
+ *
+ * HARD-FAIL vs WARN split (the CLI exits non-zero on any 'fail'):
+ *
+ *   - 'fail' is reserved for a genuinely-broken TOOLCHAIN that would crash or
+ *     500 at runtime, so CI can gate on it. Two checks can fail:
+ *       * Node version below the required major (the strip-types floor).
+ *       * `erasableSyntaxOnly` missing/false in an EXISTING tsconfig (non-erasable
+ *         TS would fail at strip time with a 500).
+ *   - 'warn' is for drift / preferences / best-effort signals that are the
+ *     app's own runtime concern, never a doctor hard-fail: a missing tsconfig
+ *     (a JS-only app legitimately has none), env drift, an outdated or
+ *     unverifiable vendor pin, a `@webjsdev/*` version drift or missing install,
+ *     and a missing/non-executable git hook.
+ *   - 'pass' is the green path.
+ *
+ * Every NETWORK touch (only the vendor-pin freshness check) is BEST-EFFORT: a
+ * fetch failure is a WARN ("could not check, network"), never a hard fail and
+ * never a throw that crashes the command. Network is flaky, and a doctor that
+ * fails CI because npm was briefly unreachable is worse than useless.
+ */
+
+import { existsSync, statSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { checkNodeInline } from './node-preflight.js';
+
+/**
+ * @typedef {'pass' | 'warn' | 'fail'} DoctorStatus
+ * @typedef {{ name: string, status: DoctorStatus, message: string, fix?: string }} DoctorResult
+ */
+
+/**
+ * Read the CLI package's own `engines.node` so the required Node major lives in
+ * one place (mirrors how `bin/webjs.js` sources it). Falls back to `>=24.0.0`.
+ * @param {string} cliDir  directory of THIS file's package (lib/ -> package root)
+ * @returns {Promise<string>}
+ */
+async function readEngines(cliDir) {
+  try {
+    const pkg = JSON.parse(await readFile(join(cliDir, '..', 'package.json'), 'utf8'));
+    return pkg?.engines?.node || '>=24.0.0';
+  } catch {
+    return '>=24.0.0';
+  }
+}
+
+/**
+ * Strip `//` line comments, block comments, and trailing commas from a JSONC
+ * string so a tsconfig (which permits all three) parses with `JSON.parse`.
+ * Deliberately simple: it does not honor comment-looking sequences inside
+ * string values, which is acceptable for a tsconfig (paths rarely contain `//`
+ * or block-comment markers, and the worst case is a parse failure the caller
+ * already degrades to a WARN).
+ * @param {string} text
+ * @returns {string}
+ */
+function stripJsonc(text) {
+  let out = '';
+  let inString = false;
+  let stringQuote = '';
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    const next = text[i + 1];
+    if (inString) {
+      out += ch;
+      if (ch === '\\') {
+        // Copy the escaped char verbatim so an escaped quote does not end the string.
+        out += text[i + 1] || '';
+        i++;
+      } else if (ch === stringQuote) {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      inString = true;
+      stringQuote = ch;
+      out += ch;
+      continue;
+    }
+    if (ch === '/' && next === '/') {
+      while (i < text.length && text[i] !== '\n') i++;
+      out += '\n';
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      i += 2;
+      while (i < text.length && !(text[i] === '*' && text[i + 1] === '/')) i++;
+      i++; // land on the '/'
+      continue;
+    }
+    out += ch;
+  }
+  // Drop trailing commas before } or ].
+  return out.replace(/,(\s*[}\]])/g, '$1');
+}
+
+/**
+ * Parse a `.env`-style file into the SET of KEY names it declares. A simple
+ * `KEY=value` line parse: comments (`#`) and blank lines are skipped, and only
+ * the key before the first `=` is taken (the value is irrelevant for drift).
+ * @param {string} text
+ * @returns {Set<string>}
+ */
+function parseEnvKeys(text) {
+  const keys = new Set();
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq <= 0) continue;
+    let key = line.slice(0, eq).trim();
+    // Tolerate a leading `export ` (a common .env.example convention).
+    if (key.startsWith('export ')) key = key.slice('export '.length).trim();
+    if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) keys.add(key);
+  }
+  return keys;
+}
+
+/**
+ * CHECK 1, Node version. HARD-FAIL when the running major is below the required
+ * major (the strip-types + recursive fs.watch floor). `opts.nodeVersion` lets a
+ * test inject the running version so the fail case is assertable without being
+ * on old Node.
+ * @param {string} cliDir
+ * @param {{ nodeVersion?: string }} opts
+ * @returns {Promise<DoctorResult>}
+ */
+async function checkNode(cliDir, opts) {
+  const engines = await readEngines(cliDir);
+  const current = opts.nodeVersion || process.versions.node;
+  const r = checkNodeInline(current, engines);
+  if (r.ok) {
+    return {
+      name: 'node-version',
+      status: 'pass',
+      message: `Node ${r.current} satisfies the required Node ${r.requiredMajor}+.`,
+    };
+  }
+  return {
+    name: 'node-version',
+    status: 'fail',
+    message:
+      `Node ${r.current} is below the required Node ${r.requiredMajor}+. ` +
+      `webjs is buildless and relies on Node ${r.requiredMajor}'s built-in TypeScript ` +
+      `strip and recursive fs.watch.`,
+    fix: `Upgrade to Node ${r.requiredMajor}+ (see https://nodejs.org).`,
+  };
+}
+
+/**
+ * CHECK 2, tsconfig erasableSyntaxOnly. PASS when `true`; WARN when no tsconfig
+ * (a JS-only app legitimately has none) or the file is unparseable; HARD-FAIL
+ * when the file EXISTS but the flag is missing/false (non-erasable TS 500s at
+ * strip time).
+ * @param {string} appDir
+ * @returns {Promise<DoctorResult>}
+ */
+async function checkTsconfig(appDir) {
+  const path = join(appDir, 'tsconfig.json');
+  if (!existsSync(path)) {
+    return {
+      name: 'tsconfig-erasable',
+      status: 'warn',
+      message: 'No tsconfig.json found. A JS-only app needs none; a TypeScript app requires one.',
+      fix: 'If this app uses TypeScript, add a tsconfig.json with "erasableSyntaxOnly": true.',
+    };
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(stripJsonc(await readFile(path, 'utf8')));
+  } catch {
+    return {
+      name: 'tsconfig-erasable',
+      status: 'warn',
+      message: 'tsconfig.json could not be parsed (even after stripping comments + trailing commas).',
+      fix: 'Fix the tsconfig.json syntax, then ensure "compilerOptions.erasableSyntaxOnly": true.',
+    };
+  }
+  const flag = parsed?.compilerOptions?.erasableSyntaxOnly;
+  if (flag === true) {
+    return {
+      name: 'tsconfig-erasable',
+      status: 'pass',
+      message: 'tsconfig.json sets "erasableSyntaxOnly": true.',
+    };
+  }
+  return {
+    name: 'tsconfig-erasable',
+    status: 'fail',
+    message:
+      'tsconfig.json is missing "compilerOptions.erasableSyntaxOnly": true. ' +
+      'Non-erasable TypeScript (enum, namespace, parameter properties, ...) 500s at strip time.',
+    fix: 'Set "compilerOptions": { "erasableSyntaxOnly": true } in tsconfig.json.',
+  };
+}
+
+/**
+ * CHECK 3, .env presence + drift vs .env.example. WARN-level only (a missing
+ * env var is the app's runtime problem, not a toolchain crash). When no
+ * `.env.example`, PASS (nothing to compare). When `.env.example` exists but
+ * `.env` is absent, WARN to copy it. Otherwise WARN listing any example key
+ * missing from `.env`, else PASS.
+ * @param {string} appDir
+ * @returns {Promise<DoctorResult>}
+ */
+async function checkEnv(appDir) {
+  const examplePath = join(appDir, '.env.example');
+  if (!existsSync(examplePath)) {
+    return {
+      name: 'env-drift',
+      status: 'pass',
+      message: 'No .env.example to compare against.',
+    };
+  }
+  const exampleKeys = parseEnvKeys(await readFile(examplePath, 'utf8'));
+  const envPath = join(appDir, '.env');
+  if (!existsSync(envPath)) {
+    return {
+      name: 'env-drift',
+      status: 'warn',
+      message: '.env.example exists but .env does not.',
+      fix: 'Copy it: cp .env.example .env  (then fill in the values).',
+    };
+  }
+  const envKeys = parseEnvKeys(await readFile(envPath, 'utf8'));
+  const missing = [...exampleKeys].filter((k) => !envKeys.has(k));
+  if (missing.length === 0) {
+    return {
+      name: 'env-drift',
+      status: 'pass',
+      message: `.env has all ${exampleKeys.size} key(s) declared in .env.example.`,
+    };
+  }
+  return {
+    name: 'env-drift',
+    status: 'warn',
+    message: `.env is missing ${missing.length} key(s) from .env.example: ${missing.join(', ')}.`,
+    fix: 'Add the missing key(s) to .env (see .env.example for the expected names).',
+  };
+}
+
+/**
+ * CHECK 4, vendor pin freshness. Applies ONLY when a pin file exists. PASS/skip
+ * for an unpinned app (it resolves live, which is fine in dev). BEST-EFFORT +
+ * NETWORK-TOLERANT: any error (network, timeout) is a WARN "could not check",
+ * never a hard fail and never a throw. PASS when all pins current, WARN listing
+ * outdated packages otherwise.
+ *
+ * The vendor functions are injected via `opts.vendor` so a test can supply a
+ * stub without a real network call; absent the override, they are dynamically
+ * imported from `@webjsdev/server`.
+ * @param {string} appDir
+ * @param {{ vendor?: { hasVendorPin: (d: string) => boolean, findOutdated: (d: string) => Promise<Array<{ pkg: string, current: string, latest: string }>> } }} opts
+ * @returns {Promise<DoctorResult>}
+ */
+async function checkVendorPin(appDir, opts) {
+  let vendor = opts.vendor;
+  if (!vendor) {
+    try {
+      const mod = await import('@webjsdev/server');
+      vendor = { hasVendorPin: mod.hasVendorPin, findOutdated: mod.findOutdated };
+    } catch {
+      return {
+        name: 'vendor-pin',
+        status: 'warn',
+        message: 'Could not load the vendor toolchain to check pin freshness.',
+        fix: 'Run `npm install` so @webjsdev/server is available, then re-run `webjs doctor`.',
+      };
+    }
+  }
+  let pinned = false;
+  try {
+    pinned = vendor.hasVendorPin(appDir);
+  } catch {
+    pinned = false;
+  }
+  if (!pinned) {
+    return {
+      name: 'vendor-pin',
+      status: 'pass',
+      message: 'No vendor pin file; the app resolves vendor imports live (fine in dev).',
+    };
+  }
+  let outdated;
+  try {
+    outdated = await vendor.findOutdated(appDir);
+  } catch {
+    // findOutdated is built to swallow fetch errors and return [], but guard
+    // anyway: a network check must NEVER throw out of doctor.
+    return {
+      name: 'vendor-pin',
+      status: 'warn',
+      message: 'Could not check pin freshness (network unreachable or registry error).',
+      fix: 'Re-run `webjs doctor` when connectivity is back, or run `webjs vendor outdated`.',
+    };
+  }
+  if (!Array.isArray(outdated) || outdated.length === 0) {
+    return {
+      name: 'vendor-pin',
+      status: 'pass',
+      message: 'All vendor pins are current.',
+    };
+  }
+  const list = outdated.map((o) => `${o.pkg} (${o.current} -> ${o.latest})`).join(', ');
+  return {
+    name: 'vendor-pin',
+    status: 'warn',
+    message: `${outdated.length} pinned package(s) are outdated: ${list}.`,
+    fix: 'Run `webjs vendor update` to re-pin to the latest versions.',
+  };
+}
+
+/**
+ * Compare an installed version against a semver range PRAGMATICALLY (no semver
+ * dependency). Supports the common scaffold shapes: `latest` / `*` / `workspace:*`
+ * (any installed version satisfies), an exact `1.2.3`, and a caret `^1.2.3`
+ * (installed must be >= the floor AND share the same major, with major 0 also
+ * pinning the minor, matching npm caret semantics). An unrecognized range is
+ * treated as "cannot statically verify" (returns null), so the caller does not
+ * warn on a shape it does not understand.
+ * @param {string} installed
+ * @param {string} range
+ * @returns {boolean | null}
+ */
+function satisfiesRange(installed, range) {
+  if (!installed) return null;
+  const r = String(range).trim();
+  if (r === 'latest' || r === '*' || r === '' || r.startsWith('workspace:')) return true;
+  const parse = (v) => {
+    const m = String(v).match(/(\d+)\.(\d+)\.(\d+)/);
+    return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+  };
+  const inst = parse(installed);
+  if (!inst) return null;
+  if (/^\d+\.\d+\.\d+$/.test(r)) {
+    const exact = parse(r);
+    return exact ? inst[0] === exact[0] && inst[1] === exact[1] && inst[2] === exact[2] : null;
+  }
+  if (r.startsWith('^')) {
+    const floor = parse(r);
+    if (!floor) return null;
+    if (inst[0] !== floor[0]) return false;
+    // For 0.x, caret pins the minor too (^0.7.0 allows 0.7.x, not 0.8.0).
+    if (floor[0] === 0 && inst[1] !== floor[1]) return false;
+    const cmp =
+      inst[0] !== floor[0] ? inst[0] - floor[0] :
+      inst[1] !== floor[1] ? inst[1] - floor[1] :
+      inst[2] - floor[2];
+    return cmp >= 0;
+  }
+  return null;
+}
+
+/**
+ * CHECK 5, @webjsdev/* version coherence. WARN-level only (a version drift is
+ * not a crash). Reads the app package.json `@webjsdev/*` ranges across
+ * dependencies + devDependencies, then for each reads the INSTALLED version from
+ * `node_modules/@webjsdev/<pkg>/package.json` and checks it satisfies the
+ * declared range. PASS when every @webjsdev dep is present + satisfied; WARN on
+ * a missing install or a range drift.
+ * @param {string} appDir
+ * @returns {Promise<DoctorResult>}
+ */
+async function checkWebjsVersions(appDir) {
+  const pkgPath = join(appDir, 'package.json');
+  if (!existsSync(pkgPath)) {
+    return {
+      name: 'webjs-versions',
+      status: 'warn',
+      message: 'No package.json found in this directory.',
+      fix: 'Run `webjs doctor` from the app root (where package.json lives).',
+    };
+  }
+  let pkg;
+  try {
+    pkg = JSON.parse(await readFile(pkgPath, 'utf8'));
+  } catch {
+    return {
+      name: 'webjs-versions',
+      status: 'warn',
+      message: 'package.json could not be parsed.',
+      fix: 'Fix the package.json syntax.',
+    };
+  }
+  const ranges = { ...(pkg.dependencies || {}), ...(pkg.devDependencies || {}) };
+  const webjsDeps = Object.keys(ranges).filter((n) => n.startsWith('@webjsdev/'));
+  if (webjsDeps.length === 0) {
+    return {
+      name: 'webjs-versions',
+      status: 'warn',
+      message: 'No @webjsdev/* dependencies declared in package.json.',
+      fix: 'A webjs app depends on @webjsdev/core + @webjsdev/server (+ @webjsdev/cli).',
+    };
+  }
+  const missing = [];
+  const drift = [];
+  for (const dep of webjsDeps) {
+    const installedPkg = join(appDir, 'node_modules', dep, 'package.json');
+    if (!existsSync(installedPkg)) {
+      missing.push(dep);
+      continue;
+    }
+    let installedVersion = '';
+    try {
+      installedVersion = JSON.parse(await readFile(installedPkg, 'utf8')).version || '';
+    } catch {
+      missing.push(dep);
+      continue;
+    }
+    const ok = satisfiesRange(installedVersion, ranges[dep]);
+    // null = a range shape we cannot statically verify; do not warn on it.
+    if (ok === false) drift.push(`${dep}@${installedVersion} does not satisfy "${ranges[dep]}"`);
+  }
+  if (missing.length > 0) {
+    return {
+      name: 'webjs-versions',
+      status: 'warn',
+      message: `${missing.length} @webjsdev/* dependency not installed: ${missing.join(', ')}.`,
+      fix: 'Run `npm install` to install the declared dependencies.',
+    };
+  }
+  if (drift.length > 0) {
+    return {
+      name: 'webjs-versions',
+      status: 'warn',
+      message: `@webjsdev version drift: ${drift.join('; ')}.`,
+      fix: 'Run `npm install` to reconcile node_modules with the declared ranges.',
+    };
+  }
+  return {
+    name: 'webjs-versions',
+    status: 'pass',
+    message: `All ${webjsDeps.length} @webjsdev/* dependency satisfy their declared ranges.`,
+  };
+}
+
+/**
+ * CHECK 6 (optional), git pre-commit hook installed + executable. WARN when the
+ * repo is a git checkout but `.git/hooks/pre-commit` is absent or
+ * non-executable, since the test-gate / changelog hook would not fire. PASS when
+ * present + executable, or skip (PASS) when this is not a git checkout at all
+ * (an exported tarball, a non-repo dir). Respects a configured `core.hooksPath`
+ * is OUT of scope here: the common scaffold installs into `.git/hooks`, so this
+ * checks the default location and a configured path is the user's own concern.
+ * @param {string} appDir
+ * @returns {DoctorResult}
+ */
+function checkGitHook(appDir) {
+  const gitDir = join(appDir, '.git');
+  if (!existsSync(gitDir)) {
+    return {
+      name: 'git-hook',
+      status: 'pass',
+      message: 'Not a git checkout; no pre-commit hook expected.',
+    };
+  }
+  const hook = join(gitDir, 'hooks', 'pre-commit');
+  if (!existsSync(hook)) {
+    return {
+      name: 'git-hook',
+      status: 'warn',
+      message: 'No .git/hooks/pre-commit hook installed.',
+      fix: 'Install the project hooks (e.g. `npm install` runs the prepare step that wires them).',
+    };
+  }
+  let executable = false;
+  try {
+    // Owner-execute bit. On a checkout without exec bits (some Windows / CI
+    // setups) the hook will not run, so flag it.
+    executable = (statSync(hook).mode & 0o100) !== 0;
+  } catch {
+    executable = false;
+  }
+  if (!executable) {
+    return {
+      name: 'git-hook',
+      status: 'warn',
+      message: '.git/hooks/pre-commit exists but is not executable.',
+      fix: 'chmod +x .git/hooks/pre-commit',
+    };
+  }
+  return {
+    name: 'git-hook',
+    status: 'pass',
+    message: '.git/hooks/pre-commit is installed and executable.',
+  };
+}
+
+/**
+ * Run every doctor check against `appDir` and return the results. PURE: no
+ * printing, no `process.exit`; the CLI renders + decides the exit code.
+ *
+ * @param {string} appDir  the app directory to check (usually `process.cwd()`)
+ * @param {{
+ *   nodeVersion?: string,
+ *   cliDir?: string,
+ *   vendor?: { hasVendorPin: (d: string) => boolean, findOutdated: (d: string) => Promise<Array<{ pkg: string, current: string, latest: string }>> },
+ * }} [opts]  test-injection seams:
+ *   - `nodeVersion`: override the running Node version (asserts the fail case
+ *     without being on old Node);
+ *   - `cliDir`: directory of the CLI package whose `engines.node` sources the
+ *     required major (defaults to THIS module's package);
+ *   - `vendor`: inject the `{ hasVendorPin, findOutdated }` pair so the pin check
+ *     runs against a stub instead of a real network call.
+ * @returns {Promise<DoctorResult[]>}
+ */
+export async function runDoctorChecks(appDir, opts = {}) {
+  const cliDir = opts.cliDir || new URL('.', import.meta.url).pathname;
+  const results = await Promise.all([
+    checkNode(cliDir, opts),
+    checkTsconfig(appDir),
+    checkEnv(appDir),
+    checkVendorPin(appDir, opts),
+    checkWebjsVersions(appDir),
+    Promise.resolve(checkGitHook(appDir)),
+  ]);
+  return results;
+}

--- a/packages/cli/templates/CONVENTIONS.md
+++ b/packages/cli/templates/CONVENTIONS.md
@@ -61,6 +61,17 @@ even if the user doesn't explicitly ask.**
 4. Sync with parent: `git fetch origin && git rebase origin/main` if behind
 5. Don't mix unrelated work on the wrong branch
 
+### After cloning: verify the toolchain
+
+Run `npm run doctor` (which runs `webjs doctor`) once after cloning to assert
+the project is set up correctly: the Node major (the strip-types floor), the
+tsconfig `erasableSyntaxOnly` flag, `.env` drift vs `.env.example`, vendor-pin
+freshness, `@webjsdev/*` version coherence, and the git pre-commit hook. It
+prints `[pass]` / `[warn]` / `[fail]` per check with an actionable fix line and
+exits non-zero only on a hard fail (a broken toolchain), so a green run means
+`npm run dev` will boot. It is a local onboarding/setup-verify tool, not a CI
+gate (its env-drift + network pin-freshness checks would make CI flaky).
+
 ### Every code change must include:
 
 1. **Commit and push per logical unit, not at the end.** A logical unit is

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -27,6 +27,7 @@ export {
   listPinned,
   auditPinned,
   findOutdated,
+  hasVendorPin,
   updatePinned,
   readPinFile,
   serveDownloadedBundle,

--- a/test/cli/doctor.test.mjs
+++ b/test/cli/doctor.test.mjs
@@ -279,3 +279,30 @@ test('CLI exits non-zero when a hard check fails (bad tsconfig)', () => {
   assert.notEqual(r.status, 0, 'a hard fail must produce a non-zero exit');
   assert.match(r.stdout + r.stderr, /\[fail\] tsconfig-erasable/);
 });
+
+// Regression: the doctor pin check imports hasVendorPin from @webjsdev/server on
+// the REAL (un-stubbed) path. If it is not re-exported, the check silently
+// reports "no pin file" for a pinned app and the freshness check is inert. The
+// other vendor tests inject opts.vendor, so they never caught this.
+test('@webjsdev/server re-exports hasVendorPin so the un-stubbed pin check works', async () => {
+  const mod = await import('@webjsdev/server');
+  assert.equal(typeof mod.hasVendorPin, 'function', 'hasVendorPin must be exported');
+  assert.equal(typeof mod.findOutdated, 'function', 'findOutdated must be exported');
+});
+
+test('the pin check detects a pin on the real import path (no vendor stub)', async () => {
+  const dir = tmpDir();
+  write(dir, 'package.json', JSON.stringify({ name: 'x' }));
+  // A pin file with no imports: hasVendorPin sees it, findOutdated has nothing
+  // to check (no network call), so the check recognizes the pin and does NOT
+  // report "no pin file". Run WITHOUT opts.vendor to exercise the real import.
+  mkdirSync(join(dir, '.webjs', 'vendor'), { recursive: true });
+  writeFileSync(join(dir, '.webjs', 'vendor', 'importmap.json'), JSON.stringify({ imports: {} }));
+  const results = await runDoctorChecks(dir, baseOpts({ nodeVersion: '24.0.0', vendor: undefined }));
+  const pin = results.find((r) => r.name === 'vendor-pin');
+  assert.ok(pin, 'a vendor-pin result is present');
+  assert.ok(
+    !/No vendor pin file/.test(pin.message),
+    `the real pin check must detect the pin, got: ${pin.status} ${pin.message}`,
+  );
+});

--- a/test/cli/doctor.test.mjs
+++ b/test/cli/doctor.test.mjs
@@ -1,0 +1,281 @@
+/**
+ * Tests for `webjs doctor` (#266): the project-health checklist.
+ *
+ * The PURE check runner `runDoctorChecks(appDir, opts?)` is exercised directly
+ * against tmp fixture appDirs (it reads files + optionally the network but never
+ * exits / prints). The CLI integration is exercised by spawning the binary and
+ * asserting the exit code (0 when no hard check fails, non-zero when one does),
+ * mirroring typecheck.test.mjs.
+ *
+ * Network: the vendor-pin freshness check is BEST-EFFORT. We never let a real
+ * network call into the test; the no-pin case is asserted directly, and the
+ * outdated / network-failure cases are driven through the `opts.vendor`
+ * injection seam (a stub `{ hasVendorPin, findOutdated }`), so the test is
+ * deterministic and offline-safe.
+ */
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO = resolve(__dirname, '..', '..');
+const CLI = resolve(REPO, 'packages', 'cli', 'bin', 'webjs.js');
+const CLI_LIB_DIR = resolve(REPO, 'packages', 'cli', 'lib');
+
+const { runDoctorChecks } = await import(
+  resolve(CLI_LIB_DIR, 'doctor.js')
+);
+
+const cleanup = [];
+after(() => { for (const d of cleanup) rmSync(d, { recursive: true, force: true }); });
+
+/** A fresh tmp fixture dir under the OS tmpdir. */
+function tmpDir() {
+  const dir = mkdtempSync(join(tmpdir(), 'doctor-'));
+  cleanup.push(dir);
+  return dir;
+}
+
+/** Write a file, creating parent dirs. */
+function write(dir, rel, content) {
+  const full = join(dir, rel);
+  mkdirSync(dirname(full), { recursive: true });
+  writeFileSync(full, content);
+}
+
+/** Find a check result by name. */
+function byName(results, name) {
+  const r = results.find((x) => x.name === name);
+  assert.ok(r, `expected a '${name}' check in the results`);
+  return r;
+}
+
+// A vendor stub that reports no pin file (the common unpinned-app case), so the
+// pin check never touches the network unless a test overrides it.
+const noPinVendor = { hasVendorPin: () => false, findOutdated: async () => [] };
+
+/** Base opts that keep every check offline + green-leaning. */
+function baseOpts(extra = {}) {
+  return { cliDir: CLI_LIB_DIR, vendor: noPinVendor, ...extra };
+}
+
+// ---------------------------------------------------------------------------
+// A well-configured app: every check should pass, none should fail.
+// ---------------------------------------------------------------------------
+test('a well-configured app produces no failures', async () => {
+  const dir = tmpDir();
+  write(dir, 'package.json', JSON.stringify({
+    name: 'good-app',
+    dependencies: { '@webjsdev/core': 'latest', '@webjsdev/server': 'latest' },
+  }));
+  write(dir, 'tsconfig.json', JSON.stringify({
+    compilerOptions: { erasableSyntaxOnly: true, strict: true },
+  }));
+  write(dir, '.env.example', 'DATABASE_URL=\nAUTH_SECRET=\n');
+  write(dir, '.env', 'DATABASE_URL=file:./dev.db\nAUTH_SECRET=abc\n');
+  // node_modules installs satisfying `latest`.
+  write(dir, 'node_modules/@webjsdev/core/package.json', JSON.stringify({ version: '0.7.4' }));
+  write(dir, 'node_modules/@webjsdev/server/package.json', JSON.stringify({ version: '0.8.0' }));
+
+  const results = await runDoctorChecks(dir, baseOpts());
+  const fails = results.filter((r) => r.status === 'fail');
+  assert.equal(fails.length, 0, `no hard fails expected, got: ${JSON.stringify(fails)}`);
+  assert.equal(byName(results, 'tsconfig-erasable').status, 'pass');
+  assert.equal(byName(results, 'env-drift').status, 'pass');
+  assert.equal(byName(results, 'vendor-pin').status, 'pass');
+  assert.equal(byName(results, 'webjs-versions').status, 'pass');
+});
+
+// ---------------------------------------------------------------------------
+// Node version: pass at/above required, fail below (the counterfactual).
+// ---------------------------------------------------------------------------
+test('node check passes when the injected version >= required', async () => {
+  const dir = tmpDir();
+  const results = await runDoctorChecks(dir, baseOpts({ nodeVersion: '24.4.0' }));
+  assert.equal(byName(results, 'node-version').status, 'pass');
+});
+
+test('node check FAILS (hard) when an older version is injected', async () => {
+  const dir = tmpDir();
+  const results = await runDoctorChecks(dir, baseOpts({ nodeVersion: '20.11.0' }));
+  const node = byName(results, 'node-version');
+  assert.equal(node.status, 'fail', 'an old Node must be a hard fail');
+  assert.match(node.fix, /Upgrade to Node/);
+});
+
+// ---------------------------------------------------------------------------
+// tsconfig erasableSyntaxOnly.
+// ---------------------------------------------------------------------------
+test('tsconfig check FAILS when erasableSyntaxOnly is missing in an existing tsconfig', async () => {
+  const dir = tmpDir();
+  write(dir, 'tsconfig.json', JSON.stringify({ compilerOptions: { strict: true } }));
+  const results = await runDoctorChecks(dir, baseOpts({ nodeVersion: '24.0.0' }));
+  assert.equal(byName(results, 'tsconfig-erasable').status, 'fail');
+});
+
+test('tsconfig check FAILS when erasableSyntaxOnly is false', async () => {
+  const dir = tmpDir();
+  write(dir, 'tsconfig.json', JSON.stringify({ compilerOptions: { erasableSyntaxOnly: false } }));
+  const results = await runDoctorChecks(dir, baseOpts({ nodeVersion: '24.0.0' }));
+  assert.equal(byName(results, 'tsconfig-erasable').status, 'fail');
+});
+
+test('tsconfig check WARNS (not fails) when no tsconfig is present', async () => {
+  const dir = tmpDir();
+  const results = await runDoctorChecks(dir, baseOpts({ nodeVersion: '24.0.0' }));
+  assert.equal(byName(results, 'tsconfig-erasable').status, 'warn');
+});
+
+test('tsconfig check tolerates JSONC (comments + trailing commas)', async () => {
+  const dir = tmpDir();
+  write(dir, 'tsconfig.json',
+    '{\n  // editor intelligence\n  "compilerOptions": {\n    "erasableSyntaxOnly": true, /* required */\n  },\n}\n');
+  const results = await runDoctorChecks(dir, baseOpts({ nodeVersion: '24.0.0' }));
+  assert.equal(byName(results, 'tsconfig-erasable').status, 'pass');
+});
+
+// ---------------------------------------------------------------------------
+// .env drift.
+// ---------------------------------------------------------------------------
+test('env check WARNS listing a key in .env.example missing from .env', async () => {
+  const dir = tmpDir();
+  write(dir, '.env.example', 'DATABASE_URL=\nAUTH_SECRET=\nWEBJS_PUBLIC_API_URL=\n');
+  write(dir, '.env', 'DATABASE_URL=file:./dev.db\n');
+  const results = await runDoctorChecks(dir, baseOpts({ nodeVersion: '24.0.0' }));
+  const env = byName(results, 'env-drift');
+  assert.equal(env.status, 'warn');
+  assert.match(env.message, /AUTH_SECRET/);
+  assert.match(env.message, /WEBJS_PUBLIC_API_URL/);
+});
+
+test('env check PASSES when all example keys are present', async () => {
+  const dir = tmpDir();
+  write(dir, '.env.example', 'DATABASE_URL=\n# a comment\nAUTH_SECRET=\n');
+  write(dir, '.env', 'AUTH_SECRET=x\nDATABASE_URL=y\n');
+  const results = await runDoctorChecks(dir, baseOpts({ nodeVersion: '24.0.0' }));
+  assert.equal(byName(results, 'env-drift').status, 'pass');
+});
+
+test('env check WARNS when .env.example exists but .env is absent', async () => {
+  const dir = tmpDir();
+  write(dir, '.env.example', 'DATABASE_URL=\n');
+  const results = await runDoctorChecks(dir, baseOpts({ nodeVersion: '24.0.0' }));
+  const env = byName(results, 'env-drift');
+  assert.equal(env.status, 'warn');
+  assert.match(env.fix, /cp \.env\.example \.env/);
+});
+
+test('env check PASSES (skips) when there is no .env.example', async () => {
+  const dir = tmpDir();
+  const results = await runDoctorChecks(dir, baseOpts({ nodeVersion: '24.0.0' }));
+  assert.equal(byName(results, 'env-drift').status, 'pass');
+});
+
+// ---------------------------------------------------------------------------
+// @webjsdev version coherence.
+// ---------------------------------------------------------------------------
+test('version check WARNS on a missing @webjsdev install', async () => {
+  const dir = tmpDir();
+  write(dir, 'package.json', JSON.stringify({
+    dependencies: { '@webjsdev/core': '^0.7.0' },
+  }));
+  // No node_modules/@webjsdev/core installed.
+  const results = await runDoctorChecks(dir, baseOpts({ nodeVersion: '24.0.0' }));
+  const v = byName(results, 'webjs-versions');
+  assert.equal(v.status, 'warn');
+  assert.match(v.message, /not installed/);
+  assert.match(v.fix, /npm install/);
+});
+
+test('version check WARNS on a range drift (installed does not satisfy)', async () => {
+  const dir = tmpDir();
+  write(dir, 'package.json', JSON.stringify({
+    dependencies: { '@webjsdev/core': '^0.7.0' },
+  }));
+  // Installed 0.8.0 does NOT satisfy ^0.7.0 (caret pins the minor for 0.x).
+  write(dir, 'node_modules/@webjsdev/core/package.json', JSON.stringify({ version: '0.8.0' }));
+  const results = await runDoctorChecks(dir, baseOpts({ nodeVersion: '24.0.0' }));
+  const v = byName(results, 'webjs-versions');
+  assert.equal(v.status, 'warn');
+  assert.match(v.message, /drift/);
+});
+
+test('version check PASSES when installed satisfies the declared range', async () => {
+  const dir = tmpDir();
+  write(dir, 'package.json', JSON.stringify({
+    dependencies: { '@webjsdev/core': '^0.7.0' },
+    devDependencies: { '@webjsdev/cli': 'latest' },
+  }));
+  write(dir, 'node_modules/@webjsdev/core/package.json', JSON.stringify({ version: '0.7.4' }));
+  write(dir, 'node_modules/@webjsdev/cli/package.json', JSON.stringify({ version: '0.10.1' }));
+  const results = await runDoctorChecks(dir, baseOpts({ nodeVersion: '24.0.0' }));
+  assert.equal(byName(results, 'webjs-versions').status, 'pass');
+});
+
+// ---------------------------------------------------------------------------
+// vendor pin freshness (best-effort + network-tolerant).
+// ---------------------------------------------------------------------------
+test('vendor-pin PASSES (skips) when there is no pin file', async () => {
+  const dir = tmpDir();
+  const results = await runDoctorChecks(dir, baseOpts({ nodeVersion: '24.0.0' }));
+  assert.equal(byName(results, 'vendor-pin').status, 'pass');
+});
+
+test('vendor-pin WARNS (never fails) when the freshness check throws (network)', async () => {
+  const dir = tmpDir();
+  const throwingVendor = {
+    hasVendorPin: () => true,
+    findOutdated: async () => { throw new Error('ENOTFOUND registry.npmjs.org'); },
+  };
+  const results = await runDoctorChecks(dir, baseOpts({ nodeVersion: '24.0.0', vendor: throwingVendor }));
+  const pin = byName(results, 'vendor-pin');
+  assert.equal(pin.status, 'warn', 'a network failure must be a warn, never a fail');
+  assert.match(pin.message, /network|registry/i);
+  // And critically, it did not throw out of runDoctorChecks.
+});
+
+test('vendor-pin WARNS listing outdated packages', async () => {
+  const dir = tmpDir();
+  const outdatedVendor = {
+    hasVendorPin: () => true,
+    findOutdated: async () => [{ pkg: 'dayjs', current: '1.11.0', latest: '1.11.13' }],
+  };
+  const results = await runDoctorChecks(dir, baseOpts({ nodeVersion: '24.0.0', vendor: outdatedVendor }));
+  const pin = byName(results, 'vendor-pin');
+  assert.equal(pin.status, 'warn');
+  assert.match(pin.message, /dayjs/);
+  assert.match(pin.fix, /vendor update/);
+});
+
+// ---------------------------------------------------------------------------
+// CLI integration: exit code behavior.
+// ---------------------------------------------------------------------------
+function runCli(cwd) {
+  return spawnSync(process.execPath, [CLI, 'doctor'], { cwd, encoding: 'utf8' });
+}
+
+test('CLI exits 0 when no hard check fails', () => {
+  // Run in the OS tmpdir: a fresh app with a good tsconfig and no @webjsdev
+  // deps. The running Node is the repo's own (24+), so node-version passes; the
+  // only warns are env / versions, which do NOT fail the exit.
+  const dir = tmpDir();
+  write(dir, 'package.json', JSON.stringify({ name: 'x' }));
+  write(dir, 'tsconfig.json', JSON.stringify({ compilerOptions: { erasableSyntaxOnly: true } }));
+  const r = runCli(dir);
+  assert.equal(r.status, 0, `expected exit 0, got ${r.status}\n${r.stdout}\n${r.stderr}`);
+  assert.match(r.stdout, /\[pass\] node-version/);
+});
+
+test('CLI exits non-zero when a hard check fails (bad tsconfig)', () => {
+  const dir = tmpDir();
+  write(dir, 'package.json', JSON.stringify({ name: 'x' }));
+  // erasableSyntaxOnly missing in an EXISTING tsconfig -> hard fail.
+  write(dir, 'tsconfig.json', JSON.stringify({ compilerOptions: { strict: true } }));
+  const r = runCli(dir);
+  assert.notEqual(r.status, 0, 'a hard fail must produce a non-zero exit');
+  assert.match(r.stdout + r.stderr, /\[fail\] tsconfig-erasable/);
+});


### PR DESCRIPTION
Closes #266

## What

There was no single command to verify a webjs project is set up correctly. webjs has unusually many fragile preconditions (the Node 24+ strip-types floor, the `erasableSyntaxOnly` TS flag, importmap pin freshness, git-hook activation, env drift, `@webjsdev` version coherence), each an independent failure mode a contributor hits only at runtime.

Add **`webjs doctor`**: a thin checklist runner. `packages/cli/lib/doctor.js` `runDoctorChecks(appDir, opts?)` is a PURE function (reads files, optionally the network, never exits or prints); the CLI renders the results and owns the exit code. Six checks:

| Check | Level |
|---|---|
| Node major >= required (sourced from `engines.node`) | **hard-fail** |
| tsconfig `erasableSyntaxOnly: true` | **hard-fail** (existing tsconfig only; warn if absent) |
| `.env` presence + drift vs `.env.example` | warn |
| vendor pin freshness (only when pinned, network) | warn |
| `@webjsdev/*` version coherence | warn |
| git pre-commit hook installed + executable | warn |

Only genuinely-broken-toolchain conditions hard-fail; drift/staleness is a warning, so CI can gate without flaking on the network or env. The command exits non-zero on any hard fail, prints a pass/warn/fail line with an actionable `Fix:` on each, and is wired as a scaffold `doctor` script for onboarding (NOT added to scaffold CI, since the network + env checks would flake there).

## Best-effort network

The only network touch is the pin-freshness `findOutdated`, gated behind a committed pin and wrapped so a fetch failure is a warn, never a hard fail or a throw.

## Tests

`test/cli/doctor.test.mjs` (19): the Node-fail counterfactual (an injected old version → fail, via an `opts.nodeVersion` override so the test runs offline), the tsconfig fail/warn/JSONC cases, env drift/pass/missing, version missing-install + range-drift + pass, the pin network-failure-is-a-warn-not-a-throw case, and the CLI exit-code spawn tests (0 with warns only, non-zero on a hard fail). Full suite 1990.

## Docs

Root `AGENTS.md` CLI reference, `packages/cli/AGENTS.md` command table, scaffold `CONVENTIONS.md` (the onboarding verify step).
