### PR TITLE
fix: hoist head tags past interleaved HTML comments (#406)

### DIFF
--- a/packages/server/src/ssr.js
+++ b/packages/server/src/ssr.js
@@ -586,16 +586,9 @@ async function collectMetadata(route, ctx, dev) {
  * @returns {{ head: string, body: string }}
  */
 function hoistHeadTags(headHtml, bodyHtml) {
-  const hoisted = [];
-  // <script>…</script> and <style>…</style> are paired; <link …> is void.
-  const re = /^\s*(<script[\s>][\s\S]*?<\/script>|<style[\s>][\s\S]*?<\/style>|<link\b[^>]*>)/i;
-
-  let remaining = bodyHtml;
-  let m;
-  while ((m = re.exec(remaining)) !== null) {
-    hoisted.push(m[1]);
-    remaining = remaining.slice(m[0].length);
-  }
+  // Shares the leading-run scanner (comment-skipping included) with the
+  // streaming path so both hoist identically. See collectHoistedHeadTags.
+  const { tags: hoisted, body: remaining } = collectHoistedHeadTags(bodyHtml);
   if (!hoisted.length) return { head: headHtml, body: bodyHtml };
   const newHead = headHtml.replace('</head>', hoisted.join('\n') + '\n</head>');
   return { head: newHead, body: remaining };
@@ -744,14 +737,33 @@ function wrapInDocument(body, opts) {
  */
 function collectHoistedHeadTags(bodyHtml) {
   const tags = [];
-  const re = /^\s*(<script[\s>][\s\S]*?<\/script>|<style[\s>][\s\S]*?<\/style>|<link\b[^>]*>)/i;
+  // <script>…</script> and <style>…</style> are paired; <link …> is void.
+  // A plain HTML comment (<!-- … -->) is consumed but NOT hoisted, so a
+  // comment interleaved with head-bound tags (e.g. "<!-- Self-hosted fonts -->"
+  // between a favicon <link> and the stylesheet <link>) does not terminate
+  // the leading run and strand the stylesheet in <body>, which caused FOUC
+  // because a <link rel="stylesheet"> in <body> is not reliably
+  // render-blocking (#406). The `(?!/?wj:)` guard exempts client-router
+  // markers (<!--wj:children:…-->, <!--/wj:children-->) so a layout that
+  // renders children directly after its head tags still terminates the run
+  // there rather than swallowing the nesting marker.
+  const re =
+    /^\s*(<!--(?!\/?wj:)[\s\S]*?-->|<script[\s>][\s\S]*?<\/script>|<style[\s>][\s\S]*?<\/style>|<link\b[^>]*>)/i;
   let remaining = bodyHtml;
+  // `body` only advances to just-past the LAST hoisted head tag. Comments
+  // are scanned through (so they don't terminate the run) but a comment that
+  // trails the final head tag stays in the body rather than being dropped.
+  let body = bodyHtml;
   let m;
   while ((m = re.exec(remaining)) !== null) {
-    tags.push(m[1]);
+    const token = m[1];
     remaining = remaining.slice(m[0].length);
+    if (!token.startsWith('<!--')) {
+      tags.push(token);
+      body = remaining;
+    }
   }
-  return { tags, body: remaining };
+  return { tags, body };
 }
 
 /**

--- a/packages/server/test/ssr/head-hoist.test.js
+++ b/packages/server/test/ssr/head-hoist.test.js
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for head-bound tag hoisting (#406).
+ *
+ * The framework hoists a contiguous leading run of <script> / <style> /
+ * <link> tags out of the rendered body and into <head>, so render-blocking
+ * assets (notably <link rel="stylesheet">) land where the browser reliably
+ * honours them. The bug: an HTML comment interleaved with those tags (e.g.
+ * "<!-- Self-hosted fonts -->" between a favicon <link> and the stylesheet
+ * <link>, as in website/app/layout.ts) terminated the run, stranding the
+ * stylesheet in <body>. A <link rel="stylesheet"> in <body> is not reliably
+ * render-blocking, so the page painted unstyled first (FOUC on webjs.dev).
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { _hoistHeadTags } from '../../src/ssr.js';
+
+const HEAD = '<head>\n<title>x</title>\n</head>';
+
+test('hoists a contiguous run of head-bound tags', () => {
+  const body = '<link rel="icon" href="/favicon.ico"><link rel="stylesheet" href="/app.css"><main>hi</main>';
+  const { head, body: out } = _hoistHeadTags(HEAD, body);
+  assert.ok(head.includes('rel="icon"'));
+  assert.ok(head.includes('rel="stylesheet"'));
+  assert.equal(out.includes('rel="stylesheet"'), false, 'stylesheet must leave the body');
+  assert.ok(out.includes('<main>hi</main>'));
+});
+
+test('a comment between head-bound tags does NOT strand the later tag (#406)', () => {
+  // This is the regression: favicon, then a comment, then the stylesheet.
+  const body =
+    '<link rel="icon" href="/favicon.ico">' +
+    '<!-- Self-hosted fonts -->' +
+    '<link rel="stylesheet" href="/tailwind.css">' +
+    '<main>content</main>';
+  const { head, body: out } = _hoistHeadTags(HEAD, body);
+
+  // Both links must reach <head> despite the interleaved comment.
+  assert.ok(head.includes('rel="icon"'), 'favicon hoisted');
+  assert.ok(head.includes('rel="stylesheet"'), 'stylesheet hoisted past the comment');
+
+  // The stylesheet must NOT remain in the body (that is the FOUC).
+  assert.equal(
+    out.includes('rel="stylesheet"'),
+    false,
+    'stylesheet must not be stranded in the body',
+  );
+
+  // The comment is consumed (not re-emitted into the body), and real
+  // content survives.
+  assert.equal(out.includes('Self-hosted fonts'), false);
+  assert.ok(out.includes('<main>content</main>'));
+});
+
+test('multiple comments interleaved still hoist every tag', () => {
+  const body =
+    '<!-- icons -->' +
+    '<link rel="icon" href="/a.ico">' +
+    '<!-- preconnect -->' +
+    '<link rel="preconnect" href="https://fonts.example">' +
+    '<!-- styles -->' +
+    '<style>.x{}</style>' +
+    '<link rel="stylesheet" href="/s.css">' +
+    '<header>nav</header>';
+  const { head, body: out } = _hoistHeadTags(HEAD, body);
+  assert.ok(head.includes('rel="icon"'));
+  assert.ok(head.includes('rel="preconnect"'));
+  assert.ok(head.includes('<style>.x{}</style>'));
+  assert.ok(head.includes('rel="stylesheet"'));
+  assert.ok(out.includes('<header>nav</header>'));
+  assert.equal(out.includes('rel="stylesheet"'), false);
+});
+
+test('a webjs client-router marker terminates the run (not swallowed)', () => {
+  // A pathological layout that renders children right after its head tags:
+  // the <!--wj:children:…--> marker must stay in the body so the client
+  // router can find its nesting slot. It must NOT be consumed like a plain
+  // comment.
+  const body =
+    '<link rel="stylesheet" href="/s.css">' +
+    '<!--wj:children:/-->' +
+    '<p>page</p>' +
+    '<!--/wj:children-->';
+  const { head, body: out } = _hoistHeadTags(HEAD, body);
+  assert.ok(head.includes('rel="stylesheet"'), 'stylesheet still hoists');
+  assert.ok(out.includes('<!--wj:children:/-->'), 'children marker preserved in body');
+  assert.ok(out.includes('<!--/wj:children-->'), 'closing children marker preserved');
+});
+
+test('a comment with no following head tag leaves the body untouched', () => {
+  // No head-bound tags at all: nothing hoists, body is returned verbatim
+  // (the comment must not be silently dropped).
+  const body = '<!-- a banner comment -->\n<main>just content</main>';
+  const { head, body: out } = _hoistHeadTags(HEAD, body);
+  assert.equal(head, HEAD, 'head unchanged when nothing hoists');
+  assert.equal(out, body, 'body returned verbatim');
+});


### PR DESCRIPTION
Closes #406

## Problem

Visitors to webjs apps (e.g. https://webjs.dev) sometimes saw a flash of unstyled HTML before the CSS applied (FOUC).

Root cause: the SSR head-hoist scanner lifts a contiguous leading run of `<script>` / `<style>` / `<link>` tags out of the rendered body into `<head>`, so render-blocking assets land where the browser reliably honours them. The scanner stopped at the first token that was not one of those tags, and an HTML comment counts as such a token. In `website/app/layout.ts` a `<!-- Self-hosted fonts ... -->` comment sits between the favicon `<link>` tags and the stylesheet `<link rel="stylesheet" href="/public/tailwind.css">`, so the run ended at the comment and the stylesheet stayed in `<body>`.

A `<link rel="stylesheet">` in `<body>` is not reliably render-blocking, so with streaming SSR and a slow CSS download the browser painted unstyled HTML first.

## Fix

`collectHoistedHeadTags` now skips-but-consumes plain HTML comments so the leading run continues past them, while client-router `<!--wj:children:...-->` / `<!--/wj:children-->` markers are exempted (a `(?!/?wj:)` guard) so a layout that renders `children` right after its head tags still terminates the run there rather than swallowing the nesting marker. Consumption only commits up to the last hoisted tag, so a comment trailing the final head tag stays in the body rather than being dropped. The buffered path (`hoistHeadTags`) now delegates to the same scanner, so both the streaming and non-streaming paths hoist identically.

## Test plan

- [x] Unit: `packages/server/test/ssr/head-hoist.test.js` (new) covers a comment between two head-bound tags hoisting both, multiple interleaved comments, the `wj:children` marker terminating the run, and a trailing comment staying in the body. Counterfactual verified: the two regression cases fail when the comment alternative is removed from the scanner.
- [x] Full node suite green: 2242/2242.
- [x] Dogfood boot (prod mode, `createRequestHandler`): website `/` 200 with the stylesheet now in `<head>` and nothing stranded in `<body>`; docs `/` 307; ui-website `/` 200 stylesheet in head.
- [x] Blog e2e: 76/76 in dist mode (production wire).

## Docs

N/A: the only doc surface describing this behaviour is the `shell-in-non-root-layout` check message ("they auto-hoist"), which stays accurate (the fix makes the hoist more complete, not different). No doc claimed hoisting stops at comments.
