### PR TITLE
chore: release @webjsdev/server 0.8.16 and @webjsdev/cli 0.10.9

### DIFF
--- a/changelog/cli/0.10.9.md
+++ b/changelog/cli/0.10.9.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.9
+date: 2026-06-03T19:32:20.730Z
+commit_count: 1
+---
+## Features
+
+- **add a read-only webjs MCP server and webjs check --json** ([#327](https://github.com/webjsdev/webjs/pull/327)) [`42f24a9e`](https://github.com/webjsdev/webjs/commit/42f24a9e)
+  * feat: add a read-only webjs MCP server and webjs check --json
+  
+  Two read-only surfaces over data webjs already computes. (1) webjs check --json
+  emits the structured Violation[] checkConventions already returns plus a summary

--- a/changelog/server/0.8.16.md
+++ b/changelog/server/0.8.16.md
@@ -1,0 +1,18 @@
+---
+package: "@webjsdev/server"
+version: 0.8.16
+date: 2026-06-03T19:32:20.679Z
+commit_count: 2
+---
+## Features
+
+- **ship a file-storage primitive for uploaded File/Blob payloads** ([#326](https://github.com/webjsdev/webjs/pull/326)) [`ccc9cff2`](https://github.com/webjsdev/webjs/commit/ccc9cff2)
+  * feat: ship a file-storage primitive for uploaded File/Blob payloads
+  
+  webjs round-trips File/Blob/FormData over the wire but had no answer for where
+  the bytes land. Add a minimal pluggable FileStore with a streaming local-disk
+- **add a read-only webjs MCP server and webjs check --json** ([#327](https://github.com/webjsdev/webjs/pull/327)) [`42f24a9e`](https://github.com/webjsdev/webjs/commit/42f24a9e)
+  * feat: add a read-only webjs MCP server and webjs check --json
+  
+  Two read-only surfaces over data webjs already computes. (1) webjs check --json
+  emits the structured Violation[] checkConventions already returns plus a summary

--- a/package-lock.json
+++ b/package-lock.json
@@ -6980,7 +6980,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.8",
+      "version": "0.10.9",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/server": "^0.8.0",
@@ -7016,7 +7016,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.15",
+      "version": "0.8.16",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Release the features that landed since server 0.8.15 / cli 0.10.8.

## Versions

- `@webjsdev/server` 0.8.15 -> **0.8.16** (patch)
- `@webjsdev/cli` 0.10.8 -> **0.10.9** (patch)

## What ships

- **#247 / #326** (server feat): a file-storage primitive (`diskStore` / `getFileStore` / `generateKey` / `signedUrl`) with streaming local-disk writes, traversal-safe keys, and signed serving URLs.
- **#262 / #327** (server + cli feat): a read-only `webjs` MCP server (`webjs mcp`) exposing routes / actions / components / check, plus `webjs check --json`. The server side adds the additive `buildActionIndex({ skipExposeLoad })` option that keeps the MCP introspection load-free.

The cli release also carries the #313 Tailwind-first scaffold-template updates (a `docs:` change, no changelog entry).

All in-repo dependents pin `^0.8.0` / `^0.10.0`, so the patches stay in range with no dependent edits; the lockfile is regenerated. Merging triggers `release.yml` to publish both to npm + GitHub Releases.