### PR TITLE
chore: release @webjsdev/cli 0.10.12

### DIFF
--- a/changelog/cli/0.10.12.md
+++ b/changelog/cli/0.10.12.md
@@ -1,0 +1,18 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.12
+date: 2026-06-07T12:20:30.208Z
+commit_count: 2
+---
+## Features
+
+- **add a knowledge + authoring layer to webjs mcp (Next-MCP parity)** ([#377](https://github.com/webjsdev/webjs/pull/377)) [`83abc2c4`](https://github.com/webjsdev/webjs/commit/83abc2c4)
+  * feat: add a knowledge + authoring layer to webjs mcp (#376)
+  
+  webjs mcp shipped four read-only introspection tools (the Next.js /_next/mcp
+  equivalent). This adds the second layer the next-devtools-mcp package showed is
+- **add a source tool to webjs mcp to read the no-build framework source** ([#379](https://github.com/webjsdev/webjs/pull/379)) [`ea4ddd27`](https://github.com/webjsdev/webjs/commit/ea4ddd27)
+  * feat: add a source tool to webjs mcp to read the no-build framework source (#378)
+  
+  webjs is no-build, so node_modules/@webjsdev/*/src is the real JSDoc that runs.
+  Surface that through the MCP:

--- a/package-lock.json
+++ b/package-lock.json
@@ -6980,7 +6980,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.11",
+      "version": "0.10.12",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/server": "^0.8.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {


### PR DESCRIPTION
## Summary

Release `@webjsdev/cli` 0.10.11 to 0.10.12 (patch), shipping the two MCP features that landed since the last release. Dependents pin `^0.10.0`, so the patch stays in range (no dependent edits); lockfile regenerated.

Merging this adds `changelog/cli/0.10.12.md` to `main`, which triggers `release.yml` to `npm publish` and cut the GitHub Release (idempotent).

## @webjsdev/cli 0.10.12

- feat: add a knowledge + authoring layer to webjs mcp (#376, PR #377). MCP resources (the agent-docs corpus + AGENTS.md), an `init` mental-model primer, a `docs` retrieval tool, and recipe prompts.
- feat: add a source tool to webjs mcp to read the no-build framework source (#378, PR #379). A read-only `source` tool that greps/reads the authored `@webjsdev/*` `src/` (scoped, traversal-guarded), plus an init pointer.

## Notes

- Changelog auto-generated by the pre-commit `backfill-changelog.js` hook from the conventional squash subjects; reviewed for accuracy.
- `core` / `server` / `ui` / `ts-plugin` have no unreleased qualifying commits, so they are not bumped.
- Once published, an installed `npx @webjsdev/cli mcp` (e.g. the user-scope one in Claude Code) upgrades to the knowledge + source layer automatically.