### PR TITLE
feat: track vscode + nvim editor packages in the changelog feed

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -69,15 +69,19 @@ if [ -n "$STAGED_PKG_BUMPS" ]; then
   #
   # The wrapper packages (create-webjs, webjsdev) are version-lockstep
   # mirrors of @webjsdev/cli and are explicitly NOT tracked in the
-  # changelog system. The vscode editor extension ships to the VS
-  # Marketplace + Open VSX (not npm), so it is likewise outside the
-  # npm changelog system. Skip them all: their bumps don't require a
-  # changelog file, and scripts/backfill-changelog.js wouldn't
-  # produce one for them anyway (they're not in its PACKAGES list).
+  # changelog system. Skip them: their bumps don't require a changelog
+  # file, and scripts/backfill-changelog.js wouldn't produce one for
+  # them anyway (they're not in its PACKAGES list).
+  #
+  # The editor packages (vscode, nvim) ARE tracked now (#413). They ship
+  # via vsce/ovsx and the nvim git subtree rather than npm, but their
+  # changelog entries carry `npm: false` so the publish-* scripts skip
+  # the registry. So a vscode/nvim version bump DOES require a changelog
+  # file, exactly like an npm package; backfill generates it.
   TO_GENERATE=""
   for bump in $STAGED_PKG_BUMPS; do
     pkg="${bump%@*}"; ver="${bump#*@}"
-    if [ "$pkg" = "create-webjs" ] || [ "$pkg" = "webjsdev" ] || [ "$pkg" = "vscode" ]; then
+    if [ "$pkg" = "create-webjs" ] || [ "$pkg" = "webjsdev" ]; then
       continue
     fi
     if [ ! -f "changelog/$pkg/$ver.md" ]; then

