### PR TITLE
ci: run the in-repo app test suites (website + blog) in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,3 +135,34 @@ jobs:
       # by the prepare hook at publish). Build them in CI so a bundling
       # break is caught on the PR, not at release time.
       - run: npm run build:dist --workspace=@webjsdev/core
+
+  apps:
+    name: In-repo app tests (website + blog)
+    runs-on: ubuntu-latest
+    # The framework jobs above cover packages/* and the root cross-package
+    # suite. This job runs each IN-REPO app's OWN test suite (its `webjs test`
+    # script), which the root runners do not discover, so a regression in an
+    # app's tests gates the merge (issue #342). The website's `test` runs both
+    # its node + browser suites (hence Playwright); the blog is node-only and
+    # touches its Prisma DB (the same setup the unit + e2e jobs do). docs and
+    # the ui-website ship no test suite yet, so they are not listed.
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+      - run: npm ci
+      - name: Install Playwright Chromium (for the website browser tests)
+        run: npx playwright install --with-deps chromium
+      - name: Prepare the blog example database
+        working-directory: examples/blog
+        run: |
+          cp .env.example .env
+          npx prisma generate
+          npx prisma migrate deploy
+          npx prisma db seed
+      - name: website tests (node + browser)
+        run: npm test --workspace=@webjsdev/website
+      - name: blog tests (node)
+        run: npm test --workspace=@webjsdev/example-blog

--- a/agent-docs/testing.md
+++ b/agent-docs/testing.md
@@ -103,6 +103,25 @@ package, it goes in that package's `test/`.
 - `npm run test:e2e` → `WEBJS_E2E=1 node --test test/e2e/e2e.test.mjs`.
 - `npm run test:all` runs node + browser (not e2e).
 
