### PR TITLE
feat: gate the in-repo Docker image on /__webjs/ready (auto-warm deploys)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,20 @@ RUN npx tailwindcss -i website/public/input.css                       -o website
  && npx tailwindcss -i examples/blog/public/input.css                 -o examples/blog/public/tailwind.css                 --minify \
  && npx tailwindcss -i packages/ui/packages/website/public/input.css  -o packages/ui/packages/website/public/tailwind.css  --minify
 
-# Defaults - Railway / compose override per service.
+# Default env vars. Railway / compose set their own per service.
 ENV NODE_ENV=production
+
+# Platform-neutral readiness gate (mirrors packages/cli/templates/Dockerfile,
+# the pattern the scaffold ships to users). webjs answers /__webjs/ready with
+# 503 until the instance is fully warm (analysis + first vendor attempt), then
+# 200. This image-level HEALTHCHECK is honoured by Docker, compose, and most
+# Docker-based platforms, so the readiness gate works the same everywhere
+# without a per-platform file. Each service sets its own PORT (compose env, or
+# Railway injects it); the probe reads it, defaulting to 8080. Dependency-free
+# (Node's built-in fetch, no curl/wget). Platforms that read their own config
+# point the equivalent knob at the same path (Railway healthcheckPath in
+# railway.json, Fly [checks], k8s readinessProbe).
+HEALTHCHECK --interval=15s --timeout=3s --start-period=40s --retries=5 \
+  CMD ["node", "-e", "fetch('http://127.0.0.1:'+(process.env.PORT||8080)+'/__webjs/ready').then(r=>process.exit(r.ok?0:1),()=>process.exit(1))"]
+
 CMD ["node", "--help"]

--- a/agent-docs/framework-dev.md
+++ b/agent-docs/framework-dev.md
@@ -4,6 +4,19 @@ Read this only when editing the webjs monorepo (this repo), not a scaffolded app
 
 ---
 
+### Deploying the in-repo apps (Docker image + readiness gate)
+
+The four in-repo apps (`website`, `docs`, `examples/blog`, `packages/ui/packages/website`) deploy from ONE image built by the root `Dockerfile`, each run as a separate service with its own `PORT` (compose sets it locally, the platform injects it in prod). `compose.yaml` is local parity for that setup; the platform never reads it.
+
+The readiness gate is the same `/__webjs/ready` endpoint the framework ships and documents (503 until fully warm, then 200, see the deployment docs page). Two seams carry it, because no single file configures every platform:
+
+- **Docker / compose / most Docker-based hosts:** the root `Dockerfile` `HEALTHCHECK` (PORT-driven, dependency-free `node -e fetch`) makes the image self-gate. This mirrors `packages/cli/templates/Dockerfile`, the pattern the scaffold ships to users.
+- **Railway:** it IGNORES the Docker `HEALTHCHECK` and only honours its own `healthcheckPath`. `railway.json` declares `healthcheckPath: /__webjs/ready`, but a service only applies it if it is wired to read `railway.json` (config-as-code) AND built via the Dockerfile builder. A service left on the RAILPACK builder with no config-file path ignores `railway.json` entirely, so its `healthcheckPath` is null and deploys serve a cold-start window. Wire each service to `railway.json` rather than setting `healthcheckPath` by hand in the dashboard (dashboard values drift from the repo).
+
+Net: edit the `HEALTHCHECK` for the Docker contract, keep `railway.json` for the Railway contract, and never hand-set deploy config in a platform dashboard.
+
+---
+
 ### Repo health: worktree-safe git config (core.bare / hooksPath)
 
 This repo uses git worktrees (the review subagents spawn throwaway ones under `.claude/worktrees/`). Git's worktree machinery can leave `core.bare=true` in the shared `.git/config`, which is lethal to the main checkout: every git operation that needs a work tree then fails with `fatal: this operation must be run in a work tree`. The shared value is harmless only while the main worktree carries a per-worktree override (`extensions.worktreeConfig=true` plus a `.git/config.worktree` pinning `core.bare=false`).

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,4 @@
-# docker compose - runs website + docs + blog + ui-website as four services
+# docker compose runs website + docs + blog + ui-website as four services
 # from a single image. Local parity with Railway deployment (same Dockerfile).
 #
 #   docker compose up --build
@@ -6,25 +6,23 @@
 #     docs       → http://localhost:15002
 #     blog       → http://localhost:15004
 #     ui-website → http://localhost:15003  (registry host + @webjsdev/ui docs)
+#
+# Readiness gate: the image carries a single PORT-driven HEALTHCHECK (it probes
+# /__webjs/ready, see Dockerfile), so each service only sets PORT and compose
+# inherits the gate. No per-service healthcheck block is duplicated here.
 services:
   website:
     image: webjs
     build: .
     working_dir: /app/website
     # @webjsdev/cli installed in the root node_modules/.bin by npm workspaces;
-    # invoke its binary directly rather than via `webjs`.
-    command: ["node", "/app/node_modules/@webjsdev/cli/bin/webjs.js", "start", "--port", "5001"]
+    # invoke its binary directly rather than via `webjs`. The server reads PORT
+    # (set below) with no --port flag, so the image HEALTHCHECK probes the same port.
+    command: ["node", "/app/node_modules/@webjsdev/cli/bin/webjs.js", "start"]
     ports:
       - "15001:5001"
-    # Readiness gate: unhealthy (503) until the first-request analysis is warm,
-    # then 200. Mirrors the railway.json healthcheckPath.
-    healthcheck:
-      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:5001/__webjs/ready"]
-      interval: 10s
-      timeout: 3s
-      retries: 5
-      start_period: 20s
     environment:
+      PORT: "5001"
       DOCS_URL: ${DOCS_URL:-http://localhost:15002}
       EXAMPLE_BLOG_URL: ${EXAMPLE_BLOG_URL:-http://localhost:15004}
       UI_URL:   ${UI_URL:-http://localhost:15003}
@@ -33,15 +31,11 @@ services:
     image: webjs
     build: .
     working_dir: /app/docs
-    command: ["node", "/app/node_modules/@webjsdev/cli/bin/webjs.js", "start", "--port", "5002"]
+    command: ["node", "/app/node_modules/@webjsdev/cli/bin/webjs.js", "start"]
     ports:
       - "15002:5002"
-    healthcheck:
-      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:5002/__webjs/ready"]
-      interval: 10s
-      timeout: 3s
-      retries: 5
-      start_period: 20s
+    environment:
+      PORT: "5002"
 
   blog:
     image: webjs
@@ -54,16 +48,11 @@ services:
       - -c
       - |
         node /app/node_modules/prisma/build/index.js migrate deploy && \
-        node /app/node_modules/@webjsdev/cli/bin/webjs.js start --port 5004
+        node /app/node_modules/@webjsdev/cli/bin/webjs.js start
     ports:
       - "15004:5004"
-    healthcheck:
-      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:5004/__webjs/ready"]
-      interval: 10s
-      timeout: 3s
-      retries: 5
-      start_period: 30s
     environment:
+      PORT: "5004"
       DATABASE_URL: file:/data/dev.db
       AUTH_SECRET:    ${AUTH_SECRET:-change-me-at-least-32-characters-long!}
       SESSION_SECRET: ${SESSION_SECRET:-change-me-at-least-32-characters-long!}
@@ -75,19 +64,15 @@ services:
     build: .
     working_dir: /app/packages/ui/packages/website
     # Registry host for @webjsdev/ui:
-    #   GET /r/<name>.json   - single registry item (CLI fetches from here)
-    #   GET /r/index.json    - flat list of all items
-    #   GET /docs/components/<name> - per-component docs page
+    #   GET /r/<name>.json          single registry item (CLI fetches from here)
+    #   GET /r/index.json           flat list of all items
+    #   GET /docs/components/<name> per-component docs page
     # The registry JSON is built at image time (see Dockerfile RUN step).
-    command: ["node", "/app/node_modules/@webjsdev/cli/bin/webjs.js", "start", "--port", "5003"]
+    command: ["node", "/app/node_modules/@webjsdev/cli/bin/webjs.js", "start"]
     ports:
       - "15003:5003"
-    healthcheck:
-      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:5003/__webjs/ready"]
-      interval: 10s
-      timeout: 3s
-      retries: 5
-      start_period: 20s
+    environment:
+      PORT: "5003"
 
 volumes:
   blog-data:


### PR DESCRIPTION
## Summary

Part of #374. (Not `Closes`: this is the portable Docker half; the Railway config-as-code wiring is an operational follow-up, see below.)

The in-repo apps served a multi-second cold-start to the first visitors right after every deploy. webjs already exposes `/__webjs/ready` (503 until fully warm, then 200) and the scaffold (`packages/cli/templates/Dockerfile`) already ships a readiness-gated image, but the framework's OWN root `Dockerfile` had no `HEALTHCHECK` at all, so a Docker/compose/bare-metal host marks the container healthy the moment the port opens, before warmup, and routes the first requests into a cold instance.

This brings the framework's own deploy image in line with the pattern it ships to users: a PORT-driven, dependency-free `HEALTHCHECK` on the root `Dockerfile` that probes `/__webjs/ready`, so the image self-gates on any Docker-based platform without a per-platform file. The compose services switch from a `--port` flag to a `PORT` env so the single image healthcheck resolves the right port per service, and the four duplicated per-service healthcheck blocks are dropped in favour of the image one.

## What this does NOT do (the Railway half)

Railway IGNORES the Docker `HEALTHCHECK` and only honours its own `healthcheckPath`. The four Railway services currently run on the RAILPACK builder with `railwayConfigFile: null`, so they ignore the committed `railway.json` (which already declares `healthcheckPath: /__webjs/ready`) and show `healthcheckPath: null`. Fixing the LIVE Railway cold-start means wiring each service to read `railway.json` (config-as-code), which also flips the builder RAILPACK -> DOCKERFILE. That is a prod build-pipeline change that needs a canary deploy to verify, so it is a deliberate operational step done after this lands, not folded into this diff. (The local image build in the test plan de-risks it: the Dockerfile builds clean.) The issue stays open until that wiring is done and a post-deploy trace confirms no cold window.

## Test plan

- **Verified the gate end to end:** built the root image, ran the website service exactly as compose does (`PORT=5001`, no `--port`), and watched `docker inspect` health go `starting -> healthy` only after `/__webjs/ready` returned 200. The probe log (`exit=1 exit=1 exit=0`) shows it held `starting` while warming, then flipped on the first 200.
- **compose validates:** `docker compose config` passes; each service carries its `PORT` and inherits the image healthcheck.
- **Dogfood:** website / docs / ui-website boot 200/307 in dist mode; blog covered by the existing e2e (unaffected, this is deploy-config only).
- **Tests N/A:** no framework runtime, client, or served-output change. The `/__webjs/ready` endpoint + warmup already exist and are tested; this only wires the deploy image to them.
- **Docs:** `agent-docs/framework-dev.md` gains a section on the two readiness-gate seams (Docker `HEALTHCHECK` + Railway `healthcheckPath`) and the RAILPACK-ignores-railway.json caveat. The user-facing deployment docs already document `/__webjs/ready` (readinessProbe / Docker HEALTHCHECK / healthcheckPath), so no change there. Scaffold templates already ship this pattern, so no change there.