--- a/changelog/nvim/0.1.0.md
+++ b/changelog/nvim/0.1.0.md
@@ -1,0 +1,19 @@
+---
+package: "webjs.nvim"
+version: 0.1.0
+date: 2026-06-08T05:08:44.287Z
+commit_count: 2
+npm: false
+---
+## Features
+
+- **editor plugin Phase 4: webjs.nvim (Neovim highlighting + intelligence)** ([#394](https://github.com/webjsdev/webjs/pull/394)) [`ecedc142`](https://github.com/webjsdev/webjs/commit/ecedc142)
+  * feat: add webjs.nvim, the Neovim editor plugin (Phase 4)
+  
+  Phase 4 of the editor-plugin epic (#381), the Neovim counterpart to the
+  `webjs` VS Code extension. No Lit dependency.
+- **self-contained editor plugins (bundle ts-plugin in nvim too) + drop ui pin** ([#401](https://github.com/webjsdev/webjs/pull/401)) [`42db65ef`](https://github.com/webjsdev/webjs/commit/42db65ef)
+  * feat: bundle @webjsdev/ts-plugin into webjs.nvim (self-contained)
+  
+  #398. webjs.nvim now bundles the language-service plugin, so a Neovim user
+  gets intelligence even when the app has no @webjsdev/ts-plugin in

--- a/changelog/vscode/0.2.0.md
+++ b/changelog/vscode/0.2.0.md
@@ -1,0 +1,19 @@
+---
+package: "webjs (VS Code extension)"
+version: 0.2.0
+date: 2026-06-07T19:27:26+05:30
+commit_count: 2
+npm: false
+---
+## Features
+
+- **add all-in-one webjs VSCode extension (no Lit plugin)** ([#384](https://github.com/webjsdev/webjs/pull/384)) [`baa82bab`](https://github.com/webjsdev/webjs/commit/baa82bab)
+  * feat: add all-in-one webjs VSCode extension (no Lit plugin)
+  
+  Phase 1 of the editor-plugin epic (#381). Ships a self-contained
+  VSCode extension that gives webjs apps html/css/svg template
+- **editor plugin Phase 2: in-template language service (ts-lit-plugin parity)** ([#391](https://github.com/webjsdev/webjs/pull/391)) [`3113960c`](https://github.com/webjsdev/webjs/commit/3113960c)
+  * feat: add webjs in-template HTML parser (Phase 2 foundation)
+  
+  Phase 2 of the editor-plugin epic (#381, #385) rebuilds ts-lit-plugin's
+  in-template intelligence inside @webjsdev/ts-plugin so webjs can drop the

--- a/package-lock.json
+++ b/package-lock.json
@@ -6626,6 +6626,10 @@
       "resolved": "packages/editors/vscode",
       "link": true
     },
+    "node_modules/webjs.nvim": {
+      "resolved": "packages/editors/nvim",
+      "link": true
+    },
     "node_modules/webjsdev": {
       "resolved": "packages/wrappers/webjsdev",
       "link": true
@@ -6819,6 +6823,10 @@
       "engines": {
         "node": ">=24.0.0"
       }
+    },
+    "packages/editors/nvim": {
+      "name": "webjs.nvim",
+      "version": "0.1.0"
     },
     "packages/editors/ts-plugin": {
       "name": "@webjsdev/ts-plugin",

--- a/packages/editors/nvim/AGENTS.md
+++ b/packages/editors/nvim/AGENTS.md
@@ -65,6 +65,14 @@ Developed here; published to the standalone `webjsdev/webjs.nvim` repo (a git
 subtree split) so lazy.nvim / packer can install it by repo name. See
 `PUBLISHING.md`.
 
+It is NOT an npm package, but it IS tracked in the unified changelog (#413).
+`package.json` exists here ONLY as the version source: bump its `version`
+and the pre-commit gate requires a `changelog/nvim/<version>.md` (backfill
+generates it). The entry carries `npm: false`, so the `publish-*` scripts
+skip the registry while the version still renders on the website
+`/changelog` feed. Keep `package.json`'s `version` in step with the
+`webjsdev/webjs.nvim` git tag.
+
 ---
 
 Framework-wide rules and full API reference:

--- a/packages/editors/nvim/package.json
+++ b/packages/editors/nvim/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "webjs.nvim",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Neovim editor support for webjs apps (html/css/svg template highlighting + in-template intelligence via the bundled @webjsdev/ts-plugin). NOT an npm package: ships to the webjsdev/webjs.nvim git repo via subtree split, installed by lazy.nvim. This manifest exists only as the version source for the unified changelog (changelog/nvim/<version>.md); see PUBLISHING.md."
+}

--- a/packages/editors/vscode/AGENTS.md
+++ b/packages/editors/vscode/AGENTS.md
@@ -66,9 +66,15 @@ regenerates the vendored plugin (what the tests exercise).
 ## Not on npm
 
 The extension ships to the VS Marketplace + Open VSX, NOT npm. It is
-`private: true`, it is NOT in `scripts/backfill-changelog.js`'s
-`PACKAGES` list, and the pre-commit hook skips `vscode` in its
-changelog-generation gate. Do not add it to any npm publish flow.
+`private: true`. Do not add it to any npm publish flow.
+
+It IS tracked in the unified changelog (#413): it is in
+`scripts/backfill-changelog.js`'s `PACKAGES` list and a version bump
+requires a `changelog/vscode/<version>.md` (the pre-commit gate enforces
+it, exactly like an npm package). The entry carries `npm: false` in its
+frontmatter, which is how the `publish-npm` / `publish-github-packages` /
+`publish-release` scripts know to skip the registry while still rendering
+it on the website `/changelog` feed.
 
 ## Module map
 

--- a/scripts/backfill-changelog.js
+++ b/scripts/backfill-changelog.js
@@ -33,27 +33,67 @@ const OUT = resolve(ROOT, 'changelog');
 // "bump to match cli@X.Y.Z" every single time, which is noise on
 // the rendered /changelog page. The release workflow auto-bumps and
 // auto-publishes them without writing changelog files.
-const PACKAGES = ['core', 'server', 'cli', 'ts-plugin', 'ui'];
+// The npm-published framework packages PLUS the two editor packages that
+// ship through other channels (the VS Code extension via vsce/ovsx, the
+// Neovim plugin via the webjsdev/webjs.nvim git subtree). The editor
+// packages are tracked here for the unified /changelog feed but are NOT
+// npm-published: they carry `npm: false` in their frontmatter so the
+// release workflow's publish-* scripts skip them (see DISPLAY_NAME /
+// NON_NPM below and scripts/publish-npm.js).
+const PACKAGES = ['core', 'server', 'cli', 'ts-plugin', 'ui', 'vscode', 'nvim'];
 
 // Some packages publish under an unscoped npm name; for those the
 // frontmatter's `package` field is the bare name. (None of the
-// PACKAGES above are unscoped today; this set is reserved for any
-// future framework-side unscoped package the changelog would
-// render.)
+// `@webjsdev/<pkg>` framework packages are unscoped; this set is
+// reserved for any future framework-side unscoped npm package.)
 const UNSCOPED = new Set();
+
+// Packages that are NOT on npm. Their changelog entries carry `npm: false`
+// so the release workflow's publish scripts skip the registry publish
+// (they ship via vsce/ovsx and the nvim git subtree instead). The display
+// name is what renders in the changelog frontmatter `package:` field, since
+// the `@webjsdev/<dir>` convention does not match their real identity (the
+// extension id is `webjsdev.webjs`; the plugin is `webjs.nvim`).
+const NON_NPM = new Set(['vscode', 'nvim']);
+const DISPLAY_NAME = {
+  vscode: 'webjs (VS Code extension)',
+  nvim: 'webjs.nvim',
+};
 
 /** @param {string} pkg short dir name */
 function npmName(pkg) {
+  if (DISPLAY_NAME[pkg]) return DISPLAY_NAME[pkg];
   return UNSCOPED.has(pkg) ? pkg : `@webjsdev/${pkg}`;
 }
 
 // Some packages live in a grouped subfolder (#402). The PACKAGES keys stay
 // the bare names (used for the npm name + the changelog/<pkg>/ dir); map a
 // key to its on-disk directory here when it is not packages/<pkg>.
-const PACKAGE_DIRS = { 'ts-plugin': 'packages/editors/ts-plugin' };
+const PACKAGE_DIRS = {
+  'ts-plugin': 'packages/editors/ts-plugin',
+  vscode: 'packages/editors/vscode',
+  nvim: 'packages/editors/nvim',
+};
 /** @param {string} pkg short dir name -> its repo-relative package dir */
 function pkgDir(pkg) {
   return PACKAGE_DIRS[pkg] || `packages/${pkg}`;
+}
+
+// Prior on-disk locations of a package, before a move. `git log` does not
+// follow a directory across a rename, so to attribute a commit that landed
+// while the package lived at its old path (the #402/#404 reorg moved the
+// editor packages from packages/<x> into packages/editors/<x>), we pass
+// BOTH the current and the historical dir as pathspecs. Without this, a
+// package's pre-move version bumps and feature commits are invisible to the
+// changelog (vscode's 0.1.0/0.2.0 and the nvim epic work all predate #404).
+const PACKAGE_OLD_DIRS = {
+  'ts-plugin': ['packages/ts-plugin'],
+  vscode: ['packages/vscode'],
+  nvim: ['packages/nvim'],
+};
+/** All historical repo-relative dirs for a package (current first). */
+function pkgDirs(pkg) {
+  return [pkgDir(pkg), ...(PACKAGE_OLD_DIRS[pkg] || [])];
 }
 
 function git(args, opts = {}) {
@@ -80,7 +120,7 @@ function versionTimeline(pkg) {
   // Then filter to commits where a `+  "version":` line shows up.
   const raw = git([
     'log', '--reverse', '--diff-filter=M', '--pretty=format:===%h\t%aI',
-    '-p', '--', `${pkgDir(pkg)}/package.json`,
+    '-p', '--', ...pkgDirs(pkg).map((d) => `${d}/package.json`),
   ]);
 
   const out = [];
@@ -162,7 +202,8 @@ function commitsInRange(pkg, fromSha, toSha) {
   const RECORD = '';
   const fmt = `%h${FIELD}%aI${FIELD}%s${FIELD}%b${RECORD}`;
   const raw = git([
-    'log', '--reverse', `--pretty=format:${fmt}`, range, '--', `${pkgDir(pkg)}/`,
+    'log', '--reverse', `--pretty=format:${fmt}`, range, '--',
+    ...pkgDirs(pkg).map((d) => `${d}/`),
   ]);
   const out = [];
   for (const rec of raw.split(RECORD)) {
@@ -205,6 +246,9 @@ function renderEntry(pkg, version, date, commits) {
     `version: ${version}`,
     `date: ${date}`,
     `commit_count: ${commits.length}`,
+    // Non-npm packages (the editor extensions) carry this flag so the
+    // release workflow's publish-* scripts skip the registry publish.
+    ...(NON_NPM.has(pkg) ? ['npm: false'] : []),
     '---',
     '',
   ].join('\n');

--- a/scripts/backfill-changelog.js
+++ b/scripts/backfill-changelog.js
@@ -5,7 +5,11 @@
  *
  *   changelog/<pkg>/<version>.md
  *
- * where <pkg> is one of `core`, `server`, `cli`, `ts-plugin`, `ui`.
+ * where <pkg> is one of `core`, `server`, `cli`, `ts-plugin`, `ui`,
+ * `vscode`, or `nvim`. The last two are the editor packages: tracked
+ * for the /changelog feed but flagged `npm: false` in their frontmatter
+ * so the publish-* scripts skip the registry (they ship via vsce/ovsx
+ * and the webjs.nvim git subtree).
  *
  * For each version of each package, the file lists every
  * conventional-commit (`feat:` / `fix:` / `breaking:` / `perf:`) that

--- a/scripts/publish-github-packages.js
+++ b/scripts/publish-github-packages.js
@@ -58,6 +58,14 @@ for (const line of m[1].split('\n')) {
   fm[k] = v;
 }
 
+// Non-npm packages (the editor extensions) are tracked in the changelog
+// but ship via vsce/ovsx and the nvim git subtree, not a registry. Their
+// entries carry `npm: false`; skip cleanly so a release does not fail.
+if (fm.npm === 'false') {
+  console.log(`[publish-github-packages] skip ${fm.package || file}: npm:false (non-npm package)`);
+  process.exit(0);
+}
+
 // Historical changelog files (the @webjskit era) record `package:
 // "@webjskit/<short>"` in their frontmatter; we cannot publish those
 // names to GitHub Packages because the @webjskit scope does not

--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -49,6 +49,16 @@ for (const line of m[1].split('\n')) {
   fm[k] = v;
 }
 
+// Non-npm packages (the editor extensions: the VS Code extension ships via
+// vsce/ovsx, webjs.nvim via the git subtree) are tracked in the changelog
+// for the /changelog feed but carry `npm: false`, so there is nothing to
+// publish to the registry. Skip cleanly so a vscode/nvim release does not
+// fail the workflow.
+if (fm.npm === 'false') {
+  console.log(`[publish-npm] skip ${fm.package || file}: npm:false (non-npm package)`);
+  process.exit(0);
+}
+
 const pkgName = fm.package; // "@webjsdev/core"
 const version = fm.version;
 if (!pkgName || !version) {

--- a/scripts/publish-release.js
+++ b/scripts/publish-release.js
@@ -47,6 +47,17 @@ for (const line of m[1].split('\n')) {
   if (v.startsWith('"') && v.endsWith('"')) v = v.slice(1, -1);
   fm[k] = v;
 }
+
+// Non-npm packages (the editor extensions) are tracked in the changelog
+// for the /changelog feed but ship via vsce/ovsx and the nvim git subtree.
+// Their `package:` is a human display name, not a scoped npm name, so the
+// derived `<short>@<version>` tag would be garbage. Skip the GitHub Release
+// for them (a dedicated editor-release tag scheme can come later).
+if (fm.npm === 'false') {
+  console.log(`[publish-release] skip ${fm.package || file}: npm:false (non-npm package)`);
+  process.exit(0);
+}
+
 // Two body transforms before publishing.
 // 1. Strip a leading h1 (e.g. `# @webjsdev/core 0.6.0`) if present.
 //    The release page renders --title above the body already, so an

--- a/test/packaging/changelog-editor-packages.test.mjs
+++ b/test/packaging/changelog-editor-packages.test.mjs
@@ -1,0 +1,100 @@
+/**
+ * #413: the two editor packages (the VS Code extension and webjs.nvim) are
+ * tracked in the unified changelog but ship through non-npm channels (vsce /
+ * ovsx, the webjs.nvim git subtree). Their changelog entries carry
+ * `npm: false`, which is the contract that decouples changelog-tracking from
+ * npm publishing: the release workflow's publish scripts MUST skip a
+ * `npm: false` entry, never attempting a registry publish.
+ *
+ * This locks that contract:
+ *   1. The committed editor entries exist and are flagged `npm: false`.
+ *   2. Every publish-* script skips (exit 0) on a `npm: false` file.
+ *   3. Counterfactual: the SAME scripts do NOT skip a file without the flag
+ *      (they fall through to the missing-frontmatter error, exit 2), proving
+ *      the skip is keyed on `npm: false` and not unconditional. This path is
+ *      fully offline: the error fires before any `npm`/`gh` call.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync, existsSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+
+const PUBLISH_SCRIPTS = [
+  'scripts/publish-npm.js',
+  'scripts/publish-github-packages.js',
+  'scripts/publish-release.js',
+];
+
+function runScript(rel, file) {
+  return spawnSync('node', [join(ROOT, rel), file], {
+    cwd: ROOT,
+    encoding: 'utf8',
+  });
+}
+
+test('the committed editor changelog entries are flagged npm:false', () => {
+  const entries = [
+    { file: 'changelog/vscode/0.2.0.md', name: 'webjs (VS Code extension)' },
+    { file: 'changelog/nvim/0.1.0.md', name: 'webjs.nvim' },
+  ];
+  for (const e of entries) {
+    const path = join(ROOT, e.file);
+    assert.ok(existsSync(path), `${e.file} should exist`);
+    const raw = readFileSync(path, 'utf8');
+    const fm = raw.match(/^---\n([\s\S]*?)\n---/)[1];
+    assert.match(fm, /^npm:\s*false$/m, `${e.file} must carry npm: false`);
+    assert.match(fm, new RegExp(`package:\\s*"${e.name.replace(/[()]/g, '\\$&')}"`), `${e.file} package name`);
+    // A real entry, not an empty placeholder.
+    assert.match(raw, /## (Features|Fixes|Performance|Breaking)/, `${e.file} has content`);
+  }
+});
+
+test('every publish script SKIPS a npm:false changelog file', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'wj-cl-'));
+  try {
+    const f = join(dir, 'entry.md');
+    writeFileSync(
+      f,
+      '---\npackage: "webjs (VS Code extension)"\nversion: 9.9.9\ndate: 2026-01-01\nnpm: false\n---\n## Features\n- x\n',
+    );
+    for (const s of PUBLISH_SCRIPTS) {
+      const r = runScript(s, f);
+      assert.equal(r.status, 0, `${s} should exit 0 on npm:false, got ${r.status}\n${r.stderr}`);
+      assert.match(r.stdout, /skip .*npm:false/, `${s} should log the npm:false skip`);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('counterfactual: publish scripts do NOT skip a file lacking npm:false', () => {
+  // No `npm:` line and no package/version -> the scripts fall through PAST the
+  // skip guard to the missing-frontmatter error (exit 2). If the skip were
+  // unconditional this would wrongly exit 0. Offline: errors before any npm/gh.
+  const dir = mkdtempSync(join(tmpdir(), 'wj-cl-'));
+  try {
+    const f = join(dir, 'entry.md');
+    writeFileSync(f, '---\ndate: 2026-01-01\n---\n## Features\n- x\n');
+    for (const s of PUBLISH_SCRIPTS) {
+      const r = runScript(s, f);
+      assert.equal(r.status, 2, `${s} should exit 2 (missing package), not skip; got ${r.status}`);
+      assert.doesNotMatch(r.stdout, /npm:false/, `${s} must not log a npm:false skip here`);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('the website badge map has colors for both editor packages', () => {
+  const badge = readFileSync(
+    join(ROOT, 'website/modules/changelog/utils/pkg-badge.ts'),
+    'utf8',
+  );
+  assert.match(badge, /\bvscode:\s*'[^']+'/, 'pkg-badge needs a vscode color');
+  assert.match(badge, /\bnvim:\s*'[^']+'/, 'pkg-badge needs an nvim color');
+});

--- a/website/app/changelog/page.ts
+++ b/website/app/changelog/page.ts
@@ -13,7 +13,7 @@ import { pkgBadge } from '../../modules/changelog/utils/pkg-badge.ts';
 
 export const metadata = {
   title: 'Changelog · webjs',
-  description: 'Per-package, per-version release notes for the webjs framework: @webjsdev/core, server, cli, ts-plugin, ui.',
+  description: 'Per-package, per-version release notes for the webjs framework (@webjsdev/core, server, cli, ts-plugin, ui) plus the webjs editor extensions for VS Code and Neovim.',
 };
 
 export default async function Changelog() {
@@ -28,7 +28,10 @@ export default async function Changelog() {
           <code class="font-mono text-[13px] bg-bg-subtle px-1 py-0.5 rounded">/server</code>,
           <code class="font-mono text-[13px] bg-bg-subtle px-1 py-0.5 rounded">/cli</code>,
           <code class="font-mono text-[13px] bg-bg-subtle px-1 py-0.5 rounded">/ts-plugin</code>, and
-          <code class="font-mono text-[13px] bg-bg-subtle px-1 py-0.5 rounded">/ui</code>.
+          <code class="font-mono text-[13px] bg-bg-subtle px-1 py-0.5 rounded">/ui</code>,
+          plus the webjs editor extensions for VS Code
+          (<code class="font-mono text-[13px] bg-bg-subtle px-1 py-0.5 rounded">vscode</code>) and Neovim
+          (<code class="font-mono text-[13px] bg-bg-subtle px-1 py-0.5 rounded">nvim</code>).
           Each version-bump produces one entry, automatically.
         </p>
       </header>

--- a/website/modules/changelog/utils/pkg-badge.ts
+++ b/website/modules/changelog/utils/pkg-badge.ts
@@ -6,6 +6,8 @@ const PKG_COLOR: Record<string, string> = {
   cli:         'bg-emerald-500/15 text-emerald-500',
   'ts-plugin': 'bg-purple-500/15 text-purple-500',
   ui:          'bg-orange-500/15 text-orange-500',
+  vscode:      'bg-sky-500/15 text-sky-500',
+  nvim:        'bg-green-600/15 text-green-600',
 };
 
 /** Color-coded pill badge for the package short-name in a changelog entry. */


### PR DESCRIPTION
Closes #413

## Problem

Of the three editor packages, only `@webjsdev/ts-plugin` appeared in the unified changelog (rendered on the website `/changelog` feed). The VS Code extension (`webjs`, private, ships to VS Marketplace + Open VSX) and `webjs.nvim` (a Lua plugin, no `package.json`, ships to the `webjsdev/webjs.nvim` git repo) were invisible.

## Why it needed care

The changelog pipeline is coupled to npm publishing: `release.yml` fires on any new `changelog/**` file and calls the `publish-*` scripts, which run `npm publish`. Naively adding `changelog/vscode/*.md` would make the release workflow try to npm-publish the private `webjs` extension (and a non-existent `webjs.nvim` workspace) and fail. So this **decouples** changelog-tracking from npm-publishing.

## Changes

- **`npm: false` frontmatter flag** for non-npm entries. `publish-npm.js`, `publish-github-packages.js`, and `publish-release.js` all early-skip on it, so an editor release never touches a registry.
- **`backfill-changelog.js`:** adds `vscode` + `nvim` to `PACKAGES`, a `DISPLAY_NAME` map (their identity is not `@webjsdev/<dir>`), and `PACKAGE_OLD_DIRS` so moved packages pass BOTH their current and pre-#404 dirs as git pathspecs (git does not follow a directory across a rename, so the editors' pre-reorg history would otherwise be lost).
- **nvim** gets a `private: true` `package.json` purely as the changelog version source.
- **Pre-commit gate** stops skipping `vscode`: a vscode/nvim version bump now requires a `changelog/<pkg>/<ver>.md`, exactly like an npm package.
- **Website `/changelog`:** sky/green badge colors for the two packages + updated hero copy and metadata description.
- Generated `changelog/vscode/0.2.0.md` and `changelog/nvim/0.1.0.md` (vscode 0.2.0 captures the whole epic history; 0.1.0 was the initial Add, filtered by `--diff-filter=M`).

## Test plan

- [x] New `test/packaging/changelog-editor-packages.test.mjs` (4 tests): the committed editor entries are flagged `npm: false`; every publish script skips a `npm: false` file (exit 0); counterfactual (a file without the flag falls through to the missing-frontmatter error, exit 2) proving the skip is keyed on the flag; the website badge map has both colors. Fully offline.
- [x] Full node suite 2247/2247.
- [x] Dogfood: website `/` and `/changelog` boot 200 in prod mode, no broken preloads; `webjs check` passes; `/changelog` renders the VSCODE + NVIM badges.

## Docs

Updated `packages/editors/vscode/AGENTS.md` and `packages/editors/nvim/AGENTS.md` (the npm:false tracking model) and the `backfill-changelog.js` header.

## Deliberately deferred

Editor versions get no GitHub Release yet (publish-release skips `npm: false`); a dedicated editor-tag scheme can be a follow-up if wanted.