### PR TITLE
fix: repoint Dockerfile at packages/editors/ts-plugin (#409)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,3 +166,25 @@ jobs:
         run: npm test --workspace=@webjsdev/website
       - name: blog tests (node)
         run: npm test --workspace=@webjsdev/example-blog
+
+  docker:
+    name: Docker image build (the deploy artifact)
+    runs-on: ubuntu-latest
+    # The jobs above run the apps in-process via createRequestHandler; NONE of
+    # them build the Docker image that every Railway service actually deploys.
+    # That gap let #404's package reorg ship a stale `COPY packages/ts-plugin`
+    # path that broke all four live deploys for a day (#409): a COPY of a
+    # missing source is a hard Docker error, invisible to every in-process
+    # check. Building the image here catches that class (stale COPY paths, a
+    # broken npm install / dist / tailwind / prisma step in the image) on the
+    # PR instead of at deploy time. Build only, no push.
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v3
+      - name: Build the monorepo image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY package.json package-lock.json ./
 COPY packages/cli/package.json                       ./packages/cli/
 COPY packages/core/package.json                      ./packages/core/
 COPY packages/server/package.json                    ./packages/server/
-COPY packages/ts-plugin/package.json                 ./packages/ts-plugin/
+COPY packages/editors/ts-plugin/package.json         ./packages/editors/ts-plugin/
 COPY packages/ui/package.json                        ./packages/ui/
 COPY packages/ui/packages/registry/package.json      ./packages/ui/packages/registry/
 COPY packages/ui/packages/website/package.json       ./packages/ui/packages/website/

--- a/test/repo-health/dockerfile-copy-paths.test.mjs
+++ b/test/repo-health/dockerfile-copy-paths.test.mjs
@@ -1,0 +1,68 @@
+// Regression guard for issue #409.
+//
+// The repo-root Dockerfile copies each workspace manifest individually
+// (for layer caching) before `npm install`. A `COPY <src> <dst>` whose
+// source path does not exist is a HARD Docker error ("not found"), not a
+// warning, so a single stale path fails the image build for every in-repo
+// app on every platform.
+//
+// This bit us in #404: the editor/wrapper package reorg moved
+// packages/ts-plugin to packages/editors/ts-plugin and updated all the JS
+// path tooling, but the Dockerfile's hard-coded `COPY packages/ts-plugin/
+// package.json` line was missed. Every Railway deploy failed from #404
+// until #409, and nothing local caught it: the four-app boot check runs
+// createRequestHandler in-process, never the Docker build.
+//
+// This asserts every file-source COPY in the Dockerfile points at a path
+// that exists in the repo, so a future move/rename of a workspace dir
+// fails CI immediately instead of only at deploy time.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+/**
+ * Parse `COPY <src...> <dst>` instructions, returning each source token.
+ * Skips `COPY --from=...` (multi-stage, source is another stage, not the
+ * build context) and treats the last token on the line as the destination.
+ */
+function dockerfileCopySources() {
+  const text = readFileSync(join(ROOT, 'Dockerfile'), 'utf8');
+  // Join backslash-continued lines so a multi-line COPY reads as one.
+  const logical = text.replace(/\\\n/g, ' ');
+  const sources = [];
+  for (const raw of logical.split('\n')) {
+    const line = raw.trim();
+    if (!/^COPY\b/i.test(line)) continue;
+    if (/--from=/i.test(line)) continue; // multi-stage copy, not a context path
+    const tokens = line.split(/\s+/).slice(1).filter((t) => !t.startsWith('--'));
+    if (tokens.length < 2) continue; // need at least one src + a dst
+    // Everything but the final token (the destination) is a source.
+    for (const src of tokens.slice(0, -1)) sources.push(src);
+  }
+  return sources;
+}
+
+test('every Dockerfile COPY source path exists in the repo', () => {
+  const sources = dockerfileCopySources();
+  assert.ok(sources.length > 0, 'expected the Dockerfile to have COPY instructions');
+
+  const missing = [];
+  for (const src of sources) {
+    // Sources may contain globs (e.g. `COPY packages ./packages`); a bare
+    // directory or file path is what we can statically verify. Skip tokens
+    // with glob metacharacters (none today, but stay robust).
+    if (/[*?\[]/.test(src)) continue;
+    if (!existsSync(join(ROOT, src))) missing.push(src);
+  }
+
+  assert.deepEqual(
+    missing,
+    [],
+    `Dockerfile COPY sources that do not exist (a moved/renamed workspace?): ${missing.join(', ')}`,
+  );
+});


### PR DESCRIPTION
Closes #409

## Problem

Every in-repo app deploy on Railway has failed since PR #404; the last green deploy was #401. All four services (`@webjsdev/{website,docs,example-blog,ui-website}`) are FAILED.

Build log root cause:

```
[ERRO] COPY packages/ts-plugin/package.json ./packages/ts-plugin/
Build Failed: failed to compute cache key: "/packages/ts-plugin/package.json": not found
```

PR #404 moved `packages/ts-plugin` to `packages/editors/ts-plugin` and updated the JS path tooling (test runner, changelog map, hooks, CI, workspaces glob), but the repo-root `Dockerfile`'s hard-coded `COPY` line was missed. A `COPY` of a non-existent source is a hard Docker error, so the image never built.

Nothing local caught it: the start-work dogfood gate boots each app via `createRequestHandler` in-process, never the Docker image build.

## Fix

Repoint the manifest COPY at `packages/editors/ts-plugin/package.json` (the only stale path; cli/core/server/ui lines are unaffected, ui stayed flat).

## Guards added (so the class cannot recur)

- `test/repo-health/dockerfile-copy-paths.test.mjs`: asserts every Dockerfile `COPY` source path exists in the repo. Counterfactual verified (fails on the stale path, passes on the fix). Runs in `npm test`.
- A CI `docker` job that builds the production image on every PR, so a stale COPY path or a broken in-image install/dist/tailwind/prisma step is caught on the PR, not at deploy time.

## Test plan

- [x] `docker build .` succeeds locally end-to-end (the exact image Railway builds), exit 0, image written.
- [x] Repo-health guard green (13/13), counterfactual fails on the stale path.
- [x] ci.yml is valid YAML.

## Docs

N/A: this is an infra path fix; no public API or doc surface changed.