### PR TITLE
fix: repoint release.yml wrapper lockstep at packages/wrappers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,7 +207,7 @@ jobs:
             # tree only (never committed). npm publish reads from here.
             node -e "
               const fs = require('node:fs');
-              const path = './packages/${pkg}/package.json';
+              const path = './packages/wrappers/${pkg}/package.json';
               const j = JSON.parse(fs.readFileSync(path, 'utf8'));
               j.version = '${CLI_VERSION}';
               if (j.dependencies && j.dependencies['@webjsdev/cli']) {

--- a/test/repo-health/release-wrapper-paths.test.mjs
+++ b/test/repo-health/release-wrapper-paths.test.mjs
@@ -1,0 +1,51 @@
+// Regression guard for issue #418.
+//
+// The auto-release workflow's wrapper lockstep step bumps `create-webjs` +
+// `webjsdev` to match `@webjsdev/cli` before publishing, reading each
+// manifest by a templated path (`./packages/.../<pkg>/package.json`). The
+// #404 reorg moved both wrappers into `packages/wrappers/`, but the workflow
+// line kept the old `./packages/<pkg>/package.json` path. The publish calls
+// are name-based (dir-move-safe), so nothing failed until a CLI release fired
+// the lockstep, at which point the `node -e` would ENOENT. Same class as #409
+// (the Dockerfile stale `packages/ts-plugin` COPY).
+//
+// This resolves the workflow's templated wrapper path for each wrapper and
+// asserts the manifest exists, so a future move of the wrappers fails CI
+// immediately instead of only at the next CLI release.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const WRAPPERS = ['create-webjs', 'webjsdev'];
+
+test('the release workflow wrapper-lockstep manifest path resolves for each wrapper', () => {
+  const yml = readFileSync(join(ROOT, '.github/workflows/release.yml'), 'utf8');
+
+  // The templated manifest path the lockstep `node -e` reads, e.g.
+  // `const path = './packages/wrappers/${pkg}/package.json';`
+  const m = yml.match(/const path = '(\.\/packages\/[^']*\$\{pkg\}\/package\.json)'/);
+  assert.ok(m, 'could not find the wrapper-lockstep manifest path in release.yml');
+
+  for (const pkg of WRAPPERS) {
+    const rel = m[1].replace('${pkg}', pkg).replace(/^\.\//, '');
+    assert.ok(
+      existsSync(join(ROOT, rel)),
+      `release.yml wrapper lockstep reads ${rel}, which does not exist (a moved wrapper?)`,
+    );
+  }
+});
+
+test('the wrapper publish calls stay name-based (dir-move-safe)', () => {
+  const yml = readFileSync(join(ROOT, '.github/workflows/release.yml'), 'utf8');
+  // `npm publish --workspace="${pkg}"` targets by npm name, so a dir move
+  // never breaks the publish itself (only the manifest read, guarded above).
+  assert.match(
+    yml,
+    /npm publish --workspace="\$\{pkg\}"/,
+    'wrapper publish should target the workspace by name, not a path',
+  );
+});


### PR DESCRIPTION
Closes #418

## Problem

The auto-release workflow's wrapper lockstep step (`Lockstep-publish wrappers`) bumps `create-webjs` + `webjsdev` to match `@webjsdev/cli` before publishing, reading each manifest via a hard-coded `./packages/${pkg}/package.json`. PR #404 moved both wrappers into `packages/wrappers/`, so that path no longer exists and the `node -e` would `ENOENT`.

Latent (not yet fired): the `npm publish --workspace=${pkg}` calls are name-based and dir-move-safe, and the last CLI release (#380, wrappers published at 0.10.12) predates #404. The NEXT `@webjsdev/cli` release would have failed the lockstep. Same class as #409 (the Dockerfile stale `packages/ts-plugin` COPY).

## Fix

- Repoint the lockstep manifest path to `./packages/wrappers/${pkg}/package.json`.
- Add `test/repo-health/release-wrapper-paths.test.mjs`: resolves the workflow's templated wrapper path for each wrapper and asserts the manifest exists (counterfactual verified: fails on the old path), plus asserts the publish stays name-based.

## Scope note

A repo-wide sweep for stale #404 flat paths (`packages/{ts-plugin,vscode,nvim,create-webjs,webjsdev}`) found NO other functional references; ts-plugin's auto-publish was already clean (name-based + changelog-driven; its one stale path, the Dockerfile, was fixed in #409). This workflow line was the last one.

## Test plan

- [x] Guard passes with the fix, fails on the reverted path (counterfactual).
- [x] release.yml is valid YAML; wrapper publish remains name-based.
- [x] N/A docs (CI-internal path fix).