### PR TITLE
Add Node builtin types to scaffolded apps

### DIFF
--- a/packages/cli/lib/create.js
+++ b/packages/cli/lib/create.js
@@ -308,6 +308,7 @@ export async function scaffoldApp(name, cwd, opts = {}) {
       // tsc --noEmit). Not needed at runtime (Node strips types in place), only
       // to type-check the app.
       typescript: '^5.6.0',
+      '@types/node': '^24.0.0',
       '@web/test-runner': '^0.20.0',
       '@web/test-runner-playwright': '^0.11.0',
       'playwright': '^1.59.0',
@@ -337,6 +338,7 @@ export async function scaffoldApp(name, cwd, opts = {}) {
       module: 'NodeNext',
       moduleResolution: 'NodeNext',
       lib: ['ES2022', 'DOM', 'DOM.Iterable'],
+      types: ['node'],
       strict: true,
       noEmit: true,
       allowImportingTsExtensions: true,

--- a/test/scaffolds/scaffold-integration.test.js
+++ b/test/scaffolds/scaffold-integration.test.js
@@ -191,6 +191,7 @@ test('scaffoldApp full-stack: writes the canonical full-stack app layout', async
     // intellisense (@webjsdev/intellisense) stays: it gives editor INTELLIGENCE from node_modules via the
     // tsconfig plugin (any tsserver editor, no editor plugin needed).
     assert.ok(pkg.devDependencies['@webjsdev/intellisense']);
+    assert.ok(pkg.devDependencies['@types/node'], 'scaffold installs Node builtin type declarations');
     // @webjsdev/ui is NOT pinned (#399): shadcn-style copy-in; `webjs ui add`
     // resolves the kit from the CLI, so the app needs no pin.
     const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
@@ -200,6 +201,7 @@ test('scaffoldApp full-stack: writes the canonical full-stack app layout', async
     const tsconfig = JSON.parse(readFileSync(join(appDir, 'tsconfig.json'), 'utf8'));
     const pluginNames = (tsconfig.compilerOptions.plugins || []).map((p) => p.name);
     assert.ok(pluginNames.includes('@webjsdev/intellisense'), 'editor plugin listed');
+    assert.deepEqual(tsconfig.compilerOptions.types, ['node'], 'tsconfig enables node: builtin types for .server.ts files');
     assert.ok(!pluginNames.includes('ts-lit-plugin'), 'no separate ts-lit-plugin entry (standalone, #386)');
     assert.ok(!pkg.devDependencies['ts-lit-plugin'] && !pkg.dependencies['ts-lit-plugin'], 'scaffold pulls no ts-lit-plugin');
 


### PR DESCRIPTION
## Summary
- add `@types/node` to generated scaffold devDependencies
- set `compilerOptions.types` to `["node"]` so `.server.ts` files resolve `node:` builtins in editors/typecheck
- cover the generated package and tsconfig shape in scaffold integration tests

Fixes #392.

## Tests
- `node --test test\scaffolds\scaffold-integration.test.js`
- `node --test test\scaffolds\scaffold-ui-integration.test.js`

Note: `npm install` failed on Windows because the existing root `prepare` script uses `2>/dev/null || true` under cmd.exe; I used `npm install --ignore-scripts` to install workspace dependencies for the test run.