### PR TITLE
test: de-flake the jspm install-order vendor test (mock the live CDN)

### DIFF
--- a/packages/server/test/vendor/vendor.test.js
+++ b/packages/server/test/vendor/vendor.test.js
@@ -404,11 +404,38 @@ test('jspmGenerate: second call with same installs hits in-process cache', { ski
   assert.deepEqual(first, second, 'cached call returns the same URLs');
 });
 
-test('jspmGenerate: install order does not affect output', { skip: !NETWORK_OK }, async () => {
-  clearVendorCache();
-  const a = await jspmGenerate(['picocolors@1.1.1', 'clsx@2.1.1']);
-  const b = await jspmGenerate(['clsx@2.1.1', 'picocolors@1.1.1']);
-  assert.deepEqual(a, b, 'output should be order-independent');
+test('jspmGenerate: install order does not affect OUR merged output (deterministic mock, no live CDN)', async () => {
+  // The property under test is OUR per-package resolve + merge being
+  // order-independent, NOT the live CDN's transitive-resolution stability. The
+  // old test hit ga.jspm.io twice and `deepEqual`d the results, which flaked
+  // (#312): the live CDN occasionally resolved a transitive in one ordering but
+  // not the other. Mock the generate endpoint so each install resolves to a
+  // FIXED fragment, isolating our code from the live CDN.
+  const fragment = (pkg) => {
+    const name = pkg.replace(/@[^@]*$/, ''); // strip the trailing @version
+    return { [name]: `https://ga.jspm.io/npm:${pkg}/mock.js` };
+  };
+  const mock = async (_url, opts) => {
+    const { install } = JSON.parse(opts.body); // jspmResolveOne sends one install per call
+    const imports = {};
+    for (const i of install) Object.assign(imports, fragment(i));
+    return { ok: true, status: 200, json: async () => ({ map: { imports } }) };
+  };
+  await withMockedFetch(mock, async () => {
+    clearVendorCache();
+    const a = await jspmGenerate(['picocolors@1.1.1', 'clsx@2.1.1']);
+    clearVendorCache(); // force b to re-resolve through the mock, not the in-process cache
+    const b = await jspmGenerate(['clsx@2.1.1', 'picocolors@1.1.1']);
+    assert.deepEqual(a, b, 'merged output must be order-independent');
+    assert.deepEqual(
+      a,
+      {
+        picocolors: 'https://ga.jspm.io/npm:picocolors@1.1.1/mock.js',
+        clsx: 'https://ga.jspm.io/npm:clsx@2.1.1/mock.js',
+      },
+      'each requested package resolved to its fixed fragment',
+    );
+  });
 });
 
 /* ---------- jspmGenerate failure modes (mocked fetch, no network) ---------- */


### PR DESCRIPTION
Closes #312

## Problem

`packages/server/test/vendor/vendor.test.js`'s `jspmGenerate: install order does not affect output` hit the live `ga.jspm.io` CDN twice and `deepEqual`d the results. It flaked roughly 1 run in 4 across this session's PRs: the live CDN occasionally resolved a transitive dep in one ordering but not the other (observed: `clsx`'s transitive), always passing on a plain re-run. A green PR could fail CI for a reason unrelated to the change, and the failure looked like a regression.

## Fix

The property under test is OUR per-package resolve + merge being order-independent, not the live CDN's transitive-resolution stability. Mock the `api.jspm.io/generate` endpoint (via the file's existing `withMockedFetch` helper, duck-typed like the neighbouring failure-mode tests) so each install resolves to a fixed fragment. The test now asserts `jspmGenerate([a, b])` deep-equals `jspmGenerate([b, a])` against deterministic fragments, with no network.

## Tests

- The rewritten test passes deterministically (verified 5/5 with `WEBJS_SKIP_NETWORK_TESTS=1`, proving no live dependency).
- Full suite: 2025 pass, 0 fail. The remaining live integration is still covered by the other network-gated tests (a real package resolves to a CDN URL, the cache-hit case); only the order-sensitivity assertion moved off the network.

Docs / dogfood: N/A (test-only change, no runtime or public-API surface).