### PR TITLE
feat: add a read-only webjs MCP server and webjs check --json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,7 +206,7 @@ node_modules/@webjsdev/
 
 Starting points: SSR pipeline → `@webjsdev/server/src/ssr.js`. Client hydration → `@webjsdev/core/src/render-client.js`. Client router → `@webjsdev/core/src/router-client.js`. Convention rules → `@webjsdev/server/src/check.js`.
 
-For UI debugging, use the Playwright MCP server (configured in `.claude.json`) instead of one-shot Bash scripts.
+For UI debugging, use the Playwright MCP server (configured in `.claude.json`) instead of one-shot Bash scripts. For live app introspection, the scaffold also wires a read-only **`webjs` MCP server** (`webjs mcp`, in `.claude.json` next to Playwright) exposing four tools (`list_routes`, `list_actions`, `list_components`, `check`) over the same data functions documented here. It mutates nothing, so it is the safe way to ask "what routes / actions / components does this app expose, and does it pass `webjs check`?" without grepping.
 
 ---
 
@@ -743,7 +743,8 @@ webjs create <name> --template saas  # auth + login/signup + protected dashboard
 webjs dev    [--port N]                               # dev server with live reload
 webjs start  [--port N]                               # prod server. No build step, source IS the runtime. Speaks plain HTTP/1.1 (put a reverse proxy in front for TLS + HTTP/2)
 webjs test   [--server] [--browser] [--watch]         # unit + browser tests
-webjs check  [--rules]                                # correctness validator (--rules lists the checks; report-only, no autofix)
+webjs check  [--rules] [--json]                       # correctness validator (--rules lists the checks; report-only, no autofix). --json emits the structured violations + a summary count as JSON (non-zero exit on violations preserved), for an agent loop
+webjs mcp                                             # read-only MCP server (stdio) exposing the live route table, server actions (with RPC hashes), custom-element tags, and structured check violations, all reusing existing functions. Mutates nothing
 webjs doctor                                          # project-health checklist (Node, tsconfig, env drift, vendor pins, @webjsdev versions, git hook); non-zero exit on a hard fail so CI can gate
 webjs types                                           # generate .webjs/routes.d.ts (typed Route union + per-route params; #258). Opt-in; webjs dev emits it automatically
 webjs typecheck [tsc args...]                         # type-check the app with the project's own tsc --noEmit (non-zero on errors; needs typescript installed)

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -27,6 +27,35 @@ lib/
                          builtins) and would itself link-fail on old Node. So the
                          primary guard depends only on `process.versions.node`.
                          Tests: `test/node-preflight/`.
