### PR TITLE
docs: steer agents to adapt scaffold layout chrome, not just the page (#356)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -740,7 +740,7 @@ webjs create <name> --template saas  # auth + login/signup + protected dashboard
    Default to full-stack when ambiguous.
 
 3. **Default to a real database (Prisma + SQLite). NEVER use JSON files, in-memory arrays, or localStorage as a substitute for persistence.** Every scaffold ships `prisma/schema.prisma`, `lib/prisma.server.ts`, and `npm run db:*` scripts. Persisting data as JSON is a project convention violation (it resets on reload and cannot scale).
-4. **Treat the scaffold as REFERENCE, not the final product.** Replace the example `app/page.ts`, `User` model, and components.
+4. **Treat the scaffold as REFERENCE, not the final product.** Replace the example `app/page.ts`, `User` model, and components. Adapt `app/layout.ts` too, rather than just dropping the real page inside the scaffold's chrome. Set the real brand, replace the example `Home` nav, and choose a content-width container that fits the app. The default `<main class="max-w-[760px]">` is a reading column meant for prose, forms, and marketing, so for a full-bleed app, dashboard, or board, widen the cap or remove it (keep the theme tokens). A wide layout left inside the 760px reading column overflows into an unnecessary horizontal scrollbar.
 5. **Update `prisma/schema.prisma` to real models FIRST.** Run `webjs db migrate <name>`, then build pages/actions/queries.
 6. Full docs at **https://docs.webjs.com**.
 

--- a/packages/cli/lib/create.js
+++ b/packages/cli/lib/create.js
@@ -846,11 +846,19 @@ ${SHADCN_THEME}
         <span>${name}</span>
       </a>
       <nav class="flex gap-4 items-center">
+        <!-- Example nav. Replace with the real navigation for your app. -->
         \${navLink('/', 'Home')}
         <theme-toggle></theme-toggle>
       </nav>
     </header>
 
+    <!--
+      Content shell. The max-w-[760px] cap is a comfortable READING width,
+      right for prose, forms, and marketing. For a full-bleed app, dashboard,
+      or board, REPLACE it: widen the cap (for example max-w-[1400px]) or
+      drop the cap and mx-auto for an edge-to-edge layout. A wide layout left
+      inside the 760px reading column overflows into a horizontal scrollbar.
+    -->
     <main class="block max-w-[760px] mx-auto px-4 sm:px-6 pt-[72px] pb-12 min-h-screen">
       \${children}
     </main>

--- a/packages/cli/templates/AGENTS.md
+++ b/packages/cli/templates/AGENTS.md
@@ -14,7 +14,13 @@ now (`app/page.ts` printing "Hello from {{APP_NAME}}", the example `User`
 model in `prisma/schema.prisma`, the `theme-toggle` component, the
 example users module in api/saas templates) are **starting-point
 references, not the final product**. Your job is to replace them with
-the app the user actually asked for.
+the app the user actually asked for. That includes adapting
+`app/layout.ts`, not just the page. Set the real brand, replace the
+example `Home` nav, and pick a content-width container that fits. The
+default `<main class="max-w-[760px]">` is a reading column for prose and
+forms, so for a full-bleed app, dashboard, or board, widen the cap or
+remove it (keep the theme tokens). A wide layout left in the 760px
+reading column overflows into a horizontal scrollbar.
 
 **Non-negotiables for every webjs app:**
 

--- a/packages/cli/templates/CONVENTIONS.md
+++ b/packages/cli/templates/CONVENTIONS.md
@@ -308,7 +308,15 @@ When the user asks the agent to build their actual app:
    need a theme picker.
 4. **Delete the example users module** (api/saas templates) if the app
    doesn't use it.
-5. **Keep:** the Prisma setup, the test config, the agent config files
+5. **Adapt `app/layout.ts` to the app, not just the page.** Set the real
+   brand, replace the example `Home` nav with the app's navigation, and
+   pick a content-width container that fits. The default
+   `<main class="max-w-[760px]">` is a reading column for prose, forms,
+   and marketing. Widen it or drop the cap for a full-bleed app,
+   dashboard, or board, or a wide layout overflows into an unnecessary
+   horizontal scrollbar. Keep the design tokens and theme setup, those
+   are infrastructure.
+6. **Keep:** the Prisma setup, the test config, the agent config files
    (`AGENTS.md`, `CONVENTIONS.md`, `CLAUDE.md`, `.cursorrules`, etc.),
    `lib/prisma.server.ts`, the directory conventions, the design tokens in
    `app/layout.ts`. These are the infrastructure, not the example app.

--- a/test/scaffolds/scaffold-integration.test.js
+++ b/test/scaffolds/scaffold-integration.test.js
@@ -94,6 +94,15 @@ test('scaffoldApp full-stack: writes the canonical full-stack app layout', async
     assert.match(toggleSrc, /classList\.toggle\(['"]dark['"]/,
       'theme-toggle must toggle the .dark class (shadcn dark-mode signal)');
 
+    // Layout-chrome guidance (#356): the scaffolded layout must steer the
+    // agent to adapt the content-width container instead of dropping a
+    // full-bleed app into the narrow reading column (which overflows into a
+    // horizontal scrollbar). Counterfactual: dropping the comment fails here.
+    assert.match(layoutSrc, /max-w-\[760px\] cap is a comfortable READING width/,
+      'layout must carry the content-width steering comment so a full-bleed app widens it');
+    assert.match(layoutSrc, /Example nav\. Replace with the real navigation/,
+      'layout must flag the example nav as replace-me');
+
     // Prisma + lib singleton wired up
     assert.ok(existsSync(join(appDir, 'prisma', 'schema.prisma')), 'prisma schema written');
     assert.ok(existsSync(join(appDir, 'lib', 'prisma.server.ts')), 'lib/prisma.server.ts written');

--- a/test/scaffolds/scaffold-integration.test.js
+++ b/test/scaffolds/scaffold-integration.test.js
@@ -263,6 +263,13 @@ test('scaffoldApp saas: writes auth + dashboard + Prisma User model', async () =
     assert.ok(existsSync(join(appDir, 'app', 'layout.ts')), 'layout.ts written');
     assert.ok(existsSync(join(appDir, 'app', 'page.ts')), 'page.ts written');
 
+    // #356: saas shares the same layout template, so it must carry the
+    // content-width steering comment too (saas is a full-bleed dashboard,
+    // the case most likely to overflow the narrow reading column).
+    const saasLayoutSrc = readFileSync(join(appDir, 'app', 'layout.ts'), 'utf8');
+    assert.match(saasLayoutSrc, /max-w-\[760px\] cap is a comfortable READING width/,
+      'saas layout must carry the content-width steering comment');
+
     // #271: saas is a UI scaffold, so it ships the opt-in service worker.
     assert.ok(existsSync(join(appDir, 'public', 'sw.js')), 'saas ships public/sw.js');
     assert.ok(existsSync(join(appDir, 'public', 'offline.html')), 'saas ships public/offline.html');


### PR DESCRIPTION
## Summary

Closes #356

When an AI agent builds a real app on a webjs scaffold, it replaces `app/page.ts` but leaves the scaffold's layout chrome (the `Home` nav and the `max-w-[760px]` reading-width `<main>`) untouched. A dogfood kanban got rendered inside the 760px reading column and overflowed into an unnecessary horizontal scrollbar even though its three columns fit the screen. The guidance only ever told agents to replace the example page/model/components, never `app/layout.ts`.

This steers agents to adapt the layout shell to the app:

- **`packages/cli/lib/create.js`** (scaffolded `layout.ts`): a steering comment on `<main>` explaining the `max-w-[760px]` cap is a reading width and to widen or remove it for a full-bleed app/dashboard/board, plus a replace-me comment on the example nav. Every newly scaffolded app now carries this guidance inline.
- **Root `AGENTS.md`** (scaffolding rule 4): extended "scaffold is REFERENCE" to explicitly cover adapting `app/layout.ts` (brand, nav, content-width container), not just the page.
- **Scaffolded `templates/AGENTS.md` + `templates/CONVENTIONS.md`**: same guidance in the docs that ship to every app.

## Test plan

- `test/scaffolds/scaffold-integration.test.js`: asserts a freshly scaffolded `layout.ts` carries the content-width steering comment and the replace-me nav comment. Counterfactual verified (removing the comment from create.js turns the assertion red).
- Full scaffold suite green (12/12). `webjs check` clean apart from a pre-existing unrelated fixture (`ssr-browser-member-error.test.js`, from #218).

## Docs / surfaces

- Updated: root `AGENTS.md`, `packages/cli/templates/AGENTS.md`, `packages/cli/templates/CONVENTIONS.md`, `packages/cli/lib/create.js`.
- Four-app dogfood gate: N/A. This changes scaffold-template comments and guidance docs only, no framework runtime or served-wire change, so the in-repo apps (which are not re-scaffolded) are unaffected.
- Version bump: none owed. `docs:`-only change, no functional surface, rides to the next functional cli bump.