### PR TITLE
feat: view transitions on partial swaps + data-webjs-permanent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -689,6 +689,8 @@ Wire-byte optimization is automatic: the router sends `X-Webjs-Have` listing mar
 
 For partial-swap NOT tied to a folder layout, wrap in `<webjs-frame id="...">`. A nested trigger drives it; an EXTERNAL `<a>` / `<form>` carrying `data-webjs-frame="<id>"` drives it by id from anywhere (Turbo-style), and `data-webjs-frame="_top"` breaks OUT to a full nav. The router sets `aria-busy="true"` on the frame during its fetch (cleared on any exit) and fires a bubbling `webjs:frame-busy` event at start + finish. A frame nav whose response lacks the frame fires a cancelable `webjs:frame-missing` event and leaves the frame unchanged (no silent full-page swap). See `agent-docs/advanced.md` for the full mechanism.
 
+**View Transitions are opt-in (#250).** Add `<meta name="view-transition" content="same-origin">` to the page head and the router wraps EVERY swap path (the deepest-marker layout swap, the `<webjs-frame>` swap, and the full-body fallback) in `document.startViewTransition`. OFF by default (no animation surprise), re-read per nav, and a browser without the API falls back to the identical synchronous swap. **Persist a live element across a nav with `data-webjs-permanent`** (the element MUST also have an `id`): the router keeps the SAME DOM node by identity across a full-body OR in-region swap, so a playing `<audio>` / `<video>` or a live widget keeps running instead of being recreated (Turbo's permanent-element behaviour). Inert server-side. See `agent-docs/advanced.md`.
+
 ---
 
 ## Invariants (for both humans and agents)

--- a/agent-docs/advanced.md
+++ b/agent-docs/advanced.md
@@ -578,6 +578,75 @@ document.addEventListener('webjs:prefetch', (e) => {
 });
 ```
 
+### View Transitions (opt-in, all three swap paths)
+
+The router can wrap a client navigation's DOM mutation in the native
+[View Transitions API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API)
+(`document.startViewTransition`), so a same-shell partial swap cross-fades
+(or runs your `::view-transition-*` CSS) instead of snapping. It is OFF by
+default and purely OPT-IN, so an unconfigured app behaves exactly as
+before (no animation surprise, no regression in a browser without the
+API). Opt in by adding a meta to the page head, mirroring Turbo's
+`<meta name="view-transition">` convention:
+
+```html
+<!-- in the root layout's <head>, or any page's head -->
+<meta name="view-transition" content="same-origin">
+```
+
+The accepted opt-in value is `same-origin` (every client-router swap is
+same-origin by construction, so it reads as "animate these in-app
+navigations"); any other value, or the meta being absent, keeps
+transitions off. The meta is re-read PER navigation, so a page can turn
+transitions on or off as the user moves through the app (the head merge
+brings in the new page's head).
+
+When enabled and supported, the transition wraps ALL THREE swap paths,
+the deepest-marker layout swap, the `<webjs-frame>` swap, AND the
+full-body fallback, not just the full-body case (the inverse of what an
+author expects, since the marker + frame swaps are the common
+designed-for paths). The transition wraps the DOM MUTATION ONLY, never
+the fetch (which already happened); the browser captures the
+before/after around the synchronous swap. When `startViewTransition` is
+unavailable (Firefox / older Safari), the swap runs synchronously,
+byte-identical to the no-transition path, with no flash and no throw.
+
+### Persisting elements across a swap (`data-webjs-permanent`)
+
+An element marked `data-webjs-permanent` (it MUST also carry an `id`)
+survives a navigation as the SAME live DOM node, by node identity, so a
+playing `<audio>` / `<video>`, a live widget, an open menu, or any element
+with accumulated JS state keeps running across the swap instead of being
+destroyed and re-created from the incoming HTML. Mirrors Turbo's
+permanent-element behaviour.
+
+```html
+<audio id="player" data-webjs-permanent controls src="/track.mp3"></audio>
+```
+
+Mechanism: before the destructive swap, for each `[data-webjs-permanent]
+[id]` in the CURRENT DOM the router looks for a matching `#id` in the
+INCOMING document; when BOTH exist, the LIVE node is moved into the
+incoming tree's position (replacing the incoming placeholder), so the swap
+adopts the live node rather than recreating it. It works for the
+full-body path AND the in-region (marker / frame) paths, and is a STRONGER
+guarantee than the keyed reconciler (which preserves identity for matched
+keyed children): a permanent node keeps EXACT identity even where the
+reconciler would otherwise recreate it. Rules:
+
+- The element must have an `id` (the match key) and the attribute on BOTH
+  the current and incoming render of the page.
+- An id present in the current but ABSENT from the incoming doc is NOT
+  force-persisted (it is being removed; the swap removes it as usual).
+- Only a CURRENT node actually carrying `data-webjs-permanent` is moved
+  (an incoming `#id` that resolves to a non-permanent current element is
+  left untouched).
+- The node is placed exactly where the incoming document puts it, so it
+  never escapes a frame / region boundary.
+
+Progressive enhancement: with JS off, `data-webjs-permanent` is an inert
+attribute and the navigation is a normal full-page load.
+
 ### Per-segment loading skeletons
 
 Each `loading.{js,ts}` in the route chain is rendered into a hidden

--- a/examples/blog/app/(marketing)/about/page.ts
+++ b/examples/blog/app/(marketing)/about/page.ts
@@ -16,6 +16,7 @@ const FEATURES = [
 
 export default function About() {
   return html`
+    <span id="perm-probe" data-webjs-permanent hidden></span>
     ${rubric('about')}
     ${displayH1('A full-stack demo, at framework scale.')}
     <p class="text-[1.15rem] leading-[1.5] font-sans text-fg-muted max-w-[56ch] m-0 mb-18">

--- a/examples/blog/app/page.ts
+++ b/examples/blog/app/page.ts
@@ -23,6 +23,7 @@ async function slowStat() {
 export default async function HomePage() {
   const [me, posts] = await Promise.all([currentUser(), listPosts()]);
   return html`
+    <span id="perm-probe" data-webjs-permanent hidden></span>
     <section class="mb-18">
       ${rubric('the webjs demo')}
       <h1 class="font-serif text-display leading-[1.02] tracking-[-0.035em] font-bold m-0 mb-4 text-balance">

--- a/packages/cli/templates/AGENTS.md
+++ b/packages/cli/templates/AGENTS.md
@@ -784,6 +784,17 @@ error, abort, or a missing frame), so AT announces it and CSS can style
 `webjs:frame-busy` event on the frame at start and finish (detail
 `{ frameId, busy }`).
 
+**View Transitions + persistent elements (opt-in).** Add
+`<meta name="view-transition" content="same-origin">` to the page head and the
+router wraps every swap (the layout-marker swap, the `<webjs-frame>` swap, and
+the full-body fallback) in `document.startViewTransition` for an animated
+crossfade. OFF by default (no animation surprise); a browser without the API
+falls back to the identical synchronous swap. To keep a live element running
+across a navigation (a playing `<audio>` / `<video>`, a map, a stateful
+widget), mark it `data-webjs-permanent` AND give it an `id`: the router keeps
+the SAME DOM node by identity across the swap instead of recreating it (Turbo's
+permanent-element behaviour). Inert with JS off.
+
 When a frame nav's response lacks the matching `<webjs-frame id>` (e.g. an
 auth redirect), the router fires a cancelable, bubbling `webjs:frame-missing`
 event (detail `{ frameId, url, document }`) and leaves the frame unchanged

--- a/packages/core/src/router-client.js
+++ b/packages/core/src/router-client.js
@@ -1667,10 +1667,24 @@ function clearFormBusy(form, token, url, ok) {
   if (formBusyTokens.get(form) !== token) return;
   formBusyTokens.delete(form);
   form.setAttribute('aria-busy', 'false');
-  form.dispatchEvent(new CustomEvent('webjs:submit-end', {
+  const evt = new CustomEvent('webjs:submit-end', {
     bubbles: true,
     detail: { form, url, ok: !!ok },
-  }));
+  });
+  // A successful submission swaps the page in place, and a full-body swap
+  // (or a swap whose region contained the form) detaches the form before
+  // this teardown runs. A bubbling event dispatched on a DISCONNECTED node
+  // never reaches a `document`-level listener, so a synchronous swap (the
+  // no-view-transition default) would silently drop `submit-end`. Dispatch
+  // on `document` when the form is no longer connected so the symmetric
+  // start/end pair always lands, regardless of swap timing.
+  if (form.isConnected) {
+    form.dispatchEvent(evt);
+  } else if (typeof document !== 'undefined') {
+    document.dispatchEvent(evt);
+  } else {
+    form.dispatchEvent(evt);
+  }
 }
 
 /**
@@ -1735,6 +1749,207 @@ function trackedReloadSignature(root) {
   let sig = '';
   for (const el of tracked) sig += outerHTMLForDiff(el);
   return sig;
+}
+
+/* ====================================================================
+ * View Transitions (opt-in) + permanent-element persistence
+ * ==================================================================== */
+
+/**
+ * Whether the current page opts into the native View Transitions API for
+ * client-router swaps. OFF by default (no animation surprise, no
+ * regression for browsers without the API): a transition is purely
+ * opt-in via a `<meta name="view-transition" content="same-origin">` in
+ * the document head, mirroring Turbo's `<meta name="view-transition">`
+ * convention. The accepted opt-in value is `same-origin` (every
+ * client-router swap is same-origin by construction, so it reads as "yes,
+ * animate these in-app navigations"). Any other value, or the meta being
+ * absent, keeps transitions off.
+ *
+ * Re-read per navigation rather than cached: the meta can be added or
+ * removed by a swap (the head merge brings in the new page's head), so a
+ * page can turn transitions on or off as the user navigates.
+ *
+ * @returns {boolean}
+ */
+function viewTransitionsEnabled() {
+  if (typeof document === 'undefined') return false;
+  const meta = document.querySelector('meta[name="view-transition"]');
+  if (!meta) return false;
+  const content = (meta.getAttribute('content') || '').trim().toLowerCase();
+  return content === 'same-origin';
+}
+
+/**
+ * Run a synchronous DOM-mutation thunk, wrapping it in
+ * `document.startViewTransition()` when the page has opted in AND the
+ * browser supports the API. Otherwise the thunk runs synchronously,
+ * byte-identical to the pre-View-Transitions behaviour (no flash, no
+ * regression). The thunk is the SAME swap code in both branches; the
+ * transition only captures the before/after around the mutation (the
+ * fetch already happened, so it is never inside the callback).
+ *
+ * @param {() => void} thunk  The synchronous DOM swap to perform.
+ * @param {() => void} [afterFinished]  Optional post-transition work
+ *   (e.g. re-upgrade custom elements) run when the transition settles; for
+ *   the synchronous fallback it runs immediately after the thunk.
+ */
+function runWithTransition(thunk, afterFinished) {
+  const start = typeof document !== 'undefined'
+    ? /** @type any */ (document).startViewTransition
+    : undefined;
+  if (viewTransitionsEnabled() && typeof start === 'function') {
+    const t = start.call(document, thunk);
+    if (t && t.finished && typeof t.finished.then === 'function') {
+      t.finished.then(() => { if (afterFinished) afterFinished(); }).catch(() => {});
+    } else if (afterFinished) {
+      afterFinished();
+    }
+    return;
+  }
+  thunk();
+  if (afterFinished) afterFinished();
+}
+
+/**
+ * Persist `data-webjs-permanent` elements across a swap by NODE IDENTITY.
+ *
+ * Mirrors Turbo's permanent-element behaviour: an element the author
+ * marks `data-webjs-permanent` (and which carries an `id`) survives a
+ * destructive swap as the SAME live DOM node, so a playing
+ * `<audio>` / `<video>`, a live widget, an open menu, or any element with
+ * accumulated JS state keeps running across the navigation instead of
+ * being destroyed and re-created from the incoming HTML.
+ *
+ * The mechanism runs BEFORE the destructive `replaceChildren` / range
+ * delete: for each `[data-webjs-permanent][id]` in the CURRENT subtree, if
+ * the INCOMING tree has a matching `#id`, the live current node is MOVED
+ * into the incoming tree's position (replacing the incoming placeholder).
+ * The subsequent swap then ADOPTS the live node (it is already part of the
+ * incoming tree) rather than destroying the current one. The keyed
+ * reconciler matches it by id afterwards and leaves it in place.
+ *
+ * Guards (correctness):
+ *   - both-exist: only regraft an id present in BOTH the current and
+ *     incoming subtree. An id in the current but NOT the incoming is being
+ *     removed; leave it (do not force it to persist).
+ *   - current-is-permanent: only move when the CURRENT node actually
+ *     carries `data-webjs-permanent` (an incoming `#id` that resolves to a
+ *     non-permanent current element is left untouched).
+ *   - boundary-respecting: the live node is placed exactly where the
+ *     incoming document puts it, so it never escapes a frame/region.
+ *
+ * @param {ParentNode} currentRoot   The live subtree being swapped out.
+ * @param {ParentNode} incomingRoot  The incoming subtree being swapped in.
+ */
+function regraftPermanentElements(currentRoot, incomingRoot) {
+  if (!currentRoot || !incomingRoot) return;
+  if (typeof currentRoot.querySelectorAll !== 'function') return;
+  const permanents = currentRoot.querySelectorAll('[data-webjs-permanent][id]');
+  for (const live of permanents) {
+    const id = live.id;
+    if (!id) continue;
+    // both-exist guard: the incoming subtree must carry a matching #id.
+    let placeholder = null;
+    try {
+      placeholder = incomingRoot.querySelector(`#${CSS.escape(id)}`);
+    } catch { placeholder = null; }
+    if (!placeholder) continue;
+    // current-is-permanent guard is implicit in the selector above, but
+    // re-assert defensively (the live node is the one we move).
+    if (!live.hasAttribute || !live.hasAttribute('data-webjs-permanent')) continue;
+    const parent = placeholder.parentNode;
+    if (!parent) continue;
+    // Move the LIVE node into the incoming tree's position, replacing the
+    // incoming placeholder. The swap then adopts the live node.
+    if (placeholder === live) continue;
+    parent.replaceChild(live, placeholder);
+  }
+}
+
+/**
+ * Permanent-element regraft for the marker-range path, where the two
+ * sides are ARRAYS of sibling nodes (the live slice between markers, and
+ * the imported-but-detached incoming slice) rather than single roots.
+ *
+ * For each `[data-webjs-permanent][id]` reachable from the LIVE slice, if
+ * a matching `#id` exists anywhere in the INCOMING slice, replace the
+ * incoming (freshly-imported) copy with the LIVE node so the reconciler
+ * adopts the live node by identity. Searches both top-level slice members
+ * and their descendants. The same both-exist + current-is-permanent
+ * guards as `regraftPermanentElements` apply.
+ *
+ * @param {Node[]} liveSlice
+ * @param {Node[]} incomingSlice
+ */
+function regraftPermanentInSlice(liveSlice, incomingSlice) {
+  /** @type {Element[]} */
+  const livePermanents = [];
+  for (const n of liveSlice) {
+    if (n.nodeType !== 1) continue;
+    const el = /** @type {Element} */ (n);
+    if (el.hasAttribute && el.hasAttribute('data-webjs-permanent') && el.id) {
+      livePermanents.push(el);
+    }
+    if (typeof el.querySelectorAll === 'function') {
+      for (const d of el.querySelectorAll('[data-webjs-permanent][id]')) livePermanents.push(d);
+    }
+  }
+  if (!livePermanents.length) return;
+
+  for (const live of livePermanents) {
+    const id = live.id;
+    if (!id) continue;
+    const placeholder = findInSlice(incomingSlice, id);
+    if (!placeholder) continue; // both-exist guard
+    if (placeholder === live) continue;
+    const parent = placeholder.parentNode;
+    if (parent) {
+      parent.replaceChild(live, placeholder);
+    } else {
+      // Placeholder is a top-level slice member with no parent (detached):
+      // replace it in the incomingSlice array so the reconciler inserts the
+      // live node in that position.
+      const idx = incomingSlice.indexOf(placeholder);
+      if (idx !== -1) incomingSlice[idx] = live;
+    }
+  }
+}
+
+/**
+ * Find an element with `#id` within an array of (possibly detached)
+ * sibling nodes, searching each member and its descendants.
+ *
+ * @param {Node[]} slice
+ * @param {string} id
+ * @returns {Element | null}
+ */
+function findInSlice(slice, id) {
+  for (const n of slice) {
+    if (n.nodeType !== 1) continue;
+    const el = /** @type {Element} */ (n);
+    if (el.id === id) return el;
+    if (typeof el.querySelector === 'function') {
+      let match = null;
+      try { match = el.querySelector(`#${CSS.escape(id)}`); } catch { match = null; }
+      if (match) return match;
+    }
+  }
+  return null;
+}
+
+/**
+ * Re-upgrade custom elements between a marker pair after a transitioned
+ * swap settles. The View Transitions API snapshots and replaces DOM, so
+ * elements can need a re-upgrade once the animation finishes.
+ *
+ * @param {{ start: Comment, end: Comment } | undefined} range
+ */
+function upgradeCustomElementsInRange(range) {
+  if (!range || !range.start) return;
+  for (let n = range.start.nextSibling; n && n !== range.end; n = n.nextSibling) {
+    if (n.nodeType === 1) upgradeCustomElements(/** @type {Element} */ (n));
+  }
 }
 
 function applySwap(doc, frameId, revalidating, href, incomingBuild) {
@@ -1854,11 +2069,17 @@ function applySwap(doc, frameId, revalidating, href, incomingBuild) {
       // (Tailwind CSS injection, etc.) that the outer layout's scripts
       // already produced.
       addNewHeadElements(doc.head);
-      diffChildren(target, source);
-      reactivateScripts(target);
-      upgradeCustomElements(target);
+      // `diffChildren` -> `reconcileChildren` regrafts permanent elements
+      // by node identity (it imports the incoming children first, then
+      // swaps the live permanent node into the imported tree), so the live
+      // `<audio>`/widget keeps running across the frame swap.
+      runWithTransition(() => {
+        diffChildren(target, source);
+        reactivateScripts(target);
+        upgradeCustomElements(target);
+        blurOutgoingFocus();
+      }, () => upgradeCustomElements(target));
       forwardSuspenseResolvers(doc.body);
-      blurOutgoingFocus();
       return;
     }
     // The response did not carry the requested frame (source null), or the
@@ -1889,15 +2110,22 @@ function applySwap(doc, frameId, revalidating, href, incomingBuild) {
     // ADD-ONLY head merge for the same reason: outer layout stays
     // mounted, its head-bound runtime state must not be invalidated.
     addNewHeadElements(doc.head);
-    swapMarkerRange(here.get(sharedPath), there.get(sharedPath), doc);
+    runWithTransition(() => {
+      swapMarkerRange(here.get(sharedPath), there.get(sharedPath), doc);
+      blurOutgoingFocus();
+    }, () => upgradeCustomElementsInRange(here.get(sharedPath)));
     forwardSuspenseResolvers(doc.body);
-    blurOutgoingFocus();
     return;
   }
 
   // 3. Full body swap fallback. Use full head merge: different root
   // layout, so stale head elements should be removed.
   mergeHead(doc.head);
+  // Persist permanent elements by node identity across the full-body
+  // swap: move each live [data-webjs-permanent][id] node into the matching
+  // position in the incoming body BEFORE replaceChildren reads it, so the
+  // live node is adopted rather than destroyed.
+  regraftPermanentElements(document.body, doc.body);
   const newChildren = [...doc.body.childNodes];
   const doSwap = () => {
     document.body.replaceChildren(...newChildren);
@@ -1905,12 +2133,7 @@ function applySwap(doc, frameId, revalidating, href, incomingBuild) {
     upgradeCustomElements(document.body);
     blurOutgoingFocus();
   };
-  if (/** @type any */ (document).startViewTransition) {
-    const t = /** @type any */ (document).startViewTransition(doSwap);
-    t.finished.then(() => upgradeCustomElements(document.body)).catch(() => {});
-  } else {
-    doSwap();
-  }
+  runWithTransition(doSwap, () => upgradeCustomElements(document.body));
 }
 
 /**
@@ -1975,6 +2198,12 @@ function swapMarkerRange(target, source, _doc) {
   for (let n = source.start.nextSibling; n && n !== source.end; n = n.nextSibling) {
     incomingSlice.push(document.importNode(n, true));
   }
+
+  // Persist permanent elements by node identity: regraft each live
+  // [data-webjs-permanent][id] node into the matching position in the
+  // imported incoming slice, replacing the freshly-imported copy, so the
+  // keyed reconciler adopts the live node instead of destroying it.
+  regraftPermanentInSlice(liveSlice, incomingSlice);
 
   // Run the keyed diff.
   reconcileSiblings(liveParent, target.start, target.end, liveSlice, incomingSlice);
@@ -2063,6 +2292,12 @@ function reconcileSiblings(parent, startMarker, endMarker, live, incoming) {
  * @param {Element} src  The element to copy from (incoming HTML).
  */
 function diffElementInPlace(dst, src) {
+  // A regrafted `data-webjs-permanent` node is the SAME node on both
+  // sides (the live node was moved into the incoming tree). Diffing it
+  // against itself would recurse into its own children and re-import
+  // them; instead leave it exactly as the user left it (that is the whole
+  // point of permanence).
+  if (dst === src) return;
   if (dst.tagName !== src.tagName) {
     dst.replaceWith(src);
     return;
@@ -2100,6 +2335,15 @@ function diffElementInPlace(dst, src) {
 function reconcileChildren(dst, src) {
   const liveChildren = [...dst.childNodes];
   const incomingChildren = [...src.childNodes].map((n) => document.importNode(n, true));
+
+  // Persist `data-webjs-permanent` elements by node identity: regraft each
+  // live permanent node into the matching position in the freshly-imported
+  // incoming children (replacing the imported copy), so the keyed match
+  // below adopts the LIVE node and the reconciler never recreates it. This
+  // is the in-region (frame + nested) counterpart of the full-body and
+  // marker-range regrafts; running it here covers permanents nested below
+  // the top keyed level too.
+  regraftPermanentInSlice(liveChildren, incomingChildren);
 
   // Build keyed map of live children for reuse.
   /** @type {Map<string, Element>} */
@@ -2542,6 +2786,10 @@ export {
   buildSubmitFormData as _buildSubmitFormData,
   restoreOptimistic as _restoreOptimistic,
   eligibleAnchorHref as _eligibleAnchorHref,
+  viewTransitionsEnabled as _viewTransitionsEnabled,
+  runWithTransition as _runWithTransition,
+  regraftPermanentElements as _regraftPermanentElements,
+  regraftPermanentInSlice as _regraftPermanentInSlice,
   prefetchSuppressed as _prefetchSuppressed,
   prefetchMode as _prefetchMode,
   prefetch as _prefetch,

--- a/packages/core/test/routing/browser/view-transitions-permanent.test.js
+++ b/packages/core/test/routing/browser/view-transitions-permanent.test.js
@@ -1,0 +1,346 @@
+/**
+ * Real-browser regression tests for View Transitions on partial swaps and
+ * `data-webjs-permanent` element persistence (#250).
+ *
+ * Two behaviours, both browser-observable:
+ *
+ *  1. View Transitions wrap ALL THREE swap paths (marker, frame, full
+ *     body), not just the full-body fallback, and only when the page opts
+ *     in via `<meta name="view-transition" content="same-origin">`. We
+ *     stub `document.startViewTransition` to capture that it was called
+ *     with the swap callback (then invoke the callback so the swap still
+ *     applies). With the meta absent it is NOT called; with the API
+ *     unavailable the swap still applies synchronously (fallback).
+ *
+ *  2. `data-webjs-permanent` persists an element by NODE IDENTITY across a
+ *     swap. We stamp a unique JS property on the live node before the nav
+ *     and assert the post-swap node is the SAME instance (=== identity),
+ *     proving it was regrafted, not recreated. Covered for the full-body
+ *     path AND an in-region (marker/frame) path. Counter-case: an incoming
+ *     doc without the id leaves/removes it (not force-persisted).
+ *
+ * MUST run in a real browser: linkedom does not model the swap pipeline or
+ * the View-Transitions API. We stub `window.fetch` to return the response
+ * and drive a real link click so `applySwap` runs exactly as in prod.
+ */
+import { enableClientRouter } from '../../../src/router-client.js';
+
+const assert = {
+  ok: (v, msg) => { if (!v) throw new Error(msg || `Expected truthy, got ${v}`); },
+  equal: (a, b, msg) => { if (a !== b) throw new Error(msg || `Expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}`); },
+  notEqual: (a, b, msg) => { if (a === b) throw new Error(msg || `Expected !== ${JSON.stringify(b)}`); },
+};
+const tick = () => new Promise((r) => setTimeout(r, 0));
+async function settle() { await tick(); await tick(); await tick(); await tick(); }
+
+const htmlResponse = (body) => Promise.resolve(new Response(body, {
+  headers: { 'content-type': 'text/html', 'x-webjs-build': '' },
+}));
+
+/** Add/remove the opt-in meta in the live head. */
+function setViewTransitionMeta(on) {
+  let meta = document.querySelector('meta[name="view-transition"]');
+  if (on) {
+    if (!meta) {
+      meta = document.createElement('meta');
+      meta.setAttribute('name', 'view-transition');
+      document.head.appendChild(meta);
+    }
+    meta.setAttribute('content', 'same-origin');
+  } else if (meta) {
+    meta.remove();
+  }
+}
+
+suite('Client router: View Transitions on partial swaps (#250)', () => {
+  let container, origFetch, origSVT, calls;
+
+  function setup() {
+    enableClientRouter();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    origFetch = window.fetch;
+    origSVT = Object.getOwnPropertyDescriptor(Document.prototype, 'startViewTransition')
+      || (document.startViewTransition !== undefined ? { value: document.startViewTransition } : null);
+    calls = [];
+  }
+  function teardown() {
+    window.fetch = origFetch;
+    restoreSVT();
+    setViewTransitionMeta(false);
+    container.remove();
+  }
+
+  // Install a capturing stub on the document instance.
+  function stubSVT() {
+    document.startViewTransition = (cb) => {
+      calls.push(cb);
+      // Run the callback synchronously so the swap still applies, and
+      // return a transition-like object with a resolved `finished`.
+      cb();
+      return { finished: Promise.resolve(), ready: Promise.resolve(), updateCallbackDone: Promise.resolve() };
+    };
+  }
+  function removeSVT() {
+    try { delete document.startViewTransition; } catch { /* ignore */ }
+    document.startViewTransition = undefined;
+  }
+  function restoreSVT() {
+    try { delete document.startViewTransition; } catch { /* ignore */ }
+    if (origSVT && 'value' in origSVT && origSVT.value) document.startViewTransition = origSVT.value;
+  }
+
+  test('marker swap is wrapped in startViewTransition when the meta opts in', async () => {
+    setup();
+    try {
+      setViewTransitionMeta(true);
+      stubSVT();
+      // A nested-layout marker shared by both pages.
+      container.innerHTML =
+        '<!--wj:children:/x-->' +
+        '<a id="m-link" href="/m-target"></a>' +
+        '<span id="m-content">OLD</span>' +
+        '<!--/wj:children-->';
+
+      window.fetch = () => htmlResponse(
+        '<!doctype html><html><head></head><body>' +
+        '<!--wj:children:/x--><span id="m-content">NEW</span><!--/wj:children-->' +
+        '</body></html>'
+      );
+
+      document.getElementById('m-link').click();
+      await settle();
+
+      assert.equal(calls.length, 1, 'startViewTransition called once for the marker swap');
+      assert.equal(typeof calls[0], 'function', 'called with the swap callback');
+      assert.equal(document.getElementById('m-content').textContent, 'NEW',
+        'the marker swap still applied (callback was invoked)');
+    } finally { teardown(); }
+  });
+
+  test('frame swap is wrapped in startViewTransition when the meta opts in', async () => {
+    setup();
+    try {
+      setViewTransitionMeta(true);
+      stubSVT();
+      container.innerHTML =
+        '<webjs-frame id="f1">' +
+          '<span id="f-content">OLD</span>' +
+          '<a id="f-link" href="/f-target"></a>' +
+        '</webjs-frame>';
+
+      window.fetch = () => htmlResponse(
+        '<!doctype html><html><head></head><body>' +
+        '<webjs-frame id="f1"><span id="f-content">NEW</span></webjs-frame>' +
+        '</body></html>'
+      );
+
+      document.getElementById('f-link').click();
+      await settle();
+
+      assert.equal(calls.length, 1, 'startViewTransition called once for the frame swap');
+      assert.equal(document.getElementById('f-content').textContent, 'NEW',
+        'the frame swap still applied');
+    } finally { teardown(); }
+  });
+
+  test('with the meta ABSENT, startViewTransition is NOT called but the swap still happens', async () => {
+    setup();
+    try {
+      setViewTransitionMeta(false); // explicit: no opt-in
+      stubSVT();
+      container.innerHTML =
+        '<!--wj:children:/y-->' +
+        '<a id="n-link" href="/n-target"></a>' +
+        '<span id="n-content">OLD</span>' +
+        '<!--/wj:children-->';
+
+      window.fetch = () => htmlResponse(
+        '<!doctype html><html><head></head><body>' +
+        '<!--wj:children:/y--><span id="n-content">NEW</span><!--/wj:children-->' +
+        '</body></html>'
+      );
+
+      document.getElementById('n-link').click();
+      await settle();
+
+      assert.equal(calls.length, 0,
+        'startViewTransition NOT called when the page did not opt in');
+      assert.equal(document.getElementById('n-content').textContent, 'NEW',
+        'the swap still applied synchronously');
+    } finally { teardown(); }
+  });
+
+  test('with startViewTransition UNAVAILABLE, the swap applies synchronously (fallback, no throw)', async () => {
+    setup();
+    try {
+      setViewTransitionMeta(true); // opted in, but the API is missing
+      removeSVT();
+      container.innerHTML =
+        '<!--wj:children:/z-->' +
+        '<a id="u-link" href="/u-target"></a>' +
+        '<span id="u-content">OLD</span>' +
+        '<!--/wj:children-->';
+
+      window.fetch = () => htmlResponse(
+        '<!doctype html><html><head></head><body>' +
+        '<!--wj:children:/z--><span id="u-content">NEW</span><!--/wj:children-->' +
+        '</body></html>'
+      );
+
+      document.getElementById('u-link').click();
+      await settle();
+
+      assert.equal(document.getElementById('u-content').textContent, 'NEW',
+        'the swap applied with no API and no throw');
+    } finally { teardown(); }
+  });
+});
+
+suite('Client router: data-webjs-permanent persistence (#250)', () => {
+  let container, sibling, origFetch;
+
+  function setup() {
+    enableClientRouter();
+    container = document.createElement('div');
+    sibling = document.createElement('div');
+    sibling.id = 'perm-sibling';
+    sibling.textContent = 'OUTSIDE';
+    document.body.appendChild(sibling);
+    document.body.appendChild(container);
+    origFetch = window.fetch;
+  }
+  function teardown() {
+    window.fetch = origFetch;
+    container.remove();
+    const s = document.getElementById('perm-sibling');
+    if (s) s.remove();
+  }
+
+  test('full-body swap: a permanent element keeps NODE IDENTITY across the nav', async () => {
+    setup();
+    try {
+      // No shared marker, no frame => full-body swap path.
+      container.innerHTML =
+        '<div id="player" data-webjs-permanent>PLAYING</div>' +
+        '<a id="fb-link" href="/fb-target"></a>';
+      const liveNode = document.getElementById('player');
+      const probe = {};
+      liveNode.__webjsLiveProbe = probe;
+
+      window.fetch = () => htmlResponse(
+        '<!doctype html><html><head></head><body>' +
+        '<div id="player" data-webjs-permanent>PLACEHOLDER</div>' +
+        '<h1 id="fb-new">New page</h1>' +
+        '</body></html>'
+      );
+
+      document.getElementById('fb-link').click();
+      await settle();
+
+      const after = document.getElementById('player');
+      assert.ok(after, 'the permanent element survives the full-body swap');
+      assert.equal(after, liveNode, 'it is the SAME node instance (regrafted, not recreated)');
+      assert.equal(after.__webjsLiveProbe, probe, 'the live JS state on the node is intact');
+      assert.equal(after.textContent, 'PLAYING',
+        'the live content is kept, NOT replaced by the incoming placeholder');
+      // The rest of the page did swap to the incoming body.
+      assert.ok(document.getElementById('fb-new'), 'the non-permanent content swapped in');
+    } finally { teardown(); }
+  });
+
+  test('in-region (frame) swap: a permanent element keeps NODE IDENTITY', async () => {
+    setup();
+    try {
+      container.innerHTML =
+        '<webjs-frame id="pf">' +
+          '<div id="widget" data-webjs-permanent>LIVE</div>' +
+          '<span id="pf-content">OLD</span>' +
+          '<a id="pf-link" href="/pf-target"></a>' +
+        '</webjs-frame>';
+      const liveNode = document.getElementById('widget');
+      const probe = {};
+      liveNode.__webjsLiveProbe = probe;
+
+      window.fetch = () => htmlResponse(
+        '<!doctype html><html><head></head><body>' +
+        '<webjs-frame id="pf">' +
+          '<div id="widget" data-webjs-permanent>PLACEHOLDER</div>' +
+          '<span id="pf-content">NEW</span>' +
+        '</webjs-frame>' +
+        '</body></html>'
+      );
+
+      document.getElementById('pf-link').click();
+      await settle();
+
+      const after = document.getElementById('widget');
+      assert.ok(after, 'the permanent element survives the frame swap');
+      assert.equal(after, liveNode, 'SAME node instance after an in-region swap');
+      assert.equal(after.__webjsLiveProbe, probe, 'live JS state intact across the region swap');
+      assert.equal(after.textContent, 'LIVE', 'live content kept');
+      assert.equal(document.getElementById('pf-content').textContent, 'NEW',
+        'the non-permanent sibling still swapped to the incoming content');
+    } finally { teardown(); }
+  });
+
+  test('in-region (marker) swap: a permanent element keeps NODE IDENTITY', async () => {
+    setup();
+    try {
+      container.innerHTML =
+        '<!--wj:children:/r-->' +
+          '<div id="m-widget" data-webjs-permanent>LIVE</div>' +
+          '<span id="r-content">OLD</span>' +
+          '<a id="r-link" href="/r-target"></a>' +
+        '<!--/wj:children-->';
+      const liveNode = document.getElementById('m-widget');
+      const probe = {};
+      liveNode.__webjsLiveProbe = probe;
+
+      window.fetch = () => htmlResponse(
+        '<!doctype html><html><head></head><body>' +
+        '<!--wj:children:/r-->' +
+          '<div id="m-widget" data-webjs-permanent>PLACEHOLDER</div>' +
+          '<span id="r-content">NEW</span>' +
+        '<!--/wj:children-->' +
+        '</body></html>'
+      );
+
+      document.getElementById('r-link').click();
+      await settle();
+
+      const after = document.getElementById('m-widget');
+      assert.ok(after, 'the permanent element survives the marker swap');
+      assert.equal(after, liveNode, 'SAME node instance after a marker-range swap');
+      assert.equal(after.__webjsLiveProbe, probe, 'live JS state intact across the marker swap');
+      assert.equal(after.textContent, 'LIVE', 'live content kept');
+      assert.equal(document.getElementById('r-content').textContent, 'NEW',
+        'the non-permanent sibling swapped');
+    } finally { teardown(); }
+  });
+
+  test('counter-case: an incoming doc WITHOUT the id does NOT force-persist (element is removed)', async () => {
+    setup();
+    try {
+      container.innerHTML =
+        '<div id="gone" data-webjs-permanent>HERE</div>' +
+        '<a id="cf-link" href="/cf-target"></a>';
+      const liveNode = document.getElementById('gone');
+      liveNode.__webjsLiveProbe = {};
+
+      // The incoming doc has NO #gone at all.
+      window.fetch = () => htmlResponse(
+        '<!doctype html><html><head></head><body>' +
+        '<h1 id="cf-new">No permanent here</h1>' +
+        '</body></html>'
+      );
+
+      document.getElementById('cf-link').click();
+      await settle();
+
+      assert.ok(!document.getElementById('gone'),
+        'a permanent element absent from the incoming doc is NOT force-persisted');
+      assert.ok(document.getElementById('cf-new'), 'the incoming body applied');
+    } finally { teardown(); }
+  });
+});

--- a/packages/core/test/routing/router-client.test.js
+++ b/packages/core/test/routing/router-client.test.js
@@ -33,6 +33,7 @@ let _collect, _longest, _keyOf, _diffEl, _reconcile,
   _currentPageUrl, _setCurrentPageUrl,
   _eligibleAnchorHref, _prefetchSuppressed, _prefetchMode, _prefetch, _prefetchTake,
   _prefetchSaysSaveData, _prefetchPeek, _prefetchInflightSize, _resetPrefetch,
+  _viewTransitionsEnabled, _runWithTransition, _regraftPermanentElements,
   enableClientRouter, disableClientRouter, revalidate,
   WebComponent, html;
 
@@ -105,6 +106,9 @@ before(async () => {
     _prefetchPeek,
     _prefetchInflightSize,
     _resetPrefetch,
+    _viewTransitionsEnabled,
+    _runWithTransition,
+    _regraftPermanentElements,
     navigate,
     revalidate,
     enableClientRouter,
@@ -2781,4 +2785,116 @@ test('revalidate evicts the prefetch cache, not just the snapshot cache', async 
     revalidate();
     assert.equal(_prefetchPeek('http://localhost/items'), null, 'revalidate() cleared the prefetch cache');
   });
+});
+
+/* ====================================================================
+ * View Transitions opt-in gate + permanent-element regraft (#250)
+ * ==================================================================== */
+
+test('viewTransitionsEnabled: off by default, on only for content="same-origin"', () => {
+  // No meta: off.
+  for (const m of document.head.querySelectorAll('meta[name="view-transition"]')) m.remove();
+  assert.equal(_viewTransitionsEnabled(), false, 'default off without the meta');
+
+  const meta = document.createElement('meta');
+  meta.setAttribute('name', 'view-transition');
+  document.head.appendChild(meta);
+
+  meta.setAttribute('content', 'same-origin');
+  assert.equal(_viewTransitionsEnabled(), true, 'same-origin opts in');
+
+  meta.setAttribute('content', 'SAME-ORIGIN');
+  assert.equal(_viewTransitionsEnabled(), true, 'case-insensitive');
+
+  meta.setAttribute('content', 'true');
+  assert.equal(_viewTransitionsEnabled(), false, 'an unrecognized value stays off');
+
+  meta.setAttribute('content', '');
+  assert.equal(_viewTransitionsEnabled(), false, 'empty content stays off');
+
+  meta.remove();
+});
+
+test('runWithTransition: synchronous fallback when the API is unavailable', () => {
+  const orig = document.startViewTransition;
+  delete document.startViewTransition;
+  document.startViewTransition = undefined;
+  try {
+    let ran = false, after = false;
+    _runWithTransition(() => { ran = true; }, () => { after = true; });
+    assert.ok(ran, 'thunk ran synchronously');
+    assert.ok(after, 'afterFinished ran synchronously in the fallback');
+  } finally {
+    if (orig) document.startViewTransition = orig; else delete document.startViewTransition;
+  }
+});
+
+test('runWithTransition: calls startViewTransition only when opted in AND supported', () => {
+  const origSVT = document.startViewTransition;
+  // Ensure opt-in meta is present.
+  for (const m of document.head.querySelectorAll('meta[name="view-transition"]')) m.remove();
+  const meta = document.createElement('meta');
+  meta.setAttribute('name', 'view-transition');
+  meta.setAttribute('content', 'same-origin');
+  document.head.appendChild(meta);
+
+  const calls = [];
+  document.startViewTransition = (cb) => { calls.push(cb); cb(); return { finished: Promise.resolve() }; };
+  try {
+    let ran = false;
+    _runWithTransition(() => { ran = true; });
+    assert.equal(calls.length, 1, 'startViewTransition invoked under opt-in + support');
+    assert.ok(ran, 'the swap thunk ran (callback invoked)');
+
+    // Opt OUT: same API present, but meta absent -> NOT called.
+    meta.remove();
+    calls.length = 0;
+    let ran2 = false;
+    _runWithTransition(() => { ran2 = true; });
+    assert.equal(calls.length, 0, 'not called when not opted in');
+    assert.ok(ran2, 'swap still ran synchronously');
+  } finally {
+    if (origSVT) document.startViewTransition = origSVT; else delete document.startViewTransition;
+    meta.remove();
+  }
+});
+
+test('regraftPermanentElements: moves the live permanent node into the incoming tree (both-exist)', () => {
+  const current = bodyFrom('<div id="p" data-webjs-permanent>LIVE</div><span>x</span>');
+  const incoming = bodyFrom('<div id="p" data-webjs-permanent>PLACEHOLDER</div><h1>new</h1>');
+  const liveNode = current.querySelector('#p');
+  liveNode.__probe = {};
+  const placeholder = incoming.querySelector('#p');
+
+  _regraftPermanentElements(current, incoming);
+
+  // The live node is now in the incoming tree, replacing the placeholder.
+  assert.equal(incoming.querySelector('#p'), liveNode, 'incoming #p is now the live node');
+  assert.equal(incoming.querySelector('#p').__probe, liveNode.__probe, 'identity (JS state) preserved');
+  assert.equal(incoming.querySelector('#p').textContent, 'LIVE', 'live content kept, not the placeholder');
+  assert.ok(!incoming.contains(placeholder), 'the imported placeholder was replaced');
+});
+
+test('regraftPermanentElements: leaves a permanent node absent from incoming (no force-persist)', () => {
+  const current = bodyFrom('<div id="gone" data-webjs-permanent>HERE</div>');
+  const incoming = bodyFrom('<h1>new</h1>');
+  const liveNode = current.querySelector('#gone');
+
+  _regraftPermanentElements(current, incoming);
+
+  assert.equal(incoming.querySelector('#gone'), null, 'incoming unchanged (no #gone synthesized)');
+  assert.equal(current.querySelector('#gone'), liveNode, 'live node not moved (will be removed by the swap)');
+});
+
+test('regraftPermanentElements: only moves when the CURRENT node is actually permanent', () => {
+  // Current #w is NOT permanent; incoming #w IS marked. The current node must
+  // NOT be moved (the selector only matches permanent current nodes).
+  const current = bodyFrom('<div id="w">PLAIN</div>');
+  const incoming = bodyFrom('<div id="w" data-webjs-permanent>INCOMING</div>');
+  const incomingNode = incoming.querySelector('#w');
+
+  _regraftPermanentElements(current, incoming);
+
+  assert.equal(incoming.querySelector('#w'), incomingNode, 'incoming node untouched');
+  assert.equal(incoming.querySelector('#w').textContent, 'INCOMING', 'non-permanent current node not regrafted');
 });

--- a/test/e2e/e2e.test.mjs
+++ b/test/e2e/e2e.test.mjs
@@ -1044,6 +1044,41 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
     assert.ok(survived, 'same-layout nav should keep the <header> DOM element mounted');
   });
 
+  test('client nav: data-webjs-permanent element survives a partial swap by node identity (#250)', async () => {
+    // Both `/` and `/about` render a `<span id="perm-probe" data-webjs-permanent>`
+    // INSIDE the swapped `<main>` region. A normal partial swap would
+    // recreate it from the incoming HTML; the permanent regraft must move
+    // the LIVE node into the incoming tree so it keeps its identity (a
+    // playing media element / live widget would keep running). Proven by
+    // stamping a unique JS property before the nav and asserting it
+    // survives, which only holds if the SAME DOM node was kept.
+    await page.goto(baseUrl, { waitUntil: 'domcontentloaded', timeout: 10000 });
+    await sleep(1500);
+    const stamped = await page.evaluate(() => {
+      const el = document.getElementById('perm-probe');
+      if (!el) return false;
+      /** @type any */ (el).__permProbe = 'kept-alive';
+      return true;
+    });
+    assert.ok(stamped, 'the permanent probe element is present on the home page');
+
+    await clickNavLink(page, 'About');
+    await sleep(2000);
+
+    const result = await page.evaluate(() => {
+      const el = document.getElementById('perm-probe');
+      return {
+        present: !!el,
+        identityKept: !!el && /** @type any */ (el).__permProbe === 'kept-alive',
+        onAbout: location.pathname === '/about',
+      };
+    });
+    assert.ok(result.onAbout, 'navigated to /about via the client router');
+    assert.ok(result.present, 'the permanent element is present after the swap');
+    assert.ok(result.identityKept,
+      'the permanent element kept its NODE IDENTITY across the partial swap (regrafted, not recreated)');
+  });
+
   // ---------------------------------------------------------------------------
   // Rate limiting: 6th rapid auth request → 429
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #250

## Summary

**1. View Transitions on the partial swaps.** `document.startViewTransition` only wrapped the full-body fallback, never the marker-scoped layout swap or the `<webjs-frame>` swap (the common designed-for paths). `runWithTransition` now wraps ALL three swap paths, gated by an opt-in `<meta name="view-transition" content="same-origin">` (re-read per nav). A browser without the API falls back to the IDENTICAL synchronous swap (the thunk is the same swap code in both branches, called exactly once), so unconfigured apps are byte-identical.

**2. `data-webjs-permanent` element persistence.** An element marked `data-webjs-permanent` (and carrying an `id`) survives a full-body OR in-region swap by NODE IDENTITY, so a playing `<audio>`/`<video>` or a live widget keeps running instead of being recreated (Turbo's permanent-element behaviour). `regraftPermanent` moves the live node into the incoming tree's `#id` position before the destructive `replaceChildren`/range-delete, guarded so it only moves a node that is `data-webjs-permanent` in the CURRENT DOM and present by id in the INCOMING doc (an element absent from the incoming page is removed, not force-persisted). The keyed reconciler then matches the adopted node by id and leaves it (a `dst === src` guard prevents diffing it against itself).

Both are inert server-side (plain attributes/meta) and client-only.

## Two confirm-intent notes (from review)

- **The full-body swap is now opt-in too.** Previously the full-body swap auto-animated `startViewTransition` unconditionally in supporting browsers. It is now gated behind the meta like the partial paths. This is the uniform per-page opt-in gate #250 asks for, and is deliberate (off by default, no animation surprise; webjs has no published users so no compat burden). The net effect: a full-body swap no longer auto-animates unless the page adds the meta.
- **A `submit-end` robustness fix rides along.** A successful submission swaps the page and detaches the form before the #246 `clearFormBusy` teardown runs, so a bubbling `webjs:submit-end` on the now-disconnected form would never reach a `document`-level listener (it would be silently dropped). `clearFormBusy` now dispatches on `document` when the form is disconnected, so the start/end pair always lands. This is a #250-induced fix to #246's event, surfaced by the swap-detaches-form interaction, and is covered by the submit-state test.

## Review

A client-router adversarial review ran the FULL routing browser suite (7 files, 36 tests, all green alongside the existing reconciler/frame/nav-error/submit tests, so no regression), the 142 unit tests, and a real-browser e2e for permanent identity. No P0/P1. It confirmed: default-off meta gate (no path wraps without opt-in), the thunk runs exactly once on both transition + fallback paths, regraft preserves node identity across full-body/frame/marker swaps with the both-exist + both-permanent + no-op guards, and the new tests are real. Documented limitation (matching Turbo): a permanent element is not excluded from the transition snapshot via `view-transition-name: none`.

## Tests

- **Browser** (`routing/browser/view-transitions-permanent.test.js`, 8): startViewTransition is CALLED for a marker + a frame swap when the meta is present, NOT called when absent, the swap still applies when the API is unavailable (fallback), the permanent node identity is preserved (`===` + a stamped JS property) across full-body / frame / marker swaps, and the counter-case (incoming lacks the id leaves it, not force-persisted).
- **Unit** (`router-client.test.js`, +6): the meta gate (case-insensitive, empty), the fallback, the regraft both-exist / no-force-persist / current-must-be-permanent guards.
- **E2E** (`test/e2e/e2e.test.mjs` + blog fixtures): a real marker-range nav keeps a `data-webjs-permanent` node's identity.
- Full suite 2109 pass, routing browser suite 36/36, blog e2e 74/74 (rebuilt core dist). `webjs check` clean.

## Docs

`agent-docs/advanced.md` (the View-Transition opt-in + `data-webjs-permanent`), root `AGENTS.md` (the client-navigation section), `packages/cli/templates/AGENTS.md` (the frame/client-router section).
