### PR TITLE
chore: release @webjsdev/server 0.8.15

### DIFF
--- a/changelog/server/0.8.15.md
+++ b/changelog/server/0.8.15.md
@@ -1,0 +1,11 @@
+---
+package: "@webjsdev/server"
+version: 0.8.15
+date: 2026-06-03T16:02:57.740Z
+commit_count: 1
+---
+## Features
+
+- **ship type declarations for @webjsdev/server (fix TS7016)** ([#322](https://github.com/webjsdev/webjs/pull/322)) [`50428c47`](https://github.com/webjsdev/webjs/commit/50428c47)
+
+  `@webjsdev/server` now ships a hand-authored `index.d.ts` overlay and `types` export conditions, so a TypeScript app under `strict` + `nodenext` resolves real types for `import { createRequestHandler, cors, cache, ... } from '@webjsdev/server'` instead of emitting TS7016. The runtime stays plain `.js` + JSDoc; the overlay is types-only with zero runtime cost. The `./check` and `./testing` subpaths are typed too.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7016,7 +7016,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.14",
+      "version": "0.8.15",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Release `@webjsdev/server` **0.8.14 -> 0.8.15** (patch).

## What ships

- **#310 / #322** (feat): `@webjsdev/server` now ships `index.d.ts` + `types` export conditions, fixing **TS7016** for any TypeScript app importing the server package under `strict` + `nodenext`. Types-only overlay, zero runtime cost.

The #312 de-flake (#323) also landed since 0.8.14 but is a test-only change with no runtime/public-API impact, so it is trimmed from the user-facing changelog.

All in-repo dependents pin `^0.8.0`, so the patch stays in range with no dependent edits; the lockfile is regenerated. Merging triggers `release.yml` to publish to npm + a GitHub Release.