+  check-json.js          Shared `webjs check` JSON projector (#262).
+                         `projectCheck(violations)` wraps the raw
+                         `checkConventions` `Violation[]` into
+                         `{ violations, summary: { count, byRule } }`. PURE
+                         (no file reads, no print). Used by BOTH `check --json`
+                         (in bin/webjs.js) and the MCP `check` tool, so the two
+                         return the identical shape.
+  mcp.js                 `webjs mcp`: a hand-rolled, READ-ONLY MCP stdio server
+                         (#262), ZERO new dependency. `runMcpServer({ stdin,
+                         stdout, stderr, cwd, version, deps? })` speaks
+                         newline-delimited JSON-RPC 2.0 (one object per line),
+                         writing ONLY JSON-RPC frames to stdout and every
+                         diagnostic to stderr (stdout is the protocol channel).
+                         Handshake: `initialize` -> serverInfo + capabilities;
+                         `notifications/initialized` -> no reply; `tools/list`
+                         -> the four tools; `tools/call` -> a content array
+                         whose text is the JSON result. Unknown method ->
+                         -32601, parse error -> -32700, a malformed line never
+                         crashes the loop. Four read-only tools, each
+                         projecting an EXISTING @webjsdev/server function:
+                         `list_routes` (buildRouteTable), `list_actions`
+                         (buildActionIndex + hashFile for the
+                         /__webjs/action/<hash>/<fn> endpoint), `list_components`
+                         (scanComponents), `check` (checkConventions via the
+                         shared `projectCheck`). Function names are extracted
+                         LEXICALLY (extractExportNames / extractRouteMethods) so
+                         no app module is loaded (no DB init side effects).
+                         `deps` is injectable for in-process tests. Tests:
+                         `test/cli/mcp.test.mjs`, `test/cli/check-json.test.mjs`.
   doctor.js              `webjs doctor` project-health checks (#266).
                          `runDoctorChecks(appDir, opts?)` is PURE (reads files +
                          optionally the network, never exits / prints) so each
@@ -60,7 +89,8 @@ README.md                npm-facing package readme.
 | `webjs dev` | Spawns `node --watch` re-entry, then `startServer({ dev: true })` |
 | `webjs start` | `startServer({ dev: false })`, plain HTTP/1.1 (front a reverse proxy for TLS + HTTP/2) |
 | `webjs test [--server\|--browser]` | `node --test` for server tests, `wtr` for browser tests |
-| `webjs check [--rules]` | `checkConventions()` from `@webjsdev/server/check`. `--rules` lists the checks. Report-only: each violation carries a prose `fix` hint, but there is no `--fix` autofix flag (the rules either rewrite code or rename files, so an automatic codemod is not safe) |
+| `webjs check [--rules] [--json]` | `checkConventions()` from `@webjsdev/server/check`. `--rules` lists the checks. `--json` emits the structured violations + a summary count as JSON (via the shared `lib/check-json.js` `projectCheck`), so an agent in a loop consumes structured data instead of regex-scraping stdout; the non-zero exit on violations is preserved. Report-only: each violation carries a prose `fix` hint, but there is no `--fix` autofix flag (the rules either rewrite code or rename files, so an automatic codemod is not safe) |
+| `webjs mcp` | Read-only MCP stdio server (#262), `runMcpServer()` from `lib/mcp.js`. Exposes four tools over newline-delimited JSON-RPC 2.0: `list_routes`, `list_actions`, `list_components`, `check`, each reusing an existing `@webjsdev/server` data function and mutating nothing. Hand-rolled, ZERO new dependency. Wired into the scaffold's `.claude.json` next to the Playwright MCP entry as `{ "command": "npx", "args": ["@webjsdev/cli", "mcp"] }`. STDOUT is the JSON-RPC channel (diagnostics go to stderr) |
 | `webjs doctor` | `runDoctorChecks()` from `lib/doctor.js`. A project-health checklist over existing signals (Node major, tsconfig `erasableSyntaxOnly`, `.env` drift vs `.env.example`, vendor-pin freshness, `@webjsdev/*` version coherence, git pre-commit hook). PURE checks render with a `[pass]` / `[warn]` / `[fail]` marker; non-zero exit iff a HARD check fails (Node below the floor, or `erasableSyntaxOnly` missing in an existing tsconfig), so CI can gate. Warns (drift / staleness) never fail the exit. The only network touch (pin freshness) is best-effort: a fetch failure is a warn, never a hard fail. An onboarding/setup-verify tool, NOT a scaffold-CI hard gate. Tests: `test/cli/doctor.test.mjs` |
 | `webjs types` | `generateRouteTypes()` from `@webjsdev/server`, writes `.webjs/routes.d.ts` (typed `Route` union + per-route params, #258). Also auto-emitted at `webjs dev` startup |
 | `webjs typecheck [tsc args]` | Resolves the project's own `typescript/bin/tsc` (via `createRequire` from the app cwd) and spawns it with `--noEmit`, passing extra args through. Exits non-zero on a type error (a CI gate). A clear message + non-zero exit when typescript is not installed (#265). The framework runs the standard compiler, it does not embed one |

--- a/packages/cli/bin/webjs.js
+++ b/packages/cli/bin/webjs.js
@@ -41,7 +41,8 @@ const USAGE = `webjs commands:
   webjs dev   [--port 8080]                       Start dev server with live reload
   webjs start [--port 8080]                       Start production server (serves source directly, no build step)
   webjs test  [--server|--browser]                 Run server + browser tests
-  webjs check                                     Run correctness checks on the app
+  webjs check [--json]                            Run correctness checks on the app (--json emits structured violations)
+  webjs mcp                                       Start the read-only MCP server (routes / actions / components / check)
   webjs doctor                                    Verify project health (Node, tsconfig, env, vendor pins, @webjsdev versions, git hook)
   webjs types                                     Generate .webjs/routes.d.ts (typed Route union + per-route params)
   webjs typecheck [tsc args...]                   Type-check the app with the project's tsc --noEmit (non-zero on errors)
@@ -265,6 +266,18 @@ async function main() {
       }
 
       const violations = await checkConventions(process.cwd());
+
+      // --json emits the raw structured violations + a summary count as JSON,
+      // so an agent running `webjs check` in a loop consumes structured data
+      // instead of regex-scraping stdout. The shared projector keeps this byte-
+      // identical to the MCP `check` tool. The non-zero exit on violations is
+      // preserved (an agent gates on the exit code AND parses the report).
+      if (rest.includes('--json')) {
+        const { projectCheck } = await import('../lib/check-json.js');
+        console.log(JSON.stringify(projectCheck(violations)));
+        if (violations.length > 0) process.exit(1);
+        break;
+      }
 
       if (violations.length === 0) {
         console.log('webjs check: all checks pass ✓');
@@ -630,6 +643,29 @@ Full docs: https://docs.webjs.com`);
         `\n` +
         `  --from PROVIDER     CDN to resolve through. One of: ${[...SUPPORTED_PROVIDERS].join(', ')}. Default: jspm.`);
       process.exit(1);
+    }
+    case 'mcp': {
+      // Read-only MCP server (#262) over stdio. STDOUT is the JSON-RPC channel,
+      // so nothing here may write to stdout: the data functions are read-only
+      // and `runMcpServer` routes all diagnostics to stderr. The CLI version is
+      // advertised in the initialize handshake's serverInfo.
+      const { readFileSync } = await import('node:fs');
+      let version = '0.0.0';
+      try {
+        const pkg = JSON.parse(
+          readFileSync(join(__dirname, '..', 'package.json'), 'utf8'),
+        );
+        version = pkg.version || version;
+      } catch {}
+      const { runMcpServer } = await import('../lib/mcp.js');
+      await runMcpServer({
+        stdin: process.stdin,
+        stdout: process.stdout,
+        stderr: process.stderr,
+        cwd: process.cwd(),
+        version,
+      });
+      break;
     }
     case 'help':
     case undefined:

--- a/packages/cli/lib/check-json.js
+++ b/packages/cli/lib/check-json.js
@@ -1,0 +1,47 @@
+/**
+ * Shared JSON projector for `webjs check` violations (#262).
+ *
+ * `webjs check --json` and the `webjs mcp` server's `check` tool BOTH return
+ * the identical shape, so the projection lives here once. The input is the raw
+ * `Violation[]` from `checkConventions(appDir)` (each `{ rule, file, message,
+ * fix }`); the output adds a `summary` count plus a per-rule breakdown so an
+ * agent consuming the structured output never has to regex-scrape stdout.
+ *
+ * Pure and side-effect-free: it neither reads files nor prints. The caller owns
+ * running `checkConventions` and (for the CLI) the non-zero exit when there are
+ * violations.
+ *
+ * @module check-json
+ */
+
+/**
+ * @typedef {{ rule: string, file: string, message: string, fix: string }} Violation
+ */
+
+/**
+ * @typedef {{
+ *   violations: Violation[],
+ *   summary: { count: number, byRule: Record<string, number> },
+ * }} CheckReport
+ */
+
+/**
+ * Project a raw `Violation[]` into the structured `{ violations, summary }`
+ * report shared by `check --json` and the MCP `check` tool. `violations` is
+ * passed through verbatim (the `{ rule, file, message, fix }` shape), and
+ * `summary.byRule` tallies how many violations each rule produced.
+ *
+ * @param {Violation[]} violations
+ * @returns {CheckReport}
+ */
+export function projectCheck(violations) {
+  /** @type {Record<string, number>} */
+  const byRule = {};
+  for (const v of violations) {
+    byRule[v.rule] = (byRule[v.rule] || 0) + 1;
+  }
+  return {
+    violations,
+    summary: { count: violations.length, byRule },
+  };
+}

