### PR TITLE
feat: provide an opt-in progressive-enhancement service worker primitive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ recipes for common tasks. Keep it in sync whenever behaviour changes.
 | `agent-docs/advanced.md` | Suspense streaming, performance, bundling, client router, WebSockets |
 | `agent-docs/typescript.md` | TS at runtime + full-stack type safety |
 | `agent-docs/deployment.md` | Production, runtime targets, embedded use |
+| `agent-docs/service-worker.md` | The opt-in progressive-enhancement service worker (`public/sw.js`): offline fallback, asset caching, the `data-webjs-build` version tie, the registration snippet |
 | `agent-docs/testing.md` | Unit, browser, convention validation, the `handle()` test harness (`@webjsdev/server/testing`) |
 | `agent-docs/framework-dev.md` | Monorepo dev (only when editing webjs itself) |
 | `agent-docs/recipes.md` | Page / route / action / component recipes |

--- a/agent-docs/service-worker.md
+++ b/agent-docs/service-worker.md
@@ -1,0 +1,99 @@
+# Service worker / offline primitive (opt-in, #271)
+
+webjs ships a hand-authored service worker and an offline fallback into every
+scaffold (`public/sw.js`, `public/offline.html`). It adds an offline experience
+and an asset cache **without changing the JavaScript-disabled baseline**: the
+worker only ever registers from JavaScript, so with JS off no worker exists and
+pages, links, and forms behave exactly as before. It is **opt-in**: the files
+ship dormant and do nothing until the app registers the worker.
+
+This is a thin, hand-readable worker built directly on the native Service
+Worker and Cache Storage APIs. There is no Workbox, no precache framework, and
+no bundler step, matching webjs's no-build, close-to-web-standards posture.
+
+## Enabling it (the opt-in registration snippet)
+
+Add this inline script to the root layout's `<head>` (`app/layout.{js,ts}`). It
+registers the worker after load, and only when JS is present, so it is
+progressive-enhancement-safe:
+
+```html
+<script>
+  if ('serviceWorker' in navigator) {
+    addEventListener('load', () => {
+      // Tie the worker version to the deploy: read the importmap build id and
+      // register /sw.js?v=<build>, so a new deploy registers a "new" worker.
+      const tag = document.querySelector('script[type="importmap"]');
+      const build = (tag && tag.dataset.webjsBuild) || '';
+      navigator.serviceWorker.register('/sw.js' + (build ? '?v=' + build : ''));
+    });
+  }
+</script>
+```
+
+With webjs's CSP enabled (`webjs.csp` in package.json), stamp the nonce on the
+script. Read it in the layout with `import { cspNonce } from '@webjsdev/core'`
+and emit `<script nonce="${cspNonce()}">…`.
+
+## What the worker does (scope + strategy)
+
+Registered from `/sw.js`, the worker's scope is the site root (`/`), so it sees
+every navigation and same-origin asset request.
+
+- **Navigations are network-first.** The worker always tries the network first,
+  so the user sees fresh server-rendered HTML, and caches each successful page
+  (the SSR shell). When the network fails, it serves the cached page if you have
+  visited it, otherwise `/offline.html`. Network-first means the cache never
+  makes a page go stale; it is purely an offline safety net.
+- **Static assets are stale-while-revalidate.** Same-origin modules (the per-file
+  ESM the no-build runtime serves), the framework runtime under `/__webjs/core/`,
+  vendor bundles under `/__webjs/vendor/`, and `public/` assets are served from
+  cache when present and refreshed in the background. In production these URLs
+  carry a `?v=<hash>` content fingerprint (#243), so a changed file gets a new
+  URL and the cache can never serve stale bytes.
+
+**Never cached:** non-GET requests (writes), cross-origin requests, the action
+RPC endpoint (`/__webjs/action/`), and the dev-only `/__webjs/events` (SSE) and
+`/__webjs/reload.js`.
+
+## Versioning ties to the deploy (`data-webjs-build`)
+
+The cache name is `webjs-<build>`, where `<build>` is the `?v=` query the
+registration passes (the importmap build id read from
+`data-webjs-build`). When a deploy changes the build id:
+
+1. the page registers `/sw.js?v=<new-build>`, a different worker URL, so the
+   browser fetches and installs the new worker;
+2. the new worker's `activate` deletes every cache whose name is not the current
+   `webjs-<new-build>`, evicting the prior deploy's cache.
+
+So a deploy refreshes the offline cache automatically, with no manual cache
+busting. Without a `?v=` (e.g. a dev registration), the cache name is
+`webjs-dev`.
+
+## Updating the worker itself
+
+The browser re-checks `/sw.js` on navigation and replaces the worker when its
+bytes change. Because the registration URL carries the build id, a deploy always
+changes that URL and triggers the update. The worker calls `skipWaiting()` +
+`clients.claim()`, so a new version takes control promptly. To change the
+caching strategy, edit `public/sw.js`; it is your file, not a framework
+internal.
+
+## Removing it
+
+Delete the registration snippet (and optionally `public/sw.js` /
+`public/offline.html`). To also un-register an already-installed worker on
+clients, ship a one-line `navigator.serviceWorker.getRegistrations().then(rs =>
+rs.forEach(r => r.unregister()))` for a release, or rely on the worker's own
+update lifecycle.
+
+## Tests
+
+`test/service-worker/sw.test.mjs` runs the REAL `public/sw.js` source in a
+`node:vm` sandbox with mocked service-worker globals and drives its handlers:
+the install precache, the activate cache eviction, the network-first navigation
+(fresh + cached), the offline-cached + offline-fallback paths, and the
+never-cache rules (non-GET, cross-origin, the RPC endpoint), plus
+stale-while-revalidate. `test/scaffolds/scaffold-integration.test.js` asserts
+both files ship into a scaffolded app.

--- a/agent-docs/service-worker.md
+++ b/agent-docs/service-worker.md
@@ -1,7 +1,8 @@
 # Service worker / offline primitive (opt-in, #271)
 
-webjs ships a hand-authored service worker and an offline fallback into every
-scaffold (`public/sw.js`, `public/offline.html`). It adds an offline experience
+webjs ships a hand-authored service worker and an offline fallback into the UI
+scaffolds (`public/sw.js`, `public/offline.html`; the full-stack and saas
+templates, since the api template has no UI). It adds an offline experience
 and an asset cache **without changing the JavaScript-disabled baseline**: the
 worker only ever registers from JavaScript, so with JS off no worker exists and
 pages, links, and forms behave exactly as before. It is **opt-in**: the files

--- a/packages/cli/lib/create.js
+++ b/packages/cli/lib/create.js
@@ -636,6 +636,14 @@ export type ActionResult<T> =
     if (existsSync(tailwindSrc)) {
       await cp(tailwindSrc, join(publicDir, 'tailwind-browser.js'));
     }
+    // Progressive-enhancement service worker (#271): ship the opt-in offline
+    // primitive (the worker + its offline fallback). Dormant until the app
+    // registers it (see agent-docs/service-worker.md); it never changes the
+    // JS-disabled baseline.
+    for (const swFile of ['sw.js', 'offline.html']) {
+      const swSrc = join(TEMPLATES, 'public', swFile);
+      if (existsSync(swSrc)) await cp(swSrc, join(publicDir, swFile));
+    }
 
     const utilsDir = join(appDir, 'lib', 'utils');
     await mkdir(utilsDir, { recursive: true });

--- a/packages/cli/lib/create.js
+++ b/packages/cli/lib/create.js
@@ -637,9 +637,10 @@ export type ActionResult<T> =
       await cp(tailwindSrc, join(publicDir, 'tailwind-browser.js'));
     }
     // Progressive-enhancement service worker (#271): ship the opt-in offline
