### PR TITLE
feat: add a source tool to webjs mcp to read the no-build framework source

### DIFF
--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -59,11 +59,25 @@ lib/
                          KNOWLEDGE layer (#376), all in `lib/mcp-docs.js`: an
                          `init` tool (the read-first mental-model primer, sourcing
                          the execution-model + invariants sections from AGENTS.md
-                         so it cannot drift), a `docs` tool (retrieve a doc by
-                         topic / search by query / index), MCP `resources/list` +
-                         `resources/read` serving the `agent-docs/*.md` corpus +
-                         AGENTS.md as `webjs-docs://<name>`, and `prompts/list` +
-                         `prompts/get` exposing the recipes as guided workflows.
+                         so it cannot drift; it also points at the `source` tool),
+                         a `docs` tool (retrieve a doc by topic / search by query
+                         / index), MCP `resources/list` + `resources/read` serving
+                         the `agent-docs/*.md` corpus + AGENTS.md as
+                         `webjs-docs://<name>`, and `prompts/list` + `prompts/get`
+                         exposing the recipes as guided workflows.
+                         SOURCE tool (#378), in `lib/mcp-source.js`: `source`
+                         reads the framework's OWN source (webjs is no-build, so
+                         `node_modules/@webjsdev/*/src` is the real JSDoc that
+                         runs). `path` reads a file (e.g. `server/src/ssr.js`),
+                         `query` greps the `@webjsdev/*` src trees (bounded, cap
+                         disclosed), no-args lists the resolved packages + entry
+                         points. `resolveFrameworkRoots` locates each package by
+                         checking the `require.resolve.paths` node_modules dirs on
+                         disk (NOT `<pkg>/package.json`, which `exports` blocks for
+                         server/cli/ui, NOR the main entry, which cli lacks), and
+                         uses `src/` or (for cli) `lib/`. READ-ONLY +
+                         traversal-guarded (cannot escape a package root), loads no
+                         module.
                          The docs are bundled into the package at `prepack`
                          (`scripts/copy-mcp-resources.js` -> `resources/`, which is
                          in `files`, gitignored) so `npx @webjsdev/cli mcp` is
@@ -107,7 +121,7 @@ README.md                npm-facing package readme.
 | `webjs start` | `startServer({ dev: false })`, plain HTTP/1.1 (front a reverse proxy for TLS + HTTP/2) |
 | `webjs test [--server\|--browser]` | `node --test` for server tests, `wtr` for browser tests |
 | `webjs check [--rules] [--json]` | `checkConventions()` from `@webjsdev/server/check`. `--rules` lists the checks. `--json` emits the structured violations + a summary count as JSON (via the shared `lib/check-json.js` `projectCheck`), so an agent in a loop consumes structured data instead of regex-scraping stdout; the non-zero exit on violations is preserved. Report-only: each violation carries a prose `fix` hint, but there is no `--fix` autofix flag (the rules either rewrite code or rename files, so an automatic codemod is not safe) |