--- a/packages/cli/lib/mcp.js
+++ b/packages/cli/lib/mcp.js
@@ -1,0 +1,403 @@
+/**
+ * `webjs mcp`: a minimal, READ-ONLY Model Context Protocol server (#262).
+ *
+ * Exposes the live introspection surface an AI agent needs while editing a
+ * webjs app (the route table, registered server actions with their RPC
+ * endpoints, registered custom-element tags, and the structured `webjs check`
+ * violations) over MCP's stdio transport. Every tool REUSES an existing
+ * `@webjsdev/server` data function and MUTATES NOTHING. The prior art is
+ * Next.js's `next-devtools-mcp` (get_routes / get_server_action_by_id /
+ * get_errors); this is deliberately tiny.
+ *
+ * Transport: MCP stdio is newline-delimited JSON-RPC 2.0. One JSON object per
+ * line arrives on stdin; exactly one JSON response line per request is written
+ * to stdout. STDOUT IS THE PROTOCOL CHANNEL, so this module writes ONLY
+ * JSON-RPC frames there and routes every diagnostic to stderr. A malformed
+ * input line is answered with a JSON-RPC parse error and never crashes the
+ * loop. Hand-rolled with zero new dependency (webjs is buildless +
+ * minimal-deps).
+ *
+ * @module mcp
+ */
+
+import { createInterface } from 'node:readline';
+import { relative } from 'node:path';
+
+const PROTOCOL_VERSION = '2024-11-05';
+
+/**
+ * The four read-only tools. Each takes an optional `{ appDir }` (default the
+ * server's cwd) and projects an EXISTING `@webjsdev/server` function's output
+ * into an agent-friendly shape. Descriptions are crisp so a model picks the
+ * right tool without reading source.
+ */
+const TOOL_DEFS = [
+  {
+    name: 'list_routes',
+    description:
+      'List the app route table: SSR pages (path, file, dynamic flag, param names) and route.{js,ts} API handlers (path, file, HTTP methods). Read-only.',
+  },
+  {
+    name: 'list_actions',
+    description:
+      'List registered server actions (the .server.{js,ts} files with "use server"): file, exported function name, and the /__webjs/action/<hash>/<fn> RPC endpoint. Read-only.',
+  },
+  {
+    name: 'list_components',
+    description:
+      'List registered custom-element tags: tag name, defining file, and class name. Read-only.',
+  },
+  {
+    name: 'check',
+    description:
+      'Run webjs check (correctness rules) and return the structured violations { rule, file, message, fix } plus a summary count and per-rule breakdown. Read-only.',
+  },
+];
+
+/** The shared input schema: every tool takes an optional appDir override. */
+const TOOL_INPUT_SCHEMA = {
+  type: 'object',
+  properties: {
+    appDir: {
+      type: 'string',
+      description: 'App directory to introspect. Defaults to the server cwd.',
+    },
+  },
+  required: [],
+};
+
+/**
+ * Lexically extract the names exported from a module source. Recognises the
+ * common forms a server-action / route file uses without LOADING the module
+ * (loading would run its top-level side effects: Prisma init, DB connects).
+ *
+ *   export async function foo() {}   export function foo() {}
+ *   export const foo = ...           export let/var foo = ...
+ *   export default ...               (recorded as 'default')
+ *   export { a, b as c }             (the EXPORTED name, so `c`)
+ *
+ * @param {string} src
+ * @returns {string[]} unique export names, in source order
+ */
+export function extractExportNames(src) {
+  /** @type {string[]} */
+  const names = [];
+  const add = (n) => { if (n && !names.includes(n)) names.push(n); };
+
+  // export [async] function NAME / export const|let|var NAME / export class NAME
+  const declRe =
+    /\bexport\s+(?:async\s+)?(?:function\*?|const|let|var|class)\s+([A-Za-z_$][\w$]*)/g;
+  let m;
+  while ((m = declRe.exec(src)) !== null) add(m[1]);
+
+  // export default ...
+  if (/\bexport\s+default\b/.test(src)) add('default');
+
+  // export { a, b as c, default as d }
+  const namedRe = /\bexport\s*\{([^}]*)\}/g;
+  while ((m = namedRe.exec(src)) !== null) {
+    for (const part of m[1].split(',')) {
+      const seg = part.trim();
+      if (!seg) continue;
+      // `local as exported` -> the exported name is what callers import.
+      const asMatch = /\bas\s+([A-Za-z_$][\w$]*)\s*$/.exec(seg);
+      if (asMatch) add(asMatch[1]);
+      else {
+        const idMatch = /^([A-Za-z_$][\w$]*)$/.exec(seg);
+        if (idMatch) add(idMatch[1]);
+      }
+    }
+  }
+  return names;
+}
+
+/**
+ * Lexically extract the HTTP method exports of a route.{js,ts} file. The webjs
+ * router dispatches on named `GET` / `POST` / `PUT` / `PATCH` / `DELETE` /
+ * `HEAD` / `OPTIONS` / `WS` exports, so we report exactly those that are
+ * exported. Read-only: no module load.
+ *
+ * @param {string} src
+ * @returns {string[]}
+ */
+export function extractRouteMethods(src) {
+  const METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'WS'];
+  const exported = new Set(extractExportNames(src));
+  return METHODS.filter((m) => exported.has(m));
+}
+
+/**
+ * The literal URL path for a page/api directory: `blog/[slug]` -> `/blog/[slug]`,
+ * the root `.` -> `/`. Route groups `(group)` and `_private` segments drop, the
+ * same normalization `buildRouteTable` uses for matching.
+ *
+ * @param {string} routeDir  POSIX-style, `.` for the app root.
+ * @returns {string}
+ */
+function routePathFromDir(routeDir) {
+  if (!routeDir || routeDir === '.') return '/';
+  const segs = routeDir
+    .split('/')
+    .filter((s) => !(s.startsWith('(') && s.endsWith(')')) && !s.startsWith('_'));
+  return segs.length ? '/' + segs.join('/') : '/';
+}
+
+/**
+ * The tool runners. Each is async, takes `(appDir)`, and returns a plain
+ * JSON-serialisable projection of an existing server data function. All are
+ * read-only.
+ *
+ * @param {{ buildRouteTable: Function, buildActionIndex: Function, hashFile: Function, scanComponents: Function, checkConventions: Function, projectCheck: Function, readFile: Function }} deps
+ */
+export function makeToolRunners(deps) {
+  const {
+    buildRouteTable,
+    buildActionIndex,
+    hashFile,
+    scanComponents,
+    checkConventions,
+    projectCheck,
+    readFile,
+  } = deps;
+
+  return {
+    async list_routes(appDir) {
+      const table = await buildRouteTable(appDir);
+      const pages = await Promise.all(
+        table.pages.map(async (r) => {
+          /** @type {{ path: string, file: string, dynamic?: boolean, params?: string[] }} */
+          const out = {
+            path: routePathFromDir(r.routeDir),
+            file: relative(appDir, r.file),
+          };
+          if (r.paramNames && r.paramNames.length) {
+            out.dynamic = true;
+            out.params = r.paramNames;
+          }
+          return out;
+        }),
+      );
+      const apis = await Promise.all(
+        table.apis.map(async (r) => {
+          let methods = [];
+          try {
+            methods = extractRouteMethods(await readFile(r.file, 'utf8'));
+          } catch {}
+          return {
+            path: routePathFromDir(r.routeDir),
+            file: relative(appDir, r.file),
+            methods,
+          };
+        }),
+      );
+      return { pages, apis };
+    },
+
+    async list_actions(appDir) {
+      const idx = await buildActionIndex(appDir, true);
+      /** @type {Array<{ file: string, fn: string, endpoint: string }>} */
+      const actions = [];
+      for (const [file, hash] of idx.fileToHash) {
+        let names = [];
+        try {
+          names = extractExportNames(await readFile(file, 'utf8'));
+        } catch {}
+        for (const fn of names) {
+          actions.push({
+            file: relative(appDir, file),
+            fn,
+            endpoint: `/__webjs/action/${hash}/${fn}`,
+          });
+        }
+      }
+      // Stable order for deterministic output.
+      actions.sort((a, b) =>
+        a.file === b.file ? a.fn.localeCompare(b.fn) : a.file.localeCompare(b.file),
+      );
+      return actions;
+    },
+
+    async list_components(appDir) {
+      const comps = await scanComponents(appDir);
+      return comps
+        .map((c) => ({
+          tag: c.tag,
+          file: relative(appDir, c.file),
+          className: c.className,
+        }))
+        .sort((a, b) => a.tag.localeCompare(b.tag));
+    },
+
+    async check(appDir) {
+      const violations = await checkConventions(appDir);
+      return projectCheck(violations);
+    },
+  };
+}
+
+/**
+ * A JSON-RPC 2.0 result frame.
+ * @param {string|number|null} id
+ * @param {any} result
+ */
+function rpcResult(id, result) {
+  return { jsonrpc: '2.0', id, result };
+}
+
+/**
+ * A JSON-RPC 2.0 error frame.
+ * @param {string|number|null} id
+ * @param {number} code
+ * @param {string} message
+ */
+function rpcError(id, code, message) {
+  return { jsonrpc: '2.0', id, error: { code, message } };
+}
+
+/**
+ * Run the read-only webjs MCP server over the given streams. Reads
+ * newline-delimited JSON-RPC from `stdin`, writes one response line per request
+ * to `stdout`, and logs diagnostics to `stderr` ONLY (stdout is the protocol
+ * channel). Resolves when stdin ends (clean shutdown).
+ *
+ * Injectable streams + `cwd` keep it testable in-process with PassThrough
+ * streams; the bin passes the real `process.std*` + `process.cwd()`.
+ *
+ * @param {{
+ *   stdin: NodeJS.ReadableStream,
+ *   stdout: NodeJS.WritableStream,
+ *   stderr: NodeJS.WritableStream,
+ *   cwd: string,
+ *   version?: string,
+ *   deps?: object,
+ * }} opts
+ * @returns {Promise<void>}
+ */
+export async function runMcpServer(opts) {
+  const { stdin, stdout, stderr, cwd } = opts;
+  const version = opts.version || '0.0.0';
+
+  // Resolve the data functions from @webjsdev/server (reading them is
+  // read-only). Injectable for tests so they need not boot the real server.
+  let deps = opts.deps;
+  if (!deps) {
+    const server = await import('@webjsdev/server');
+    const check = await import('@webjsdev/server/check');
+    const { readFile } = await import('node:fs/promises');
+    const { projectCheck } = await import('./check-json.js');
+    deps = {
+      buildRouteTable: server.buildRouteTable,
+      buildActionIndex: server.buildActionIndex,
+      hashFile: server.hashFile,
+      scanComponents: server.scanComponents,
+      checkConventions: check.checkConventions,
+      projectCheck,
+      readFile,
+    };
+  }
+  const runners = makeToolRunners(deps);
+
+  /** Write one JSON-RPC frame as a single line to stdout. */
+  const send = (frame) => {
+    stdout.write(JSON.stringify(frame) + '\n');
+  };
+  /** Diagnostics go to stderr only, never stdout. */
+  const logErr = (msg) => {
+    try { stderr.write(`[webjs mcp] ${msg}\n`); } catch {}
+  };
+
+  /**
+   * Dispatch one parsed JSON-RPC message. Returns a frame to send, or null
+   * for a notification (no `id`) which gets no response.
+   */
+  const dispatch = async (msg) => {
+    const id = msg && Object.prototype.hasOwnProperty.call(msg, 'id') ? msg.id : null;
+    const isNotification = id === null || id === undefined;
+    const method = msg && msg.method;
+
+    if (method === 'initialize') {
+      return rpcResult(id, {
+        protocolVersion: PROTOCOL_VERSION,
+        capabilities: { tools: {} },
+        serverInfo: { name: 'webjs', version },
+      });
+    }
+
+    // `notifications/initialized` (and any other notification) gets no reply.
+    if (isNotification) return null;
+
+    if (method === 'tools/list') {
+      return rpcResult(id, {
+        tools: TOOL_DEFS.map((t) => ({
+          name: t.name,
+          description: t.description,
+          inputSchema: TOOL_INPUT_SCHEMA,
+        })),
+      });
+    }
+
+    if (method === 'tools/call') {
+      const params = (msg && msg.params) || {};
+      const name = params.name;
+      const args = params.arguments || {};
+      const runner = runners[name];
+      if (!runner) {
+        return rpcError(id, -32602, `Unknown tool: ${String(name)}`);
+      }
+      const appDir = typeof args.appDir === 'string' && args.appDir ? args.appDir : cwd;
+      try {
+        const result = await runner(appDir);
+        return rpcResult(id, {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        });
+      } catch (e) {
+        // A tool failure is an MCP tool-result error (isError), not a transport
+        // error, so the agent sees the message in the content channel.
+        logErr(`tool ${name} failed: ${e && e.message ? e.message : e}`);
+        return rpcResult(id, {
+          isError: true,
+          content: [
+            { type: 'text', text: `Error running ${name}: ${e && e.message ? e.message : String(e)}` },
+          ],
+        });
+      }
+    }
+
+    return rpcError(id, -32601, `Method not found: ${String(method)}`);
+  };
+
+  const rl = createInterface({ input: stdin, crlfDelay: Infinity });
+
+  await new Promise((resolveRun) => {
+    // Serialise line handling so responses preserve request order even though
+    // dispatch is async.
+    let chain = Promise.resolve();
+    rl.on('line', (line) => {
+      const trimmed = line.trim();
+      if (!trimmed) return;
+      chain = chain.then(async () => {
+        let msg;
+        try {
+          msg = JSON.parse(trimmed);
+        } catch {
+          // Malformed line: a JSON-RPC parse error, never a crash.
+          send(rpcError(null, -32700, 'Parse error'));
+          return;
+        }
+        try {
+          const frame = await dispatch(msg);
+          if (frame) send(frame);
+        } catch (e) {
+          logErr(`dispatch error: ${e && e.message ? e.message : e}`);
+          const id =
+            msg && Object.prototype.hasOwnProperty.call(msg, 'id') ? msg.id : null;
+          send(rpcError(id, -32603, 'Internal error'));
+        }
+      });
+    });
+    rl.on('close', () => {
+      // Drain the in-flight chain, then resolve (clean shutdown on stdin end).
+      chain.then(() => resolveRun()).catch(() => resolveRun());
+    });
+  });
+}

