### PR TITLE
fix: ignore .webjs/routes.d.ts at any depth via **/.webjs/*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,15 @@ out/
 # DO NOT collapse to `.webjs/`: parent exclusion blocks child
 # negations and silently breaks `webjs vendor pin`. The
 # `gitignore-vendor-not-ignored` lint rule guards this.
-.webjs/*
-!.webjs/vendor/
-!.webjs/vendor/**
+# The `**/` prefix is REQUIRED in this monorepo: a slash-bearing
+# `.webjs/*` anchors to the repo root, so the nested in-repo apps
+# (website/, docs/, packages/ui/packages/website/) leaked their
+# generated `.webjs/routes.d.ts` into `git status`. `**/.webjs/*`
+# matches the dir at every depth while the negations still re-include
+# vendor at each (a re-included parent allows child negation).
+**/.webjs/*
+!**/.webjs/vendor/
+!**/.webjs/vendor/**
 
 # generated Tailwind CSS - built from public/input.css via `npm run dev` / `npm run start`
 **/public/tailwind.css

--- a/examples/blog/.gitignore
+++ b/examples/blog/.gitignore
@@ -7,9 +7,12 @@ node_modules/
 # DO NOT collapse to `.webjs/`: parent exclusion blocks child
 # negations and silently breaks `webjs vendor pin`. The
 # `gitignore-vendor-not-ignored` lint rule guards this.