-    // primitive (the worker + its offline fallback). Dormant until the app
-    // registers it (see agent-docs/service-worker.md); it never changes the
-    // JS-disabled baseline.
+    // primitive (the worker + its offline fallback) into the UI scaffolds
+    // (full-stack / saas; this block is api-excluded since api has no UI).
+    // Dormant until the app registers it (see agent-docs/service-worker.md);
+    // it never changes the JS-disabled baseline.
     for (const swFile of ['sw.js', 'offline.html']) {
       const swSrc = join(TEMPLATES, 'public', swFile);
       if (existsSync(swSrc)) await cp(swSrc, join(publicDir, swFile));

--- a/packages/cli/templates/AGENTS.md
+++ b/packages/cli/templates/AGENTS.md
@@ -906,10 +906,11 @@ Full reference: see the [Client Router docs](https://docs.webjs.dev/docs/client-
 
 ## Offline support (opt-in service worker)
 
-This scaffold ships a progressive-enhancement service worker at `public/sw.js`
-plus a `public/offline.html` fallback. They are **dormant until you register
-them**, so the JS-disabled baseline is unchanged. To enable offline support, add
-the opt-in registration snippet to the root layout `<head>`:
+The UI scaffolds (full-stack and saas) ship a progressive-enhancement service
+worker at `public/sw.js` plus a `public/offline.html` fallback (the api template
+has no UI, so it omits them). They are **dormant until you register them**, so
+the JS-disabled baseline is unchanged. To enable offline support, add the opt-in
+registration snippet to the root layout `<head>`:
 
 ```html
 <script>

--- a/packages/cli/templates/AGENTS.md
+++ b/packages/cli/templates/AGENTS.md
@@ -904,6 +904,31 @@ default export, scoped to that boundary (outer layouts stay alive).
 
 Full reference: see the [Client Router docs](https://docs.webjs.dev/docs/client-router) and the framework AGENTS.md "Client navigation" section.
 
+## Offline support (opt-in service worker)
+
+This scaffold ships a progressive-enhancement service worker at `public/sw.js`
+plus a `public/offline.html` fallback. They are **dormant until you register
+them**, so the JS-disabled baseline is unchanged. To enable offline support, add
+the opt-in registration snippet to the root layout `<head>`:
+
+```html
+<script>
+  if ('serviceWorker' in navigator) {
+    addEventListener('load', () => {
+      const tag = document.querySelector('script[type="importmap"]');
+      const build = (tag && tag.dataset.webjsBuild) || '';
+      navigator.serviceWorker.register('/sw.js' + (build ? '?v=' + build : ''));
+    });
+  }
+</script>
+```
+
+Navigations become network-first (fresh server HTML, with an offline fallback to
+a cached page or `/offline.html`); same-origin assets are stale-while-revalidate.
+The cache version ties to the deploy via the `?v=<build>` id, so a new deploy
+evicts the old cache automatically. `sw.js` is YOUR file, so edit the strategy as
+needed. Full reference: `agent-docs/service-worker.md`.
+
 ## Metadata (per-page)
 
 The `metadata` export is Next.js-compatible. Common fields shown below;

--- a/packages/cli/templates/public/offline.html
+++ b/packages/cli/templates/public/offline.html
@@ -14,18 +14,21 @@
     main { max-width: 28rem; padding: 2rem; text-align: center; }
     h1 { font-size: 1.5rem; margin: 0 0 0.5rem; }
     p { margin: 0 0 1.5rem; opacity: 0.8; }
-    button {
-      font: inherit; padding: 0.6rem 1.2rem; border: 0; border-radius: 0.5rem;
-      background: #1a1a1a; color: #fff; cursor: pointer;
+    .retry {
+      display: inline-block; font: inherit; padding: 0.6rem 1.2rem;
+      border-radius: 0.5rem; background: #1a1a1a; color: #fff;
+      text-decoration: none; cursor: pointer;
     }
-    @media (prefers-color-scheme: dark) { button { background: #e6e6e6; color: #0d0d10; } }
+    @media (prefers-color-scheme: dark) { .retry { background: #e6e6e6; color: #0d0d10; } }
   </style>
 </head>
 <body>
   <main>
     <h1>You are offline</h1>
     <p>This page is not available without a network connection. Pages you have already visited still work offline.</p>
-    <button onclick="location.reload()">Try again</button>
+    <!-- An empty href reloads the current URL (the page the user tried to
+         reach), so retry works with NO inline JS, staying CSP-compatible. -->
+    <a class="retry" href="">Try again</a>
   </main>
 </body>
 </html>

--- a/packages/cli/templates/public/offline.html
+++ b/packages/cli/templates/public/offline.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Offline</title>
+  <style>
+    :root { color-scheme: light dark; }
+    body {
+      margin: 0; min-height: 100vh; display: grid; place-items: center;
+      font: 16px/1.6 system-ui, sans-serif; background: #fafafa; color: #1a1a1a;
+    }
+    @media (prefers-color-scheme: dark) { body { background: #0d0d10; color: #e6e6e6; } }
+    main { max-width: 28rem; padding: 2rem; text-align: center; }
+    h1 { font-size: 1.5rem; margin: 0 0 0.5rem; }
+    p { margin: 0 0 1.5rem; opacity: 0.8; }
+    button {
+      font: inherit; padding: 0.6rem 1.2rem; border: 0; border-radius: 0.5rem;
+      background: #1a1a1a; color: #fff; cursor: pointer;
+    }
+    @media (prefers-color-scheme: dark) { button { background: #e6e6e6; color: #0d0d10; } }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>You are offline</h1>
+    <p>This page is not available without a network connection. Pages you have already visited still work offline.</p>
+    <button onclick="location.reload()">Try again</button>
+  </main>
+</body>
+</html>

--- a/packages/cli/templates/public/sw.js
+++ b/packages/cli/templates/public/sw.js
@@ -1,0 +1,97 @@
+/*
+ * webjs progressive-enhancement service worker (OPT-IN, #271).
+ *
+ * This adds an offline fallback and an asset cache WITHOUT changing the
+ * JavaScript-disabled baseline: with JS off no service worker registers, so
+ * pages, links, and forms behave exactly as they do today. It is registered
+ * explicitly (see the opt-in snippet in agent-docs/service-worker.md), never
+ * automatically.
+ *
+ * Strategy:
+ *   - Navigations are NETWORK-FIRST: always try the network so the user sees
+ *     fresh server-rendered HTML, caching each successful page (the SSR shell)
+ *     so a later OFFLINE visit to a page you have seen still renders. When the
+ *     network fails and nothing is cached, serve /offline.html.
+ *   - Same-origin static assets (the per-file ESM modules, the framework
+ *     runtime under /__webjs/core/, vendor bundles, public assets) are
+ *     stale-while-revalidate, so a repeat visit works offline. In production
+ *     these URLs carry a ?v=<hash> content fingerprint, so a changed file gets
+ *     a new URL and the cache can never serve stale bytes.
+ *
+ * Versioning ties to the deploy. The page registers this worker as
+ * `/sw.js?v=<data-webjs-build>` (the importmap build id), so a new deploy
+ * changes the worker's own URL, the browser fetches the new worker, and its
+ * `activate` deletes every cache that is not the current version. The cache
+ * name is derived from that `?v=` below.
+ *
+ * NEVER cached: non-GET requests, cross-origin requests, the action RPC
+ * endpoint (/__webjs/action/), the dev live-reload SSE (/__webjs/events) and
+ * dev reload client (/__webjs/reload.js).
+ */
+
+const BUILD = new URL(self.location.href).searchParams.get('v') || 'dev';
+const CACHE = 'webjs-' + BUILD;
+const OFFLINE_URL = '/offline.html';
+
+self.addEventListener('install', (event) => {
+  event.waitUntil((async () => {
+    const cache = await caches.open(CACHE);
+    // Precache the offline fallback. `reload` bypasses the HTTP cache so the
+    // freshly-deployed offline page is stored, not a stale one.
+    await cache.add(new Request(OFFLINE_URL, { cache: 'reload' }));
+    await self.skipWaiting();
+  })());
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil((async () => {
+    const keys = await caches.keys();
+    await Promise.all(keys.filter((k) => k !== CACHE).map((k) => caches.delete(k)));
+    await self.clients.claim();
+  })());
+});
+
+/** Decide whether a GET request to a same-origin path is a cacheable asset. */
+function isCacheableAsset(pathname) {
+  if (pathname.startsWith('/__webjs/action/')) return false; // RPC, never cache
+  if (pathname === '/__webjs/events' || pathname === '/__webjs/reload.js') return false; // dev
+  if (pathname.startsWith('/__webjs/core/') || pathname.startsWith('/__webjs/vendor/')) return true;
+  return /\.(?:js|mjs|ts|css|woff2?|png|jpe?g|svg|webp|gif|ico|json|map)$/.test(pathname);
+}
+
+self.addEventListener('fetch', (event) => {
+  const req = event.request;
+  if (req.method !== 'GET') return; // never cache writes
+  const url = new URL(req.url);
+  if (url.origin !== self.location.origin) return; // only same-origin
+
+  // Network-first for page navigations: fresh server HTML, cache it for offline,
+  // fall back to the cached page then the offline page.
+  if (req.mode === 'navigate') {
+    event.respondWith((async () => {
+      try {
+        const fresh = await fetch(req);
+        const cache = await caches.open(CACHE);
+        cache.put(req, fresh.clone());
+        return fresh;
+      } catch (_err) {
+        const cache = await caches.open(CACHE);
+        const cached = await cache.match(req);
+        return cached || (await cache.match(OFFLINE_URL)) || Response.error();
+      }
+    })());
+    return;
+  }
+
+  // Stale-while-revalidate for static assets.
+  if (isCacheableAsset(url.pathname)) {
+    event.respondWith((async () => {
+      const cache = await caches.open(CACHE);
+      const cached = await cache.match(req);
+      const network = fetch(req)
+        .then((res) => { if (res && res.ok) cache.put(req, res.clone()); return res; })
+        .catch(() => cached);
+      return cached || network;
+    })());
+  }
+});

--- a/packages/cli/templates/public/sw.js
+++ b/packages/cli/templates/public/sw.js
@@ -71,8 +71,14 @@ self.addEventListener('fetch', (event) => {
     event.respondWith((async () => {
       try {
         const fresh = await fetch(req);
-        const cache = await caches.open(CACHE);
-        cache.put(req, fresh.clone());
+        // Cache ONLY a successful page (never a 404/500 error page, or an
+        // offline visit would serve the cached error instead of the fallback).
+        // waitUntil keeps the worker alive until the write lands (a worker can
+        // be terminated the moment respondWith settles).
+        if (fresh && fresh.ok) {
+          const copy = fresh.clone();
+          event.waitUntil(caches.open(CACHE).then((cache) => cache.put(req, copy)));
+        }
         return fresh;
       } catch (_err) {
         const cache = await caches.open(CACHE);
@@ -91,6 +97,9 @@ self.addEventListener('fetch', (event) => {
       const network = fetch(req)
         .then((res) => { if (res && res.ok) cache.put(req, res.clone()); return res; })
         .catch(() => cached);
+      // Keep the worker alive for the background revalidation + write, which
+      // would otherwise be a floating promise lost on worker termination.
+      event.waitUntil(network.catch(() => {}));
       return cached || network;
     })());
   }

--- a/test/scaffolds/scaffold-integration.test.js
+++ b/test/scaffolds/scaffold-integration.test.js
@@ -59,7 +59,8 @@ test('scaffoldApp full-stack: writes the canonical full-stack app layout', async
     }
 
     // #271: the opt-in progressive-enhancement service worker + its offline
-    // fallback ship into every scaffold (dormant until the app registers it).
+    // fallback ship into the UI scaffolds (full-stack / saas; api has no UI),
+    // dormant until the app registers it. This test covers full-stack.
     assert.ok(existsSync(join(appDir, 'public', 'sw.js')), 'public/sw.js should exist');
     assert.ok(existsSync(join(appDir, 'public', 'offline.html')), 'public/offline.html should exist');
 

--- a/test/scaffolds/scaffold-integration.test.js
+++ b/test/scaffolds/scaffold-integration.test.js
@@ -218,6 +218,12 @@ test('scaffoldApp api: writes API-only template (no layout, no components)', asy
     // Never demonstrate the invalid wildcard + credentials combination.
     assert.doesNotMatch(mw, /origin:\s*'\*'/, 'no wildcard origin with credentials');
 
+    // #271: the api template has no UI, so it must NOT ship the service worker
+    // (this locks the corrected UI-only scoping; the copy lives in create.js's
+    // !isApi block).
+    assert.ok(!existsSync(join(appDir, 'public', 'sw.js')), 'api ships no sw.js');
+    assert.ok(!existsSync(join(appDir, 'public', 'offline.html')), 'api ships no offline.html');
+
     // Module skeleton
     assert.ok(existsSync(join(appDir, 'modules', 'users', 'queries', 'list-users.server.ts')));
     assert.ok(existsSync(join(appDir, 'modules', 'users', 'actions', 'create-user.server.ts')));
@@ -247,6 +253,10 @@ test('scaffoldApp saas: writes auth + dashboard + Prisma User model', async () =
     // Core scaffold still in place
     assert.ok(existsSync(join(appDir, 'app', 'layout.ts')), 'layout.ts written');
     assert.ok(existsSync(join(appDir, 'app', 'page.ts')), 'page.ts written');
+
+    // #271: saas is a UI scaffold, so it ships the opt-in service worker.
+    assert.ok(existsSync(join(appDir, 'public', 'sw.js')), 'saas ships public/sw.js');
+    assert.ok(existsSync(join(appDir, 'public', 'offline.html')), 'saas ships public/offline.html');
 
     // SaaS-specific lib files
     assert.ok(existsSync(join(appDir, 'lib', 'prisma.server.ts')), 'lib/prisma.server.ts present');

--- a/test/scaffolds/scaffold-integration.test.js
+++ b/test/scaffolds/scaffold-integration.test.js
@@ -58,6 +58,11 @@ test('scaffoldApp full-stack: writes the canonical full-stack app layout', async
       assert.ok(existsSync(join(appDir, f)), `${f} should exist`);
     }
 
+    // #271: the opt-in progressive-enhancement service worker + its offline
+    // fallback ship into every scaffold (dormant until the app registers it).
+    assert.ok(existsSync(join(appDir, 'public', 'sw.js')), 'public/sw.js should exist');
+    assert.ok(existsSync(join(appDir, 'public', 'offline.html')), 'public/offline.html should exist');
+
     // #259: the VS Code settings that associate the webjs-config JSON Schema
     // with package.json's `webjs` block must reach the scaffolded app. This
     // file is under a `.vscode/` dir that .gitignore would normally exclude, so

--- a/test/service-worker/sw.test.mjs
+++ b/test/service-worker/sw.test.mjs
@@ -1,7 +1,8 @@
 /**
  * Tests for the progressive-enhancement service worker template (#271).
  *
- * The worker (`packages/cli/templates/public/sw.js`) ships into every scaffold.
+ * The worker (`packages/cli/templates/public/sw.js`) ships into the UI scaffolds
+ * (full-stack / saas; the api template has no UI).
  * These tests run the REAL worker source in a `node:vm` sandbox with mocked
  * service-worker globals (self / caches / fetch / Request / Response / URL),
  * capture its event handlers, and drive them to prove the headline behaviours:

--- a/test/service-worker/sw.test.mjs
+++ b/test/service-worker/sw.test.mjs
@@ -28,7 +28,10 @@ function makeCaches() {
     if (!stores.has(name)) stores.set(name, new Map());
     const m = stores.get(name);
     return {
-      add: async (req) => { m.set(keyOf(req), new Resp('PRECACHED ' + keyOf(req))); },
+      // A real cache.add fetches + stores the response; the mock stores a
+      // DISTINGUISHABLE sentinel body so the offline-fallback test asserts on
+      // real offline content, not just a URL substring.
+      add: async (req) => { m.set(keyOf(req), new Resp('OFFLINE_FALLBACK_CONTENT')); },
       put: async (req, res) => { m.set(keyOf(req), res); },
       match: async (req) => m.get(keyOf(req)) || undefined,
     };
@@ -138,7 +141,38 @@ test('an OFFLINE navigation to an UNVISITED page serves the offline fallback', a
   const w = []; handlers.install({ waitUntil: (p) => w.push(p) }); await Promise.all(w);
   sandbox.fetch = async () => { throw new Error('offline'); };
   const res = await dispatchFetch(handlers, sandbox, new Req('/never-seen', { mode: 'navigate' }));
-  assert.match(res.body, /offline\.html/, 'the offline fallback is served');
+  assert.equal(res.body, 'OFFLINE_FALLBACK_CONTENT', 'the precached offline page is served (not a cached page)');
+});
+
+test('a non-200 navigation response is NOT cached (offline then serves the fallback, not the error)', async () => {
+  const { handlers, sandbox, cachesMock } = loadWorker();
+  const w = []; handlers.install({ waitUntil: (p) => w.push(p) }); await Promise.all(w);
+  // Online: the server returns a 500 error page for /broken.
+  sandbox.fetch = async () => new Resp('<html>ERROR 500</html>', { ok: false, status: 500 });
+  const online = await dispatchFetch(handlers, sandbox, new Req('/broken', { mode: 'navigate' }));
+  assert.equal(online.body, '<html>ERROR 500</html>', 'the error page is still shown online');
+  const store = cachesMock.stores.get('webjs-build123');
+  assert.ok(!store.has('https://app.test/broken'), 'the error page was NOT cached');
+  // Offline: a later visit serves the offline fallback, NOT the cached error.
+  sandbox.fetch = async () => { throw new Error('offline'); };
+  const offline = await dispatchFetch(handlers, sandbox, new Req('/broken', { mode: 'navigate' }));
+  assert.equal(offline.body, 'OFFLINE_FALLBACK_CONTENT', 'offline serves the fallback, not a cached error');
+});
+
+test('a non-ok static asset response is NOT cached (no cache poisoning)', async () => {
+  const { handlers, sandbox, cachesMock } = loadWorker();
+  sandbox.fetch = async () => new Resp('NOT FOUND', { ok: false, status: 404 });
+  await dispatchFetch(handlers, sandbox, new Req('/app/missing.js?v=x', { mode: 'cors' }));
+  const store = cachesMock.stores.get('webjs-build123') || new Map();
+  assert.ok(!store.has('https://app.test/app/missing.js?v=x'), 'a 404 asset is not cached');
+});
+
+test('the dev SSE + reload client are never cached', async () => {
+  const { handlers, sandbox } = loadWorker();
+  const sse = await dispatchFetch(handlers, sandbox, new Req('/__webjs/events', { mode: 'cors' }));
+  assert.equal(sse, undefined, '/__webjs/events is not intercepted');
+  const reload = await dispatchFetch(handlers, sandbox, new Req('/__webjs/reload.js', { mode: 'cors' }));
+  assert.equal(reload, undefined, '/__webjs/reload.js is not intercepted');
 });
 
 test('a non-GET request is NOT intercepted (writes never cached)', async () => {

--- a/test/service-worker/sw.test.mjs
+++ b/test/service-worker/sw.test.mjs
@@ -1,0 +1,170 @@
+/**
+ * Tests for the progressive-enhancement service worker template (#271).
+ *
+ * The worker (`packages/cli/templates/public/sw.js`) ships into every scaffold.
+ * These tests run the REAL worker source in a `node:vm` sandbox with mocked
+ * service-worker globals (self / caches / fetch / Request / Response / URL),
+ * capture its event handlers, and drive them to prove the headline behaviours:
+ * navigations are network-first and fall back to the offline page when offline,
+ * and a non-GET / cross-origin request is left alone.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import vm from 'node:vm';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SW_SRC = readFileSync(
+  resolve(__dirname, '../../packages/cli/templates/public/sw.js'),
+  'utf8',
+);
+
+/** A minimal in-memory Cache + CacheStorage mock. */
+function makeCaches() {
+  const stores = new Map();
+  const open = async (name) => {
+    if (!stores.has(name)) stores.set(name, new Map());
+    const m = stores.get(name);
+    return {
+      add: async (req) => { m.set(keyOf(req), new Resp('PRECACHED ' + keyOf(req))); },
+      put: async (req, res) => { m.set(keyOf(req), res); },
+      match: async (req) => m.get(keyOf(req)) || undefined,
+    };
+  };
+  return {
+    storage: { open, keys: async () => [...stores.keys()], delete: async (k) => stores.delete(k) },
+    stores,
+  };
+}
+// A real Cache resolves a relative request URL against the worker scope, so
+// `match('/offline.html')` finds an entry stored under the absolute URL.
+const keyOf = (req) => {
+  const u = typeof req === 'string' ? req : req.url;
+  return u.startsWith('http') ? u : 'https://app.test' + u;
+};
+
+/** A tiny Response stand-in. */
+class Resp {
+  constructor(body, init = {}) { this.body = body; this.ok = init.ok !== false; this.status = init.status || 200; }
+  clone() { return new Resp(this.body, { ok: this.ok, status: this.status }); }
+  static error() { return new Resp('', { ok: false, status: 0 }); }
+}
+class Req {
+  constructor(url, init = {}) { this.url = url.startsWith('http') ? url : 'https://app.test' + url; this.method = init.method || 'GET'; this.mode = init.mode || 'cors'; }
+}
+
+/** Load sw.js into a sandbox, return its captured handlers + the cache mock. */
+function loadWorker(swUrl = 'https://app.test/sw.js?v=build123') {
+  const handlers = {};
+  const cachesMock = makeCaches();
+  const sandbox = {
+    self: {
+      location: new URL(swUrl), // a real URL: has href, origin, searchParams
+      addEventListener: (type, fn) => { handlers[type] = fn; },
+      skipWaiting: async () => {},
+      clients: { claim: async () => {} },
+    },
+    caches: cachesMock.storage,
+    fetch: async () => { throw new Error('fetch not stubbed'); },
+    Response: Resp,
+    Request: Req,
+    URL,
+    Promise,
+    console,
+  };
+  sandbox.self.caches = cachesMock.storage;
+  vm.createContext(sandbox);
+  vm.runInContext(SW_SRC, sandbox);
+  return { handlers, cachesMock, sandbox };
+}
+
+/** Drive a fetch event through the worker, returning the response it commits. */
+async function dispatchFetch(handlers, sandbox, request) {
+  let responded;
+  const waits = [];
+  handlers.fetch({
+    request,
+    respondWith: (p) => { responded = p; },
+    waitUntil: (p) => waits.push(p),
+  });
+  await Promise.all(waits);
+  return responded ? await responded : undefined;
+}
+
+test('install precaches the offline page and the cache name derives from the ?v build id', async () => {
+  const { handlers, cachesMock } = loadWorker('https://app.test/sw.js?v=build123');
+  const waits = [];
+  handlers.install({ waitUntil: (p) => waits.push(p) });
+  await Promise.all(waits);
+  assert.ok(cachesMock.stores.has('webjs-build123'), 'cache name folds in the build id');
+  const store = cachesMock.stores.get('webjs-build123');
+  assert.ok(store.has('https://app.test/offline.html'), 'the offline page is precached');
+});
+
+test('activate deletes caches that are not the current version', async () => {
+  const { handlers, cachesMock } = loadWorker('https://app.test/sw.js?v=v2');
+  cachesMock.stores.set('webjs-v1', new Map()); // a stale prior-deploy cache
+  cachesMock.stores.set('webjs-v2', new Map());
+  const waits = [];
+  handlers.activate({ waitUntil: (p) => waits.push(p) });
+  await Promise.all(waits);
+  assert.ok(!cachesMock.stores.has('webjs-v1'), 'the stale cache is evicted');
+  assert.ok(cachesMock.stores.has('webjs-v2'), 'the current cache is kept');
+});
+
+test('a navigation is network-first: fresh response is returned AND cached', async () => {
+  const { handlers, sandbox, cachesMock } = loadWorker();
+  sandbox.fetch = async () => new Resp('<html>FRESH</html>');
+  const res = await dispatchFetch(handlers, sandbox, new Req('/dashboard', { mode: 'navigate' }));
+  assert.equal(res.body, '<html>FRESH</html>', 'the fresh network response is served');
+  const store = cachesMock.stores.get('webjs-build123');
+  assert.ok(store.has('https://app.test/dashboard'), 'the SSR shell was cached for offline');
+});
+
+test('an OFFLINE navigation to a cached page serves the cached page', async () => {
+  const { handlers, sandbox, cachesMock } = loadWorker();
+  // Prime the cache with a prior successful visit.
+  cachesMock.stores.set('webjs-build123', new Map([['https://app.test/dashboard', new Resp('<html>CACHED</html>')]]));
+  sandbox.fetch = async () => { throw new Error('offline'); };
+  const res = await dispatchFetch(handlers, sandbox, new Req('/dashboard', { mode: 'navigate' }));
+  assert.equal(res.body, '<html>CACHED</html>', 'the cached page is served offline');
+});
+
+test('an OFFLINE navigation to an UNVISITED page serves the offline fallback', async () => {
+  const { handlers, sandbox } = loadWorker();
+  // Run install so the offline page is precached.
+  const w = []; handlers.install({ waitUntil: (p) => w.push(p) }); await Promise.all(w);
+  sandbox.fetch = async () => { throw new Error('offline'); };
+  const res = await dispatchFetch(handlers, sandbox, new Req('/never-seen', { mode: 'navigate' }));
+  assert.match(res.body, /offline\.html/, 'the offline fallback is served');
+});
+
+test('a non-GET request is NOT intercepted (writes never cached)', async () => {
+  const { handlers, sandbox } = loadWorker();
+  const res = await dispatchFetch(handlers, sandbox, new Req('/api/x', { method: 'POST', mode: 'cors' }));
+  assert.equal(res, undefined, 'respondWith is never called for a POST');
+});
+
+test('a cross-origin request is NOT intercepted', async () => {
+  const { handlers, sandbox } = loadWorker();
+  const res = await dispatchFetch(handlers, sandbox, new Req('https://cdn.other.com/x.js', { mode: 'cors' }));
+  assert.equal(res, undefined, 'respondWith is never called cross-origin');
+});
+
+test('the RPC action endpoint is never cached', async () => {
+  const { handlers, sandbox } = loadWorker();
+  const res = await dispatchFetch(handlers, sandbox, new Req('/__webjs/action/abc/fn', { mode: 'cors' }));
+  assert.equal(res, undefined, 'respondWith is never called for an action RPC GET');
+});
+
+test('a static asset is stale-while-revalidate (served from cache, refreshed in the background)', async () => {
+  const { handlers, sandbox, cachesMock } = loadWorker();
+  cachesMock.stores.set('webjs-build123', new Map([['https://app.test/app/page.js?v=abc', new Resp('OLD')]]));
+  let fetched = false;
+  sandbox.fetch = async () => { fetched = true; return new Resp('NEW'); };
+  const res = await dispatchFetch(handlers, sandbox, new Req('/app/page.js?v=abc', { mode: 'cors' }));
+  assert.equal(res.body, 'OLD', 'the cached asset is served immediately');
+  assert.ok(fetched, 'the network revalidation still fired');
+});


### PR DESCRIPTION
Closes #271

## Summary

webjs shipped the manifest route (installability) but had no service-worker story: no offline fallback, no precache of the SSR shell, no documented PE-safe registration. This ships a thin, hand-authored service worker primitive built directly on the native Service Worker + Cache Storage APIs (no Workbox, no precache framework, no bundler), matching webjs's no-build posture.

**What ships.** The UI scaffolds (full-stack / saas; the api template has no UI) now get `public/sw.js` and `public/offline.html`, copied by `create.js`. They are **dormant until the app registers them**, so the JavaScript-disabled baseline is completely unchanged: the worker only ever registers from JS, and the scaffold injects no registration. Enabling it is an opt-in snippet documented in `agent-docs/service-worker.md` (an inline `<script>` in the root layout head, inside `if ('serviceWorker' in navigator)`).

**Strategy.** Navigations are network-first (always fresh server HTML, caching each successful page so an offline repeat visit renders, falling back to the cached page then `/offline.html`). Same-origin static assets (the per-file ESM modules, `/__webjs/core/`, `/__webjs/vendor/`, `public/`) are stale-while-revalidate, safe to cache because prod URLs carry a `?v=<hash>` content fingerprint (#243). Never cached: non-GET requests, cross-origin requests, the action RPC endpoint, and the dev SSE / reload client.

**Versioning ties to the deploy.** The registration passes the importmap build id (read from the `<script type="importmap">` `data-webjs-build`) as `/sw.js?v=<build>`, so the cache name is `webjs-<build>`; a new deploy registers a new worker whose `activate` evicts every non-current cache. No manual cache busting.

## Review

A two-round fresh-context adversarial review (worktree-isolated, read-only git) ran to convergence. Round 1 found a P1 and several P2s, all fixed: the network-first branch cached ANY response, so a 404/500 error page was cached and served on a later offline visit instead of the fallback (now caches only when `fresh.ok`); both cache writes were floating promises a terminated worker could drop (now `event.waitUntil`'d); the offline.html retry used an inline `onclick` that CSP blocks (now a CSP-safe `<a href="">`); and the "every scaffold" wording was corrected to UI-scaffolds-only. Round 2 verified the code fixes are correct (a redirect resolves to a final 200 so it is still cached; the `event.waitUntil` calls fire while the response is pending, the standard SWR pattern; `href=""` reloads the current URL with no JS) and flagged three test-coverage P2s, all addressed: the saas scaffold now asserts the SW ships and the api scaffold asserts it is omitted (a regression guard locking the UI-only scoping), and a stale "every scaffold" comment was corrected. Round 3 returned CLEAN.

## Tests

- **Unit** (`test/service-worker/sw.test.mjs`, 12): runs the REAL `public/sw.js` source in a `node:vm` sandbox with mocked SW globals and drives its handlers: the install precache + build-id-derived cache name, the activate eviction of stale caches, network-first (fresh + cached for offline), offline-to-a-cached-page, offline-to-an-unvisited-page (serves the fallback, asserted on a distinct sentinel body), a non-200 navigation NOT cached (offline then serves the fallback, not the error), a non-ok asset NOT cached (no poisoning), non-GET / cross-origin / the RPC endpoint / the dev SSE + reload client never intercepted, and stale-while-revalidate.
- **Scaffold** (`test/scaffolds/scaffold-integration.test.js`): asserts `public/sw.js` + `public/offline.html` ship into a scaffolded app.
- Full suite 2149 pass, scaffold tests 12 pass (all three templates, confirming the api scaffold is unaffected). `webjs check` clean (the one violation is a pre-existing intentional `no-browser-globals-in-render` test fixture).
- Dogfood: N/A. This PR only changes CLI templates + `create.js` (scaffold-time) and adds a test; it touches no `packages/core` or `packages/server` runtime, so the in-repo apps (website / docs / blog / ui-website) are unaffected.

## Docs

`agent-docs/service-worker.md` (NEW: scope, the network-first + SWR strategy, the never-cache rules, the `data-webjs-build` version tie, the opt-in registration snippet with a CSP-nonce note, update/removal); root `AGENTS.md` (the agent-docs table entry); `packages/cli/templates/AGENTS.md` (a scaffold-facing "Offline support" section with the registration snippet).

## Deliberately excluded

Auto-registration is intentionally not done: registering a service worker changes app behavior, so it must be the app's explicit opt-in, not a scaffold default. A Workbox-style precache manifest is out of scope (the worker is hand-authored on native APIs, by design).
