### PR TITLE
chore: release core 0.7.10, server 0.8.14, cli 0.10.8

### DIFF
--- a/changelog/cli/0.10.8.md
+++ b/changelog/cli/0.10.8.md
@@ -1,0 +1,19 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.8
+date: 2026-06-03T15:15:55.451Z
+commit_count: 2
+---
+## Features
+
+- **add a hydrating ssrFixture() and an opt-in a11y assertion** ([#317](https://github.com/webjsdev/webjs/pull/317)) [`26ea8841`](https://github.com/webjsdev/webjs/commit/26ea8841)
+  * feat: add a hydrating ssrFixture() and an opt-in a11y assertion to the test layer
+  
+  The shipped fixture() renders via renderToString and parses HTML into a container but never drives client hydration or awaits a true update cycle (waitForUpdate yielded two macrotasks, never el.updateComplete), and nothing did accessibility testing.
+
+## Fixes
+
+- **strike the phantom check --fix flag and anchor runtime errors to docs** ([#316](https://github.com/webjsdev/webjs/pull/316)) [`ec189feb`](https://github.com/webjsdev/webjs/commit/ec189feb)
+  * fix: strike the phantom check --fix flag and anchor two runtime errors to docs
+  
+  AGENTS.md and packages/cli/AGENTS.md advertised webjs check --fix, but bin/webjs.js only handles --rules; --fix was never read, so an agent running it saw violations printed unchanged and assumed its code was fixed (false confidence). None of the rules can be auto-fixed safely (they rewrite code or rename files breaking imports), so strike --fix from the docs rather than ship a risky codemod, and note in the cli docs that check is report-only with a prose fix hint per violation.

--- a/changelog/core/0.7.10.md
+++ b/changelog/core/0.7.10.md
@@ -1,0 +1,17 @@
+---
+package: "@webjsdev/core"
+version: 0.7.10
+date: 2026-06-03T15:15:55.345Z
+commit_count: 2
+---
+## Features
+
+- **add a hydrating ssrFixture() and an opt-in a11y assertion** ([#317](https://github.com/webjsdev/webjs/pull/317)) [`26ea8841`](https://github.com/webjsdev/webjs/commit/26ea8841)
+  * feat: add a hydrating ssrFixture() and an opt-in a11y assertion to the test layer
+  
+  The shipped fixture() renders via renderToString and parses HTML into a container but never drives client hydration or awaits a true update cycle (waitForUpdate yielded two macrotasks, never el.updateComplete), and nothing did accessibility testing.
+- **content-hash asset URLs for immutable caching + preconnect hints** ([#319](https://github.com/webjsdev/webjs/pull/319)) [`0b55cfe8`](https://github.com/webjsdev/webjs/commit/0b55cfe8)
+  * feat: content-hash asset URLs for immutable caching + preconnect hints
+  
+  App modules and public assets shipped public, max-age=3600 because their
+  URLs were un-versioned, so immutable caching was unsafe (a deploy that

--- a/changelog/server/0.8.14.md
+++ b/changelog/server/0.8.14.md
@@ -1,0 +1,20 @@
+---
+package: "@webjsdev/server"
+version: 0.8.14
+date: 2026-06-03T15:15:55.396Z
+commit_count: 2
+---
+## Features
+
+- **content-hash asset URLs for immutable caching + preconnect hints** ([#319](https://github.com/webjsdev/webjs/pull/319)) [`0b55cfe8`](https://github.com/webjsdev/webjs/commit/0b55cfe8)
+  * feat: content-hash asset URLs for immutable caching + preconnect hints
+  
+  App modules and public assets shipped public, max-age=3600 because their
+  URLs were un-versioned, so immutable caching was unsafe (a deploy that
+
+## Fixes
+
+- **strike the phantom check --fix flag and anchor runtime errors to docs** ([#316](https://github.com/webjsdev/webjs/pull/316)) [`ec189feb`](https://github.com/webjsdev/webjs/commit/ec189feb)
+  * fix: strike the phantom check --fix flag and anchor two runtime errors to docs
+  
+  AGENTS.md and packages/cli/AGENTS.md advertised webjs check --fix, but bin/webjs.js only handles --rules; --fix was never read, so an agent running it saw violations printed unchanged and assumed its code was fixed (false confidence). None of the rules can be auto-fixed safely (they rewrite code or rename files breaking imports), so strike --fix from the docs rather than ship a risky codemod, and note in the cli docs that check is report-only with a prose fix hint per violation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6980,7 +6980,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.7",
+      "version": "0.10.8",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/server": "^0.8.0",
@@ -6995,7 +6995,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.9",
+      "version": "0.7.10",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.24.0"
@@ -7016,7 +7016,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.13",
+      "version": "0.8.14",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.13",
+  "version": "0.8.14",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Release the features and fixes that landed since the #314 release (server 0.8.13).

## Versions

- `@webjsdev/core` 0.7.9 -> **0.7.10**
- `@webjsdev/server` 0.8.13 -> **0.8.14**
- `@webjsdev/cli` 0.10.7 -> **0.10.8**

All patch bumps. Every in-repo dependent pins `^0.x.0`, so the ranges stay satisfied with no dependent edits, and the lockfile is regenerated.

## What ships

- **server** (#319 feat, #316 fix): content-hash asset URLs (`?v=<digest>`) for immutable caching + auto preconnect hints; strike the phantom `check --fix` flag and anchor runtime errors to docs.
- **core** (#317 feat, #319 type): a hydrating `ssrFixture()` + opt-in a11y assertion; the `metadata.preconnect` / `metadata.dnsPrefetch` types.
- **cli** (#317, #316): scaffold ships `typescript` + `axe-core` devDeps; report-only `check` docs.

Changelogs are auto-generated by the pre-commit hook from the conventional-commit subjects. Merging this triggers `release.yml` to publish the three packages to npm + GitHub Releases.