### PR TITLE
feat: add a hydrating ssrFixture() and an opt-in a11y assertion

### DIFF
--- a/agent-docs/testing.md
+++ b/agent-docs/testing.md
@@ -116,6 +116,54 @@ package, it goes in that package's `test/`.
 
 ---
 
+## Component test helpers (`@webjsdev/core/testing`)
+
+`import { fixture, ssrFixture, waitForUpdate, assertNoA11yViolations, click, shadowQuery, shadowQueryAll } from '@webjsdev/core/testing'`. The mount + hydrate + a11y helpers run in the WTR Chromium session (real DOM), thin wrappers over the browser already running.
+
+### `fixture()` vs `ssrFixture()`
+
+Both server-render an `html\`…\`` template (via `renderToString`, with DSD) and set the markup into a container so the browser upgrades the custom element. The difference is how they wait:
+
+- **`fixture(template)`** waits two macrotasks. Use it for a quick mount where the SSR-then-hydrate distinction does not matter.
+- **`ssrFixture(template)`** awaits the element's NATIVE `updateComplete` promise (the real render-cycle resolution), not a timer, so the post-hydration DOM is observable deterministically. It is the documented SSR + hydrate entry. Its contract: the SSR'd markup and the post-hydration DOM agree, so a hydration mismatch (server renders one thing, client another) is observable by comparing the SSR'd inner HTML against `el.innerHTML` / `el.shadowRoot.innerHTML` after it resolves. The component class must already be registered (the test imports its module, same as `fixture()`).
+
+`waitForUpdate(el)` now also awaits the native `updateComplete` when present (falling back to a macrotask flush for a plain element), so a re-render after a property assignment or signal `set()` settles deterministically.
+
+```js
+import { html } from '@webjsdev/core';
+import { ssrFixture, waitForUpdate } from '@webjsdev/core/testing';
+
+const el = await ssrFixture(html`<my-counter count="5"></my-counter>`);
+assert.ok(el.innerHTML.includes('5'));          // post-hydration DOM
+
+el.count = 10;
+await waitForUpdate(el);                          // awaits the real cycle
+assert.ok(el.innerHTML.includes('10'));
+```
+
+**Hydration-mismatch pattern.** To assert SSR and the hydrated DOM agree, normalise the SSR string (strip the `<!--webjs-hydrate-->` marker, `data-webjs-prop-*` attributes, part comments) and compare against the live `el.innerHTML`. The counterfactual is a component whose `render()` is non-deterministic across the SSR call and the hydration render; `ssrFixture` returns the live hydrated element, so the divergence is detectable. The worked tests live in `packages/core/test/testing/browser/ssr-fixture.test.js`, alongside the broader SSR-vs-client parity corpus in `packages/core/test/rendering/browser/ssr-client-parity.test.js`.
+
+### `assertNoA11yViolations(el, opts?)` (opt-in)
+
+An OPT-IN accessibility assertion that runs the standard axe-core engine against an element's subtree in the WTR Chromium session. Nothing calls it for you, it is never a forced gate.
+
+axe-core is a TEST-ONLY peer, imported dynamically by the helper, so it is NOT a hard dependency of `@webjsdev/core`. Install it where you run the test (`npm install -D axe-core`; the scaffold and this repo already ship it). If it is missing, the helper throws a clear message: `assertNoA11yViolations needs axe-core. Install it: npm install -D axe-core`.
+
+On zero violations it resolves; on a violation it throws an Error whose message lists each violation's id, impact, a short help string, and the failing nodes' selectors, so the failure is actionable. `opts` passes through to `axe.run` (e.g. `{ rules: { 'color-contrast': { enabled: false } } }`).
+
+```js
+import { ssrFixture, assertNoA11yViolations } from '@webjsdev/core/testing';
+
+const el = await ssrFixture(html`<my-form></my-form>`);
+await assertNoA11yViolations(el);                // passes a clean subtree
+
+// a <button> with no accessible name, an <input> with no label, an <img>
+// with no alt: each throws a named violation. Worked both-direction tests
+// live in packages/core/test/testing/browser/a11y.test.js.
+```
+
+---
+
 ## The handle() test harness (`@webjsdev/server/testing`)
 
 `createRequestHandler({ appDir }).handle(request)` drives the FULL request

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@tailwindcss/cli": "^4.2.2",
         "@web/test-runner": "^0.20.2",
         "@web/test-runner-playwright": "^0.11.1",
