### PR TITLE
chore: release core 0.7.9, server 0.8.13, cli 0.10.7

### DIFF
--- a/changelog/cli/0.10.7.md
+++ b/changelog/cli/0.10.7.md
@@ -1,0 +1,20 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.7
+date: 2026-06-03T13:20:48.123Z
+commit_count: 3
+---
+## Features
+
+- **add a webjs typecheck command (tsc --noEmit wrapper)** ([#307](https://github.com/webjsdev/webjs/pull/307)) [`0eb4e9f4`](https://github.com/webjsdev/webjs/commit/0eb4e9f4)
+  webjs ships erasable TypeScript as a first-class authoring mode (strict + noEmit + erasableSyntaxOnly + @webjsdev/ts-plugin) but had no command to run the type checker. The runtime only catches strip-time failures (non-erasable syntax) with a 500; genuine type errors were surfaced by nothing, since webjs check is correctness-only and explicitly does not type-check.
+  
+  Add `webjs typecheck`: it resolves the project's OWN typescript/bin/tsc (via createRequire from the app cwd, so it reads the app's tsconfig) and spawns it with --noEmit, passing extra args through, exiting non-zero on a type error so it works as a CI gate. When TypeScript is not installed it prints a clear message and exits non-zero. The framework runs the standard compiler, it does not embed one. The scaffold now ships a typecheck npm script and typescript as a devDependency, with CONVENTIONS.md documenting it as the separate is-my-TypeScript-valid gate to add to CI once the app type-checks cleanly. Not auto-added to the scaffold CI to avoid a day-one failure before the app is verified to type-check.
+- **document the handle() test harness, ship test helpers, fix the saas auth test** ([#308](https://github.com/webjsdev/webjs/pull/308)) [`9df85d23`](https://github.com/webjsdev/webjs/commit/9df85d23)
+  createRequestHandler().handle(request) drives the full pipeline (middleware, routing, SSR, actions, auth/CSRF) and the framework's own suite uses it, but it was documented only as an embedding API, with no testRequest() recipe, no helper to build an authenticated/CSRF request, and no helper to round-trip an action through the /__webjs/action/<hash>/<fn> serializer+dispatch path. Actions were tested by direct import, bypassing CSRF and prod error sanitization. The saas template's test asserted only TypeScript shapes and sat on test/unit/, contradicting the documented test/<feature>/ convention.
+  
+  Add packages/server/src/testing.js (a ./testing export): testRequest fires a native Request through handle(); getCsrf mints a valid token+cookie off the first SSR response (reusing the real csrf.js constants); loginAndGetCookies drives the real credentials login and captures the genuine signed session cookie; actionEndpoint computes the real /__webjs/action/<hash>/<fn> path; and invokeActionForTest round-trips an action through that endpoint with the real serializer + CSRF, so a regression test proves it catches what a direct import misses (a Map surviving only because the wire serializer ran, a 403 on a CSRF-missing request, and prod error sanitization hiding a stack + secret field the direct throw leaks). The saas scaffold now ships a real auth-flow test at test/auth/auth.test.ts: the unauthenticated-protected-route-redirect always runs, and the signup/login/authenticated-render path runs when the DB is set up (skips cleanly otherwise).
+- **add a webjs doctor project-health command** ([#311](https://github.com/webjsdev/webjs/pull/311)) [`44ff8600`](https://github.com/webjsdev/webjs/commit/44ff8600)
+  * feat: add a webjs doctor project-health command
+  
+  There was no single command to verify a webjs project is set up correctly. webjs has unusually many fragile preconditions (the Node 24+ strip-types floor, the erasableSyntaxOnly TS flag, importmap pin freshness, git-hook activation, env drift, @webjsdev version coherence), each an independent failure mode a contributor onboarding to an existing repo hits only at runtime.

--- a/changelog/core/0.7.9.md
+++ b/changelog/core/0.7.9.md
@@ -1,0 +1,12 @@
+---
+package: "@webjsdev/core"
+version: 0.7.9
+date: 2026-06-03T13:20:48.046Z
+commit_count: 1
+---
+## Features
+
+- **input validation on the RPC action path, shared with expose()** ([#309](https://github.com/webjsdev/webjs/pull/309)) [`4cbe55d9`](https://github.com/webjsdev/webjs/commit/4cbe55d9)
+  * feat: input validation on the RPC action path, shared with expose()
+  
+  The primary way actions are called (importing them from a client component, which becomes the RPC stub) had no input-validation seam: invokeAction deserialized args and called fn(...args) with no hook. A validate option was honored only on the expose() REST path, so a validator could not be declared once and shared by both paths, and a REST validation failure was a thrown 400 rather than a structured field-error result an app can render.

--- a/changelog/server/0.8.13.md
+++ b/changelog/server/0.8.13.md
@@ -1,0 +1,28 @@
+---
+package: "@webjsdev/server"
+version: 0.8.13
+date: 2026-06-03T13:20:48.082Z
+commit_count: 5
+---
+## Features
+
+- **emit SRI integrity for live-resolved vendor imports** ([#300](https://github.com/webjsdev/webjs/pull/300)) [`72ae06f9`](https://github.com/webjsdev/webjs/commit/72ae06f9)
+  * feat: emit SRI integrity for live-resolved (unpinned) vendor imports
+  
+  SRI was already computed when an app pins (the pin importmap carries sha384 integrity), but an app with no pin file (the in-repo norm and a fresh scaffold) hit the live-resolve path, which returned integrity:{}, so cross-origin jspm.io modules served with crossorigin but no integrity attribute. A swapped or compromised CDN response then executed unverified.
+- **add sitemap() and sitemapIndex() helpers for spec-valid XML** ([#306](https://github.com/webjsdev/webjs/pull/306)) [`9cc6d9af`](https://github.com/webjsdev/webjs/commit/9cc6d9af)
+  * feat: add sitemap() and sitemapIndex() helpers for spec-valid XML
+  
+  An author of app/sitemap.{js,ts} had to hand-construct the entire <urlset> XML string, escaping URLs and formatting lastmod dates by hand, and a malformed string is silently rejected by search engines. There was also no sitemap-index support, so a site over the 50,000-URL / 50MB per-file limit had no built-in sharding path.
+- **document the handle() test harness, ship test helpers, fix the saas auth test** ([#308](https://github.com/webjsdev/webjs/pull/308)) [`9df85d23`](https://github.com/webjsdev/webjs/commit/9df85d23)
+  createRequestHandler().handle(request) drives the full pipeline (middleware, routing, SSR, actions, auth/CSRF) and the framework's own suite uses it, but it was documented only as an embedding API, with no testRequest() recipe, no helper to build an authenticated/CSRF request, and no helper to round-trip an action through the /__webjs/action/<hash>/<fn> serializer+dispatch path. Actions were tested by direct import, bypassing CSRF and prod error sanitization. The saas template's test asserted only TypeScript shapes and sat on test/unit/, contradicting the documented test/<feature>/ convention.
+  
+  Add packages/server/src/testing.js (a ./testing export): testRequest fires a native Request through handle(); getCsrf mints a valid token+cookie off the first SSR response (reusing the real csrf.js constants); loginAndGetCookies drives the real credentials login and captures the genuine signed session cookie; actionEndpoint computes the real /__webjs/action/<hash>/<fn> path; and invokeActionForTest round-trips an action through that endpoint with the real serializer + CSRF, so a regression test proves it catches what a direct import misses (a Map surviving only because the wire serializer ran, a 403 on a CSRF-missing request, and prod error sanitization hiding a stack + secret field the direct throw leaks). The saas scaffold now ships a real auth-flow test at test/auth/auth.test.ts: the unauthenticated-protected-route-redirect always runs, and the signup/login/authenticated-render path runs when the DB is set up (skips cleanly otherwise).
+- **input validation on the RPC action path, shared with expose()** ([#309](https://github.com/webjsdev/webjs/pull/309)) [`4cbe55d9`](https://github.com/webjsdev/webjs/commit/4cbe55d9)
+  * feat: input validation on the RPC action path, shared with expose()
+  
+  The primary way actions are called (importing them from a client component, which becomes the RPC stub) had no input-validation seam: invokeAction deserialized args and called fn(...args) with no hook. A validate option was honored only on the expose() REST path, so a validator could not be declared once and shared by both paths, and a REST validation failure was a thrown 400 rather than a structured field-error result an app can render.
+- **add a webjs doctor project-health command** ([#311](https://github.com/webjsdev/webjs/pull/311)) [`44ff8600`](https://github.com/webjsdev/webjs/commit/44ff8600)
+  * feat: add a webjs doctor project-health command
+  
+  There was no single command to verify a webjs project is set up correctly. webjs has unusually many fragile preconditions (the Node 24+ strip-types floor, the erasableSyntaxOnly TS flag, importmap pin freshness, git-hook activation, env drift, @webjsdev version coherence), each an independent failure mode a contributor onboarding to an existing repo hits only at runtime.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6969,7 +6969,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.6",
+      "version": "0.10.7",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/server": "^0.8.0",
@@ -6984,7 +6984,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.8",
+      "version": "0.7.9",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.24.0"
@@ -7005,7 +7005,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.12",
+      "version": "0.8.13",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Batches the package work landed since the last release (#299) into three patch bumps (all stay within the dependents' `^0.7.0` / `^0.8.0` / `^0.10.0` ranges, so no dependent-range edits).

## Versions

- `@webjsdev/core` 0.7.8 to 0.7.9 (RPC input validation)
- `@webjsdev/server` 0.8.12 to 0.8.13 (RPC validation, the handle() test harness, sitemap helpers, live-resolved SRI, the doctor pin-check export)
- `@webjsdev/cli` 0.10.6 to 0.10.7 (webjs typecheck, webjs doctor, the saas auth-test fixes)

The changelogs were auto-generated by the pre-commit hook from the conventional-commit history. On merge, `release.yml` publishes each new version to npm and creates the matching GitHub Releases.