--- a/packages/cli/lib/mcp.js
+++ b/packages/cli/lib/mcp.js
@@ -113,15 +113,16 @@ export function extractExportNames(src) {
 
 /**
  * Lexically extract the HTTP method exports of a route.{js,ts} file. The webjs
- * router dispatches on named `GET` / `POST` / `PUT` / `PATCH` / `DELETE` /
- * `HEAD` / `OPTIONS` / `WS` exports, so we report exactly those that are
- * exported. Read-only: no module load.
+ * API router (`api.js`) dispatches the five standard verbs, plus `WS` for a
+ * WebSocket upgrade. We report exactly those that are exported, NOT `HEAD` /
+ * `OPTIONS` (the router does not dispatch a named handler for them, so listing
+ * them would imply a route the framework ignores). Read-only: no module load.
  *
  * @param {string} src
  * @returns {string[]}
  */
 export function extractRouteMethods(src) {
-  const METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'WS'];
+  const METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'WS'];
   const exported = new Set(extractExportNames(src));
   return METHODS.filter((m) => exported.has(m));
 }
@@ -194,7 +195,11 @@ export function makeToolRunners(deps) {
     },
 
     async list_actions(appDir) {
-      const idx = await buildActionIndex(appDir, true);
+      // `skipExposeLoad` builds the file -> hash maps WITHOUT importing any
+      // `expose()` module, so this stays truly read-only (no Prisma/DB init, and
+      // no stray stdout from a loaded module corrupting the JSON-RPC channel).
+      // The RPC hash is over the file path only, so no module load is needed.
+      const idx = await buildActionIndex(appDir, false, { skipExposeLoad: true });
       /** @type {Array<{ file: string, fn: string, endpoint: string }>} */
       const actions = [];
       for (const [file, hash] of idx.fileToHash) {

--- a/packages/cli/templates/.claude.json
+++ b/packages/cli/templates/.claude.json
@@ -4,6 +4,11 @@
       "type": "stdio",
       "command": "npx",
       "args": ["@playwright/mcp@latest"]
+    },
+    "webjs": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["@webjsdev/cli", "mcp"]
     }
   }
 }

