### PR TITLE
fix: skip GH-packages mirror for a removed/renamed package

### DIFF
--- a/scripts/publish-github-packages.js
+++ b/scripts/publish-github-packages.js
@@ -99,11 +99,17 @@ const workspacePkgJson = ['packages', 'packages/editors', 'packages/wrappers']
   .map((base) => resolve(REPO_ROOT, base, shortPkg, 'package.json'))
   .find((p) => existsSync(p));
 if (!workspacePkgJson) {
-  console.error(
-    `[publish-github-packages] cannot find a workspace package.json for ${pkgName} ` +
-      `(tried packages/${shortPkg}, packages/editors/${shortPkg}, packages/wrappers/${shortPkg})`,
+  // No workspace dir for this name. `npm publish` (the prior release step)
+  // resolves a workspace BY NAME, so a current package provably exists by the
+  // time we get here; a not-found means the package was renamed or removed
+  // (e.g. @webjsdev/ts-plugin -> @webjsdev/intellisense, #416, whose frozen
+  // changelog/ts-plugin/ entries a bootstrap re-processes). There is nothing
+  // to mirror, so SKIP rather than fail the whole run (#423).
+  console.log(
+    `[publish-github-packages] skip ${pkgName}@${version}: no workspace dir ` +
+      `(renamed/removed package; tried packages/${shortPkg}, packages/editors/${shortPkg}, packages/wrappers/${shortPkg})`,
   );
-  process.exit(2);
+  process.exit(0);
 }
 const workspaceVersion = JSON.parse(readFileSync(workspacePkgJson, 'utf8')).version;
 if (workspaceVersion !== version) {

--- a/test/repo-health/published-package-dirs.test.mjs
+++ b/test/repo-health/published-package-dirs.test.mjs
@@ -14,7 +14,9 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { readFileSync, readdirSync, existsSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -57,4 +59,20 @@ test('every @webjsdev npm-published changelog package resolves through the probe
     if (!resolvePkgDir(key)) missing.push(key);
   }
   assert.deepEqual(missing, [], `published packages whose dir the probe cannot resolve: ${missing.join(', ')}`);
+});
+
+test('publish-github-packages SKIPS (not fails) a package whose workspace dir is absent (#423)', () => {
+  // A renamed/removed package's frozen changelog entries (e.g. ts-plugin after
+  // the intellisense rename) must not fail a bootstrap re-run. The dir check is
+  // before any registry/.npmrc side effect, so this is offline.
+  const dir = mkdtempSync(join(tmpdir(), 'wj-ghp-'));
+  try {
+    const f = join(dir, '0.9.9.md');
+    writeFileSync(f, '---\npackage: "@webjsdev/this-package-was-removed"\nversion: 0.9.9\ndate: 2026-01-01\n---\n## Fixes\n- x\n');
+    const r = spawnSync('node', [join(ROOT, 'scripts/publish-github-packages.js'), f], { cwd: ROOT, encoding: 'utf8' });
+    assert.equal(r.status, 0, `should exit 0 (skip), got ${r.status}\n${r.stderr}`);
+    assert.match(r.stdout, /skip .*no workspace dir/, 'should log the renamed/removed skip');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
Closes #423

## Problem

`publish-github-packages.js` `exit(2)`'d on a not-found workspace dir. A `workflow_dispatch` bootstrap re-processes every changelog file, including the frozen `changelog/ts-plugin/` entries whose dir no longer exists after the @webjsdev/intellisense rename (#420). The bootstrap hit a ts-plugin entry first and died, never reaching intellisense (so its GH-Packages mirror + GH Release never ran). Follow-up to #421/#422.

## Fix

Skip (exit 0, clear log) when the workspace dir is absent. `npm publish` resolves the workspace by NAME, so a current package provably exists by the GH-packages step; a not-found means renamed/removed, nothing to mirror. Guard test asserts the skip (counterfactual: an absent package now exits 0 with a skip log instead of 2).

## After merge

Re-run the release in bootstrap mode (`workflow_dispatch -f bootstrap_github_packages=true`); it will skip the ts-plugin entries and mirror @webjsdev/intellisense@0.5.0 + create its GH Release.

## Test plan

- [x] New guard passes; full repo-health suite green.
- [x] N/A docs (CI-internal).