### PR TITLE
perf: preload JetBrains Mono to remove the website CSS-to-font waterfall

### DIFF
--- a/website/app/layout.ts
+++ b/website/app/layout.ts
@@ -60,16 +60,21 @@ export default function RootLayout({ children }: { children: unknown }) {
     <link rel="icon" href="/public/favicon.png" type="image/png">
     <link rel="apple-touch-icon" href="/public/favicon.png">
 
-    <!-- Self-hosted fonts (declared via @font-face in input.css). Preload the
-         two above-the-fold families so they fetch in parallel with the
-         stylesheet: the display face (Inter Tight, hero headline) and the body
-         face (Inter). Each is one variable file covering all weights. The hero
-         install command is the one above-the-fold monospace text, but JetBrains
-         Mono is deliberately not preloaded. The preload budget stays on the two
-         LCP text faces, and the ui-monospace fallback is close enough that the
-         late swap on a single command line is negligible. -->
+    <!-- Self-hosted fonts (declared via @font-face in input.css), preloaded so
+         they fetch in parallel with the stylesheet instead of being discovered
+         only after the CSS parses. The display face (Inter Tight, hero
+         headline) and the body face (Inter) are the LCP text faces. JetBrains
+         Mono is preloaded too: the hero install command is above-the-fold
+         monospace text and the primary CTA, and a trace of the live site showed
+         the un-preloaded mono file as the tail of the critical request chain
+         (document, then tailwind.css, then the font, discovered late via its
+         @font-face). Preloading it drops that hop so the command paints its
+         final face without the late swap. Each family is one variable file
+         covering every weight, so three small woff2 files over h2 is a cheap
+         preload budget. -->
     <link rel="preload" href="/public/fonts/inter-tight.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="/public/fonts/inter.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="/public/fonts/jetbrains-mono.woff2" as="font" type="font/woff2" crossorigin>
 
     <!-- Warm the analytics connection so the async gtag handshake (and the
          beacon to google-analytics.com it then opens) overlaps head parse


### PR DESCRIPTION
## Summary

Closes #372.

A performance trace of the live https://webjs.dev showed one remaining critical-path waterfall: `document -> tailwind.css -> jetbrains-mono.woff2`. The mono font was the only one of the three families NOT in the `<head>` preload set, so the browser discovered it only after downloading and parsing `tailwind.css` (via its `@font-face`), serializing it behind the stylesheet instead of fetching it in parallel. The two Inter faces were already preloaded and so fetched early in parallel.

This adds `<link rel="preload" as="font" type="font/woff2" crossorigin>` for `jetbrains-mono.woff2` next to the two Inter preloads, collapsing the chain from `HTML -> CSS -> font` to `HTML -> {CSS, font, modules}`.

## What this is and isn't

- The hero install command is above-the-fold monospace text and the primary CTA. The font is `font-display: swap`, so this does NOT change LCP (text paints immediately in the `ui-monospace` fallback); it removes the *late mono swap* on that command by getting the final face in flight from the head. The win is the visible FOUT on the most prominent CTA, not a render-blocking fix.
- It reverses a previously deliberate decision (the old comment kept mono off the preload budget, judging the swap negligible). The trace evidence (mono as the critical-chain tail) plus the command being the primary CTA is why; the comment is rewritten to record the new rationale.
- The `@font-face` src (`/public/fonts/jetbrains-mono.woff2`) matches the preload href exactly, so there is no unused-preload console warning.

## Test plan / definition of done

- **Verified** by booting `website` through `createRequestHandler` in prod: `/` returns 200, the head now carries exactly 3 font preloads (`inter-tight`, `inter`, `jetbrains-mono`, mono once), and `/public/fonts/jetbrains-mono.woff2` serves 200.
- **Tests N/A:** this is a static `<head>` markup change in one app, with no framework code, no logic, and no new public surface to unit/e2e-test. The blog e2e is unaffected (different app).
- **Docs:** the inline rationale comment in `website/app/layout.ts` is updated. No other markdown/docs surface describes the website's font-preload set. No framework change, so no `AGENTS.md` / `agent-docs` / scaffold / version bump.
- **Dogfood:** website-only change; `website` boots 200 in dist mode with the new preload resolving. The other three apps are untouched.