### PR TITLE
refactor: rename DEMO_URL to EXAMPLE_BLOG_URL, point at example-blog.webjs.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ WEBSITE_PORT=8001 DOCS_PORT=8002 UI_PORT=8003 BLOG_PORT=8004 npm run dev
 
 The apps cross-link by URL (the landing site links to docs/demo/UI,
 the UI site links back). Those default to the localhost ports above and
-are overridable via `DOCS_URL` / `DEMO_URL` / `UI_URL` / `WEBSITE_URL`
+are overridable via `DOCS_URL` / `EXAMPLE_BLOG_URL` / `UI_URL` / `WEBSITE_URL`
 (this is also how deploys point them at real domains).
 
 ## Example

--- a/compose.yaml
+++ b/compose.yaml
@@ -26,7 +26,7 @@ services:
       start_period: 20s
     environment:
       DOCS_URL: ${DOCS_URL:-http://localhost:15002}
-      DEMO_URL: ${DEMO_URL:-http://localhost:15004}
+      EXAMPLE_BLOG_URL: ${EXAMPLE_BLOG_URL:-http://localhost:15004}
       UI_URL:   ${UI_URL:-http://localhost:15003}
 
   docs:

--- a/website/.env.example
+++ b/website/.env.example
@@ -5,4 +5,4 @@
 # override these with real public URLs (e.g. via Railway service env).
 DOCS_URL=http://localhost:5002
 UI_URL=http://localhost:5003
-DEMO_URL=http://localhost:5004
+EXAMPLE_BLOG_URL=http://localhost:5004

--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -85,8 +85,8 @@ applied (the navbar and most of the layout look broken). Same in prod:
 prefer `npm start` over `webjs start` so the `prestart: css:build` hook
 fires.
 
-Set `DOCS_URL` / `UI_URL` / `DEMO_URL` env vars to point the header links at
-the right hosts when deploying. `DEMO_URL` is the live example-blog app
+Set `DOCS_URL` / `UI_URL` / `EXAMPLE_BLOG_URL` env vars to point the header links at
+the right hosts when deploying. `EXAMPLE_BLOG_URL` is the live example-blog app
 surfaced as the "Demo" link. Locally, `.env` in this directory sets them to
 the sibling apps' localhost ports. Blog and Changelog are in-app routes, so
 they need no env var.

--- a/website/app/layout.ts
+++ b/website/app/layout.ts
@@ -2,7 +2,7 @@ import { html, cspNonce } from '@webjsdev/core';
 import '@webjsdev/core/client-router';
 import '../components/theme-toggle.ts';
 import '../components/cursor-glow.ts';
-import { DOCS_URL, UI_URL, DEMO_URL, GH_URL, NEW_TAB } from '../lib/links.ts';
+import { DOCS_URL, UI_URL, EXAMPLE_BLOG_URL, GH_URL, NEW_TAB } from '../lib/links.ts';
 
 /**
  * Root layout for the redesigned marketing site.
@@ -15,7 +15,7 @@ import { DOCS_URL, UI_URL, DEMO_URL, GH_URL, NEW_TAB } from '../lib/links.ts';
  * layer and cursor-glow blob, the hover-only scrollbar (`.scroll-thin`), and
  * the <details> icon swap. Everything else is Tailwind.
  *
- * Shared link config (DOCS_URL / UI_URL / DEMO_URL / GH_URL / NEW_TAB) lives in
+ * Shared link config (DOCS_URL / UI_URL / EXAMPLE_BLOG_URL / GH_URL / NEW_TAB) lives in
  * lib/links.ts, imported here and by app/page.ts.
  */
 
@@ -25,7 +25,7 @@ const DESCRIPTION = 'AI-first, web-components-first, no-build full-stack framewo
 const NAV = [
   { label: 'Docs', href: DOCS_URL + '/docs/getting-started', ext: true },
   { label: 'UI', href: UI_URL, ext: true },
-  { label: 'Demo', href: DEMO_URL, ext: true },
+  { label: 'Demo', href: EXAMPLE_BLOG_URL, ext: true },
   { label: 'Blog', href: '/blog', ext: false },
   { label: 'Changelog', href: '/changelog', ext: false },
   { label: 'GitHub', href: GH_URL, ext: true },

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -1,7 +1,7 @@
 import { html } from '@webjsdev/core';
 import '../components/copy-cmd.ts';
 import '../components/scroll-reveal.ts';
-import { DOCS_URL, UI_URL, DEMO_URL, GH_URL, NEW_TAB } from '../lib/links.ts';
+import { DOCS_URL, UI_URL, EXAMPLE_BLOG_URL, GH_URL, NEW_TAB } from '../lib/links.ts';
 // highlight() runs only at SSR (codeWindow renders its output into the served
 // HTML), but it does ship to the client as a small dead module: the page loads
 // in the browser to register copy-cmd / scroll-reveal, and that pulls in its
@@ -348,7 +348,7 @@ lib/session.server.ts</pre>
           <a class="text-fg-muted no-underline text-[13.5px] hover:text-accent" href=${GH_URL} target="_blank" rel="noopener noreferrer">GitHub${NEW_TAB}</a>
           <a class="text-fg-muted no-underline text-[13.5px] hover:text-accent" href=${DOCS_URL + '/docs/getting-started'} target="_blank" rel="noopener noreferrer">Docs${NEW_TAB}</a>
           <a class="text-fg-muted no-underline text-[13.5px] hover:text-accent" href=${UI_URL} target="_blank" rel="noopener noreferrer">UI${NEW_TAB}</a>
-          <a class="text-fg-muted no-underline text-[13.5px] hover:text-accent" href=${DEMO_URL} target="_blank" rel="noopener noreferrer">Demo${NEW_TAB}</a>
+          <a class="text-fg-muted no-underline text-[13.5px] hover:text-accent" href=${EXAMPLE_BLOG_URL} target="_blank" rel="noopener noreferrer">Demo${NEW_TAB}</a>
           <a class="text-fg-muted no-underline text-[13.5px] hover:text-accent" href="/blog">Blog</a>
           <a class="text-fg-muted no-underline text-[13.5px] hover:text-accent" href="/changelog">Changelog</a>
         </nav>

--- a/website/lib/links.ts
+++ b/website/lib/links.ts
@@ -16,7 +16,7 @@ export const DOCS_URL = env.DOCS_URL || 'https://docs.webjs.com';
 export const UI_URL = env.UI_URL || 'https://ui.webjs.dev';
 // DEMO_URL points at the live example-blog app (a real webjs app), surfaced as
 // the "Demo" nav link.
-export const DEMO_URL = env.DEMO_URL || 'https://demo.webjs.dev';
+export const DEMO_URL = env.DEMO_URL || 'https://example-blog.webjs.dev';
 export const GH_URL = 'https://github.com/webjsdev/webjs';
 
 // Visually-hidden cue appended inside target="_blank" links so a screen reader

--- a/website/lib/links.ts
+++ b/website/lib/links.ts
@@ -14,9 +14,9 @@ const env = (globalThis as any).process?.env ?? {};
 
 export const DOCS_URL = env.DOCS_URL || 'https://docs.webjs.com';
 export const UI_URL = env.UI_URL || 'https://ui.webjs.dev';
-// DEMO_URL points at the live example-blog app (a real webjs app), surfaced as
+// EXAMPLE_BLOG_URL points at the live example-blog app (a real webjs app), surfaced as
 // the "Demo" nav link.
-export const DEMO_URL = env.DEMO_URL || 'https://example-blog.webjs.dev';
+export const EXAMPLE_BLOG_URL = env.EXAMPLE_BLOG_URL || 'https://example-blog.webjs.dev';
 export const GH_URL = 'https://github.com/webjsdev/webjs';
 
 // Visually-hidden cue appended inside target="_blank" links so a screen reader

--- a/website/test/ssr/layout-ssr.test.ts
+++ b/website/test/ssr/layout-ssr.test.ts
@@ -18,7 +18,7 @@ import RootLayout from '../../app/layout.ts';
 import LandingPage from '../../app/page.ts';
 import NotFound from '../../app/not-found.ts';
 import ErrorBoundary from '../../app/error.ts';
-import { DEMO_URL } from '../../lib/links.ts';
+import { EXAMPLE_BLOG_URL } from '../../lib/links.ts';
 
 test('the root layout SSR emits no phantom copy-cmd element or copy button', async () => {
   const out = await renderToString(RootLayout({ children: html`<main>content</main>` }));
@@ -66,14 +66,14 @@ test('external new-tab links announce the context change and hide decorative gly
 });
 
 test('the nav links to the live example-blog app via a Demo link', async () => {
-  // The "Demo" link surfaces the deployed example-blog app (DEMO_URL). It
+  // The "Demo" link surfaces the deployed example-blog app (EXAMPLE_BLOG_URL). It
   // falls back to the production domain, so it renders even with no env var
   // set. Guards against the link being dropped again.
   const out = await renderToString(RootLayout({ children: LandingPage() }));
   assert.ok(out.includes('>Demo<'), 'a Demo nav link is rendered');
   // Assert against the value the code resolved (env override or the production
-  // fallback), not a hardcoded URL, so exporting DEMO_URL cannot break the test.
-  assert.ok(out.includes(DEMO_URL), `the Demo link points at the configured DEMO_URL (${DEMO_URL})`);
+  // fallback), not a hardcoded URL, so exporting EXAMPLE_BLOG_URL cannot break the test.
+  assert.ok(out.includes(EXAMPLE_BLOG_URL), `the Demo link points at the configured EXAMPLE_BLOG_URL (${EXAMPLE_BLOG_URL})`);
 });
 
 test('the layout ships an Escape-to-close handler for the mobile menu', async () => {


### PR DESCRIPTION
Align the website's demo-link naming with the example-blog app (the `examples/blog`/`@webjsdev/example-blog` rename to `demo` was deferred to #341):

- The `DEMO_URL` env var is renamed to `EXAMPLE_BLOG_URL` (lib/links.ts, layout.ts, page.ts, the SSR test, the website .env files, website/AGENTS.md, README, compose.yaml).
- Its production fallback is `https://example-blog.webjs.dev` (was demo.webjs.dev).
- The user-facing "Demo" nav label is unchanged (the link's purpose is still 'see the live demo', now hosted at the example-blog subdomain).

An `EXAMPLE_BLOG_URL` env override still wins at deploy time. The SSR test asserts the Demo link against the resolved `EXAMPLE_BLOG_URL`, so it follows automatically.