+        "axe-core": "^4.10.0",
         "concurrently": "^9.2.1",
         "linkedom": "^0.18.12",
         "playwright": "^1.59.1",
@@ -2561,6 +2562,16 @@
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.0.tgz",
+      "integrity": "sha512-FTavr/7Ba0IptwGOPxnQvdyW2tAsdLBMTBXz7rKH6xJ2skpyxpBxyHkDdBs4lf69yRqYpkqCdfhnwS8YULGOmg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/b4a": {
       "version": "1.8.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@tailwindcss/cli": "^4.2.2",
     "@web/test-runner": "^0.20.2",
     "@web/test-runner-playwright": "^0.11.1",
+    "axe-core": "^4.10.0",
     "concurrently": "^9.2.1",
     "linkedom": "^0.18.12",
     "playwright": "^1.59.1",

--- a/packages/cli/lib/create.js
+++ b/packages/cli/lib/create.js
@@ -311,6 +311,10 @@ export async function scaffoldApp(name, cwd, opts = {}) {
       '@web/test-runner': '^0.20.0',
       '@web/test-runner-playwright': '^0.11.0',
       'playwright': '^1.59.0',
+      // The standard accessibility engine, used opt-in by the
+      // assertNoA11yViolations() test helper from @webjsdev/core/testing.
+      // Test-only: dynamically imported, never shipped to the app runtime.
+      'axe-core': '^4.10.0',
       // tsserver plugin for editor intelligence inside html`` templates.
       // @webjsdev/ts-plugin bundles ts-lit-plugin internally, so just one
       // plugin entry is needed in tsconfig (see below).

--- a/packages/cli/templates/AGENTS.md
+++ b/packages/cli/templates/AGENTS.md
@@ -469,7 +469,7 @@ import '@webjsdev/core/client-router';              // enable SPA nav
 import { unsafeHTML, live } from '@webjsdev/core/directives';
 import { createContext } from '@webjsdev/core/context';
 import { Task } from '@webjsdev/core/task';
-import { fixture, waitForUpdate } from '@webjsdev/core/testing';
+import { fixture, ssrFixture, waitForUpdate, assertNoA11yViolations } from '@webjsdev/core/testing';
 
 import { rateLimit, cors, cache, createAuth, Credentials, Session } from '@webjsdev/server';
 ```

--- a/packages/cli/templates/CONVENTIONS.md
+++ b/packages/cli/templates/CONVENTIONS.md
@@ -442,6 +442,16 @@ test/
 | node (unit + integration) | `test/<feature>/*.test.ts` | Fast, no spawned process. Import server actions/queries/utilities and call them directly. Use `renderToString` for SSR HTML assertions. |
 | browser | `test/<feature>/browser/*.test.js` | Real Chromium via web-test-runner + Playwright. Shadow DOM, events, `adoptedStyleSheets`, `IntersectionObserver`. |
 | e2e | `test/<feature>/e2e/*.test.ts` | Boots the app and drives it through HTTP / a real browser. Gated behind `WEBJS_E2E=1` so it doesn't run on every `webjs test`. |
+
+For a browser component test, `ssrFixture(html\`<my-el></my-el>\`)` from
+`@webjsdev/core/testing` server-renders THEN hydrates the component, awaiting
+its native `updateComplete`, so the post-hydration DOM is observable and an
+SSR-vs-hydrate mismatch shows up (contrast `fixture()`, which only waits two
+macrotasks). `assertNoA11yViolations(el)` is the OPT-IN axe-core accessibility
+assertion: axe-core is a test-only devDependency, dynamically imported, never
+shipped to the app runtime, and the assertion is never an automatic gate.
+Install it once with `npm install -D axe-core` (the scaffold already lists it).
+The scaffold's `test/hello/browser/hello.test.js` demonstrates both.
 | smoke | `test/<feature>/smoke/*.test.ts` | Fast deploy-time sanity check (single critical path; "does this surface still return 200"). |
 
 ### Running

--- a/packages/cli/templates/test/hello/browser/hello.test.js
+++ b/packages/cli/templates/test/hello/browser/hello.test.js
@@ -8,6 +8,9 @@
  * adoptedStyleSheets, IntersectionObserver, events, etc.
  */
 
+import { html } from '@webjsdev/core';
+import { ssrFixture, assertNoA11yViolations } from '@webjsdev/core/testing';
+
 const assert = {
   ok: (v, msg) => { if (!v) throw new Error(msg || `Expected truthy`); },
   equal: (a, b, msg) => { if (a !== b) throw new Error(msg || `Expected ${b}, got ${a}`); },
@@ -29,12 +32,30 @@ suite('Example browser tests', () => {
     assert.ok(!host.querySelector('p'), 'Shadow content not in light DOM');
   });
 
+  // ssrFixture() server-renders a template THEN hydrates it in this real
+  // browser, awaiting the component's native updateComplete (the real
+  // render-cycle promise), so the post-hydration DOM is observable. Use it
+  // for any component test where the SSR-then-hydrate round-trip matters.
+  test('ssrFixture hydrates a server-rendered button', async () => {
+    const el = await ssrFixture(html`<button type="button">Save</button>`);
+    assert.equal(el.tagName, 'BUTTON', 'button hydrated');
+    assert.ok(el.textContent.includes('Save'), 'rendered label survives hydration');
+  });
+
+  // assertNoA11yViolations() is the OPT-IN accessibility assertion. It runs
+  // the standard axe-core engine against the element subtree (axe-core is a
+  // test-only devDependency, dynamically imported, never shipped to the app
+  // runtime). Resolves on a clean element, throws a named violation otherwise.
+  test('a button with an accessible name has no a11y violations', async () => {
+    const el = await ssrFixture(html`<button type="button">Submit form</button>`);
+    await assertNoA11yViolations(el);
+  });
+
   // Replace with your component tests:
-  // test('my-widget renders correctly', () => {
-  //   import('../../components/my-widget.ts');
-  //   const el = document.createElement('my-widget');
-  //   document.body.appendChild(el);
-  //   assert.ok(el.shadowRoot);
-  //   el.remove();
+  // test('my-widget renders correctly', async () => {
+  //   await import('../../components/my-widget.ts');
+  //   const el = await ssrFixture(html`<my-widget></my-widget>`);
+  //   assert.ok(el.shadowRoot ?? el.firstElementChild);
+  //   await assertNoA11yViolations(el);   // opt-in a11y check
   // });
 });

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -47,7 +47,7 @@ the same output in all three.
 | `rich-fetch.js` | Content-negotiated fetch helper |
 | `websocket-client.js` | `connectWS()` with auto-reconnect |
 | `serialize.js` | Wire-format primitives (Date/Map/Set/BigInt/cycles…) used by RPC |
-| `testing.js` | `fixture`, `waitForUpdate`, `click`, `shadowQuery`, `shadowQueryAll` |
+| `testing.js` | `fixture`, `ssrFixture` (SSR + hydrate, awaits the native `updateComplete`), `waitForUpdate` (awaits `updateComplete` when present), `assertNoA11yViolations` (opt-in axe-core a11y assertion, dynamically imports the test-only `axe-core` peer), `click`, `shadowQuery`, `shadowQueryAll` |
 
 ## Public exports (re-exported from `index.js`)
 

--- a/packages/core/src/testing.js
+++ b/packages/core/src/testing.js
@@ -58,6 +58,60 @@ export async function fixture(template) {
 }
 
 /**
+ * Server-render a template THEN hydrate it in the same browser session,
+ * awaiting the element's native `updateComplete` so the post-hydration DOM
+ * is observable deterministically.
+ *
+ * This is the SSR + hydrate entry, distinct from `fixture()`. `fixture()`
+ * server-renders and parses the HTML into the container, but it only waits
+ * two macrotasks and never awaits the real update cycle. `ssrFixture()`
+ * renders the SAME SSR markup (with DSD), lets the browser upgrade the
+ * custom element, then awaits the element's `updateComplete` promise (the
+ * actual render-cycle resolution), not a timer.
+ *
+ * **What it proves.** The SSR'd markup and the post-hydration DOM agree.
+ * Because the returned element is the live, hydrated element, a hydration
+ * mismatch (the server rendered one thing, the client rendered another) is
+ * observable: compare the SSR'd inner HTML against `el.innerHTML` /
+ * `el.shadowRoot.innerHTML` after this resolves and a divergence shows up.
+ *
+ * **When to use (AI hint):** Use `ssrFixture()` when the test is about the
+ * SSR-then-hydrate round-trip (does the server paint survive hydration, does
+ * a `.prop` decode back, does a signal-backed render match). Use the plain
+ * `fixture()` for a quick mount where the SSR-vs-hydrate distinction does not
+ * matter.
+ *
+ * Requires a real DOM (the WTR Chromium session). The component class must
+ * already be registered (the test imports its module, same as `fixture()`).
+ *
+ * @param {import('./html.js').TemplateResult | string} template
+ *   Either a `html\`…\`` result or a raw HTML string.
+ * @returns {Promise<Element>} The hydrated root element.
+ */
+export async function ssrFixture(template) {
+  const container = getContainer();
+  if (typeof template === 'string') {
+    container.innerHTML = template;
+  } else if (template && typeof template === 'object' && template._$webjs === 'template') {
+    const { renderToString } = await import('./render-server.js');
+    const html = await renderToString(template, { ssr: true });
+    container.innerHTML = html;
+  } else {
+    throw new Error('ssrFixture() expects an html`…` template or an HTML string');
+  }
+
+  const el = container.firstElementChild;
+  if (!el) throw new Error('ssrFixture() produced no element');
+
+  // Drive the real update cycle. The browser upgrades the SSR'd custom
+  // element on innerHTML assignment; its connectedCallback queues the first
+  // render. Awaiting the native updateComplete promise (not a timer) is the
+  // whole point: the test observes the post-hydration DOM deterministically.
+  await flushUpdate(el);
+  return el;
+}
+
+/**
  * Wait for a component's next render cycle to complete.
  *
  * **When to use (AI hint):** Call after `setAttribute()`, a property
@@ -65,15 +119,103 @@ export async function fixture(template) {
  * subscribes to, any change that triggers a re-render. The re-render
  * is async (microtask-batched), so you need to await before asserting.
  *
+ * Awaits the element's native `updateComplete` promise when present (the
+ * real render-cycle resolution), falling back to a microtask flush for a
+ * plain element that has no `updateComplete` (back-compatible).
+ *
  * @param {Element} el  The component element.
  * @returns {Promise<void>}
  */
 export async function waitForUpdate(el) {
-  // WebComponent batches via queueMicrotask, so two microtask yields
-  // is sufficient: one for the scheduling microtask, one for any
-  // cascading updates.
+  await flushUpdate(el);
+}
+
+/**
+ * Await the real update cycle of an element. For a WebComponent this awaits
+ * the native `updateComplete` promise; for anything else it yields two
+ * macrotasks (the legacy behaviour) so cascading updates settle.
+ *
+ * @param {Element} el
+ * @returns {Promise<void>}
+ */
+async function flushUpdate(el) {
+  const uc = el && /** @type {any} */ (el).updateComplete;
+  if (uc && typeof uc.then === 'function') {
+    await uc;
+    // A microtask yield lets any cascading child update flush too.
+    await Promise.resolve();
+    return;
+  }
   await new Promise((r) => setTimeout(r, 0));
   await new Promise((r) => setTimeout(r, 0));
+}
+
+/**
+ * Assert an element's subtree has no accessibility violations, using the
+ * axe-core engine in the real browser. OPT-IN: nothing calls this for you,
+ * it is never a forced gate.
+ *
+ * axe-core is a TEST-ONLY peer: it is imported dynamically here, so it is
+ * NOT a hard dependency of `@webjsdev/core`. An app that does not do a11y
+ * testing never needs it. Install it where you run the test:
+ * `npm install -D axe-core`.
+ *
+ * On a violation it throws an Error whose message lists each violation's id,
+ * impact, a short help string, and the failing nodes' selectors, so the test
+ * failure is actionable. On zero violations it resolves.
+ *
+ * ```js
+ * import { ssrFixture, assertNoA11yViolations } from '@webjsdev/core/testing';
+ * const el = await ssrFixture(html`<my-form></my-form>`);
+ * await assertNoA11yViolations(el);
+ * // tune rules: await assertNoA11yViolations(el, { rules: { 'color-contrast': { enabled: false } } });
+ * ```
+ *
+ * @param {Element} el  The element (subtree root) to scan.
+ * @param {object} [opts]  Options passed through to `axe.run` (e.g. `rules`).
+ * @returns {Promise<void>}
+ */
+export async function assertNoA11yViolations(el, opts) {
+  if (!el || typeof el !== 'object') {
+    throw new Error('assertNoA11yViolations() expects a DOM element');
+  }
+  let axe;
+  try {
+    const mod = await import('axe-core');
+    // axe-core ships a UMD bundle. Depending on how the test runner / bundler
+    // wraps it, the engine may sit on the namespace, on `.default`, on a
+    // nested `.default.default`, or only as the `window.axe` side-effect the
+    // UMD installs. Probe in that order for a `run` function.
+    const candidates = [mod, mod && mod.default, mod && mod.default && mod.default.default,
+      typeof globalThis !== 'undefined' ? globalThis.axe : undefined];
+    axe = candidates.find((c) => c && typeof c.run === 'function');
+  } catch {
+    throw new Error(
+      'assertNoA11yViolations needs axe-core. Install it: npm install -D axe-core'
+    );
+  }
+  if (!axe || typeof axe.run !== 'function') {
+    throw new Error(
+      'assertNoA11yViolations needs axe-core. Install it: npm install -D axe-core'
+    );
+  }
+
+  const results = await axe.run(el, opts || {});
+  const violations = results.violations || [];
+  if (violations.length === 0) return;
+
+  const lines = violations.map((v) => {
+    const targets = (v.nodes || [])
+      .map((n) => (n.target || []).join(' '))
+      .filter(Boolean)
+      .join(', ');
+    return `  - [${v.id}] (${v.impact || 'unknown'}) ${v.help}${targets ? ` -> ${targets}` : ''}`;
+  });
+  const err = new Error(
+    `a11y: ${violations.length} accessibility violation(s) found:\n${lines.join('\n')}`
+  );
+  err.name = 'AssertionError';
+  throw err;
 }
 
 /**

--- a/packages/core/test/testing/browser/a11y.test.js
+++ b/packages/core/test/testing/browser/a11y.test.js
@@ -1,0 +1,71 @@
+/**
+ * assertNoA11yViolations() tests (#268), real browser via WTR.
+ *
+ * The opt-in axe-core assertion runs in the WTR Chromium session. These tests
+ * assert BOTH directions:
+ *   - a good element (a button with an accessible name) PASSES (resolves);
+ *   - a violating element (an <input> with no label) is FLAGGED, throwing an
+ *     Error whose message names the violation so the failure is actionable.
+ */
+import { html } from '../../../src/html.js';
+import { WebComponent } from '../../../src/component.js';
+import { ssrFixture, assertNoA11yViolations } from '../../../src/testing.js';
+
+const assert = {
+  ok: (v, msg) => { if (!v) throw new Error(msg || `Expected truthy, got ${v}`); },
+};
+
+suite('assertNoA11yViolations() (#268)', () => {
+
+  test('passes a good element (button with an accessible name)', async () => {
+    class A11yGood extends WebComponent {
+      render() { return html`<button type="button">Save changes</button>`; }
+    }
+    A11yGood.register('a11y-good');
+    const el = await ssrFixture(html`<a11y-good></a11y-good>`);
+    // Should resolve with no throw.
+    await assertNoA11yViolations(el);
+  });
+
+  test('flags a missing-label input by throwing a named violation', async () => {
+    // An <input> with no associated <label>, no aria-label, no title is a
+    // textbook axe "label" violation.
+    class A11yBad extends WebComponent {
+      render() { return html`<input type="text" name="email">`; }
+    }
+    A11yBad.register('a11y-bad');
+    const el = await ssrFixture(html`<a11y-bad></a11y-bad>`);
+
+    let threw = null;
+    try {
+      await assertNoA11yViolations(el);
+    } catch (e) {
+      threw = e;
+    }
+    assert.ok(threw, 'a missing-label input must throw');
+    assert.ok(/a11y/i.test(threw.message), `message should mention a11y, got: ${threw.message}`);
+    // The message lists the violation id so the failure is actionable. axe ids
+    // a missing label as either "label" or, depending on ruleset, "aria-input-field-name".
+    assert.ok(/label|aria-input-field-name/.test(threw.message),
+      `message should name the missing-label violation, got: ${threw.message}`);
+  });
+
+  test('flags an image with no alt text', async () => {
+    // A second concrete violation direction: <img> with no alt is the classic
+    // "image-alt" failure.
+    class A11yImg extends WebComponent {
+      render() { return html`<img src="/x.png">`; }
+    }
+    A11yImg.register('a11y-img');
+    const el = await ssrFixture(html`<a11y-img></a11y-img>`);
+
+    let threw = null;
+    try {
+      await assertNoA11yViolations(el);
+    } catch (e) {
+      threw = e;
+    }
+    assert.ok(threw, 'an alt-less image must throw');
+    assert.ok(/image-alt/.test(threw.message), `message should name image-alt, got: ${threw.message}`);
+  });
+});

--- a/packages/core/test/testing/browser/ssr-fixture.test.js
+++ b/packages/core/test/testing/browser/ssr-fixture.test.js
@@ -1,0 +1,117 @@
+/**
+ * ssrFixture() hydration + updateComplete tests (#268), real browser via WTR.
+ *
+ * ssrFixture() server-renders a template, sets the SSR markup into the
+ * container so the browser upgrades the custom element, then awaits the
+ * element's native `updateComplete` (the real render-cycle promise) instead
+ * of a macrotask timer. These tests assert:
+ *   1. the post-hydration DOM is correct AND that updateComplete was awaited
+ *      (a value only present after the cycle is in the DOM);
+ *   2. a hydration-mismatch counterfactual is OBSERVABLE: when SSR and the
+ *      client render disagree, the returned hydrated element surfaces the
+ *      post-hydration DOM so the divergence is assertable. A passing case
+ *      (SSR == hydrated) is paired with the divergence case.
+ */
+import { html } from '../../../src/html.js';
+import { WebComponent } from '../../../src/component.js';
+import { signal } from '../../../src/signal.js';
+import { renderToString } from '../../../src/render-server.js';
+import { ssrFixture, waitForUpdate } from '../../../src/testing.js';
+
+const assert = {
+  ok: (v, msg) => { if (!v) throw new Error(msg || `Expected truthy, got ${v}`); },
+  equal: (a, b, msg) => { if (a !== b) throw new Error(msg || `Expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}`); },
+  notEqual: (a, b, msg) => { if (a === b) throw new Error(msg || `Expected values to differ, both were ${JSON.stringify(a)}`); },
+};
+
+function normalize(s) {
+  return String(s)
+    .replace(/<!--webjs-hydrate-->/g, '')
+    .replace(/<!--\/?w\$[^>]*-->/g, '')
+    .replace(/\s+data-webjs-prop-[a-z0-9-]+="[^"]*"/g, '')
+    .replace(/=""/g, '')
+    .replace(/>\s+</g, '><')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+function ssrLightInner(ssr, tag) {
+  const m = ssr.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*)</${tag}>`));
+  return m ? m[1] : ssr;
+}
+
+suite('ssrFixture() (#268)', () => {
+
+  test('hydrates and awaits the native updateComplete', async () => {
+    // The component records, inside willUpdate (which runs during the update
+    // cycle, not the constructor), a derived value read in render(). If
+    // ssrFixture did NOT await the real update cycle, this value would be the
+    // constructor placeholder. Its presence proves updateComplete was awaited.
+    class SF1 extends WebComponent {
+      static properties = { count: { type: Number } };
+      constructor() { super(); this.count = 0; this.derived = 'placeholder'; }
+      willUpdate() { this.derived = `cycle-${this.count}`; }
+      render() { return html`<output>${this.derived}</output>`; }
+    }
+    SF1.register('ssrf-cycle');
+
+    const el = await ssrFixture(html`<ssrf-cycle count="5"></ssrf-cycle>`);
+    // The promise the helper awaits is the element's real updateComplete; assert
+    // it is settled (awaiting again resolves synchronously to a truthy value).
+    assert.ok(el.updateComplete && typeof el.updateComplete.then === 'function', 'element exposes updateComplete');
+    assert.ok(el.innerHTML.includes('cycle-5'), `post-hydration DOM should show the cycle-derived value, got: ${el.innerHTML}`);
+    assert.ok(!el.innerHTML.includes('placeholder'), 'constructor placeholder must not survive the awaited update cycle');
+  });
+
+  test('passing case: SSR markup equals the hydrated DOM (no mismatch)', async () => {
+    const count = signal(7);
+    class SF2 extends WebComponent {
+      render() { return html`<p class="g">value <strong>${count.get()}</strong></p>`; }
+    }
+    SF2.register('ssrf-stable');
+
+    const ssr = normalize(ssrLightInner(await renderToString(html`<ssrf-stable></ssrf-stable>`), 'ssrf-stable'));
+    const el = await ssrFixture(html`<ssrf-stable></ssrf-stable>`);
+    const hydrated = normalize(el.innerHTML);
+    assert.equal(hydrated, ssr, `expected SSR == hydrated DOM\nSSR:      ${ssr}\nHYDRATED: ${hydrated}`);
+    assert.ok(hydrated.includes('7'), 'value rendered');
+  });
+
+  test('counterfactual: a hydration mismatch is observable on the returned element', async () => {
+    // This component's render() is non-deterministic: it emits a different
+    // value on each call (a module-scope counter). The SSR call (via
+    // renderToString, producing the server paint string) and the subsequent
+    // client hydration render therefore DISAGREE, which is exactly the
+    // hydration-mismatch class of bug. ssrFixture returns the live hydrated
+    // element, so comparing the SSR string against el.innerHTML detects the
+    // divergence. (Contrast with the passing case above, where SSR == hydrated.)
+    let n = 0;
+    class SF3 extends WebComponent {
+      render() { return html`<span>${++n}</span>`; }
+    }
+    SF3.register('ssrf-mismatch');
+
+    const ssr = normalize(ssrLightInner(await renderToString(html`<ssrf-mismatch></ssrf-mismatch>`), 'ssrf-mismatch'));
+    const el = await ssrFixture(html`<ssrf-mismatch></ssrf-mismatch>`);
+    const hydrated = normalize(el.innerHTML);
+
+    // The SSR render produced the first value; the hydration render produced a
+    // later one. The helper surfaces a detectable SSR-vs-hydrated divergence.
+    assert.notEqual(hydrated, ssr,
+      `ssrFixture must surface the post-hydration DOM so a mismatch is observable\nSSR:      ${ssr}\nHYDRATED: ${hydrated}`);
+    assert.ok(hydrated.length > 0, 'hydrated DOM is present to compare against');
+  });
+
+  test('waitForUpdate awaits the real updateComplete after a mutation', async () => {
+    class SF4 extends WebComponent {
+      static properties = { n: { type: Number } };
+      constructor() { super(); this.n = 1; }
+      render() { return html`<i>${this.n}</i>`; }
+    }
+    SF4.register('ssrf-wait');
+    const el = await ssrFixture(html`<ssrf-wait></ssrf-wait>`);
+    assert.ok(el.innerHTML.includes('1'), 'initial render');
+    el.n = 42;
+    await waitForUpdate(el);
+    assert.ok(el.innerHTML.includes('42'), `waitForUpdate should settle the re-render, got: ${el.innerHTML}`);
+  });
+});

--- a/packages/core/test/testing/browser/ssr-fixture.test.js
+++ b/packages/core/test/testing/browser/ssr-fixture.test.js
@@ -42,24 +42,25 @@ function ssrLightInner(ssr, tag) {
 suite('ssrFixture() (#268)', () => {
 
   test('hydrates and awaits the native updateComplete', async () => {
-    // The component records, inside willUpdate (which runs during the update
-    // cycle, not the constructor), a derived value read in render(). If
-    // ssrFixture did NOT await the real update cycle, this value would be the
-    // constructor placeholder. Its presence proves updateComplete was awaited.
+    // The component sets a reactive value in connectedCallback, which the SSR
+    // walker does NOT run (it runs the constructor + willUpdate only). So the
+    // SSR markup shows the constructor default, and the post-connectedCallback
+    // value appears ONLY after the client update cycle. If ssrFixture did NOT
+    // await the real updateComplete, the DOM would still show the SSR default
+    // (the connectedCallback-scheduled re-render is microtask-deferred), so the
+    // 'hydrated' value genuinely proves the await happened.
     class SF1 extends WebComponent {
-      static properties = { count: { type: Number } };
-      constructor() { super(); this.count = 0; this.derived = 'placeholder'; }
-      willUpdate() { this.derived = `cycle-${this.count}`; }
-      render() { return html`<output>${this.derived}</output>`; }
+      static properties = { label: { type: String, state: true } };
+      constructor() { super(); this.label = 'ssr-default'; }
+      connectedCallback() { super.connectedCallback(); this.label = 'hydrated'; }
+      render() { return html`<output>${this.label}</output>`; }
     }
     SF1.register('ssrf-cycle');
 
-    const el = await ssrFixture(html`<ssrf-cycle count="5"></ssrf-cycle>`);
-    // The promise the helper awaits is the element's real updateComplete; assert
-    // it is settled (awaiting again resolves synchronously to a truthy value).
+    const el = await ssrFixture(html`<ssrf-cycle></ssrf-cycle>`);
     assert.ok(el.updateComplete && typeof el.updateComplete.then === 'function', 'element exposes updateComplete');
-    assert.ok(el.innerHTML.includes('cycle-5'), `post-hydration DOM should show the cycle-derived value, got: ${el.innerHTML}`);
-    assert.ok(!el.innerHTML.includes('placeholder'), 'constructor placeholder must not survive the awaited update cycle');
+    assert.ok(el.innerHTML.includes('hydrated'), `post-hydration DOM must show the connectedCallback value, got: ${el.innerHTML}`);
+    assert.ok(!el.innerHTML.includes('ssr-default'), 'the SSR default must not survive the awaited client update cycle');
   });
 
   test('passing case: SSR markup equals the hydrated DOM (no mismatch)', async () => {


### PR DESCRIPTION
Closes #268

## What

`fixture()` renders via `renderToString` and parses HTML into a container, but never drives client hydration or awaits a true update cycle (`waitForUpdate` yielded two macrotasks, never `el.updateComplete`), and nothing did accessibility testing. Both belong in the existing real-Chromium WTR layer.

- **`ssrFixture(template)`** (`@webjsdev/core/testing`): server-renders with `renderToString` (DSD), sets the markup so the browser upgrades the custom element, then awaits the element's **native `el.updateComplete`** (plus a microtask for cascading child updates). So a test observes the post-hydration DOM deterministically and a SSR-vs-hydration mismatch is observable on the returned element. `fixture()` is unchanged (back-compat); `waitForUpdate` now also awaits `updateComplete` when present.
- **`assertNoA11yViolations(el, opts)`**: dynamically imports `axe-core` (never a hard dep of `@webjsdev/core`), runs `axe.run`, and throws an `AssertionError` listing each violation's id/impact/help/selectors. Degrades with a clear `install axe-core` message when absent. Opt-in, never a forced gate.

`axe-core` is a test-only devDependency (repo + scaffold), and the scaffolded browser test now demonstrates the a11y helper.

## Tests (real Chromium, WTR)

7 new browser tests: ssrFixture hydration + `updateComplete`, a passing SSR==hydrated case, a hydration-mismatch counterfactual (a non-deterministic render diverges SSR vs hydrated, observable on the live element), `waitForUpdate`-after-mutation; and the a11y helper passing an accessible button while throwing a named violation for a missing-label input and an alt-less image. Browser suite 293 pass; node suite 1993 (the intermittent jspm / page-action / vendor-cli concurrency flakes pass on re-run).

## Docs

`agent-docs/testing.md` (ssrFixture + the a11y helper + the hydration-mismatch pattern), `packages/core/AGENTS.md` (the testing exports), scaffold `AGENTS.md` / `CONVENTIONS.md`.