-.webjs/*
-!.webjs/vendor/
-!.webjs/vendor/**
+# `**/.webjs/*` (not `.webjs/*`) so the dir is ignored at any depth: a
+# slash-bearing `.webjs/*` anchors to this file's dir and would miss a
+# nested app. The negations still re-include vendor at each depth.
+**/.webjs/*
+!**/.webjs/vendor/
+!**/.webjs/vendor/**
 
 # generated Tailwind CSS, built from public/input.css via npm run dev / start
 public/tailwind.css

--- a/packages/cli/templates/.dockerignore
+++ b/packages/cli/templates/.dockerignore
@@ -6,10 +6,12 @@ node_modules
 # `.webjs/` is ignored EXCEPT for `.webjs/vendor/`, which holds the committed
 # importmap manifest (and optionally downloaded bundle bytes) the server needs
 # at boot without reaching api.jspm.io. DO NOT collapse to `**/.webjs`: parent
-# exclusion blocks child negations and the vendor files would never ship.
-.webjs/*
-!.webjs/vendor/
-!.webjs/vendor/**
+# exclusion blocks child negations and the vendor files would never ship. The
+# `**/` prefix matches `.webjs/` at any depth so a nested build context does
+# not ship the per-machine cache, mirroring the `.gitignore` pattern.
+**/.webjs/*
+!**/.webjs/vendor/
+!**/.webjs/vendor/**
 
 dist
 build

--- a/packages/cli/templates/.gitignore
+++ b/packages/cli/templates/.gitignore
@@ -8,13 +8,13 @@ node_modules/
 # manifest (.webjs/vendor/importmap.json) and optionally the vendored
 # bundle files (after `webjs vendor pin --download`). Both ship to
 # production via source control so the server doesn't need
-# api.jspm.io reachable at boot. Pattern is `.webjs/*` ignored,
+# api.jspm.io reachable at boot. Pattern is `**/.webjs/*` ignored,
 # `.webjs/vendor/` un-ignored, mirroring Rails' config/importmap.rb
 # + vendor/javascript/ being committed.
 #
 # DO NOT "simplify" the three lines below to `.webjs/`. Git's
 # gitignore semantics excludes the parent first; once the parent is
-# excluded, no `!.webjs/vendor/` negation can ever re-include children
+# excluded, no `!**/.webjs/vendor/` negation can ever re-include children
 # (the failure is silent: `webjs vendor pin` runs, writes files, and
 # git ignores them with no warning). The `gitignore-vendor-not-ignored`
 # lint rule (run via `webjs check`) verifies this with

--- a/packages/cli/templates/.gitignore
+++ b/packages/cli/templates/.gitignore
@@ -3,7 +3,7 @@ node_modules/
 
 # webjs / framework caches.
 # `.webjs/routes.d.ts` (the generated route-types overlay, regenerated per
-# machine by `webjs types` / `webjs dev`) is correctly ignored by `.webjs/*`.
+# machine by `webjs types` / `webjs dev`) is correctly ignored by `**/.webjs/*`.
 # `.webjs/vendor/` is the EXCEPTION: it holds the committed importmap
 # manifest (.webjs/vendor/importmap.json) and optionally the vendored
 # bundle files (after `webjs vendor pin --download`). Both ship to
@@ -19,9 +19,16 @@ node_modules/
 # git ignores them with no warning). The `gitignore-vendor-not-ignored`
 # lint rule (run via `webjs check`) verifies this with
 # `git check-ignore` and will fail CI if the pattern regresses.
-.webjs/*
-!.webjs/vendor/
-!.webjs/vendor/**
+#
+# The `**/` prefix matches `.webjs/` at ANY depth, not just this app's
+# root. A slash-bearing `.webjs/*` anchors to this file's directory, so
+# an app nested below its repo root (a monorepo package) would leak its
+# generated `.webjs/routes.d.ts` into `git status`. `**/.webjs/*` covers
+# the nested case while the negations still re-include vendor at each
+# depth (a re-included parent dir permits a child negation).
+**/.webjs/*
+!**/.webjs/vendor/
+!**/.webjs/vendor/**
 
 # generated Tailwind CSS, built from public/input.css via npm run dev / start
 public/tailwind.css

--- a/packages/cli/templates/AGENTS.md
+++ b/packages/cli/templates/AGENTS.md
@@ -461,15 +461,18 @@ URLs or transitive deps drift. Pin is a deliberate developer action,
 like `npm install` itself.
 
 **Do NOT modify the `.webjs/` lines in `.gitignore` / `.dockerignore`.**
-The scaffolded pattern is three lines (`.webjs/*` + `!.webjs/vendor/`
-+ `!.webjs/vendor/**`) and is structurally load-bearing. Collapsing it
-to a single `.webjs/` excludes the parent directory; once the parent
-is excluded, git cannot re-include `.webjs/vendor/` via a child
-negation (gitignore semantics: parent exclusion blocks child
-negations). The breakage is invisible: `webjs vendor pin` runs, writes
-files, and git silently ignores them. Production then has no
-importmap.json and the server falls back to calling api.jspm.io on
-every cold start. The `gitignore-vendor-not-ignored` lint rule
+The scaffolded `.gitignore` pattern is three lines (`**/.webjs/*` +
+`!**/.webjs/vendor/` + `!**/.webjs/vendor/**`) and is structurally
+load-bearing. Collapsing it to a single `.webjs/` excludes the parent
+directory; once the parent is excluded, git cannot re-include
+`.webjs/vendor/` via a child negation (gitignore semantics: parent
+exclusion blocks child negations). The breakage is invisible: `webjs
+vendor pin` runs, writes files, and git silently ignores them.
+Production then has no importmap.json and the server falls back to
+calling api.jspm.io on every cold start. The `**/` prefix matters too:
+it ignores `.webjs/` at any depth, so an app nested below its repo root
+(a monorepo package) does not leak its generated `.webjs/routes.d.ts`
+into `git status`. The `gitignore-vendor-not-ignored` lint rule
 (`webjs check`) verifies the pattern with `git check-ignore` and will
 fail CI if it regresses.
 

--- a/packages/server/src/check.js
+++ b/packages/server/src/check.js
@@ -754,9 +754,12 @@ export async function checkConventions(appDir) {
   // --- Rule: gitignore-vendor-not-ignored ---
   // The .gitignore pattern for .webjs/vendor/ is subtle: `.webjs/`
   // alone excludes the directory entirely and git can't re-include
-  // children of an excluded parent. The correct pattern is `.webjs/*`
-  // plus `!.webjs/vendor/` plus `!.webjs/vendor/**`. AI agents
-  // and human reviewers frequently "simplify" this back to `.webjs/`,
+  // children of an excluded parent. The correct pattern is `**/.webjs/*`
+  // plus `!**/.webjs/vendor/` plus `!**/.webjs/vendor/**` (the `**/`
+  // prefix ignores `.webjs/` at any depth so a nested app does not leak
+  // its generated routes.d.ts; the older root-anchored `.webjs/*` also
+  // passes, since this probe runs from the app root). AI agents and
+  // human reviewers frequently "simplify" this back to `.webjs/`,
   // silently breaking `webjs vendor pin`.
   //
   // This rule verifies the actual gitignore behavior by spawning

--- a/packages/server/src/check.js
+++ b/packages/server/src/check.js
@@ -91,7 +91,7 @@ export const RULES = [
   {
     name: 'gitignore-vendor-not-ignored',
     description:
-      'Verifies the `.gitignore` exception for `.webjs/vendor/` is structurally correct via `git check-ignore`. The intended pattern is `.webjs/*` (NOT `.webjs/`) plus `!.webjs/vendor/` plus `!.webjs/vendor/**`. The common-looking pattern `.webjs/` excludes the directory itself, after which git cannot re-include children (gitignore semantics: a parent exclusion blocks child negations). Without this rule, an AI agent or human editor would silently break `webjs vendor pin` by simplifying the pattern; the failure is invisible until production. Rule fires when the working directory is a git repo and a `.gitignore` exists; skipped when neither is true.',
+      'Verifies the `.gitignore` exception for `.webjs/vendor/` is structurally correct via `git check-ignore`. The intended pattern is `**/.webjs/*` (NOT `.webjs/`) plus `!**/.webjs/vendor/` plus `!**/.webjs/vendor/**`. The `**/` prefix matches `.webjs/` at any depth so a nested / monorepo app does not leak its generated `.webjs/routes.d.ts`; the older root-anchored `.webjs/*` also passes this rule (the probe is run from the app root). The common-looking pattern `.webjs/` excludes the directory itself, after which git cannot re-include children (gitignore semantics: a parent exclusion blocks child negations). Without this rule, an AI agent or human editor would silently break `webjs vendor pin` by simplifying the pattern; the failure is invisible until production. Rule fires when the working directory is a git repo and a `.gitignore` exists; skipped when neither is true.',
   },
   {
     name: 'no-browser-globals-in-render',
@@ -804,9 +804,10 @@ export async function checkConventions(appDir) {
               `${probe} is gitignored, but \`webjs vendor pin\` writes files under .webjs/vendor/ and they MUST be committed for production deploys to use the pin (instead of calling api.jspm.io on every cold start). The most common cause: a \`.webjs/\` line in .gitignore that excludes the parent directory before the \`!.webjs/vendor/\` exception can take effect (git semantics: a parent exclusion blocks child negations). A second possible cause is a broader rule (e.g. \`*.js\` at root) that hides bundle files added by \`webjs vendor pin --download\`.`,
           fix:
             'Replace `.webjs/` in your .gitignore with this three-line pattern:\n' +
-            '  .webjs/*\n' +
-            '  !.webjs/vendor/\n' +
-            '  !.webjs/vendor/**\n' +
+            '  **/.webjs/*\n' +
+            '  !**/.webjs/vendor/\n' +
+            '  !**/.webjs/vendor/**\n' +
+            'The `**/` prefix ignores `.webjs/` at any depth (so a nested / monorepo app does not leak its generated `.webjs/routes.d.ts`) while still re-including the committed vendor pin. ' +
             'Verify with `git check-ignore -q .webjs/vendor/importmap.json` (exit 1 means correctly un-ignored).',
         });
       }

