### PR TITLE
docs: repoint 2 stale bare ts-plugin/ dir refs at intellisense/

### DIFF
--- a/agent-docs/testing.md
+++ b/agent-docs/testing.md
@@ -71,7 +71,7 @@ packages/
   cli/test/                        scaffold validation only
   ui/test/                         schema, resolver, project-detect, components
     components/browser/            real-browser tests for the kit
-  ts-plugin/test/plugin/           tsserver plugin tests (.test.mjs)
+  intellisense/test/plugin/        tsserver plugin tests (.test.mjs)
 test/                              cross-package only
   ssr/                             SSR pipeline (core + server)
   actions/                         expose() (core + server)

--- a/packages/cli/templates/AGENTS.md
+++ b/packages/cli/templates/AGENTS.md
@@ -89,7 +89,7 @@ node_modules/@webjsdev/
     src/actions.js            ← .server.ts scanner, RPC, expose()
     src/auth.js, session.js, cache.js, rate-limit.js, csrf.js
   cli/             webjs CLI (dev / start / build / test / check / create / db)
-  ts-plugin/       tsserver plugin: go-to-definition + diagnostic suppression
+  intellisense/    tsserver plugin: go-to-definition + diagnostic suppression
                    + attribute auto-complete for Class.register('tag') elements
 ```
 


### PR DESCRIPTION
Closes #425

Two docs used a bare `ts-plugin/` dir entry the rename's bulk-replace (which targeted `@webjsdev/ts-plugin` + `packages/editors/ts-plugin`) did not match:
- `agent-docs/testing.md` (`ts-plugin/test/plugin/` -> `intellisense/test/plugin/`)
- `packages/cli/templates/AGENTS.md` (the `node_modules/@webjsdev/` tree entry; ships to every scaffold)

All other `ts-plugin` references are intentional: frozen `changelog/ts-plugin/` history, the legacy pkg-badge color for those entries, and explanatory comments (incl. one historical comment in `ci.yml`). GitHub Actions are functionally clean.

Docs-only; no code change.