### PR TITLE
Type nav sentinels as never

### DIFF
--- a/packages/core/src/nav.d.ts
+++ b/packages/core/src/nav.d.ts
@@ -1,0 +1,4 @@
+export function notFound(): never;
+export function redirect(url: string, status?: number): never;
+export function isNotFound(e: unknown): boolean;
+export function isRedirect(e: unknown): boolean;

--- a/test/types/nav-types.test-d.ts
+++ b/test/types/nav-types.test-d.ts
@@ -1,0 +1,48 @@
+/**
+ * Compile-time type tests for the navigation sentinels (#390). `notFound()`
+ * and `redirect()` throw at runtime and are documented `@returns {never}`;
+ * `packages/core/src/nav.d.ts` makes that explicit in the published type
+ * surface so TypeScript treats them as control-flow terminators and narrows
+ * values after a guarded call.
+ *
+ * Run by `test/types/type-fixtures.test.mjs` via `tsc --noEmit --strict`. Each
+ * `// @ts-expect-error` is a self-checking counterfactual (tsc reports an
+ * unused directive if the type ever widens to accept the bad usage).
+ *
+ * The narrowing blocks are the real assertion: they compile ONLY because the
+ * sentinels return `never`. If either widened to `void`, the `return x` lines
+ * would fail (`T | null` is not assignable to `T`), so a regression in
+ * nav.d.ts turns these into hard tsc errors.
+ */
+import { notFound, redirect, isNotFound, isRedirect } from '@webjsdev/core';
+
+// notFound() is a control-flow terminator: `null` is removed after the guard.
+function requireValue(x: string | null): string {
+  if (x === null) notFound();
+  return x; // OK only because notFound(): never
+}
+
+// redirect() is a control-flow terminator too.
+function requireNumber(x: number | undefined): number {
+  if (x === undefined) redirect('/login');
+  return x; // OK only because redirect(): never
+}
+
+// Explicit return-type checks (never is the bottom type).
+const _n1: never = notFound();
+const _n2: never = redirect('/x');
+const _n3: never = redirect('/x', 308);
+
+// The type guards report booleans.
+const _b1: boolean = isNotFound(new Error());
+const _b2: boolean = isRedirect({});
+
+// redirect requires a url.
+// @ts-expect-error redirect needs a string url argument
+redirect();
+
+// the status, when given, is a number.
+// @ts-expect-error status is a number, not a string
+redirect('/x', '308');
+
+export { requireValue, requireNumber, _n1, _n2, _n3, _b1, _b2 };


### PR DESCRIPTION
Fixes https://github.com/webjsdev/webjs/issues/390.

`notFound()` and `redirect()` throw navigation sentinels at runtime and already document `@returns {never}` in JSDoc, but the published TypeScript surface re-exports them from JS without a dedicated declaration. This adds `src/nav.d.ts` so TypeScript treats them as control-flow terminators and narrows values after guarded calls.

Duplicate check:
- Checked upstream PRs for notFound/redirect/narrow/never/control-flow terms; no same-scope open PR found.
- Checked Charles webjs notFound/redirect/narrow terms; no same-scope issue found before submitting.

Verification:
- Reproduced the pre-fix TypeScript errors: after `if (!post) notFound();`, `post` was still possibly undefined; same for `redirect()`.
- Added `packages/core/src/nav.d.ts` and reran the narrowing repro; it passes under strict TypeScript.
- `node --test packages/core/test/nav/nav.test.js` passed 6 tests.
- `git diff --check` passed.

Note: `npm test -- packages/core/test/nav/nav.test.js` invokes the repository-wide test runner on this Windows workspace and hit unrelated temp-directory/symlink/WSL hook failures. The direct nav runtime test above passed.