### PR TITLE
fix: reconcile plain .map() arrays in place instead of rebuilding (#353)

### DIFF
--- a/agent-docs/lit-muscle-memory-gotchas.md
+++ b/agent-docs/lit-muscle-memory-gotchas.md
@@ -380,6 +380,55 @@ page function rather than through context. Reserve `ContextProvider`
 for client-time concerns (interaction state, focus management,
 transient UI state).
 
+## List rendering
+
+### 11. Reordering a `.map()` list needs a keyed `repeat()`
+
+A plain `.map()` list reconciles in place, matching lit-html's non-keyed
+child-part behaviour. When one item's binding changes (a card flips its
+`dragging` class on `@dragstart`, a row's input is edited), the framework
+patches that item's existing nodes instead of rebuilding the whole list,
+so DOM node identity survives. That is what makes native drag-and-drop,
+focus, caret, text selection, scroll position, and uncontrolled input
+value all survive an item-level update, no `repeat()` required. (This
+used to be a real gotcha. Before the fix, any change to a `.map()`'s
+output tore down and replaced every node, which silently aborted a
+drag-in-progress and lost focus and input state.)
+
+```ts
+// Item updates preserve node identity. Drag-and-drop, focus, and
+// input state all survive. No repeat() needed.
+render() {
+  return html`<ul>${this.cards.map((c) => html`
+    <li class=${c.id === this.draggingId ? 'dragging' : 'idle'}
+        draggable="true"
+        @dragstart=${() => (this.draggingId = c.id)}>${c.text}</li>`)}</ul>`;
+}
+```
+
+What plain `.map()` still does NOT do is **keyed reordering**.
+Reconciliation is positional (by index): if the array is reordered or an
+item is inserted/removed in the MIDDLE, index *i* is patched from the new
+item at *i*, so the nodes stay put and their contents are rewritten
+rather than the nodes themselves moving. For an item carrying live state
+(a focused input, a playing media element, an in-flight CSS transition)
+across a reorder, that state stays with the old position. When a list
+**reorders** or splices in the middle and node identity must follow the
+item, reach for the keyed directive, exactly as in lit:
+
+```ts
+import { repeat } from '@webjsdev/core/directives';
+render() {
+  return html`<ul>${repeat(this.cards, (c) => c.id, (c) => html`
+    <li>${c.text}</li>`)}</ul>`;
+}
+```
+
+Rule of thumb. Append-only or update-in-place list, where items keep
+their position, plain `.map()` is fine and preserves identity. List that
+**reorders or splices in the middle** and each item owns DOM state that
+must move with it, use `repeat()` with a stable key.
+
 ## Quick reference
 
 | Lit pattern | Webjs equivalent |
@@ -392,6 +441,7 @@ transient UI state).
 | `student: Student = { ... }` field initializer | `declare student: Student` plus constructor default |
 | `@property()` decorator | `static properties = { ... }` plus `declare` |
 | `static styles = css` / inline `<style>` with semantic class names in a light-DOM component | Tailwind utilities (the default); or `static shadow = true` for genuinely scoped CSS |
+| Plain `.map()` for an interactive/stateful list | Works (reconciles in place, keeps node identity); use `repeat(items, key, t)` only when the list **reorders** |
 | `willUpdate` for SSR-visible derived state | Works (runs at SSR); keep it a pure derivation |
 | `this.hasAttribute` / `getAttribute` in `render()` | Works (server attribute shim) |
 | `ContextProvider` for server-known data | Pass via props from the page function |