+The root drivers above ONLY discover the framework packages and the root
+cross-package suite (`packages/*/test/` + `test/`). They do NOT walk the in-repo
+apps' own test dirs (`website/test/`, `examples/blog/test/`), so those run from
+each app's OWN `webjs test` script, not the root runner.
+
+### In-repo app tests in CI (#342)
+
+Each in-repo app (`website`, `examples/blog`) carries its own test suite under
+its `test/` dir and runs it through its own `webjs test` script (the website's
+`test` runs node + browser; the blog's `test` is node-only). The root runners do
+not discover these, so a dedicated `.github/workflows/ci.yml` job, **In-repo app
+tests (website + blog)**, runs `npm test --workspace=@webjsdev/website` and
+`npm test --workspace=@webjsdev/example-blog` (with Playwright installed for the
+website browser tests and the Prisma DB prepared for the blog, the same setup
+the `unit` + `e2e` jobs use). It is a required status check, so a regression in
+an app's tests gates the merge. The app test dirs are not walked by the root
+runner, so the framework-package tests never double-run. `docs` and the
+ui-website ship no test suite yet, so they are not in the job.
+
 ### Adding a new test
 
 1. Find the feature folder that matches what you're testing

--- a/examples/blog/AGENTS.md
+++ b/examples/blog/AGENTS.md
@@ -193,6 +193,18 @@ In Docker / Railway, prefer `npm start` as the CMD over `node ...
 webjs.js start ...`. The npm form fires `prestart` (which runs
 `prisma migrate deploy`); the direct binary form skips it.
 
+## Tests
+
+The blog's own tests live under `test/` (`auth`, `posts`, `comments`, `chat`)
+and run via `npm test` (the `webjs test --server` script; the blog has no
+browser tests). They touch the Prisma DB, so run `npm run db:migrate` (and the
+seed) first, exactly like running the app. These tests are NOT discovered by the
+framework's root `npm test`; CI runs them in the dedicated **In-repo app tests
+(website + blog)** job (issue #342), which prepares the DB the same way the
+e2e job does. The separate root-level `test/e2e/e2e.test.mjs` exercises the blog
+in a real browser (the framework's `e2e` CI job), and `test/examples/blog/`
+holds its smoke + browser probes.
+
 ## Conventions
 
 - **One exported function per action/query file.** Name the file after the function.

--- a/examples/blog/package.json
+++ b/examples/blog/package.json
@@ -13,7 +13,8 @@
     "css:build": "tailwindcss -i ./public/input.css -o ./public/tailwind.css --minify",
     "db:generate": "webjs db generate",
     "db:migrate": "webjs db migrate",
-    "db:seed": "prisma db seed"
+    "db:seed": "prisma db seed",
+    "test": "webjs test --server"
   },
   "prisma": {
     "seed": "node prisma/seed.js"

--- a/scripts/protect-main.sh
+++ b/scripts/protect-main.sh
@@ -32,7 +32,8 @@ gh api -X PUT "repos/${REPO}/branches/main/protection" \
       "Unit + integration (node --test)",
       "Browser (web-test-runner / Playwright)",
       "E2E (Puppeteer against the blog example)",
-      "Build (@webjsdev/core dist)"
+      "Build (@webjsdev/core dist)",
+      "In-repo app tests (website + blog)"
     ]
   },
   "enforce_admins": false,


### PR DESCRIPTION
Closes #342

## Summary

The in-repo app test suites did not run in CI, so a regression in any of them merged green. The root runners only discover the framework packages and the root cross-package suite (`scripts/run-node-tests.js` walks `packages/*/test/` + `test/`; the WTR globs are the same scope), so each app's own `test/` dir was never executed by an automated job.

This adds a dedicated CI job, **In-repo app tests (website + blog)**, that runs each in-repo app's OWN test suite through its own `webjs test` script:
- the **website** (`npm test --workspace=@webjsdev/website`), which runs both its node and browser suites (so the job installs Playwright Chromium);
- the **blog** (`npm test --workspace=@webjsdev/example-blog`), node-only, with the same Prisma DB preparation (`generate` / `migrate deploy` / `db seed`) the `unit` and `e2e` jobs already do.

The blog had no `test` script, so this adds `"test": "webjs test --server"` (it has no browser tests). The job is registered as a required status check in `scripts/protect-main.sh` so a regression in an app's tests gates the merge.

`docs` and the ui-website ship no test suite yet, so they are not in the job (a one-line addition each when they grow one).

## Approach

Of the two paths the issue floated, I took the per-workspace one (run each app's own `webjs test`) rather than folding the app test dirs into the root `run-node-tests.js`. Each app's `webjs test` respects its own environment (the blog needs its Prisma client + DB; the website drives its own WTR config), and keeping the app tests OUT of the root runner is exactly what prevents a double-run: the root `npm test` still walks only `packages/*/test/` + `test/`, so the framework-package tests are untouched and run exactly once.

## Tests / verification

- **The wiring catches failures (the acceptance counterfactual).** I injected a deliberately failing test into each app and confirmed the workspace command CI runs goes non-zero: `npm test --workspace=@webjsdev/website` exits 1, `npm test --workspace=@webjsdev/example-blog` exits 1, and the blog returns to exit 0 once the failing test is removed. That exit code is exactly what the CI job gates on.
- **The suites are green on main today,** so wiring them in does not red CI: website 27 browser + its node tests pass, blog 46 node tests pass (with the DB prepared).
- **No double-run / no flake for the framework tests:** the app test dirs (`website/test/`, `examples/blog/test/`) are not under `packages/*/test/` or root `test/`, so the root runner never discovers them; the `unit` / `browser` / `e2e` jobs are unchanged.
- The new `apps` job running green on this PR is the end-to-end proof that the website (node + browser, headless Chromium) and the blog (node + DB) suites run in CI.
- **Dogfood: N/A.** This PR changes only CI config (`ci.yml`, `protect-main.sh`), the blog's `package.json` test script, and docs. It touches no `packages/core` / `server` / `cli` runtime, the dist build, or the importmap, so the in-repo apps serve byte-identically and there is nothing for the four-app boot check to catch.

## Activating the required check (follow-up note)

`scripts/protect-main.sh` now lists the new job, but I did NOT run it on this PR: doing so makes the check required for EVERY open PR immediately, and the open website-redesign PRs (which branched before this) do not yet carry the `apps` job, so it would block them until they rebase. Run `bash scripts/protect-main.sh` once (needs repo admin) to activate the gate after the open PRs have picked up this change.

## Docs

`agent-docs/testing.md` (a new "In-repo app tests in CI" subsection under Drivers, plus a note that the root drivers do NOT walk the app test dirs), `examples/blog/AGENTS.md` (a Tests section, since the blog now has a `test` script and a DB-setup prerequisite).
