### PR TITLE
fix: attribute the ~99 KB wire figure to Next.js, not react+react-dom

### DIFF
--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -45,9 +45,11 @@ const GRADTEXT = 'bg-[linear-gradient(105deg,var(--accent),color-mix(in_oklch,va
 
 // Framework-weight stats. Measured: gzipped production browser bundle,
 // npm package metadata, and framework source line counts. Kept honest
-// and comparative against react + react-dom.
+// and comparative against a Next.js app's first-load JS (react + react-dom
+// alone is ~44 KB. The ~99 KB is the full Next baseline, react + react-dom
+// plus the Next runtime plus the app-router client).
 const STATS = [
-  { big: '~22 KB', label: 'Client runtime, gzipped', sub: 'react + react-dom ship ~99 KB. webjs core is about 4.5x lighter on the wire.' },
+  { big: '~22 KB', label: 'Client runtime, gzipped', sub: 'A Next.js app ships ~99 KB on first load. webjs core is about 4.5x lighter on the wire.' },
   { big: '0', label: 'Runtime dependencies', sub: '@webjsdev/core has none. The whole stack adds only ws, for WebSockets.' },
   { big: '~15k', label: 'Lines of framework code', sub: 'Small enough that an AI agent can read and grep the whole framework, not guess.' },
   { big: 'No build', label: 'Source is the runtime', sub: 'What you read in node_modules is what runs. No bundler, no compile step.' },


### PR DESCRIPTION
The website's framework-weight stat claimed `react + react-dom ship ~99 KB`, but react + react-dom alone is **~44 KB** gzipped. The **~99 KB** is a **Next.js** app's first-load JS (react + react-dom + the Next runtime + the app-router client), which is the apples-to-apples baseline for webjs's always-loaded **22 KB** client runtime (hydration + client router + signals + the rich-type wire serializer, all in one bundle).

- Relabels the `sub` caption to "A Next.js app ships ~99 KB on first load."
- Documents the breakdown in the source comment so the mislabel does not return.
- The 4.5x figure (99/22) is unchanged.

A measured default Next 16 + Turbopack app actually came out higher (~186 KB homepage first-load), so ~99 KB is a conservative, representative figure for a typical Next App Router baseline.