### PR TITLE
chore: release @webjsdev/server 0.8.18 + @webjsdev/cli 0.10.11

### DIFF
--- a/changelog/cli/0.10.11.md
+++ b/changelog/cli/0.10.11.md
@@ -1,0 +1,20 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.11
+date: 2026-06-06T19:20:52.336Z
+commit_count: 2
+---
+## Features
+
+- **enforce scaffold-content removal via a check rule + markers (#359)** ([#360](https://github.com/webjsdev/webjs/pull/360)) [`c631ffe3`](https://github.com/webjsdev/webjs/commit/c631ffe3)
+  * feat: enforce scaffold-content removal via a check rule + markers (#359)
+  
+  * docs: document the no-scaffold-placeholder enforcement (#359)
+
+## Fixes
+
+- **ignore .webjs/routes.d.ts at any depth via **/.webjs/*** ([#366](https://github.com/webjsdev/webjs/pull/366)) [`2207bf3e`](https://github.com/webjsdev/webjs/commit/2207bf3e)
+  * fix: ignore .webjs/routes.d.ts at any depth via **/.webjs/*
+  
+  The gitignore pattern .webjs/* carries a slash, so git anchors it to the
+  .gitignore's own directory. In this monorepo the nested in-repo apps

--- a/changelog/server/0.8.18.md
+++ b/changelog/server/0.8.18.md
@@ -1,0 +1,25 @@
+---
+package: "@webjsdev/server"
+version: 0.8.18
+date: 2026-06-06T19:20:52.271Z
+commit_count: 3
+---
+## Features
+
+- **enforce scaffold-content removal via a check rule + markers (#359)** ([#360](https://github.com/webjsdev/webjs/pull/360)) [`c631ffe3`](https://github.com/webjsdev/webjs/commit/c631ffe3)
+  * feat: enforce scaffold-content removal via a check rule + markers (#359)
+  
+  * docs: document the no-scaffold-placeholder enforcement (#359)
+
+## Fixes
+
+- **ignore .webjs/routes.d.ts at any depth via **/.webjs/*** ([#366](https://github.com/webjsdev/webjs/pull/366)) [`2207bf3e`](https://github.com/webjsdev/webjs/commit/2207bf3e)
+  * fix: ignore .webjs/routes.d.ts at any depth via **/.webjs/*
+  
+  The gitignore pattern .webjs/* carries a slash, so git anchors it to the
+  .gitignore's own directory. In this monorepo the nested in-repo apps
+- **version nested relative import specifiers to match modulepreload (#369)** ([#370](https://github.com/webjsdev/webjs/pull/370)) [`0e547046`](https://github.com/webjsdev/webjs/commit/0e547046)
+  * fix: version nested relative import specifiers to match modulepreload (#369)
+  
+  A layout/page imports its components with a bare relative specifier
+  (import '../components/x.ts'). The browser resolves that against the

--- a/package-lock.json
+++ b/package-lock.json
@@ -6980,7 +6980,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.9",
+      "version": "0.10.11",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/server": "^0.8.0",
@@ -6995,7 +6995,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.10",
+      "version": "0.7.11",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.24.0"
@@ -7016,7 +7016,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.16",
+      "version": "0.8.18",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",
@@ -7060,7 +7060,7 @@
     },
     "packages/ui": {
       "name": "@webjsdev/ui",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.0",
@@ -7110,6 +7110,11 @@
         "@webjsdev/cli": "^0.10.0",
         "@webjsdev/core": "^0.7.0",
         "@webjsdev/server": "^0.8.0"
+      },
+      "devDependencies": {
+        "@web/test-runner": "^0.20.0",
+        "@web/test-runner-playwright": "^0.11.0",
+        "playwright": "^1.59.0"
       },
       "engines": {
         "node": ">=24.0.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.10",
+  "version": "0.10.11",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.17",
+  "version": "0.8.18",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
## Summary

Release the accumulated unreleased work on `@webjsdev/server` and `@webjsdev/cli`. Patch bumps: both packages stay in their current minor line and every in-repo dependent pins `^0.8.0` / `^0.10.0`, so the new versions satisfy the existing ranges (no dependent range edits, no lockfile dependency churn beyond the two versions).

Merging this adds the `changelog/**.md` files to `main`, which triggers `release.yml` to `npm publish` and cut the GitHub Releases (idempotent).

## @webjsdev/server 0.8.18 (was 0.8.17)

- feat: enforce scaffold-content removal via a check rule + markers (#359, PR #360)
- fix: ignore `.webjs/routes.d.ts` at any depth via `**/.webjs/*` (#366)
- fix: version nested relative import specifiers to match modulepreload (#369, PR #370)

## @webjsdev/cli 0.10.11 (was 0.10.10)

- feat: enforce scaffold-content removal via a check rule + markers (#359, PR #360)
- fix: ignore `.webjs/routes.d.ts` at any depth via `**/.webjs/*` (#366)

## Notes

- Changelogs auto-generated by the `backfill-changelog.js` pre-commit hook from the conventional squash subjects; reviewed for accuracy.
- `core`, `ui`, `ts-plugin` have no unreleased qualifying commits since their last release, so they are not bumped.
- Mechanical release (version lines + generated changelogs only); bump level, dependent ranges, lockfile, and changelog content verified by hand.