### PR TITLE
chore: release core 0.7.11, server 0.8.17, cli 0.10.10, ui 0.3.5

### DIFF
--- a/changelog/cli/0.10.10.md
+++ b/changelog/cli/0.10.10.md
@@ -1,0 +1,46 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.10
+date: 2026-06-04T19:45:32.906Z
+commit_count: 7
+---
+## Features
+
+- **drive a webjs-frame by id from outside it, plus _top and aria-busy** ([#338](https://github.com/webjsdev/webjs/pull/338)) [`430e6cca`](https://github.com/webjsdev/webjs/commit/430e6cca)
+  * feat: drive a webjs-frame by id from outside it, plus aria-busy
+  
+  A swap was scoped to a frame only when the trigger was DOM-nested inside it
+  (closest-only). Add external frame targeting: a link or form carrying
+- **recover from a failed navigation in place instead of a full reload** ([#339](https://github.com/webjsdev/webjs/pull/339)) [`43eaf64f`](https://github.com/webjsdev/webjs/commit/43eaf64f)
+  * feat: recover from a failed navigation in place instead of a full reload
+  
+  On a non-HTML error response (a JSON 500), a transport failure, or an
+  unparseable HTML body, fetchAndApply did a destructive location.href full
+- **view transitions on partial swaps + data-webjs-permanent** ([#343](https://github.com/webjsdev/webjs/pull/343)) [`77c1216d`](https://github.com/webjsdev/webjs/commit/77c1216d)
+  View Transitions only wrapped the full-body fallback, never the partial
+  layout-marker swap or the webjs-frame swap (the common designed-for paths).
+  Wrap all three swap paths in document.startViewTransition via runWithTransition,
+  gated by an opt-in <meta name="view-transition" content="same-origin"> (OFF
+- **src-driven <webjs-frame> self-loading + server subtree render** ([#346](https://github.com/webjsdev/webjs/pull/346)) [`86f6ae44`](https://github.com/webjsdev/webjs/commit/86f6ae44)
+  * feat: src-driven webjs-frame self-loading + server subtree render
+  
+  A <webjs-frame> could not self-load a region's content, forcing the
+  fetch-in-handler anti-pattern for deferred content (comments, a recommendations
+- **add the <webjs-stream> stream-action protocol (HTTP + live channel)** ([#347](https://github.com/webjsdev/webjs/pull/347)) [`a489c97d`](https://github.com/webjsdev/webjs/commit/a489c97d)
+  * feat: add the <webjs-stream> surgical DOM-update applier
+  
+  Ship one small custom element that reads a server-sent <template> carrying an
+  action + target id and applies it via native DOM (append/prepend/before/after/
+- **provide an opt-in progressive-enhancement service worker primitive** ([#350](https://github.com/webjsdev/webjs/pull/350)) [`ced742f8`](https://github.com/webjsdev/webjs/commit/ced742f8)
+  * feat: ship an opt-in progressive-enhancement service worker primitive
+  
+  Scaffold a hand-authored public/sw.js + public/offline.html into every app
+  (copied by create.js, dormant until the app registers it, so the JS-disabled
+
+## Fixes
+
+- **soften the scaffolded test-with-source gate to a warning** ([#331](https://github.com/webjsdev/webjs/pull/331)) [`a6291b34`](https://github.com/webjsdev/webjs/commit/a6291b34)
+  The scaffolded require-tests-with-src.sh hard-blocked (exit 2) a commit that
+  staged app code with no test, contradicting the convention-vs-check principle
+  the same scaffolded AGENTS.md / CONVENTIONS.md state (a sensible app can
+  legitimately want a test-less commit, so every change ships with a test is a

--- a/changelog/core/0.7.11.md
+++ b/changelog/core/0.7.11.md
@@ -1,0 +1,51 @@
+---
+package: "@webjsdev/core"
+version: 0.7.11
+date: 2026-06-04T19:45:32.800Z
+commit_count: 8
+---
+## Features
+
+- **drive a webjs-frame by id from outside it, plus _top and aria-busy** ([#338](https://github.com/webjsdev/webjs/pull/338)) [`430e6cca`](https://github.com/webjsdev/webjs/commit/430e6cca)
+  * feat: drive a webjs-frame by id from outside it, plus aria-busy
+  
+  A swap was scoped to a frame only when the trigger was DOM-nested inside it
+  (closest-only). Add external frame targeting: a link or form carrying
+- **recover from a failed navigation in place instead of a full reload** ([#339](https://github.com/webjsdev/webjs/pull/339)) [`43eaf64f`](https://github.com/webjsdev/webjs/commit/43eaf64f)
+  * feat: recover from a failed navigation in place instead of a full reload
+  
+  On a non-HTML error response (a JSON 500), a transport failure, or an
+  unparseable HTML body, fetchAndApply did a destructive location.href full
+- **form submission-state events + aria-busy + an optimistic() helper** ([#340](https://github.com/webjsdev/webjs/pull/340)) [`342ae484`](https://github.com/webjsdev/webjs/commit/342ae484)
+  A form submitting through the JS-enhanced router had no signal for a pending
+  state. The router now sets the native aria-busy on the form for the in-flight
+  duration (the readable is-this-form-submitting primitive) and dispatches a
+  bubbling webjs:submit-start ({ form, url }) at the start and webjs:submit-end
+- **view transitions on partial swaps + data-webjs-permanent** ([#343](https://github.com/webjsdev/webjs/pull/343)) [`77c1216d`](https://github.com/webjsdev/webjs/commit/77c1216d)
+  View Transitions only wrapped the full-body fallback, never the partial
+  layout-marker swap or the webjs-frame swap (the common designed-for paths).
+  Wrap all three swap paths in document.startViewTransition via runWithTransition,
+  gated by an opt-in <meta name="view-transition" content="same-origin"> (OFF
+- **src-driven <webjs-frame> self-loading + server subtree render** ([#346](https://github.com/webjsdev/webjs/pull/346)) [`86f6ae44`](https://github.com/webjsdev/webjs/commit/86f6ae44)
+  * feat: src-driven webjs-frame self-loading + server subtree render
+  
+  A <webjs-frame> could not self-load a region's content, forcing the
+  fetch-in-handler anti-pattern for deferred content (comments, a recommendations
+- **add the <webjs-stream> stream-action protocol (HTTP + live channel)** ([#347](https://github.com/webjsdev/webjs/pull/347)) [`a489c97d`](https://github.com/webjsdev/webjs/commit/a489c97d)
+  * feat: add the <webjs-stream> surgical DOM-update applier
+  
+  Ship one small custom element that reads a server-sent <template> carrying an
+  action + target id and applies it via native DOM (append/prepend/before/after/
+- **ship a rich dev error overlay pushed live over SSE** ([#348](https://github.com/webjsdev/webjs/pull/348)) [`30772213`](https://github.com/webjsdev/webjs/commit/30772213)
+  * feat: ship a rich dev error overlay pushed live over SSE
+  
+  A dev SSR render crash, a non-erasable-TS strip failure, and a failed rebuild
+  each push a structured error frame (message, parsed file:line:col, a source
+
+## Fixes
+
+- **reconcile plain .map() arrays in place instead of rebuilding (#353)** ([#354](https://github.com/webjsdev/webjs/pull/354)) [`950026a8`](https://github.com/webjsdev/webjs/commit/950026a8)
+  * fix: reconcile plain .map() arrays in place instead of rebuilding
+  
+  A `.map()` / list interpolation used to rebuild its entire child part on
+  ANY change to the array's rendered output, replacing every DOM node. The

--- a/changelog/server/0.8.17.md
+++ b/changelog/server/0.8.17.md
@@ -1,0 +1,33 @@
+---
+package: "@webjsdev/server"
+version: 0.8.17
+date: 2026-06-04T19:45:32.851Z
+commit_count: 5
+---
+## Features
+
+- **fold an app-source fingerprint into the HTML cache key** ([#329](https://github.com/webjsdev/webjs/pull/329)) [`c4dbb8a9`](https://github.com/webjsdev/webjs/commit/c4dbb8a9)
+  * feat: fold an app-source fingerprint into the HTML cache key
+  
+  The #241 HTML cache key folds the published build id, but that is a fingerprint
+  of the IMPORTMAP (core + vendor) only, so a deploy that changes ONLY an app
+- **form submission-state events + aria-busy + an optimistic() helper** ([#340](https://github.com/webjsdev/webjs/pull/340)) [`342ae484`](https://github.com/webjsdev/webjs/commit/342ae484)
+  A form submitting through the JS-enhanced router had no signal for a pending
+  state. The router now sets the native aria-busy on the form for the in-flight
+  duration (the readable is-this-form-submitting primitive) and dispatches a
+  bubbling webjs:submit-start ({ form, url }) at the start and webjs:submit-end
+- **src-driven <webjs-frame> self-loading + server subtree render** ([#346](https://github.com/webjsdev/webjs/pull/346)) [`86f6ae44`](https://github.com/webjsdev/webjs/commit/86f6ae44)
+  * feat: src-driven webjs-frame self-loading + server subtree render
+  
+  A <webjs-frame> could not self-load a region's content, forcing the
+  fetch-in-handler anti-pattern for deferred content (comments, a recommendations
+- **add the <webjs-stream> stream-action protocol (HTTP + live channel)** ([#347](https://github.com/webjsdev/webjs/pull/347)) [`a489c97d`](https://github.com/webjsdev/webjs/commit/a489c97d)
+  * feat: add the <webjs-stream> surgical DOM-update applier
+  
+  Ship one small custom element that reads a server-sent <template> carrying an
+  action + target id and applies it via native DOM (append/prepend/before/after/
+- **ship a rich dev error overlay pushed live over SSE** ([#348](https://github.com/webjsdev/webjs/pull/348)) [`30772213`](https://github.com/webjsdev/webjs/commit/30772213)
+  * feat: ship a rich dev error overlay pushed live over SSE
+  
+  A dev SSR render crash, a non-erasable-TS strip failure, and a failed rebuild
+  each push a structured error frame (message, parsed file:line:col, a source

--- a/changelog/ui/0.3.5.md
+++ b/changelog/ui/0.3.5.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/ui"
+version: 0.3.5
+date: 2026-06-04T19:45:33.020Z
+commit_count: 1
+---
+## Features
+
+- **support closest() and host IDL reflections in the SSR shim** ([#228](https://github.com/webjsdev/webjs/pull/228)) [`a9c26ea7`](https://github.com/webjsdev/webjs/commit/a9c26ea7)
+  * feat: support closest() and host IDL reflections in the SSR shim
+  
+  Compound components derive active/pressed state by walking to a parent
+  with this.closest('parent-tag') and reading its state. The server

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.16",
+  "version": "0.8.17",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/ui",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "type": "module",
   "description": "An AI-first component library - class-helper functions for visuals, custom elements only where state matters. Source-copied into your repo, you own it. Works with any Tailwind v4 project.",
   "bin": {


### PR DESCRIPTION
## Release

Publishes the accumulated unreleased `feat:` / `fix:` work across four packages. Merging adds the new `changelog/**.md` files on `main`, which triggers `release.yml` to `npm publish` each new version and create its GitHub Release.

| Package | From | To | Notable |
|---|---|---|---|
| `@webjsdev/core` | 0.7.10 | **0.7.11** | **fix #353**: `.map()` arrays reconcile in place (DnD / focus / input identity); webjs-frame external targeting, in-place nav recovery, submit-state events, view transitions, `<webjs-frame src>`, `<webjs-stream>`, dev error overlay |
| `@webjsdev/server` | 0.8.16 | **0.8.17** | app-source HTML-cache fingerprint, submit-state events, `<webjs-frame src>` subtree render, `<webjs-stream>`, dev error overlay |
| `@webjsdev/cli` | 0.10.9 | **0.10.10** | webjs-frame external targeting, in-place nav recovery, view transitions, `<webjs-frame src>`, `<webjs-stream>`, service-worker scaffold, softened test-gate |
| `@webjsdev/ui` | 0.3.4 | **0.3.5** | tabs/toggle-group use `closest()` + host IDL reflections at SSR |

`@webjsdev/ts-plugin` has no unreleased changes, so it is not bumped.

### Why now

The kanban dogfood app (crisp project 2) couldn't drag cards between columns because of the #353 renderer bug. The fix is merged but apps pull `@webjsdev/core@latest` from npm, so they stay on the broken 0.7.10 until this release publishes 0.7.11.

Changelogs were auto-generated by the pre-commit `backfill-changelog.js` hook (not hand-written).