### PR TITLE
chore: drop the redundant @webjsdev/ui pin from scaffolded apps

### DIFF
--- a/docs/app/docs/ui/page.ts
+++ b/docs/app/docs/ui/page.ts
@@ -19,8 +19,10 @@ export default function UiDocs() {
     <h2>For webjs users</h2>
     <p>
       Nothing to install. <code>@webjsdev/ui</code> is a hard dependency of <code>@webjsdev/cli</code>, so a global
-      webjs install already includes it. Apps scaffolded with <code>webjs create</code> list it in
-      <code>devDependencies</code> too.
+      webjs install already includes it, and <code>webjs ui add</code> resolves the kit from there. A
+      scaffolded app does NOT pin <code>@webjsdev/ui</code>: <code>webjs ui add</code> copies the component
+      source into <code>components/ui/</code> (shadcn-style), and those files import
+      <code>@webjsdev/core</code>, not the kit.
     </p>
     <pre>webjs ui init
 webjs ui add button card dialog input label</pre>

--- a/examples/blog/package.json
+++ b/examples/blog/package.json
@@ -28,7 +28,6 @@
   },
   "devDependencies": {
     "@webjsdev/ts-plugin": "^0.5.0",
-    "@webjsdev/ui": "^0.3.0",
     "prisma": "^5.22.0",
     "typescript": "^6.0.3"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,6 @@
       },
       "devDependencies": {
         "@webjsdev/ts-plugin": "^0.5.0",
-        "@webjsdev/ui": "^0.3.0",
         "prisma": "^5.22.0",
         "typescript": "^6.0.3"
       },

--- a/packages/cli/lib/create.js
+++ b/packages/cli/lib/create.js
@@ -315,14 +315,18 @@ export async function scaffoldApp(name, cwd, opts = {}) {
       // assertNoA11yViolations() test helper from @webjsdev/core/testing.
       // Test-only: dynamically imported, never shipped to the app runtime.
       'axe-core': '^4.10.0',
-      // tsserver plugin for editor intelligence inside html`` templates.
-      // @webjsdev/ts-plugin is standalone (no Lit dependency): one plugin
-      // entry in tsconfig (see below).
+      // tsserver plugin (wired into tsconfig below). It gives the language
+      // INTELLIGENCE (go-to-def, completions, diagnostics, hover inside html``
+      // templates) in any tsserver editor (VS Code, Neovim, JetBrains) with no
+      // extra install, since editors load tsconfig plugins from node_modules.
+      // Template HIGHLIGHTING is the one thing a tsserver plugin can't provide;
+      // install the `webjs` VS Code extension or webjs.nvim for that (they also
+      // bundle this plugin). Standalone, no Lit dependency. Editor-only.
       '@webjsdev/ts-plugin': 'latest',
-      // AI-first component library CLI, preinstalled so `webjs ui add button`
-      // works immediately after scaffold. Users can remove if they prefer
-      // to add it later.
-      '@webjsdev/ui': 'latest',
+      // NOTE: @webjsdev/ui is intentionally NOT an app dependency. The UI kit is
+      // shadcn-style copy-in: `webjs ui add <name>` copies component source into
+      // components/ui/ (they import @webjsdev/core, not the kit), and the CLI
+      // resolves @webjsdev/ui from its own install. Nothing to pin here.
     },
   }, null, 2) + '\n');
 

--- a/test/scaffolds/scaffold-integration.test.js
+++ b/test/scaffolds/scaffold-integration.test.js
@@ -188,7 +188,13 @@ test('scaffoldApp full-stack: writes the canonical full-stack app layout', async
     assert.ok(pkg.dependencies['@webjsdev/core']);
     assert.ok(pkg.dependencies['@webjsdev/server']);
     assert.ok(pkg.dependencies['@prisma/client']);
+    // ts-plugin stays: it gives editor INTELLIGENCE from node_modules via the
+    // tsconfig plugin (any tsserver editor, zero install).
     assert.ok(pkg.devDependencies['@webjsdev/ts-plugin']);
+    // @webjsdev/ui is NOT pinned (#399): the UI kit is shadcn-style copy-in and
+    // `webjs ui add` resolves the kit from the CLI, so the app needs no pin.
+    const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
+    assert.ok(!allDeps['@webjsdev/ui'], 'no @webjsdev/ui in a scaffolded app');
 
     // tsconfig.json has the editor plugin, standalone (no ts-lit-plugin entry).
     const tsconfig = JSON.parse(readFileSync(join(appDir, 'tsconfig.json'), 'utf8'));


### PR DESCRIPTION
Closes #399.

## What

Drops the redundant `@webjsdev/ui` pin from scaffolded apps. The UI kit is shadcn-style copy-in: `webjs ui add <name>` copies component source into `components/ui/` (those files import `@webjsdev/core`, not the kit), and the CLI resolves `@webjsdev/ui` from its own install (it hard-depends on it). So a scaffolded app's `@webjsdev/ui` devDependency did nothing at runtime.

- Remove the pin from `create.js`; remove it from `examples/blog`; regenerate the lockfile.
- `scaffold-integration` asserts no `@webjsdev/ui` is pinned.
- Fix the UI docs line that claimed the scaffold pins it.

## What stays (and why)

A scaffolded app's `@webjsdev/*` deps are now **core + server + cli + ts-plugin**:

- `core` / `server`: the framework runtime.
- `cli`: the dev/prod toolchain (`webjs dev/start/...`), pinned locally exactly like Next.js ships `next` and Remix ships `@remix-run/dev` as local deps.
- `ts-plugin`: stays on purpose. It delivers the editor **intelligence** (go-to-def, completions, diagnostics, hover) from `node_modules` via the `tsconfig` `plugins` entry, in any tsserver editor (VS Code with workspace TS, Neovim `ts_ls`, JetBrains) with zero install. This is exactly how Next.js ships its language service (a tsconfig plugin inside `next`). The one thing `node_modules` can't provide is template **highlighting** (a TextMate grammar / treesitter query), which is what the `webjs` VS Code extension and `webjs.nvim` add.

## Test plan

- `npm test` green (full suite). The `scaffold-ui-integration` test confirms `webjs ui add` still copies components in with no app pin (resolved from the CLI). `scaffold-integration` asserts the dep set.
- Dogfood: docs `/docs/ui` and `/docs/editor-setup` boot 200.

Context: this is the outcome of the node_modules-slimming discussion. webjs.nvim self-containment (#398) was considered and declined (Neovim's `ts_ls` already auto-loads the tsconfig plugin, so bundling would be redundant + risk a double-load); the VS Code extension keeps bundling ts-plugin because VS Code won't load a tsconfig plugin without the workspace-TS switch.