--- a/packages/server/test/check/check.test.js
+++ b/packages/server/test/check/check.test.js
@@ -728,6 +728,75 @@ test('gitignore-vendor-not-ignored: passes for the correct pattern', async () =>
   }
 });
 
+test('gitignore-vendor-not-ignored: passes for the depth-robust `**/.webjs/*` pattern', async () => {
+  const appDir = await makeTempApp();
+  try {
+    if (!initGit(appDir)) return;
+    await writeFile(
+      join(appDir, '.gitignore'),
+      '**/.webjs/*\n!**/.webjs/vendor/\n!**/.webjs/vendor/**\n',
+    );
+    const violations = await checkConventions(appDir);
+    const v = violations.find((v) => v.rule === 'gitignore-vendor-not-ignored');
+    assert.equal(v, undefined, '`**/.webjs/*` keeps the vendor pin un-ignored');
+  } finally {
+    await rm(appDir, { recursive: true, force: true });
+  }
+});
+
+test('`**/.webjs/*` ignores nested routes.d.ts while the anchored `.webjs/*` does not', async () => {
+  // The actual #365 bug: a slash-bearing `.webjs/*` anchors to the
+  // .gitignore's dir, so a nested app (a monorepo package) leaks its
+  // generated `.webjs/routes.d.ts`. `**/.webjs/*` ignores it at any
+  // depth while still re-including the committed vendor pin. Probed
+  // directly with `git check-ignore` since the rule only checks the
+  // root-level vendor path.
+  const appDir = await makeTempApp();
+  try {
+    if (!initGit(appDir)) return;
+    const { GIT_DIR, GIT_WORK_TREE, GIT_INDEX_FILE, GIT_PREFIX, ...env } = process.env;
+    const ignored = (rel) =>
+      spawnSync('git', ['check-ignore', '-q', rel], { cwd: appDir, stdio: 'pipe', env })
+        .status === 0;
+
+    // Counterfactual: the old anchored pattern misses the nested file.
+    await writeFile(
+      join(appDir, '.gitignore'),
+      '.webjs/*\n!.webjs/vendor/\n!.webjs/vendor/**\n',
+    );
+    assert.equal(
+      ignored('website/.webjs/routes.d.ts'),
+      false,
+      'anchored `.webjs/*` leaks a nested routes.d.ts (the bug)',
+    );
+
+    // The fix: `**/.webjs/*` ignores routes.d.ts at every depth and
+    // still tracks the vendor pin at root and nested depths.
+    await writeFile(
+      join(appDir, '.gitignore'),
+      '**/.webjs/*\n!**/.webjs/vendor/\n!**/.webjs/vendor/**\n',
+    );
+    assert.equal(ignored('.webjs/routes.d.ts'), true, 'root routes.d.ts ignored');
+    assert.equal(
+      ignored('website/.webjs/routes.d.ts'),
+      true,
+      'nested routes.d.ts ignored',
+    );
+    assert.equal(
+      ignored('.webjs/vendor/importmap.json'),
+      false,
+      'root vendor pin stays tracked',
+    );
+    assert.equal(
+      ignored('website/.webjs/vendor/importmap.json'),
+      false,
+      'nested vendor pin stays tracked',
+    );
+  } finally {
+    await rm(appDir, { recursive: true, force: true });
+  }
+});
+
 test('gitignore-vendor-not-ignored: flags broader `*.js` rule that hides bundle files', async () => {
   // The pin manifest gets through because it ends in .json, but
   // `webjs vendor pin --download` writes <pkg>@<version>.js files

--- a/test/repo-health/gitignore-webjs-depth.test.mjs
+++ b/test/repo-health/gitignore-webjs-depth.test.mjs
@@ -1,0 +1,94 @@
+// Regression guard for issue #365 (nested .webjs/routes.d.ts leaked into
+// git status). The generated route-types overlay .webjs/routes.d.ts is
+// per-machine and must be gitignored at ANY depth, while the committed
+// .webjs/vendor/ pin must stay tracked at any depth. A slash-bearing
+// `.webjs/*` anchors to the .gitignore's own directory, so it misses a
+// nested in-repo app; the fix is the depth-robust `**/.webjs/*` form.
+//
+// The check.test.js rule tests verify git's SEMANTICS with inline
+// patterns, but nothing there ties the assertion to the SHIPPED files,
+// so a revert of any shipped .gitignore to `.webjs/*` would pass every
+// other test while reintroducing the exact bug. This guards the real
+// artifacts: it copies each shipped .gitignore into a throwaway git repo
+// and asserts the observable behavior via `git check-ignore`.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, copyFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+// The shipped .gitignore artifacts this PR fixes. The scaffold template
+// is the one that ships into every `webjs create` app.
+const SHIPPED = [
+  '.gitignore',
+  'examples/blog/.gitignore',
+  'packages/cli/templates/.gitignore',
+];
+
+// `git check-ignore -q` exits 0 when ignored, 1 when not ignored, so
+// execFileSync throws iff the path is NOT ignored. Strip inherited git
+// env so cwd is the sole authority on which repo is consulted (a
+// worktree pre-commit hook leaks GIT_DIR / GIT_WORK_TREE).
+function isIgnored(repo, relPath) {
+  const { GIT_DIR, GIT_WORK_TREE, GIT_INDEX_FILE, GIT_PREFIX, ...env } = process.env;
+  try {
+    execFileSync('git', ['check-ignore', '-q', relPath], { cwd: repo, env, stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function initRepo() {
+  const { GIT_DIR, GIT_WORK_TREE, GIT_INDEX_FILE, GIT_PREFIX, ...env } = process.env;
+  const repo = mkdtempSync(join(tmpdir(), 'webjs-gitignore365-'));
+  execFileSync('git', ['init', '-q'], { cwd: repo, env, stdio: 'ignore' });
+  return repo;
+}
+
+for (const shipped of SHIPPED) {
+  test(`shipped ${shipped} ignores nested .webjs/routes.d.ts and keeps vendor (#365)`, () => {
+    const repo = initRepo();
+    try {
+      copyFileSync(join(repoRoot, shipped), join(repo, '.gitignore'));
+
+      // routes.d.ts is the per-machine overlay: ignored at root AND when
+      // the app is a nested package (the leak this PR fixes).
+      assert.equal(
+        isIgnored(repo, '.webjs/routes.d.ts'),
+        true,
+        `${shipped}: root .webjs/routes.d.ts must be ignored`,
+      );
+      assert.equal(
+        isIgnored(repo, 'packages/site/.webjs/routes.d.ts'),
+        true,
+        `${shipped}: a NESTED .webjs/routes.d.ts must be ignored (the #365 leak)`,
+      );
+
+      // The committed vendor pin must stay tracked at root and nested
+      // depths, including a deeply nested downloaded bundle file.
+      assert.equal(
+        isIgnored(repo, '.webjs/vendor/importmap.json'),
+        false,
+        `${shipped}: root vendor pin must stay tracked`,
+      );
+      assert.equal(
+        isIgnored(repo, 'packages/site/.webjs/vendor/importmap.json'),
+        false,
+        `${shipped}: a NESTED vendor pin must stay tracked`,
+      );
+      assert.equal(
+        isIgnored(repo, '.webjs/vendor/dayjs@1.11.0.js'),
+        false,
+        `${shipped}: a downloaded vendor bundle must stay tracked`,
+      );
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+}

--- a/test/scaffolds/scaffold-integration.test.js
+++ b/test/scaffolds/scaffold-integration.test.js
@@ -176,8 +176,8 @@ test('scaffoldApp full-stack: writes the canonical full-stack app layout', async
     // .dockerignore must preserve the .webjs/vendor negation (parent
     // exclusion would silently drop the committed importmap).
     const dockerignore = readFileSync(join(appDir, '.dockerignore'), 'utf8');
-    assert.match(dockerignore, /!\.webjs\/vendor\//,
-      '.dockerignore keeps .webjs/vendor/ (committed importmap ships)');
+    assert.match(dockerignore, /^!\*\*\/\.webjs\/vendor\/$/m,
+      '.dockerignore keeps **/.webjs/vendor/ (committed importmap ships)');
 
     // package.json contents
     const pkg = JSON.parse(readFileSync(join(appDir, 'package.json'), 'utf8'));

--- a/test/scaffolds/scaffold-integration.test.js
+++ b/test/scaffolds/scaffold-integration.test.js
@@ -203,6 +203,21 @@ test('scaffoldApp full-stack: writes the canonical full-stack app layout', async
     const gitignore = readFileSync(join(appDir, '.gitignore'), 'utf8');
     assert.match(gitignore, /prisma\/dev\.db/, '.gitignore covers SQLite');
 
+    // .gitignore ignores .webjs/ at ANY depth (#365): a scaffolded app
+    // nested below its repo root must not leak its generated
+    // .webjs/routes.d.ts. The depth-robust `**/.webjs/*` prefix is what
+    // distinguishes the fix from the old root-anchored `.webjs/*`.
+    assert.match(
+      gitignore,
+      /\*\*\/\.webjs\/\*/,
+      '.gitignore uses **/.webjs/* so a nested app does not leak routes.d.ts',
+    );
+    assert.match(
+      gitignore,
+      /!\*\*\/\.webjs\/vendor\//,
+      '.gitignore keeps the **/ vendor negation so the committed pin ships',
+    );
+
     // .env.example mentions DATABASE_URL
     const envExample = readFileSync(join(appDir, '.env.example'), 'utf8');
     assert.match(envExample, /DATABASE_URL/, '.env.example carries DATABASE_URL');

--- a/test/scaffolds/scaffold-integration.test.js
+++ b/test/scaffolds/scaffold-integration.test.js
@@ -207,14 +207,18 @@ test('scaffoldApp full-stack: writes the canonical full-stack app layout', async
     // nested below its repo root must not leak its generated
     // .webjs/routes.d.ts. The depth-robust `**/.webjs/*` prefix is what
     // distinguishes the fix from the old root-anchored `.webjs/*`.
+    // Anchor to a line start (multiline) so these match the ACTIVE rule
+    // lines, not the surrounding comment prose that also names the
+    // pattern. Without the anchor a revert of the real rule to `.webjs/*`
+    // would still pass while a stale comment kept the `**/` text.
     assert.match(
       gitignore,
-      /\*\*\/\.webjs\/\*/,
+      /^\*\*\/\.webjs\/\*$/m,
       '.gitignore uses **/.webjs/* so a nested app does not leak routes.d.ts',
     );
     assert.match(
       gitignore,
-      /!\*\*\/\.webjs\/vendor\//,
+      /^!\*\*\/\.webjs\/vendor\/$/m,
       '.gitignore keeps the **/ vendor negation so the committed pin ships',
     );
 


### PR DESCRIPTION
## Summary

Closes #365.

The gitignore pattern `.webjs/*` carries a slash, so git anchors it to the directory the `.gitignore` lives in. In this monorepo the nested in-repo apps (`website/`, `docs/`, `packages/ui/packages/website/`) leaked their generated `.webjs/routes.d.ts` into `git status`, because the root-anchored rule never reached them. `routes.d.ts` is a per-machine generated route-types overlay that is meant to be ignored (only `.webjs/vendor/` is committed), so this was a real bug, and the same gap shipped in the scaffold template (any app nested below its repo root had it).

The fix switches the gitignore to `**/.webjs/*` (plus the matching `**/` vendor negations), which matches `.webjs/` at any depth while still re-including the committed `.webjs/vendor/` pin at each depth (a re-included parent dir permits a child negation). Verified empirically before and after: nested `routes.d.ts` is now ignored at every depth, and the vendor pin stays tracked at both root and nested depths.

## What changed

- **Gitignores** switched to `**/.webjs/*` + `!**/.webjs/vendor/` + `!**/.webjs/vendor/**`:
  - root `.gitignore` (fixes the three untracked dirs in this repo)
  - `examples/blog/.gitignore`
  - `packages/cli/templates/.gitignore` (the shipped scaffold, so a nested/monorepo scaffolded app no longer leaks the file)
- **Docs:** `packages/cli/templates/AGENTS.md` (the "do NOT modify the `.webjs/` lines" block now documents the `**/` form and why it matters).
- **Check rule:** `gitignore-vendor-not-ignored` description + fix hint now recommend the depth-robust `**/.webjs/*`. The older anchored `.webjs/*` still passes the rule (the probe runs from the app root), so this is guidance only, not a behavior change.
- **Tests:** added a rule test that `**/.webjs/*` keeps the vendor pin un-ignored, plus a behavioral test that proves the fix end to end. The new pattern ignores a nested `routes.d.ts` while the old anchored `.webjs/*` leaks it (the counterfactual), and the vendor pin stays tracked at root and nested depths.

## Test plan / Definition of done

- [x] Unit coverage added with a counterfactual; full server suite green (2160 pass, 0 fail).
- [x] `git check-ignore` confirms the three nested `routes.d.ts` are now ignored; vendor pins stay tracked at root and nested depths; `git status` is clean of `.webjs/`.
- [x] Scaffold tests pass (12/12) with the new template `.gitignore`.
- [x] Dogfood boot: website `/` 200, docs `/` 307, ui-website `/` 200, no broken modulepreloads. Blog e2e N/A (this change touches no served or browser-wire code).
- [x] Docs: scaffold `AGENTS.md` updated. Root `AGENTS.md`, `agent-docs/`, and the docs site do not document the literal `.webjs/*` gitignore pattern, so nothing else drifts.
- Browser / e2e tests: **N/A** because this is a git-config and check-rule-string change with no DOM, hydration, or served-wire impact.
- `.dockerignore`: **aligned** for consistency. The repo-root `.dockerignore` already used `**/.webjs/*`, and the scaffold `AGENTS.md` note groups `.gitignore` and `.dockerignore`, so the scaffold template `.dockerignore` was updated to match (a nested Docker build context no longer ships the per-machine `.webjs` cache). This does not affect `git status`; it keeps the scaffold artifacts uniform.
- Version bump: **N/A** on this PR (assessed separately after merge per the release workflow).