--- a/packages/server/index.d.ts
+++ b/packages/server/index.d.ts
@@ -247,7 +247,7 @@ export declare function handleApi(
 // ---------------------------------------------------------------------------
 
 /** Scan the app for `.server.{js,ts}` files and build the RPC + expose index. */
-export declare function buildActionIndex(appDir: string, dev: boolean): Promise<unknown>;
+export declare function buildActionIndex(appDir: string, dev: boolean, opts?: { skipExposeLoad?: boolean }): Promise<unknown>;
 /** Whether a file path is a `.server.{js,ts,mjs,mts}` server file. */
 export declare function isServerFile(file: string): boolean;
 /** SHA-256 hash of an action file's absolute path (the RPC endpoint addressing scheme). */

--- a/packages/server/src/actions.js
+++ b/packages/server/src/actions.js
@@ -151,9 +151,17 @@ async function rpcResponse(payload, init = {}) {
  *
  * @param {string} appDir
  * @param {boolean} dev
+ * @param {{ skipExposeLoad?: boolean }} [opts]
+ *   `skipExposeLoad: true` builds the (load-free) `fileToHash` / `hashToFile`
+ *   maps WITHOUT importing any `expose()`-referencing module, so `httpRoutes`
+ *   stays empty. A read-only introspection caller (the MCP `list_actions` tool,
+ *   #262) uses this to derive RPC endpoint hashes without running a server
+ *   module's top-level side effects (Prisma init, DB connect) or risking a
+ *   stray stdout write. The request pipeline keeps the default (loads expose
+ *   routes, which the router must know before a request can hit them).
  * @returns {Promise<ActionIndex>}
  */
-export async function buildActionIndex(appDir, dev) {
+export async function buildActionIndex(appDir, dev, opts = {}) {
   /** @type {Map<string,string>} */
   const hashToFile = new Map();
   /** @type {Map<string,string>} */
@@ -190,6 +198,9 @@ export async function buildActionIndex(appDir, dev) {
     // mention in a comment or string only over-matches, costing one harmless
     // extra module load; the common pure-RPC file never names `expose` and so
     // still defers entirely.
+    // A read-only caller (MCP introspection) only needs the file -> hash maps
+    // above, so skip the expose-load entirely (no module side effects).
+    if (opts.skipExposeLoad) continue;
     let src = '';
     try { src = await readFile(file, 'utf8'); } catch {}
     if (!/\bexpose\b/.test(src)) continue;

--- a/packages/server/test/actions/actions.test.js
+++ b/packages/server/test/actions/actions.test.js
@@ -182,3 +182,48 @@ test('a pure-RPC server module is hashed at boot but NOT executed until first ca
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test('skipExposeLoad builds the hash index WITHOUT loading an expose() module (#262)', async () => {
+  // An expose()-referencing module IS loaded by the default index (the router
+  // needs its REST route before a request). A read-only introspection caller
+  // (the MCP list_actions tool) passes skipExposeLoad so it derives the same
+  // path-only hash without running the module's top-level side effects (Prisma
+  // init, DB connect) or risking a stray stdout write into the JSON-RPC channel.
+  // Inject the absolute file:// URL to the real core `expose`, so the scaffolded
+  // module (in a tmpdir) actually resolves it and the default load populates a
+  // REST route, proving the load truly happened.
+  const exposeUrl = new URL('../../../core/src/expose.js', import.meta.url).href;
+  const files = {
+    'actions/exposed.server.js': `'use server';
+      import { expose } from ${JSON.stringify(exposeUrl)};
+      globalThis.__webjs_expose_probe = (globalThis.__webjs_expose_probe || 0) + 1;
+      async function ping() { return 'pong'; }
+      export const handler = expose('GET /ping', ping);
+    `,
+  };
+  // Default: loads the expose module (probe fires), and httpRoutes is populated.
+  const dirA = await scaffold(files);
+  try {
+    delete globalThis.__webjs_expose_probe;
+    const loaded = await buildActionIndex(dirA, true);
+    assert.equal(globalThis.__webjs_expose_probe, 1, 'default index loads the expose module');
+    assert.ok(loaded.httpRoutes.length >= 1, 'default index populates the expose REST route');
+  } finally {
+    delete globalThis.__webjs_expose_probe;
+    await rm(dirA, { recursive: true, force: true });
+  }
+  // skipExposeLoad: the module is NOT loaded (probe stays undefined), but the
+  // file IS still hashed (so list_actions can emit its RPC endpoint).
+  const dirB = await scaffold(files);
+  try {
+    delete globalThis.__webjs_expose_probe;
+    const lean = await buildActionIndex(dirB, false, { skipExposeLoad: true });
+    assert.equal(globalThis.__webjs_expose_probe, undefined, 'skipExposeLoad must NOT load the module');
+    assert.equal(lean.httpRoutes.length, 0, 'skipExposeLoad leaves httpRoutes empty');
+    const file = resolveServerModule(lean, '/actions/exposed.server.js');
+    assert.ok(lean.fileToHash.get(file), 'the file is still hashed for RPC dispatch');
+  } finally {
+    delete globalThis.__webjs_expose_probe;
+    await rm(dirB, { recursive: true, force: true });
+  }
+});

--- a/test/cli/check-json.test.mjs
+++ b/test/cli/check-json.test.mjs
@@ -1,0 +1,135 @@
+/**
+ * Tests for `webjs check --json` (#262).
+ *
+ * The CLI's `check` command already returns structured `Violation[]` from
+ * `checkConventions(appDir)` and pretty-prints them; `--json` emits the raw
+ * structured violations plus a summary count as JSON, so an agent running
+ * `webjs check` in a loop consumes structured data instead of regex-scraping
+ * stdout.
+ *
+ * Covered:
+ *   - stdout PARSES as JSON (no pretty-print leakage) whose `violations` match
+ *     `checkConventions` (shape `{ rule, file, message, fix }`), plus a
+ *     `summary.count`.
+ *   - exits NON-ZERO when there are violations, ZERO when clean.
+ *   - the shared `projectCheck` projector is byte-identical to what the MCP
+ *     `check` tool returns (single source of truth).
+ */
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO = resolve(__dirname, '..', '..');
+const CLI = resolve(REPO, 'packages', 'cli', 'bin', 'webjs.js');
+
+const { checkConventions } = await import('@webjsdev/server/check');
+const { projectCheck } = await import(
+  resolve(REPO, 'packages', 'cli', 'lib', 'check-json.js')
+);
+
+const cleanup = [];
+after(() => { for (const d of cleanup) rmSync(d, { recursive: true, force: true }); });
+
+function tmpDir() {
+  const dir = mkdtempSync(join(tmpdir(), 'check-json-'));
+  cleanup.push(dir);
+  return dir;
+}
+
+function write(dir, rel, content) {
+  const full = join(dir, rel);
+  mkdirSync(dirname(full), { recursive: true });
+  writeFileSync(full, content);
+}
+
+/** Run `node bin/webjs.js check --json` in appDir, return { code, stdout }. */
+function runCheckJson(appDir, extraArgs = []) {
+  const r = spawnSync(process.execPath, [CLI, 'check', '--json', ...extraArgs], {
+    cwd: appDir,
+    encoding: 'utf8',
+  });
+  return { code: r.status, stdout: r.stdout, stderr: r.stderr };
+}
+
+test('check --json: clean app emits parseable JSON and exits 0', async () => {
+  const dir = tmpDir();
+  // A minimal, convention-clean app: a page that default-exports a function.
+  write(dir, 'app/page.ts', `import { html } from '@webjsdev/core';\nexport default function Home() { return html\`<h1>Hi</h1>\`; }\n`);
+
+  const { code, stdout } = runCheckJson(dir);
+  // No pretty-print leakage: the WHOLE stdout parses as JSON.
+  const report = JSON.parse(stdout.trim());
+  assert.ok(Array.isArray(report.violations), 'violations is an array');
+  assert.equal(report.violations.length, 0, 'no violations for a clean app');
+  assert.equal(report.summary.count, 0, 'summary.count is 0');
+  assert.deepEqual(report.summary.byRule, {}, 'byRule is empty');
+  assert.equal(code, 0, 'exit 0 when clean');
+
+  // Matches checkConventions directly (the projector wraps the raw array).
+  const violations = await checkConventions(dir);
+  assert.deepEqual(report, projectCheck(violations));
+});
+
+test('check --json: app with a violation emits the violation and exits non-zero', async () => {
+  const dir = tmpDir();
+  // A component that defines a WebComponent subclass but never registers it
+  // trips `components-have-register`.
+  write(
+    dir,
+    'components/broken.ts',
+    `import { WebComponent, html } from '@webjsdev/core';\n` +
+    `export class Broken extends WebComponent {\n` +
+    `  render() { return html\`<p>x</p>\`; }\n` +
+    `}\n`,
+  );
+
+  const { code, stdout } = runCheckJson(dir);
+  const report = JSON.parse(stdout.trim());
+  assert.ok(report.violations.length > 0, 'at least one violation reported');
+  // Each violation carries the { rule, file, message, fix } shape.
+  for (const v of report.violations) {
+    assert.equal(typeof v.rule, 'string');
+    assert.equal(typeof v.file, 'string');
+    assert.equal(typeof v.message, 'string');
+    assert.equal(typeof v.fix, 'string');
+  }
+  assert.equal(report.summary.count, report.violations.length, 'count matches length');
+  // byRule tallies per rule.
+  const total = Object.values(report.summary.byRule).reduce((a, b) => a + b, 0);
+  assert.equal(total, report.violations.length, 'byRule sums to the total');
+  assert.notEqual(code, 0, 'exit non-zero when violations exist');
+
+  // Cross-check against the raw checker.
+  const violations = await checkConventions(dir);
+  assert.deepEqual(report, projectCheck(violations));
+});
+
+test('check --json: --rules still short-circuits (does not emit JSON)', () => {
+  const dir = tmpDir();
+  write(dir, 'app/page.ts', `export default function P() {}\n`);
+  // --rules is the existing behavior; --json must not hijack it.
+  const r = spawnSync(process.execPath, [CLI, 'check', '--rules', '--json'], {
+    cwd: dir,
+    encoding: 'utf8',
+  });
+  assert.match(r.stdout, /correctness rules/, '--rules prints the rule listing');
+  assert.throws(() => JSON.parse(r.stdout.trim()), 'rule listing is not JSON');
+});
+
+test('projectCheck: summary tallies per rule', () => {
+  const violations = [
+    { rule: 'a', file: 'x', message: 'm', fix: 'f' },
+    { rule: 'a', file: 'y', message: 'm', fix: 'f' },
+    { rule: 'b', file: 'z', message: 'm', fix: 'f' },
+  ];
+  const report = projectCheck(violations);
+  assert.equal(report.summary.count, 3);
+  assert.deepEqual(report.summary.byRule, { a: 2, b: 1 });
+  // violations are passed through verbatim.
+  assert.deepEqual(report.violations, violations);
+});

--- a/test/cli/mcp.test.mjs
+++ b/test/cli/mcp.test.mjs
@@ -270,3 +270,37 @@ test('extractRouteMethods: only exported HTTP method names', () => {
   const src = `export async function GET() {}\nexport async function POST() {}\nexport function helper() {}\n`;
   assert.deepEqual(extractRouteMethods(src).sort(), ['GET', 'POST']);
 });
+
+test('mcp: a falsy id (0) and a string id are echoed, not dropped', async () => {
+  const dir = tmpDir();
+  write(dir, 'app/page.ts', `export default function P() {}\n`);
+  const { frames } = await driveMcp(dir, [
+    { jsonrpc: '2.0', id: 0, method: 'tools/list' },
+    { jsonrpc: '2.0', id: 'abc', method: 'tools/list' },
+  ]);
+  assert.equal(frames.length, 2);
+  assert.equal(frames[0].id, 0, 'a 0 id must be echoed (no falsy drop)');
+  assert.equal(frames[1].id, 'abc', 'a string id must be echoed');
+});
+
+test('mcp: a request split across stdin chunks (mid-line) still parses', async () => {
+  const dir = tmpDir();
+  write(dir, 'app/page.ts', `export default function P() {}\n`);
+  const stdin = new PassThrough();
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  let out = '';
+  stdout.on('data', (c) => { out += c.toString(); });
+  const done = runMcpServer({ stdin, stdout, stderr, cwd: dir, version: '9.9.9' });
+  // Write a single JSON-RPC request in TWO chunks split mid-line. A line-based
+  // reader must buffer until the newline rather than parsing each chunk.
+  stdin.write('{"jsonrpc":"2.0","id":7,"method":"too');
+  await new Promise((r) => setTimeout(r, 10));
+  stdin.write('ls/list"}\n');
+  stdin.end();
+  await done;
+  const frames = out.split('\n').filter((l) => l.trim()).map((l) => JSON.parse(l));
+  assert.equal(frames.length, 1);
+  assert.equal(frames[0].id, 7, 'the chunk-split request parsed once the full line arrived');
+  assert.ok(frames[0].result.tools, 'and dispatched correctly');
+});

--- a/test/cli/mcp.test.mjs
+++ b/test/cli/mcp.test.mjs
@@ -1,0 +1,272 @@
+/**
+ * Smoke tests for the read-only `webjs mcp` server (#262).
+ *
+ * `runMcpServer({ stdin, stdout, stderr, cwd })` is driven IN-PROCESS with
+ * PassThrough streams for determinism (no spawned process). We assert the MCP
+ * stdio handshake + the four tools:
+ *   - `initialize` returns serverInfo + capabilities + protocolVersion.
+ *   - `notifications/initialized` (a notification, no id) gets NO reply.
+ *   - `tools/list` returns the four tools, each with an inputSchema.
+ *   - `tools/call` for `check` returns a content array whose text parses to
+ *     `{ violations, summary }`; for `list_routes` returns the route projection.
+ *   - the server MUTATES NOTHING (read-only).
+ *   - a MALFORMED line is answered with a JSON-RPC parse error and does NOT
+ *     crash the loop (a following valid request still works).
+ *   - stdout carries ONLY JSON-RPC frames (protocol purity).
+ */
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { PassThrough } from 'node:stream';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO = resolve(__dirname, '..', '..');
+const { runMcpServer, extractExportNames, extractRouteMethods } = await import(
+  resolve(REPO, 'packages', 'cli', 'lib', 'mcp.js')
+);
+
+const cleanup = [];
+after(() => { for (const d of cleanup) rmSync(d, { recursive: true, force: true }); });
+
+function tmpDir() {
+  const dir = mkdtempSync(join(tmpdir(), 'mcp-'));
+  cleanup.push(dir);
+  return dir;
+}
+function write(dir, rel, content) {
+  const full = join(dir, rel);
+  mkdirSync(dirname(full), { recursive: true });
+  writeFileSync(full, content);
+}
+
+/** Recursively list every file path (relative) under a dir, sorted. */
+function listFiles(dir, base = dir, out = []) {
+  for (const ent of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, ent.name);
+    if (ent.isDirectory()) listFiles(full, base, out);
+    else out.push(resolve(full).slice(base.length));
+  }
+  return out.sort();
+}
+
+/**
+ * Drive the MCP server with a list of request objects (one per line). Returns
+ * the parsed response frames (in order) plus the raw stdout text.
+ */
+async function driveMcp(cwd, requests, { rawLines = [] } = {}) {
+  const stdin = new PassThrough();
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+
+  let outBuf = '';
+  stdout.on('data', (c) => { outBuf += c.toString(); });
+
+  const done = runMcpServer({ stdin, stdout, stderr, cwd, version: '9.9.9' });
+
+  // Write each request as one newline-delimited JSON line, plus any raw lines.
+  for (const line of rawLines) stdin.write(line + '\n');
+  for (const req of requests) stdin.write(JSON.stringify(req) + '\n');
+  stdin.end();
+
+  await done;
+
+  const frames = outBuf
+    .split('\n')
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l));
+  return { frames, raw: outBuf };
+}
+
+test('mcp: initialize handshake returns serverInfo + capabilities', async () => {
+  const dir = tmpDir();
+  write(dir, 'app/page.ts', `export default function P() {}\n`);
+  const { frames } = await driveMcp(dir, [
+    { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} },
+  ]);
+  assert.equal(frames.length, 1);
+  const r = frames[0];
+  assert.equal(r.id, 1);
+  assert.equal(r.result.protocolVersion, '2024-11-05');
+  assert.deepEqual(r.result.capabilities, { tools: {} });
+  assert.deepEqual(r.result.serverInfo, { name: 'webjs', version: '9.9.9' });
+});
+
+test('mcp: notifications/initialized gets NO response', async () => {
+  const dir = tmpDir();
+  const { frames } = await driveMcp(dir, [
+    { jsonrpc: '2.0', method: 'notifications/initialized' },
+    { jsonrpc: '2.0', id: 2, method: 'tools/list' },
+  ]);
+  // Only the tools/list reply, the notification produced nothing.
+  assert.equal(frames.length, 1);
+  assert.equal(frames[0].id, 2);
+});
+
+test('mcp: tools/list returns the four tools with inputSchemas', async () => {
+  const dir = tmpDir();
+  const { frames } = await driveMcp(dir, [
+    { jsonrpc: '2.0', id: 3, method: 'tools/list' },
+  ]);
+  const tools = frames[0].result.tools;
+  const names = tools.map((t) => t.name).sort();
+  assert.deepEqual(names, ['check', 'list_actions', 'list_components', 'list_routes']);
+  for (const t of tools) {
+    assert.equal(typeof t.description, 'string');
+    assert.equal(t.inputSchema.type, 'object');
+    assert.ok(t.inputSchema.properties.appDir, 'inputSchema declares appDir');
+  }
+});
+
+test('mcp: tools/call check returns a content array parsing to { violations, summary }', async () => {
+  const dir = tmpDir();
+  // Trip a violation so the report is non-trivial.
+  write(
+    dir,
+    'components/broken.ts',
+    `import { WebComponent, html } from '@webjsdev/core';\n` +
+    `export class Broken extends WebComponent { render() { return html\`<p>x</p>\`; } }\n`,
+  );
+  const before = listFiles(dir);
+  const { frames } = await driveMcp(dir, [
+    { jsonrpc: '2.0', id: 4, method: 'tools/call', params: { name: 'check', arguments: {} } },
+  ]);
+  const content = frames[0].result.content;
+  assert.ok(Array.isArray(content));
+  assert.equal(content[0].type, 'text');
+  const report = JSON.parse(content[0].text);
+  assert.ok(Array.isArray(report.violations));
+  assert.ok(report.violations.length > 0);
+  assert.equal(typeof report.summary.count, 'number');
+  assert.equal(report.summary.count, report.violations.length);
+  // Read-only: the tool did not write / delete anything.
+  assert.deepEqual(listFiles(dir), before, 'check mutated nothing');
+});
+
+test('mcp: tools/call list_routes returns the route projection', async () => {
+  const dir = tmpDir();
+  write(dir, 'app/page.ts', `export default function P() {}\n`);
+  write(dir, 'app/blog/[slug]/page.ts', `export default function B() {}\n`);
+  write(dir, 'app/api/users/route.ts', `export async function GET() {}\nexport async function POST() {}\n`);
+  const { frames } = await driveMcp(dir, [
+    { jsonrpc: '2.0', id: 5, method: 'tools/call', params: { name: 'list_routes', arguments: {} } },
+  ]);
+  const out = JSON.parse(frames[0].result.content[0].text);
+  const paths = out.pages.map((p) => p.path).sort();
+  assert.ok(paths.includes('/'), 'root page present');
+  assert.ok(paths.includes('/blog/[slug]'), 'dynamic page present');
+  const dyn = out.pages.find((p) => p.path === '/blog/[slug]');
+  assert.equal(dyn.dynamic, true);
+  assert.deepEqual(dyn.params, ['slug']);
+  // API route with its methods.
+  const api = out.apis.find((a) => a.path === '/api/users');
+  assert.ok(api, 'api route present');
+  assert.deepEqual(api.methods.sort(), ['GET', 'POST']);
+});
+
+test('mcp: tools/call list_actions reports file + fn + RPC endpoint', async () => {
+  const dir = tmpDir();
+  write(
+    dir,
+    'modules/posts/actions/create.server.ts',
+    `'use server';\nexport async function createPost(input) { return { success: true }; }\n`,
+  );
+  const { frames } = await driveMcp(dir, [
+    { jsonrpc: '2.0', id: 6, method: 'tools/call', params: { name: 'list_actions', arguments: {} } },
+  ]);
+  const actions = JSON.parse(frames[0].result.content[0].text);
+  const a = actions.find((x) => x.fn === 'createPost');
+  assert.ok(a, 'createPost action listed');
+  assert.match(a.file, /create\.server\.ts$/);
+  assert.match(a.endpoint, /^\/__webjs\/action\/[0-9a-f]+\/createPost$/);
+});
+
+test('mcp: tools/call list_components reports tag + file + className', async () => {
+  const dir = tmpDir();
+  write(
+    dir,
+    'components/my-thing.ts',
+    `import { WebComponent, html } from '@webjsdev/core';\n` +
+    `export class MyThing extends WebComponent { render() { return html\`<p>x</p>\`; } }\n` +
+    `MyThing.register('my-thing');\n`,
+  );
+  const { frames } = await driveMcp(dir, [
+    { jsonrpc: '2.0', id: 7, method: 'tools/call', params: { name: 'list_components', arguments: {} } },
+  ]);
+  const comps = JSON.parse(frames[0].result.content[0].text);
+  const c = comps.find((x) => x.tag === 'my-thing');
+  assert.ok(c, 'my-thing component listed');
+  assert.equal(c.className, 'MyThing');
+  assert.match(c.file, /my-thing\.ts$/);
+});
+
+test('mcp: unknown method -> JSON-RPC -32601', async () => {
+  const dir = tmpDir();
+  const { frames } = await driveMcp(dir, [
+    { jsonrpc: '2.0', id: 8, method: 'no/such/method' },
+  ]);
+  assert.equal(frames[0].error.code, -32601);
+});
+
+test('mcp: unknown tool -> JSON-RPC error', async () => {
+  const dir = tmpDir();
+  const { frames } = await driveMcp(dir, [
+    { jsonrpc: '2.0', id: 9, method: 'tools/call', params: { name: 'nope', arguments: {} } },
+  ]);
+  assert.equal(frames[0].error.code, -32602);
+});
+
+test('mcp: a malformed line yields a parse error and does NOT crash the loop', async () => {
+  const dir = tmpDir();
+  write(dir, 'app/page.ts', `export default function P() {}\n`);
+  // A junk line first, then a valid request: both must be answered.
+  const { frames } = await driveMcp(
+    dir,
+    [{ jsonrpc: '2.0', id: 11, method: 'tools/list' }],
+    { rawLines: ['this is not json {{{'] },
+  );
+  // First frame: parse error (id null). Second: the valid tools/list reply.
+  const parseErr = frames.find((f) => f.error && f.error.code === -32700);
+  assert.ok(parseErr, 'a -32700 parse error was emitted');
+  const listReply = frames.find((f) => f.id === 11);
+  assert.ok(listReply && listReply.result.tools, 'valid request still served after junk');
+});
+
+test('mcp: stdout carries only JSON-RPC frames (protocol purity)', async () => {
+  const dir = tmpDir();
+  write(dir, 'app/page.ts', `export default function P() {}\n`);
+  const { raw } = await driveMcp(dir, [
+    { jsonrpc: '2.0', id: 12, method: 'initialize', params: {} },
+    { jsonrpc: '2.0', id: 13, method: 'tools/list' },
+  ]);
+  for (const line of raw.split('\n').filter((l) => l.trim())) {
+    const f = JSON.parse(line); // throws if any non-JSON leaked to stdout
+    assert.equal(f.jsonrpc, '2.0');
+  }
+});
+
+test('extractExportNames: recognises decl, default, and named exports', () => {
+  const src = `
+    export async function createPost() {}
+    export const listPosts = async () => {};
+    export function helper() {}
+    export default function Page() {}
+    const a = 1, b = 2;
+    export { a, b as renamed };
+  `;
+  const names = extractExportNames(src);
+  assert.ok(names.includes('createPost'));
+  assert.ok(names.includes('listPosts'));
+  assert.ok(names.includes('helper'));
+  assert.ok(names.includes('default'));
+  assert.ok(names.includes('a'));
+  assert.ok(names.includes('renamed'), 'the EXPORTED name of an alias');
+  assert.ok(!names.includes('b'), 'the local name of an alias is not the export');
+});
+
+test('extractRouteMethods: only exported HTTP method names', () => {
+  const src = `export async function GET() {}\nexport async function POST() {}\nexport function helper() {}\n`;
+  assert.deepEqual(extractRouteMethods(src).sort(), ['GET', 'POST']);
+});


### PR DESCRIPTION
Closes #262

## Summary

Two read-only introspection surfaces over data webjs already computes, so an agent can query the framework instead of working blind.

**1. `webjs check --json`.** The `check` command already calls `checkConventions(appDir)`, which returns structured `Violation[]` (`{ rule, file, message, fix }`), but only pretty-printed them. `--json` emits the raw violations plus a `summary` (`count`, `byRule`), so an agent running `check` in a loop consumes JSON instead of regex-scraping stdout. The non-zero exit on violations is preserved, and `--rules` still wins when both are passed.

**2. `webjs mcp`.** A hand-rolled, ZERO-dependency MCP stdio server (newline-delimited JSON-RPC 2.0) exposing four read-only tools, each taking an optional `{ appDir }`:
- `list_routes` (from `buildRouteTable`): pages + API routes with their paths, params, and methods.
- `list_actions` (from `buildActionIndex`): each server action's file, function, and `/__webjs/action/<hash>/<fn>` RPC endpoint.
- `list_components` (from `scanComponents`): registered custom-element tags + files.
- `check` (from `checkConventions`): the same `{ violations, summary }` projection as `check --json` (shared projector).

It reuses the existing functions, mutates nothing, extracts export names lexically (no app module load), and writes ONLY JSON-RPC frames to stdout with all diagnostics on stderr, so the protocol channel stays pure. A malformed line returns `-32700` without crashing; an id of `0` and string ids echo correctly; a request split across stdin chunks buffers until the newline. The scaffold `.claude.json` wires the `webjs` MCP next to the existing Playwright entry, so every new app gets it.

## Security / correctness

This went through a two-round adversarial review (the MCP server drives untrusted stdin and reuses server internals):

- **Stdout purity** (a stray stdout write corrupts the JSON-RPC channel) holds: the reused data functions contain no `console.log`, and the server's only stdout write is the single frame emitter.
- **Truly read-only.** Round 1 found `list_actions` called `buildActionIndex(appDir, true)`, which imports every `expose()`-referencing module, running its top-level side effects (Prisma/DB init) and risking a stdout write from a loaded module. Fixed with an additive `buildActionIndex(appDir, dev, { skipExposeLoad: true })` that builds the load-free `fileToHash` maps without importing anything. The emitted RPC hashes are byte-identical to the request pipeline's (verified), and the default 2-arg behaviour is unchanged. A server-side counterfactual proves the default loads (a side-effect probe fires + `httpRoutes` populates) while `skipExposeLoad` does neither but still hashes.

## Tests

- `test/cli/check-json.test.mjs`: valid-JSON output, the `{ rule, file, message, fix }` + `summary.count` shape, non-zero exit on violations / zero when clean, and `--rules` precedence (spawns the real CLI).
- `test/cli/mcp.test.mjs`: drives `runMcpServer` in-process with PassThrough streams. The handshake, the four tools, read-only (a file-list diff), malformed-line robustness, stdout purity (every stdout line is valid JSON-RPC), the id:0/string-id echo, and the chunk-split-stdin parse.
- `packages/server/test/actions/actions.test.js`: the `skipExposeLoad` counterfactual.
- Full suite: **2076 pass, 0 fail.** Blog e2e 69/69 (the action pipeline is unaffected by the additive change). `webjs check` clean (modulo the one pre-existing fixture violation).

## Dogfood

The blog e2e exercises the action RPC path (green). Verified live against `examples/blog`: `list_routes` returns 14 pages / 8 APIs, `list_actions` 10 actions with valid hashes, `list_components` 23 tags, `check --json` parses with exit 0. The scaffold `.claude.json` stays valid JSON with both `playwright` + `webjs` servers.

## Docs

Root `AGENTS.md` (CLI reference: `webjs check --json`, `webjs mcp`), `packages/cli/AGENTS.md` (command table + the `lib/mcp.js` module note + the four tools).