-| `webjs mcp` | MCP stdio server (#262, knowledge layer #376), `runMcpServer()` from `lib/mcp.js`. Hand-rolled, ZERO new dependency, newline-delimited JSON-RPC 2.0. INTROSPECTION tools (read-only): `list_routes`, `list_actions`, `list_components`, `check`. KNOWLEDGE layer: an `init` mental-model primer + a `docs` retrieval tool, MCP `resources` (the `agent-docs` corpus + AGENTS.md as `webjs-docs://*`), and `prompts` (the recipes as guided workflows). Docs bundled into the package at `prepack` (self-contained `npx`), repo-root fallback in dev. Wired into the scaffold's `.claude.json` next to the Playwright MCP entry as `{ "command": "npx", "args": ["@webjsdev/cli", "mcp"] }`; mountable in any MCP host (Cursor `.cursor/mcp.json`, etc.). STDOUT is the JSON-RPC channel (diagnostics go to stderr) |
+| `webjs mcp` | MCP stdio server (#262, knowledge layer #376), `runMcpServer()` from `lib/mcp.js`. Hand-rolled, ZERO new dependency, newline-delimited JSON-RPC 2.0. INTROSPECTION tools (read-only): `list_routes`, `list_actions`, `list_components`, `check`. KNOWLEDGE layer: an `init` mental-model primer + a `docs` retrieval tool, MCP `resources` (the `agent-docs` corpus + AGENTS.md as `webjs-docs://*`), and `prompts` (the recipes as guided workflows). SOURCE: a `source` tool reads the framework's own no-build source from `node_modules/@webjsdev/*/src` (read-only, traversal-guarded). Docs bundled into the package at `prepack` (self-contained `npx`), repo-root fallback in dev. Wired into the scaffold's `.claude.json` next to the Playwright MCP entry as `{ "command": "npx", "args": ["@webjsdev/cli", "mcp"] }`; mountable in any MCP host (Cursor `.cursor/mcp.json`, etc.). STDOUT is the JSON-RPC channel (diagnostics go to stderr) |
 | `webjs doctor` | `runDoctorChecks()` from `lib/doctor.js`. A project-health checklist over existing signals (Node major, tsconfig `erasableSyntaxOnly`, `.env` drift vs `.env.example`, vendor-pin freshness, `@webjsdev/*` version coherence, git pre-commit hook). PURE checks render with a `[pass]` / `[warn]` / `[fail]` marker; non-zero exit iff a HARD check fails (Node below the floor, or `erasableSyntaxOnly` missing in an existing tsconfig), so CI can gate. Warns (drift / staleness) never fail the exit. The only network touch (pin freshness) is best-effort: a fetch failure is a warn, never a hard fail. An onboarding/setup-verify tool, NOT a scaffold-CI hard gate. Tests: `test/cli/doctor.test.mjs` |
 | `webjs types` | `generateRouteTypes()` from `@webjsdev/server`, writes `.webjs/routes.d.ts` (typed `Route` union + per-route params, #258). Also auto-emitted at `webjs dev` startup |
 | `webjs typecheck [tsc args]` | Resolves the project's own `typescript/bin/tsc` (via `createRequire` from the app cwd) and spawns it with `--noEmit`, passing extra args through. Exits non-zero on a type error (a CI gate). A clear message + non-zero exit when typescript is not installed (#265). The framework runs the standard compiler, it does not embed one |

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -75,9 +75,11 @@ lib/
                          checking the `require.resolve.paths` node_modules dirs on
                          disk (NOT `<pkg>/package.json`, which `exports` blocks for
                          server/cli/ui, NOR the main entry, which cli lacks), and
-                         uses `src/` or (for cli) `lib/`. READ-ONLY +
-                         traversal-guarded (cannot escape a package root), loads no
-                         module.
+                         uses `src/` or (for cli) `lib/`. READ-ONLY and scoped to
+                         the AUTHORED source dir: the built `@webjsdev/core` browser
+                         `dist/` bundle, `package.json`, etc. are NOT readable, only
+                         `src/`. Traversal-guarded lexically AND via `realpath` (a
+                         symlink inside `src/` cannot escape), loads no module.
                          The docs are bundled into the package at `prepack`
                          (`scripts/copy-mcp-resources.js` -> `resources/`, which is
                          in `files`, gitignored) so `npx @webjsdev/cli mcp` is

--- a/packages/cli/lib/mcp-docs.js
+++ b/packages/cli/lib/mcp-docs.js
@@ -194,10 +194,11 @@ export async function initText(deps) {
     'When writing a component, read `webjs-docs://lit-muscle-memory-gotchas` first:',
     'the Lit habits that break webjs SSR/reactivity each have a webjs-shaped fix there.',
     '',
-    'webjs is NO-BUILD: the full framework source ships as readable JSDoc `.js` in',
-    '`node_modules/@webjsdev/*/src` (what you read is what runs, no compiled dist to',
-    'see through). When the docs do not answer something, read the real source with',
-    'the `source` tool (grep it, read a file, or list the packages and entry points).',
+    'webjs is buildless: the authored framework source is readable JSDoc in',
+    '`node_modules/@webjsdev/<pkg>/src`, and server-side that source runs directly.',
+    '(The one built artifact is the `@webjsdev/core` BROWSER bundle in `dist/`;',
+    'its authored source is still in `src/`.) When the docs do not answer something,',
+    'use the `source` tool to grep or read that real `src/` source (it skips `dist/`).',
   ].join('\n');
 
   const parts = [

--- a/packages/cli/lib/mcp-docs.js
+++ b/packages/cli/lib/mcp-docs.js
@@ -193,6 +193,11 @@ export async function initText(deps) {
     'state primitive. Server-only code lives behind the `.server.{js,ts}` boundary.',
     'When writing a component, read `webjs-docs://lit-muscle-memory-gotchas` first:',
     'the Lit habits that break webjs SSR/reactivity each have a webjs-shaped fix there.',
+    '',
+    'webjs is NO-BUILD: the full framework source ships as readable JSDoc `.js` in',
+    '`node_modules/@webjsdev/*/src` (what you read is what runs, no compiled dist to',
+    'see through). When the docs do not answer something, read the real source with',
+    'the `source` tool (grep it, read a file, or list the packages and entry points).',
   ].join('\n');
 
   const parts = [

--- a/packages/cli/lib/mcp-source.js
+++ b/packages/cli/lib/mcp-source.js
@@ -1,0 +1,215 @@
+/**
+ * The `source` tool for `webjs mcp` (#378): read-only access to the FRAMEWORK
+ * source itself.
+ *
+ * webjs is no-build, so every app's `node_modules/@webjsdev/<pkg>/src` holds the
+ * authored JSDoc `.js` that actually runs (no compiled/minified dist to see
+ * through). That is a real advantage: when the docs do not answer a question,
+ * an agent can read the real source. This tool makes that first-class and
+ * discoverable (and reachable for an MCP-only client with no filesystem tools):
+ *   - no args (or `package`): list the resolved `@webjsdev/*` packages + their
+ *     `src/` entry-point files.
+ *   - `query`: grep the framework `src/` trees, returning bounded `file:line`
+ *     hits (with a disclosed cap, no silent truncation).
+ *   - `path`: read one source file (e.g. `server/src/ssr.js`), traversal-guarded
+ *     to stay inside a resolved framework package root.
+ *
+ * READ-ONLY and side-effect-free: it only reads files, loads no module, and
+ * cannot read outside the resolved `@webjsdev/*` package roots. Zero-dependency,
+ * consistent with the rest of the server. PURE given injected `deps`
+ * (`{ roots, readFile, readdir }`), so it is testable against a fake tree.
+ *
+ * @module mcp-source
+ */
+
+import { createRequire } from 'node:module';
+import { join, resolve, sep, relative } from 'node:path';
+
+/** The published framework packages whose source an agent may want to read. */
+export const FRAMEWORK_PACKAGES = ['core', 'server', 'cli', 'ts-plugin', 'ui'];
+
+/** Source file extensions worth grepping / reading (text, not assets). */
+const TEXT_EXT = /\.(?:js|ts|mjs|mts|cjs|cts|json|md)$/i;
+
+/** Bound the grep output (disclosed when hit) and the walk (defensive). */
+const MAX_HITS = 60;
+const MAX_FILES = 4000;
+
+/**
+ * Resolve each `@webjsdev/*` package's root + `src/` dir from `cwd`. Uses
+ * `createRequire(cwd).resolve('<pkg>/package.json')`, so it works for a real
+ * `node_modules` install AND the monorepo workspace (where the specifier
+ * resolves through the symlink to `packages/<pkg>`). A package that is not
+ * installed is skipped (not every app depends on every `@webjsdev/*`).
+ *
+ * @param {string} cwd
+ * @param {{ exists: (p: string) => boolean }} fsDeps
+ * @returns {Array<{ pkg: string, root: string, src: string }>}
+ */
+export function resolveFrameworkRoots(cwd, fsDeps) {
+  const req = createRequire(join(cwd, '__webjs_mcp_source__.js'));
+  /** @type {Array<{ pkg: string, root: string, src: string }>} */
+  const out = [];
+  for (const pkg of FRAMEWORK_PACKAGES) {
+    // Find the package ROOT by checking each node_modules search path on disk,
+    // NOT via `require.resolve('<pkg>')` or `<pkg>/package.json`: a package whose
+    // `exports` omits `./package.json` (server/cli/ui) or that has no main entry
+    // (cli is a bin-only package) would otherwise be unreachable. The fs check
+    // bypasses both and still honours hoisting (the search paths include every
+    // parent `node_modules`).
+    const bases = req.resolve.paths(`@webjsdev/${pkg}`) || [];
+    let root = '';
+    for (const base of bases) {
+      const cand = join(base, '@webjsdev', pkg);
+      if (fsDeps.exists(join(cand, 'package.json'))) { root = cand; break; }
+    }
+    if (!root) continue;
+    // Most packages keep source in `src/`; the cli keeps it in `lib/`. Use
+    // whichever exists so every framework package's source is reachable.
+    const src = fsDeps.exists(join(root, 'src'))
+      ? join(root, 'src')
+      : fsDeps.exists(join(root, 'lib'))
+        ? join(root, 'lib')
+        : '';
+    if (src) out.push({ pkg, root, src });
+  }
+  return out;
+}
+
+/**
+ * Recursively list text-source files under `dir` (absolute paths), skipping
+ * `node_modules` / `dist` and bounded by {@link MAX_FILES}.
+ *
+ * @param {string} dir
+ * @param {{ readdir: (d: string) => Array<{ name: string, isDir: boolean }> }} deps
+ * @returns {string[]}
+ */
+export function walkSource(dir, deps) {
+  /** @type {string[]} */
+  const files = [];
+  /** @type {string[]} */
+  const stack = [dir];
+  while (stack.length && files.length < MAX_FILES) {
+    const d = stack.pop();
+    let entries = [];
+    try { entries = deps.readdir(d); } catch { continue; }
+    for (const e of entries) {
+      if (e.isDir) {
+        if (e.name === 'node_modules' || e.name === 'dist' || e.name === '.git') continue;
+        stack.push(join(d, e.name));
+      } else if (TEXT_EXT.test(e.name)) {
+        files.push(join(d, e.name));
+        if (files.length >= MAX_FILES) break;
+      }
+    }
+  }
+  return files.sort();
+}
+
+/**
+ * No-args / `package` mode: list the resolved packages and their `src/`
+ * top-level files (the entry points), so the agent has a map to grep or read.
+ *
+ * @param {{ roots: Array<{ pkg: string, root: string, src: string }>, readdir: Function }} deps
+ * @param {string} [pkgFilter]
+ * @returns {string}
+ */
+export function listSources(deps, pkgFilter) {
+  const roots = pkgFilter ? deps.roots.filter((r) => r.pkg === pkgFilter) : deps.roots;
+  if (!roots.length) {
+    return pkgFilter
+      ? `@webjsdev/${pkgFilter} is not installed/resolvable here. Resolvable: ${deps.roots.map((r) => r.pkg).join(', ') || '(none)'}`
+      : 'No @webjsdev/* packages resolvable from here (run inside a webjs app or the monorepo).';
+  }
+  const lines = ['webjs framework source (no-build: this is what runs). Read with `source({ path })` or search with `source({ query })`.', ''];
+  for (const r of roots) {
+    const dirName = r.src.split(sep).pop(); // 'src' for most, 'lib' for cli
+    let entries = [];
+    try { entries = deps.readdir(r.src); } catch { entries = []; }
+    const top = entries.filter((e) => !e.isDir && TEXT_EXT.test(e.name)).map((e) => e.name).sort();
+    const dirs = entries.filter((e) => e.isDir).map((e) => e.name).sort();
+    lines.push(`@webjsdev/${r.pkg}/${dirName}:`);
+    if (top.length) lines.push(`  files: ${top.map((f) => `${r.pkg}/${dirName}/${f}`).join(', ')}`);
+    if (dirs.length) lines.push(`  subdirs: ${dirs.join(', ')}`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * `query` mode: grep every resolved `src/` tree for the (case-insensitive)
+ * substring, returning bounded `[<pkg>/src/<rel>:<line>] <text>` hits. Discloses
+ * truncation rather than silently capping.
+ *
+ * @param {{ roots: Array<{ pkg: string, root: string, src: string }>, readFile: Function, readdir: Function }} deps
+ * @param {string} query
+ * @returns {Promise<string>}
+ */
+export async function grepSources(deps, query) {
+  const q = String(query).toLowerCase();
+  if (!q) return 'Provide a non-empty `query`.';
+  /** @type {string[]} */
+  const hits = [];
+  let capped = false;
+  outer: for (const r of deps.roots) {
+    for (const file of walkSource(r.src, deps)) {
+      let text = '';
+      try { text = await deps.readFile(file, 'utf8'); } catch { continue; }
+      if (!text.toLowerCase().includes(q)) continue; // fast skip whole file
+      const lines = text.split('\n');
+      const rel = relative(r.root, file).split(sep).join('/');
+      for (let i = 0; i < lines.length; i++) {
+        if (!lines[i].toLowerCase().includes(q)) continue;
+        if (hits.length >= MAX_HITS) { capped = true; break outer; }
+        hits.push(`[@webjsdev/${r.pkg}/${rel}:${i + 1}] ${lines[i].trim()}`);
+      }
+    }
+  }
+  if (!hits.length) return `No matches for "${query}" in the @webjsdev/* source.`;
+  if (capped) hits.push(`... (truncated at ${MAX_HITS} matches; narrow the query or read a file with \`path\`)`);
+  return hits.join('\n');
+}
+
+/**
+ * `path` mode: read one source file. Accepts `<pkg>/...` or
+ * `@webjsdev/<pkg>/...`; resolves under that package's ROOT and refuses to
+ * escape it (traversal guard). Read-only.
+ *
+ * @param {{ roots: Array<{ pkg: string, root: string, src: string }>, readFile: Function }} deps
+ * @param {string} path
+ * @returns {Promise<string>}
+ */
+export async function readSource(deps, path) {
+  const cleaned = String(path).replace(/^@webjsdev\//, '');
+  const segs = cleaned.split('/').filter(Boolean);
+  const pkg = segs[0];
+  const entry = deps.roots.find((r) => r.pkg === pkg);
+  if (!entry) {
+    return `Unknown or unresolvable package "${pkg || path}". Resolvable: ${deps.roots.map((r) => r.pkg).join(', ') || '(none)'}. Pass a path like server/src/ssr.js.`;
+  }
+  const abs = resolve(entry.root, segs.slice(1).join('/'));
+  // Traversal guard: must stay inside the resolved package root.
+  if (abs !== entry.root && !abs.startsWith(entry.root + sep)) {
+    return `Refusing to read outside @webjsdev/${pkg} (path escapes the package root).`;
+  }
+  try {
+    return await deps.readFile(abs, 'utf8');
+  } catch {
+    return `Could not read ${path} (not a file under @webjsdev/${pkg}).`;
+  }
+}
+
+/**
+ * The `source` tool entry point. Dispatches on the args: `path` reads a file,
+ * `query` greps, otherwise (or with `package`) lists the packages. PURE given
+ * `deps` (`{ roots, readFile, readdir }`).
+ *
+ * @param {object} deps
+ * @param {{ query?: string, path?: string, package?: string }} [args]
+ * @returns {Promise<string>}
+ */
+export async function runSourceTool(deps, args) {
+  const a = args || {};
+  if (a.path) return readSource(deps, a.path);
+  if (a.query) return grepSources(deps, a.query);
+  return listSources(deps, a.package);
+}

--- a/packages/cli/lib/mcp-source.js
+++ b/packages/cli/lib/mcp-source.js
@@ -2,10 +2,12 @@
  * The `source` tool for `webjs mcp` (#378): read-only access to the FRAMEWORK
  * source itself.
  *
- * webjs is no-build, so every app's `node_modules/@webjsdev/<pkg>/src` holds the
- * authored JSDoc `.js` that actually runs (no compiled/minified dist to see
- * through). That is a real advantage: when the docs do not answer a question,
- * an agent can read the real source. This tool makes that first-class and
+ * webjs is buildless, so every app's `node_modules/@webjsdev/<pkg>/src` holds the
+ * authored JSDoc `.js`, and server-side that source runs directly. (The one built
+ * artifact is the `@webjsdev/core` browser bundle in `dist/`, which this tool
+ * deliberately skips: it surfaces only the authored `src/`.) That is a real
+ * advantage: when the docs do not answer a question, an agent can read the real
+ * authored source. This tool makes that first-class and
  * discoverable (and reachable for an MCP-only client with no filesystem tools):
  *   - no args (or `package`): list the resolved `@webjsdev/*` packages + their
  *     `src/` entry-point files.
@@ -36,11 +38,15 @@ const MAX_HITS = 60;
 const MAX_FILES = 4000;
 
 /**
- * Resolve each `@webjsdev/*` package's root + `src/` dir from `cwd`. Uses
- * `createRequire(cwd).resolve('<pkg>/package.json')`, so it works for a real
- * `node_modules` install AND the monorepo workspace (where the specifier
- * resolves through the symlink to `packages/<pkg>`). A package that is not
- * installed is skipped (not every app depends on every `@webjsdev/*`).
+ * Resolve each `@webjsdev/*` package's root + source dir from `cwd`. Locates the
+ * root by checking each `require.resolve.paths` node_modules dir on disk for
+ * `@webjsdev/<pkg>/package.json`, so it works for a real `node_modules` install
+ * AND the monorepo workspace (where the dir is a symlink to `packages/<pkg>`),
+ * and honours hoisting. This fs check is deliberate: `<pkg>/package.json` is
+ * blocked by `exports` for server/cli/ui, and the bin-only cli has no main
+ * entry, so neither `resolve('<pkg>/package.json')` nor `resolve('<pkg>')` is
+ * reliable. The source dir is `src/`, or `lib/` for the cli. A package that is
+ * not installed is skipped (not every app depends on every `@webjsdev/*`).
  *
  * @param {string} cwd
  * @param {{ exists: (p: string) => boolean }} fsDeps
@@ -121,7 +127,7 @@ export function listSources(deps, pkgFilter) {
       ? `@webjsdev/${pkgFilter} is not installed/resolvable here. Resolvable: ${deps.roots.map((r) => r.pkg).join(', ') || '(none)'}`
       : 'No @webjsdev/* packages resolvable from here (run inside a webjs app or the monorepo).';
   }
-  const lines = ['webjs framework source (no-build: this is what runs). Read with `source({ path })` or search with `source({ query })`.', ''];
+  const lines = ['webjs framework authored source (buildless; server-side this runs directly, and core ships a built browser dist/ that is excluded here). Read with `source({ path })` or search with `source({ query })`.', ''];
   for (const r of roots) {
     const dirName = r.src.split(sep).pop(); // 'src' for most, 'lib' for cli
     let entries = [];
@@ -169,12 +175,21 @@ export async function grepSources(deps, query) {
   return hits.join('\n');
 }
 
+/** True when `p` is `base` itself or a descendant of it. */
+function within(base, p) {
+  return p === base || p.startsWith(base + sep);
+}
+
 /**
- * `path` mode: read one source file. Accepts `<pkg>/...` or
- * `@webjsdev/<pkg>/...`; resolves under that package's ROOT and refuses to
- * escape it (traversal guard). Read-only.
+ * `path` mode: read one AUTHORED-source file. Accepts `<pkg>/...` or
+ * `@webjsdev/<pkg>/...`. Scoped to the package's SOURCE dir (`src/`, or `lib/`
+ * for cli), so it serves only the authored source and NOT the built `dist/`
+ * browser bundle, `node_modules`, etc. Refuses any path that escapes the source
+ * dir lexically (`..`/absolute), and (when `deps.realpath` is provided)
+ * re-checks the symlink-resolved path so a symlink inside `src/` cannot reach
+ * outside. Read-only.
  *
- * @param {{ roots: Array<{ pkg: string, root: string, src: string }>, readFile: Function }} deps
+ * @param {{ roots: Array<{ pkg: string, root: string, src: string }>, readFile: Function, realpath?: Function }} deps
  * @param {string} path
  * @returns {Promise<string>}
  */
@@ -187,7 +202,21 @@ export async function readSource(deps, path) {
     return `Unknown or unresolvable package "${pkg || path}". Resolvable: ${deps.roots.map((r) => r.pkg).join(', ') || '(none)'}. Pass a path like server/src/ssr.js.`;
   }
   const abs = resolve(entry.root, segs.slice(1).join('/'));
-  // Traversal guard: must stay inside the resolved package root.
+  const srcLabel = entry.src.split(sep).pop();
+  // Scope to the authored source dir, so dist/ (the built core browser bundle),
+  // package.json, node_modules, etc. are not readable; only `src/` (or cli `lib/`).
+  if (!within(entry.src, abs)) {
+    return `Refusing to read outside the @webjsdev/${pkg} authored source (only ${srcLabel}/ is exposed; the built dist/ is not).`;
+  }
+  // Defense in depth: a symlink inside the source dir must not resolve outside it.
+  if (deps.realpath) {
+    try {
+      if (!within(deps.realpath(entry.src), deps.realpath(abs))) {
+        return `Refusing to read outside the @webjsdev/${pkg} authored source (a symlink escapes ${srcLabel}/).`;
+      }
+    } catch { /* abs does not exist; the readFile below returns the not-a-file message */ }
+  }
+  // Legacy guard kept as a belt-and-suspenders against a root escape too.
   if (abs !== entry.root && !abs.startsWith(entry.root + sep)) {
     return `Refusing to read outside @webjsdev/${pkg} (path escapes the package root).`;
   }

--- a/packages/cli/lib/mcp.js
+++ b/packages/cli/lib/mcp.js
@@ -116,7 +116,7 @@ const TOOL_DEFS = [
   {
     name: 'source',
     description:
-      'Read the FRAMEWORK source itself (webjs is no-build, so node_modules/@webjsdev/*/src is the real JSDoc that runs). Pass `path` to read a file (e.g. server/src/ssr.js), `query` to grep the @webjsdev/* src trees, or no args to list the packages + entry points. Use when the docs do not answer something. Read-only.',
+      'Read the FRAMEWORK authored source (webjs is buildless: node_modules/@webjsdev/*/src is the JSDoc source, run directly server-side; only the core browser bundle is built into dist/, which this skips). Pass `path` to read a file (e.g. server/src/ssr.js), `query` to grep the @webjsdev/* src trees, or no args to list the packages + entry points. Use when the docs do not answer something. Read-only.',
     inputSchema: SOURCE_SCHEMA,
   },
   {
@@ -404,12 +404,13 @@ export async function runMcpServer(opts) {
   let sourceDeps = opts.sourceDeps;
   if (!sourceDeps) {
     const { readFile } = await import('node:fs/promises');
-    const { readdirSync, existsSync } = await import('node:fs');
+    const { readdirSync, existsSync, realpathSync } = await import('node:fs');
     const readdir = (d) => readdirSync(d, { withFileTypes: true }).map((e) => ({ name: e.name, isDir: e.isDirectory() }));
     sourceDeps = {
       roots: resolveFrameworkRoots(cwd, { exists: existsSync }),
       readFile,
       readdir,
+      realpath: realpathSync,
     };
   }
 

--- a/packages/cli/lib/mcp.js
+++ b/packages/cli/lib/mcp.js
@@ -32,6 +32,7 @@ import {
   PROMPTS,
   getPrompt,
 } from './mcp-docs.js';
+import { resolveFrameworkRoots, runSourceTool } from './mcp-source.js';
 
 const PROTOCOL_VERSION = '2024-11-05';
 
@@ -72,6 +73,26 @@ const DOCS_SCHEMA = {
   required: [],
 };
 
+/** `source` reads the framework source: a `path` to read, a `query` to grep, or a `package` to list. */
+const SOURCE_SCHEMA = {
+  type: 'object',
+  properties: {
+    path: {
+      type: 'string',
+      description: 'A framework source file to read, e.g. server/src/ssr.js or @webjsdev/core/src/render-client.js.',
+    },
+    query: {
+      type: 'string',
+      description: 'Grep the @webjsdev/* src trees for this substring. Returns file:line hits.',
+    },
+    package: {
+      type: 'string',
+      description: 'Limit a no-args listing to one package (core, server, cli, ts-plugin, ui).',
+    },
+  },
+  required: [],
+};
+
 /**
  * The tools. The four introspection tools project an EXISTING @webjsdev/server
  * function (read-only, appDir-scoped). `init` + `docs` (#376) surface the
@@ -91,6 +112,12 @@ const TOOL_DEFS = [
     description:
       'Retrieve webjs framework docs: pass `topic` for a full doc (components, recipes, styling, built-ins, configuration, advanced, metadata, typescript, testing, lit-muscle-memory-gotchas, AGENTS, ...) or `query` to search the corpus. No args returns the topic index. Read-only.',
     inputSchema: DOCS_SCHEMA,
+  },
+  {
+    name: 'source',
+    description:
+      'Read the FRAMEWORK source itself (webjs is no-build, so node_modules/@webjsdev/*/src is the real JSDoc that runs). Pass `path` to read a file (e.g. server/src/ssr.js), `query` to grep the @webjsdev/* src trees, or no args to list the packages + entry points. Use when the docs do not answer something. Read-only.',
+    inputSchema: SOURCE_SCHEMA,
   },
   {
     name: 'list_routes',
@@ -371,6 +398,21 @@ export async function runMcpServer(opts) {
     };
   }
 
+  // The `source` tool (#378): read the framework's own source from
+  // node_modules/@webjsdev/*/src (no-build, so it is the real JSDoc). Roots are
+  // resolved once from the server cwd. Injectable for tests.
+  let sourceDeps = opts.sourceDeps;
+  if (!sourceDeps) {
+    const { readFile } = await import('node:fs/promises');
+    const { readdirSync, existsSync } = await import('node:fs');
+    const readdir = (d) => readdirSync(d, { withFileTypes: true }).map((e) => ({ name: e.name, isDir: e.isDirectory() }));
+    sourceDeps = {
+      roots: resolveFrameworkRoots(cwd, { exists: existsSync }),
+      readFile,
+      readdir,
+    };
+  }
+
   /** Write one JSON-RPC frame as a single line to stdout. */
   const send = (frame) => {
     stdout.write(JSON.stringify(frame) + '\n');
@@ -441,8 +483,8 @@ export async function runMcpServer(opts) {
       const params = (msg && msg.params) || {};
       const name = params.name;
       const args = params.arguments || {};
-      // The knowledge tools route to the docs layer; they return markdown text.
-      const isKnowledgeTool = name === 'init' || name === 'docs';
+      // The knowledge tools route to the docs / source layer; they return text.
+      const isKnowledgeTool = name === 'init' || name === 'docs' || name === 'source';
       if (!isKnowledgeTool && !runners[name]) {
         return rpcError(id, -32602, `Unknown tool: ${String(name)}`);
       }
@@ -451,7 +493,9 @@ export async function runMcpServer(opts) {
         const result = isKnowledgeTool
           ? name === 'init'
             ? await initText(docsDeps)
-            : await searchDocs(docsDeps, args)
+            : name === 'docs'
+              ? await searchDocs(docsDeps, args)
+              : await runSourceTool(sourceDeps, args)
           : await runners[name](appDir);
         // Knowledge tools return a markdown string; introspection tools return
         // a JSON-serialisable object.

--- a/test/cli/mcp-source.test.mjs
+++ b/test/cli/mcp-source.test.mjs
@@ -6,7 +6,8 @@
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { existsSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { resolve, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -96,14 +97,40 @@ test('grepSources: discloses the cap at > 60 matches (no silent truncation)', as
   assert.match(out, /truncated at 60 matches/);
 });
 
-test('readSource: reads a file; refuses traversal; rejects unknown package', async () => {
-  const t = fakeTree();
+test('readSource: reads authored src; refuses traversal, dist, and out-of-src files', async () => {
+  const t = fakeTree({ '/fw/core/dist/webjs-core-browser.js': 'built bundle\n', '/fw/core/package.json': '{}' });
   assert.match(await readSource(t, 'core/src/html.js'), /export const html/);
   assert.match(await readSource(t, '@webjsdev/server/src/ssr.js'), /renderToString/, 'accepts the @webjsdev/ prefix');
   // Counterfactual: a traversal path must be refused, not read.
   assert.match(await readSource(t, 'core/../../etc/passwd'), /Refusing to read outside/);
   assert.match(await readSource(t, 'core/../server/src/ssr.js'), /Refusing to read outside/, 'cannot hop packages via ..');
+  // Scoped to src/: the built dist bundle and package.json are NOT readable.
+  assert.match(await readSource(t, 'core/dist/webjs-core-browser.js'), /Refusing to read outside/, 'dist (the built bundle) is not exposed');
+  assert.match(await readSource(t, 'core/package.json'), /Refusing to read outside/, 'only the authored source dir is exposed');
   assert.match(await readSource(t, 'nope/src/x.js'), /Unknown or unresolvable/);
+});
+
+test('readSource: a symlink inside src that points outside is refused (realpath hardening)', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'mcp-src-symlink-'));
+  const src = join(root, 'pkg', 'src');
+  const secret = join(root, 'secret.txt');
+  mkdirSync(src, { recursive: true });
+  writeFileSync(join(src, 'real.js'), 'export const ok = 1;\n');
+  writeFileSync(secret, 'SECRET\n');
+  let symlinked = true;
+  try { symlinkSync(secret, join(src, 'evil.js')); } catch { symlinked = false; } // skip if symlinks unsupported
+  const deps = {
+    roots: [{ pkg: 'pkg', root: join(root, 'pkg'), src }],
+    readFile: async (p) => (await import('node:fs/promises')).readFile(p, 'utf8'),
+    realpath: realpathSync,
+  };
+  assert.match(await readSource(deps, 'pkg/src/real.js'), /export const ok/, 'a normal src file still reads');
+  if (symlinked) {
+    const out = await readSource(deps, 'pkg/src/evil.js');
+    assert.match(out, /Refusing to read outside/, 'the escaping symlink is refused');
+    assert.ok(!/SECRET/.test(out), 'the symlink target is never returned');
+  }
+  rmSync(root, { recursive: true, force: true });
 });
 
 test('runSourceTool: dispatches path -> read, query -> grep, none -> list', async () => {

--- a/test/cli/mcp-source.test.mjs
+++ b/test/cli/mcp-source.test.mjs
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for the `source` tool (#378): `mcp-source.js`. The grep/read/list
+ * logic is driven with an INJECTED fake framework tree (no real fs), so it is
+ * deterministic; `resolveFrameworkRoots` is additionally exercised against the
+ * real monorepo (it must find every `@webjsdev/*` package) and a fail-soft path.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO = resolve(__dirname, '..', '..');
+const {
+  resolveFrameworkRoots,
+  walkSource,
+  listSources,
+  grepSources,
+  readSource,
+  runSourceTool,
+} = await import(resolve(REPO, 'packages', 'cli', 'lib', 'mcp-source.js'));
+
+/** An in-memory framework tree: core (src/), server (src/), cli (lib/). */
+function fakeTree(extraFiles = {}) {
+  const files = {
+    '/fw/core/src/render-client.js': '// hydration\nexport function hydrate() {}\n',
+    '/fw/core/src/html.js': 'export const html = 1;\n',
+    '/fw/core/src/dir/util.js': 'export const x = signal();\n',
+    '/fw/server/src/ssr.js': 'export async function renderToString() {}\n',
+    '/fw/cli/lib/mcp.js': '// cli source lives in lib\n',
+    ...extraFiles,
+  };
+  const dirChildren = {};
+  for (const p of Object.keys(files)) {
+    const parts = p.split('/');
+    for (let i = 1; i < parts.length; i++) {
+      const d = parts.slice(0, i).join('/') || '/';
+      const child = parts[i];
+      (dirChildren[d] ||= new Set()).add(child + (i < parts.length - 1 ? '/' : ''));
+    }
+  }
+  const isDir = (p) => dirChildren[p] !== undefined;
+  const readdir = (d) => {
+    const kids = dirChildren[d];
+    if (!kids) throw new Error('ENOENT ' + d);
+    return [...kids].map((k) => ({ name: k.replace(/\/$/, ''), isDir: k.endsWith('/') }));
+  };
+  const readFile = async (p) => {
+    if (!(p in files)) throw new Error('ENOENT ' + p);
+    return files[p];
+  };
+  const roots = [
+    { pkg: 'core', root: '/fw/core', src: '/fw/core/src' },
+    { pkg: 'server', root: '/fw/server', src: '/fw/server/src' },
+    { pkg: 'cli', root: '/fw/cli', src: '/fw/cli/lib' },
+  ];
+  return { roots, readFile, readdir, isDir };
+}
+
+test('walkSource: recurses, returns text files, skips node_modules/dist', () => {
+  const t = fakeTree({ '/fw/core/src/node_modules/dep/x.js': 'skip me\n', '/fw/core/src/logo.png': 'binary' });
+  const files = walkSource('/fw/core/src', t);
+  assert.ok(files.includes('/fw/core/src/html.js'));
+  assert.ok(files.includes('/fw/core/src/dir/util.js'), 'recurses into subdirs');
+  assert.ok(!files.some((f) => f.includes('node_modules')), 'skips node_modules');
+  assert.ok(!files.some((f) => f.endsWith('.png')), 'skips non-text');
+});
+
+test('listSources: lists packages + entry points; cli uses lib/ not src/', () => {
+  const out = listSources(fakeTree());
+  assert.match(out, /@webjsdev\/core\/src:/);
+  assert.match(out, /core\/src\/html\.js/);
+  assert.match(out, /@webjsdev\/cli\/lib:/, 'cli source dir is lib, labelled correctly');
+  assert.match(out, /cli\/lib\/mcp\.js/);
+  // package filter
+  const justServer = listSources(fakeTree(), 'server');
+  assert.match(justServer, /@webjsdev\/server\/src:/);
+  assert.ok(!/@webjsdev\/core/.test(justServer), 'filter limits to one package');
+  // unresolvable package
+  assert.match(listSources(fakeTree(), 'nope'), /not installed\/resolvable/);
+});
+
+test('grepSources: returns pkg-qualified file:line hits; no-match message', async () => {
+  const hits = await grepSources(fakeTree(), 'signal');
+  assert.match(hits, /\[@webjsdev\/core\/src\/dir\/util\.js:1\]/, 'hit is tagged with pkg + rel path + line');
+  assert.match(await grepSources(fakeTree(), 'zzzznotfound'), /No matches/);
+  assert.match(await grepSources(fakeTree(), ''), /non-empty/);
+});
+
+test('grepSources: discloses the cap at > 60 matches (no silent truncation)', async () => {
+  const many = Array.from({ length: 70 }, (_, i) => `hit signal ${i}`).join('\n');
+  const out = await grepSources(fakeTree({ '/fw/core/src/big.js': many }), 'hit signal');
+  const lines = out.split('\n');
+  assert.equal(lines.length, 61, '60 hits + the disclosure line');
+  assert.match(out, /truncated at 60 matches/);
+});
+
+test('readSource: reads a file; refuses traversal; rejects unknown package', async () => {
+  const t = fakeTree();
+  assert.match(await readSource(t, 'core/src/html.js'), /export const html/);
+  assert.match(await readSource(t, '@webjsdev/server/src/ssr.js'), /renderToString/, 'accepts the @webjsdev/ prefix');
+  // Counterfactual: a traversal path must be refused, not read.
+  assert.match(await readSource(t, 'core/../../etc/passwd'), /Refusing to read outside/);
+  assert.match(await readSource(t, 'core/../server/src/ssr.js'), /Refusing to read outside/, 'cannot hop packages via ..');
+  assert.match(await readSource(t, 'nope/src/x.js'), /Unknown or unresolvable/);
+});
+
+test('runSourceTool: dispatches path -> read, query -> grep, none -> list', async () => {
+  const t = fakeTree();
+  assert.match(await runSourceTool(t, { path: 'core/src/html.js' }), /export const html/);
+  assert.match(await runSourceTool(t, { query: 'renderToString' }), /server\/src\/ssr\.js/);
+  assert.match(await runSourceTool(t, {}), /@webjsdev\/core\/src:/);
+  assert.match(await runSourceTool(t, { package: 'cli' }), /@webjsdev\/cli\/lib:/);
+});
+
+test('resolveFrameworkRoots: finds every @webjsdev/* package in the monorepo', () => {
+  const roots = resolveFrameworkRoots(REPO, { exists: existsSync });
+  const names = roots.map((r) => r.pkg).sort();
+  assert.deepEqual(names, ['cli', 'core', 'server', 'ts-plugin', 'ui'], 'all five resolve (cli is bin-only, ui/server hide package.json from exports)');
+  // cli source dir is lib/, the rest src/.
+  assert.match(roots.find((r) => r.pkg === 'cli').src, /\/lib$/);
+  assert.match(roots.find((r) => r.pkg === 'server').src, /\/src$/);
+});
+
+test('resolveFrameworkRoots: fail-soft when nothing resolves', () => {
+  // A cwd with no @webjsdev/* on any search path yields an empty list, not a throw.
+  const roots = resolveFrameworkRoots('/nonexistent-xyz', { exists: () => false });
+  assert.deepEqual(roots, []);
+});

--- a/test/cli/mcp.test.mjs
+++ b/test/cli/mcp.test.mjs
@@ -298,7 +298,7 @@ test('mcp: tools/call source reads/greps/lists the framework source (driven agai
   ]);
   let text = frames[0].result.content[0].text;
   assert.match(text, /@webjsdev\/server\/src:/, 'lists the server source dir');
-  assert.match(text, /no-build/i, 'frames it as the real running source');
+  assert.match(text, /buildless|authored source/i, 'frames it as the real authored source');
 
   // path -> read a real source file
   ({ frames } = await driveMcp(REPO, [
@@ -318,6 +318,12 @@ test('mcp: tools/call source reads/greps/lists the framework source (driven agai
     { jsonrpc: '2.0', id: 43, method: 'tools/call', params: { name: 'source', arguments: { path: 'server/../../../etc/passwd' } } },
   ]));
   assert.match(frames[0].result.content[0].text, /Refusing to read outside/, 'traversal guard holds end to end');
+
+  // the built core browser bundle (dist/) is NOT readable; only authored src/
+  ({ frames } = await driveMcp(REPO, [
+    { jsonrpc: '2.0', id: 44, method: 'tools/call', params: { name: 'source', arguments: { path: 'core/dist/webjs-core-browser.js' } } },
+  ]));
+  assert.match(frames[0].result.content[0].text, /Refusing to read outside/, 'dist (built bundle) not exposed, only src');
 });
 
 /* ---------------- knowledge layer (#376): init / docs / resources / prompts ---------------- */

--- a/test/cli/mcp.test.mjs
+++ b/test/cli/mcp.test.mjs
@@ -112,7 +112,7 @@ test('mcp: tools/list returns the introspection + knowledge tools with inputSche
   ]);
   const tools = frames[0].result.tools;
   const names = tools.map((t) => t.name).sort();
-  assert.deepEqual(names, ['check', 'docs', 'init', 'list_actions', 'list_components', 'list_routes']);
+  assert.deepEqual(names, ['check', 'docs', 'init', 'list_actions', 'list_components', 'list_routes', 'source']);
   for (const t of tools) {
     assert.equal(typeof t.description, 'string');
     assert.equal(t.inputSchema.type, 'object');
@@ -122,6 +122,7 @@ test('mcp: tools/list returns the introspection + knowledge tools with inputSche
   assert.ok(byName.list_routes.inputSchema.properties.appDir, 'introspection tool declares appDir');
   assert.deepEqual(byName.init.inputSchema.properties, {}, 'init takes no args');
   assert.ok(byName.docs.inputSchema.properties.topic && byName.docs.inputSchema.properties.query, 'docs takes topic/query');
+  assert.ok(byName.source.inputSchema.properties.path && byName.source.inputSchema.properties.query, 'source takes path/query/package');
 });
 
 test('mcp: tools/call check returns a content array parsing to { violations, summary }', async () => {
@@ -285,6 +286,38 @@ test('mcp: a falsy id (0) and a string id are echoed, not dropped', async () => 
   assert.equal(frames.length, 2);
   assert.equal(frames[0].id, 0, 'a 0 id must be echoed (no falsy drop)');
   assert.equal(frames[1].id, 'abc', 'a string id must be echoed');
+});
+
+/* ---------------- source tool (#378): read the framework's own source ---------------- */
+
+test('mcp: tools/call source reads/greps/lists the framework source (driven against the monorepo)', async () => {
+  // Drive with cwd = the repo so @webjsdev/* resolves to the workspace packages.
+  // no-args -> the package listing
+  let { frames } = await driveMcp(REPO, [
+    { jsonrpc: '2.0', id: 40, method: 'tools/call', params: { name: 'source', arguments: {} } },
+  ]);
+  let text = frames[0].result.content[0].text;
+  assert.match(text, /@webjsdev\/server\/src:/, 'lists the server source dir');
+  assert.match(text, /no-build/i, 'frames it as the real running source');
+
+  // path -> read a real source file
+  ({ frames } = await driveMcp(REPO, [
+    { jsonrpc: '2.0', id: 41, method: 'tools/call', params: { name: 'source', arguments: { path: 'server/src/check.js' } } },
+  ]));
+  text = frames[0].result.content[0].text;
+  assert.ok(text.length > 200 && /export/.test(text), 'returns the real check.js source');
+
+  // query -> grep with pkg-qualified hits
+  ({ frames } = await driveMcp(REPO, [
+    { jsonrpc: '2.0', id: 42, method: 'tools/call', params: { name: 'source', arguments: { query: 'renderToString' } } },
+  ]));
+  assert.match(frames[0].result.content[0].text, /\[@webjsdev\/[a-z-]+\/src\/[^\]]+:\d+\]/, 'grep hits carry pkg + file:line');
+
+  // traversal is refused, not read
+  ({ frames } = await driveMcp(REPO, [
+    { jsonrpc: '2.0', id: 43, method: 'tools/call', params: { name: 'source', arguments: { path: 'server/../../../etc/passwd' } } },
+  ]));
+  assert.match(frames[0].result.content[0].text, /Refusing to read outside/, 'traversal guard holds end to end');
 });
 
 /* ---------------- knowledge layer (#376): init / docs / resources / prompts ---------------- */


### PR DESCRIPTION
## Summary

Closes #378.

Because webjs is no-build, every app's `node_modules/@webjsdev/*/src` holds the authored JSDoc that actually runs (no compiled dist to see through), so an agent can read the real framework source when the docs do not cover something. This makes that first-class and discoverable through the MCP, and reachable for an MCP-only client with no filesystem tools:

- A read-only **`source` tool** (`lib/mcp-source.js`): `path` reads a file (e.g. `server/src/ssr.js`), `query` greps the `@webjsdev/*` src trees and returns bounded `file:line` hits with a disclosed cap, and no-args lists the resolved packages + their entry points. It loads no module and is traversal-guarded (cannot read outside a resolved package root).
- An **`init` primer pointer** telling the agent up front that the source is greppable in `node_modules/@webjsdev/*/src` and to use `source` when the docs fall short.

## Notable implementation detail

Package resolution does NOT use `require.resolve('<pkg>/package.json')` (a package whose `exports` omits `./package.json` blocks it: server/cli/ui) nor the main entry (the bin-only cli has none). Instead it checks each `require.resolve.paths` node_modules dir on disk for `@webjsdev/<pkg>/package.json`, which is uniform across all packages and honours hoisting. Source lives in `src/` for most packages and `lib/` for the cli, so it uses whichever exists. This is verified against the real monorepo (all five packages resolve).

## Test plan

- **Unit** (`test/cli/mcp-source.test.mjs`, new): grep/read/list against an injected fake tree, the cap disclosure at > 60 matches, the `src/`-vs-`lib/` labelling, and the **traversal-guard counterfactual** (`core/../../etc/passwd` and `core/../server/...` are refused). Plus `resolveFrameworkRoots` against the real monorepo (finds all five) and a fail-soft when nothing resolves.
- **Integration** (`test/cli/mcp.test.mjs`, +1, and the tools/list set updated): `tools/call source` driven against the monorepo reads/greps/lists real source, and the traversal guard holds end to end through the dispatch.
- **Real binary**: `node bin/webjs.js mcp` answers a `source` listing + a `server/src/check.js` read (42KB of real source).
- Full `npm test`: 2202 pass.

## Definition-of-done surfaces

- **MCP (item 5):** this PR IS the MCP change; `init` + the new `source` tool covered above. `init` still sources the AGENTS.md Execution-model + Invariants headings (unchanged).
- **Docs:** `packages/cli/AGENTS.md` updated (the `mcp.js` module-map entry + the `webjs mcp` row now describe the `source` tool + the resolution detail).
- **Dogfood:** website / docs / ui-website boot 200/307 in dist mode; blog covered by the existing e2e (unaffected). **e2e/browser N/A** (a CLI-tool change, no runtime/served-wire change).
- **Version bump:** owed on `@webjsdev/cli`; the release PR (which already covers #377) follows the merge.