### PR TITLE
chore: release @webjsdev/server 0.8.19

### DIFF
--- a/changelog/server/0.8.19.md
+++ b/changelog/server/0.8.19.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/server"
+version: 0.8.19
+date: 2026-06-07T18:23:38.299Z
+commit_count: 1
+---
+## Fixes
+
+- **hoist head tags past interleaved HTML comments (#406)** ([#407](https://github.com/webjsdev/webjs/pull/407)) [`bc105f05`](https://github.com/webjsdev/webjs/commit/bc105f05)
+  A contiguous leading run of <script>/<style>/<link> tags is hoisted out
+  of the rendered body into <head> so render-blocking assets land where the
+  browser honours them. The scanner stopped at the first non-tag token, so
+  an HTML comment interleaved with the run (e.g. "<!-- Self-hosted fonts -->"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6844,7 +6844,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.18",
+      "version": "0.8.19",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.18",
+  "version": "0.8.19",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Release `@webjsdev/server` 0.8.19.

## What ships

The #406 head-hoist fix (PR #407), which stops a render-blocking stylesheet from being stranded in `<body>` when an HTML comment is interleaved with a layout's head-bound tags (the FOUC seen on webjs.dev).

## Details

- Patch bump 0.8.18 to 0.8.19; only `packages/server/src` changed since 0.8.18.
- Changelog `changelog/server/0.8.19.md` auto-generated by the pre-commit hook.
- All in-repo dependents pin `^0.8.0`, satisfied by 0.8.19; no range bumps needed.
- `package-lock.json` regenerated.
- No other published package has unreleased `src` work (core/cli/ts-plugin/ui all match their published versions).