--- a/packages/core/src/render-client.js
+++ b/packages/core/src/render-client.js
@@ -37,8 +37,12 @@ import {
  *   - Event listeners are attached once and retargeted when the handler
  *     reference changes (swap-in-place via a dispatch closure, so `addEventListener`
  *     isn't churned every render).
- *   - This is a conservative implementation; no keyed list diffing yet: array
- *     changes rebuild the whole text part.
+ *   - A plain `.map()` array reconciles POSITIONALLY (non-keyed), matching
+ *     lit-html: each index updates its item instance in place when the
+ *     template shape is unchanged, so DOM node identity (and the focus,
+ *     selection, scroll, and in-progress native drag it carries) survives an
+ *     item-level update. See `reconcileArray`. Keyed reordering still needs
+ *     the `repeat()` directive.
  */
 
 /** @type {WeakMap<TemplateStringsArray | string[], { templateEl: HTMLTemplateElement, parts: PartDescriptor[] }>} */
@@ -911,11 +915,34 @@ function applyChildInner(part, value) {
     return;
   }
 
+  // Plain array (a `.map()` / list interpolation): positional, non-keyed
+  // reconciliation. Update each position's instance IN PLACE when its
+  // template shape is unchanged, so DOM node identity survives an item
+  // update (focus, selection, scroll, and an in-progress native drag all
+  // survive). Mirrors lit-html's non-keyed array child part. Without this,
+  // flipping one item's binding rebuilt the WHOLE list and detached every
+  // node, which cancels a native drag mid-gesture. Use `repeat()` for keyed
+  // reordering.
+  if (Array.isArray(value)) {
+    if (part.child && /** @type any */ (part.child).kind === 'array') {
+      reconcileArray(part, value);
+      return;
+    }
+    teardownChild(part);
+    const arrState = { kind: 'array', items: [] };
+    part.child = arrState;
+    applyArrayFresh(marker, /** @type any */ (arrState), value);
+    return;
+  }
+
   // Remove previously rendered nodes between marker and its next sibling we own.
   if (part.child) {
     const c = /** @type any */ (part.child);
     if (c.kind === 'repeat') {
       teardownRepeat(c);
+      part.child = undefined;
+    } else if (c.kind === 'array') {
+      teardownArray(/** @type any */ (c));
       part.child = undefined;
     } else if (c.kind === 'async-stream') {
       teardownAsyncStream(c);
@@ -963,29 +990,6 @@ function applyChildInner(part, value) {
       if (p.kind === 'slot') applyPart(p, undefined, undefined, []);
     }
     part.child = { strings: tr.strings, bound, lastValues, startNode, endNode };
-    return;
-  }
-
-  if (Array.isArray(value)) {
-    const list = [];
-    for (const v of value) {
-      if (isTemplate(v)) {
-        // Create an inline instance. No keyed reconciliation yet.
-        const tr = /** @type any */ (v);
-        const { templateEl, parts } = compile(tr);
-        const frag = /** @type DocumentFragment */ (templateEl.content.cloneNode(true));
-        const bound = parts.map((p) => bindPart(p, frag));
-        for (let i = 0; i < tr.values.length; i++) {
-          applyPart(bound[i], tr.values[i], undefined, tr.values);
-        }
-        list.push(...frag.childNodes);
-      } else if (v != null && v !== false && v !== true) {
-        list.push(document.createTextNode(String(v)));
-      }
-    }
-    const frag = nodesToFrag(list);
-    marker.parentNode?.insertBefore(frag, marker);
-    part.child = list;
     return;
   }
 
@@ -1150,6 +1154,151 @@ function teardownRepeat(state) {
   state.map.clear();
 }
 
+/* ================================================================
+ * Plain array (.map) support: positional, non-keyed reconciliation
+ * ================================================================ */
+
+/**
+ * One rendered slot of a plain array. A `tpl` carries a detached template
+ * instance (bookended by its own markers), a `text` carries a single text
+ * node, and an `empty` slot (a nullish / boolean element) renders nothing
+ * but still holds the position so index-based reconciliation stays aligned.
+ * @typedef {{ type: 'tpl', inst: TemplateInstance } | { type: 'text', node: Text } | { type: 'empty' }} ArrayItem
+ */
+
+/** @param {ArrayItem} item @returns {ChildNode | null} */
+function arrayItemFirstNode(item) {
+  if (item.type === 'tpl') return item.inst.startNode;
+  if (item.type === 'text') return item.node;
+  return null;
+}
+
+/** @param {ArrayItem} item */
+function removeArrayItem(item) {
+  if (item.type === 'tpl') {
+    disposeInstance(item.inst);
+    removeBetween(item.inst.startNode, item.inst.endNode);
+  } else if (item.type === 'text') {
+    item.node.parentNode?.removeChild(item.node);
+  }
+}
+
+/**
+ * Build the slot for one array element, plus the fragment to insert (null
+ * for an empty slot). A TemplateResult becomes a detached instance, a
+ * primitive becomes a text node, and nullish / boolean renders nothing.
+ * @param {unknown} v
+ * @returns {{ item: ArrayItem, frag: Node | null }}
+ */
+function buildArrayItem(v) {
+  if (isTemplate(v)) {
+    const { inst, frag } = buildDetached(/** @type any */ (v));
+    return { item: { type: 'tpl', inst }, frag };
+  }
+  if (v != null && v !== false && v !== true) {
+    const node = document.createTextNode(String(v));
+    return { item: { type: 'text', node }, frag: node };
+  }
+  return { item: { type: 'empty' }, frag: null };
+}
+
+/**
+ * Initial render of a plain array: insert every slot's nodes before the marker.
+ * @param {Comment} marker
+ * @param {{ kind: 'array', items: ArrayItem[] }} state
+ * @param {unknown[]} value
+ */
+function applyArrayFresh(marker, state, value) {
+  const parent = marker.parentNode;
+  if (!parent) return;
+  const bulk = document.createDocumentFragment();
+  /** @type {ArrayItem[]} */
+  const items = [];
+  for (const v of value) {
+    const { item, frag } = buildArrayItem(v);
+    if (frag) bulk.appendChild(frag);
+    items.push(item);
+  }
+  parent.insertBefore(bulk, marker);
+  state.items = items;
+}
+
+/**
+ * Positional (non-keyed) reconciliation. For each index, update the slot
+ * in place when its shape is unchanged (preserving DOM node identity),
+ * otherwise replace it; grow or shrink at the tail. There is no key
+ * matching, so a reorder reduces to a series of in-place value updates;
+ * reach for `repeat()` when element identity must follow a moved key.
+ * @param {Extract<BoundPart, {kind:'child'}>} part
+ * @param {unknown[]} value
+ */
+function reconcileArray(part, value) {
+  const marker = part.marker;
+  const parent = marker.parentNode;
+  if (!parent) return;
+  const state = /** @type {{ kind: 'array', items: ArrayItem[] }} */ (part.child);
+  const old = state.items;
+  /** @type {ArrayItem[]} */
+  const next = [];
+
+  for (let i = 0; i < value.length; i++) {
+    const v = value[i];
+    const o = old[i];
+    if (isTemplate(v)) {
+      const tr = /** @type any */ (v);
+      if (o && o.type === 'tpl' && o.inst.strings === tr.strings) {
+        updateInstance(o.inst, tr.values);
+        next.push(o);
+        continue;
+      }
+    } else if (v != null && v !== false && v !== true) {
+      if (o && o.type === 'text') {
+        const str = String(v);
+        if (o.node.data !== str) o.node.data = str;
+        next.push(o);
+        continue;
+      }
+    } else {
+      // Empty slot: drop any prior nodes that occupied this position.
+      if (o) removeArrayItem(o);
+      next.push({ type: 'empty' });
+      continue;
+    }
+    // Shape changed, or the array grew past the old length. Build fresh,
+    // insert at this position (before the current / next still-attached
+    // old node, else the marker), then drop the old slot it replaced.
+    const { item, frag } = buildArrayItem(v);
+    if (frag) parent.insertBefore(frag, nextArrayAnchor(old, i, marker));
+    if (o) removeArrayItem(o);
+    next.push(item);
+  }
+
+  // Shrink: remove slots beyond the new length.
+  for (let i = value.length; i < old.length; i++) removeArrayItem(old[i]);
+  state.items = next;
+}
+
+/**
+ * The node a freshly-built slot at index `i` inserts before: the first
+ * node of the current or next still-attached old slot, else the part
+ * marker (a tail append).
+ * @param {ArrayItem[]} old @param {number} i @param {Comment} marker
+ * @returns {ChildNode}
+ */
+function nextArrayAnchor(old, i, marker) {
+  for (let j = i; j < old.length; j++) {
+    const f = arrayItemFirstNode(old[j]);
+    if (f && f.parentNode) return f;
+  }
+  return marker;
+}
+
+/** @param {{ kind: 'array', items: ArrayItem[] }} state */
+function teardownArray(state) {
+  for (const it of state.items) removeArrayItem(it);
+  state.items = [];
+}
+
 /**
  * Collect [start .. end] (inclusive) and insert immediately before `anchor`.
  * Browsers treat insertBefore of an already-connected node as a move and
@@ -1208,6 +1357,8 @@ function teardownChild(part) {
   const c = /** @type any */ (part.child);
   if (c.kind === 'repeat') {
     teardownRepeat(c);
+  } else if (c.kind === 'array') {
+    teardownArray(c);
   } else if (c.kind === 'async-stream') {
     teardownAsyncStream(c);
   } else if ('strings' in c) {

--- a/packages/core/test/rendering/browser/render-client.test.js
+++ b/packages/core/test/rendering/browser/render-client.test.js
@@ -217,4 +217,49 @@ suite('Shadow DOM (real browser)', () => {
     assert.ok(shadow.querySelector('p'));
     el.remove();
   });
+
+  // #353: a .map() list item that changes its own binding must keep its DOM
+  // node, not get replaced. Replacing the node mid-drag is what cancelled
+  // native drag-and-drop (the browser drags the original node; if a re-render
+  // detaches it, the drag aborts and `drop` never fires).
+  test('.map() dragged item keeps the SAME node when @dragstart flips its class', () => {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    const view = (draggingId) =>
+      html`<div>${[1, 2, 3].map((id) => html`<div class="card ${id === draggingId ? 'dragging' : ''}" data-id=${id} draggable="true">card ${id}</div>`)}</div>`;
+
+    render(view(0), el);
+    const card2 = el.querySelector('[data-id="2"]');
+    // Simulate what @dragstart does: flip a signal that changes this card's class.
+    render(view(2), el);
+    const card2After = el.querySelector('[data-id="2"]');
+
+    assert.strictEqual(card2After, card2, 'the dragged card is the SAME node after the re-render');
+    assert.ok(document.body.contains(card2), 'the dragged card is still attached (drag survives)');
+    assert.ok(card2.className.includes('dragging'), 'class updated in place');
+    assert.ok(card2.getAttribute('draggable') === 'true');
+    el.remove();
+  });
+
+  test('.map() update keeps focus + caret in an input while a sibling re-renders', () => {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    const view = (highlightId) =>
+      html`<div>${[1, 2].map((id) => html`<div class=${id === highlightId ? 'on' : 'off'}><input data-id=${id} value="row ${id}"></div>`)}</div>`;
+
+    render(view(0), el);
+    const input2 = el.querySelector('input[data-id="2"]');
+    input2.focus();
+    input2.setSelectionRange(2, 2);
+    assert.strictEqual(document.activeElement, input2, 'precondition: input 2 is focused');
+
+    // Re-render flipping item 1's class (item 2's input must be untouched).
+    render(view(1), el);
+    const input2After = el.querySelector('input[data-id="2"]');
+
+    assert.strictEqual(input2After, input2, 'the focused input is the same node');
+    assert.strictEqual(document.activeElement, input2, 'focus is retained across the sibling re-render');
+    assert.equal(input2.selectionStart, 2, 'caret position retained');
+    el.remove();
+  });
 });

--- a/packages/core/test/rendering/render-client.test.js
+++ b/packages/core/test/rendering/render-client.test.js
@@ -186,6 +186,95 @@ test('repeat() removal drops only removed keys', async () => {
   assert.equal(preB.parentNode, null);
 });
 
+// Plain `.map()` arrays reconcile in place (positional, non-keyed), the way
+// lit-html does. The headline case below (an item's own binding changes, node
+// identity must survive) is the #353 fix: the old renderer rebuilt the whole
+// list on any change, which detached a dragging node mid-gesture and cancelled
+// native drag-and-drop.
+test('.map() item keeps node identity when only its own binding changes', () => {
+  const el = document.createElement('div');
+  // The dragged card flips a class on @dragstart; the list must NOT rebuild.
+  const view = (draggingId) =>
+    html`<ul>${[1, 2, 3].map((id) => html`<li class=${id === draggingId ? 'dragging' : 'idle'}>card ${id}</li>`)}</ul>`;
+
+  render(view(0), el);
+  const [pre1, pre2, pre3] = Array.from(el.querySelectorAll('li'));
+  // Flip card 2 into the dragging state (its class binding changes).
+  render(view(2), el);
+  const [post1, post2, post3] = Array.from(el.querySelectorAll('li'));
+
+  assert.strictEqual(post1, pre1, 'card 1 node preserved');
+  assert.strictEqual(post2, pre2, 'the dragged card node is patched, NOT replaced');
+  assert.strictEqual(post3, pre3, 'card 3 node preserved');
+  assert.equal(post2.getAttribute('class'), 'dragging');
+  assert.equal(pre2.parentNode, post2.parentNode, 'dragged card stays attached');
+});
+
+test('.map() in-place value update reuses item nodes', () => {
+  const el = document.createElement('div');
+  const view = (labels) => html`<ul>${labels.map((l) => html`<li>${l}</li>`)}</ul>`;
+  render(view(['a', 'b', 'c']), el);
+  const pre = Array.from(el.querySelectorAll('li'));
+  render(view(['x', 'y', 'z']), el);
+  const post = Array.from(el.querySelectorAll('li'));
+  assert.strictEqual(post[0], pre[0]);
+  assert.strictEqual(post[1], pre[1]);
+  assert.strictEqual(post[2], pre[2]);
+  assert.deepEqual(post.map((li) => li.textContent), ['x', 'y', 'z']);
+});
+
+test('.map() grow appends without disturbing existing item nodes', () => {
+  const el = document.createElement('div');
+  const view = (n) => html`<ul>${Array.from({ length: n }, (_, i) => html`<li>${i}</li>`)}</ul>`;
+  render(view(2), el);
+  const [pre0, pre1] = Array.from(el.querySelectorAll('li'));
+  render(view(4), el);
+  const post = Array.from(el.querySelectorAll('li'));
+  assert.equal(post.length, 4);
+  assert.strictEqual(post[0], pre0);
+  assert.strictEqual(post[1], pre1);
+  assert.deepEqual(post.map((li) => li.textContent), ['0', '1', '2', '3']);
+});
+
+test('.map() shrink removes the tail, keeps survivor nodes', () => {
+  const el = document.createElement('div');
+  const view = (n) => html`<ul>${Array.from({ length: n }, (_, i) => html`<li>${i}</li>`)}</ul>`;
+  render(view(3), el);
+  const [pre0, pre1, pre2] = Array.from(el.querySelectorAll('li'));
+  render(view(1), el);
+  const post = Array.from(el.querySelectorAll('li'));
+  assert.equal(post.length, 1);
+  assert.strictEqual(post[0], pre0);
+  assert.equal(pre1.parentNode, null);
+  assert.equal(pre2.parentNode, null);
+});
+
+test('.map() replaces a slot whose template shape changed, keeps order + siblings', () => {
+  const el = document.createElement('div');
+  // Middle item flips between an <li> and a <p>: that slot must be replaced,
+  // the neighbours kept, and order preserved.
+  const view = (asP) =>
+    html`<div>${[html`<li>a</li>`, asP ? html`<p>b</p>` : html`<li>b</li>`, html`<li>c</li>`]}</div>`;
+  render(view(false), el);
+  const preFirst = el.querySelector('li');
+  render(view(true), el);
+  const root = el.querySelector('div');
+  const tags = Array.from(root.children).map((c) => c.tagName.toLowerCase());
+  assert.deepEqual(tags, ['li', 'p', 'li'], 'shape-changed slot replaced, order preserved');
+  assert.strictEqual(el.querySelector('li'), preFirst, 'first sibling node preserved');
+});
+
+test('.map() primitive array updates reuse the text nodes', () => {
+  const el = document.createElement('div');
+  const view = (a, b) => html`<p>${[a, ' ', b]}</p>`;
+  render(view('one', 'two'), el);
+  const p = el.querySelector('p');
+  const preText = p.firstChild;
+  render(view('uno', 'dos'), el);
+  assert.strictEqual(p.firstChild, preText, 'text node reused');
+  assert.equal(p.textContent, 'uno dos');
+});
+
 test('mixed attr: single hole with surrounding static text composes correctly', () => {
   const el = document.createElement('div');
   const view = (cls) => html`<div class="prefix ${cls} suffix">x</div>`;


### PR DESCRIPTION
## Problem

A plain `.map()` list interpolation rebuilt its **entire** child part on any change to the array's rendered output, replacing every DOM node. The client renderer preserved node identity everywhere else, but a plain array was the one hole.

That broke native HTML5 drag-and-drop (found by AI-agent dogfooding a kanban built through crisp, #353): a card's `@dragstart` flips a signal, which re-rendered the list, which detached and replaced the dragged node mid-gesture. The browser drags the original node, so when it vanishes the drag aborts and `drop` never fires. The same wholesale rebuild also lost focus, caret, text selection, scroll, and uncontrolled input value for any updating list item.

## Fix

Reconcile a `.map()` array **positionally** in place, the way lit-html handles a non-keyed array (a child part per item): each index updates its item instance in place when the template shape is unchanged, replaces it when the shape changes, and grows/shrinks at the tail. Node identity (and the drag, focus, caret, and selection it carries) now survives an item-level update. Keyed **reordering** still uses the `repeat()` directive.

This restores lit parity so idiomatic agent-written `.map()` lists work, closing the gap in `agent-docs/lit-muscle-memory-gotchas.md` (also updated to document that `repeat()` is now only needed for reorder, not for item updates).

## Tests (every applicable layer)

- **Unit** (`render-client.test.js`): node identity on a single-item binding change (the `@dragstart` case), focus + caret retention while a sibling re-renders, in-place value update, tail grow/shrink, shape-change replacement. Genuine counterfactuals (`assert.strictEqual(post2, pre2)` fails if the fix is reverted).
- **Browser** (`browser/render-client.test.js`): dragged item keeps the SAME node when `@dragstart` flips its class; focus + caret survive a sibling re-render.
- Full suite green: node **2155/2155**, browser **347 pass / 1 skip**, e2e **75/75**.

## Dogfood verification

- blog: e2e 75/75 (real browser)
- website: GET / 200
- ui-website: GET / 200
- docs: GET / 307 -> /docs/getting-started 200 (intentional app redirect)

`webjs check`: clean except a pre-existing unrelated fixture violation (`ssr-browser-member-error.test.js`, from #218, a deliberate negative test).

Closes #353