### PR TITLE
chore: release @webjsdev/core 0.7.12 + @webjsdev/cli 0.10.13

### DIFF
--- a/changelog/cli/0.10.13.md
+++ b/changelog/cli/0.10.13.md
@@ -1,0 +1,27 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.13
+date: 2026-06-08T07:00:14.033Z
+commit_count: 4
+---
+## Features
+
+- **editor plugin Phase 3: drop ts-lit-plugin dep, standalone @webjsdev/ts-plugin** ([#393](https://github.com/webjsdev/webjs/pull/393)) [`cbb309fd`](https://github.com/webjsdev/webjs/commit/cbb309fd)
+  * test: remove obsolete ts-lit suppression tests (Phase 3)
+  
+  Phase 3 (#386) removes the ts-lit-plugin dependency, so the tests that
+  simulated ts-lit diagnostics and asserted the suppression path no longer
+- **self-contained editor plugins (bundle ts-plugin in nvim too) + drop ui pin** ([#401](https://github.com/webjsdev/webjs/pull/401)) [`42db65ef`](https://github.com/webjsdev/webjs/commit/42db65ef)
+  * feat: bundle @webjsdev/ts-plugin into webjs.nvim (self-contained)
+  
+  #398. webjs.nvim now bundles the language-service plugin, so a Neovim user
+  gets intelligence even when the app has no @webjsdev/ts-plugin in
+- **extract the MCP server into a standalone @webjsdev/mcp package** ([#417](https://github.com/webjsdev/webjs/pull/417)) [`b4c86b67`](https://github.com/webjsdev/webjs/commit/b4c86b67)
+  * feat: extract the MCP server into a standalone @webjsdev/mcp package (#415)
+  
+  The MCP server lived inside @webjsdev/cli (lib/mcp.js + mcp-docs.js +
+  mcp-source.js + check-json.js), reachable ONLY as `webjs mcp`. Following
+
+## Fixes
+
+- **scaffold @types/node so node: builtins resolve in apps** ([#392](https://github.com/webjsdev/webjs/pull/392)) [`7ddd36e9`](https://github.com/webjsdev/webjs/commit/7ddd36e9)

--- a/changelog/core/0.7.12.md
+++ b/changelog/core/0.7.12.md
@@ -1,0 +1,16 @@
+---
+package: "@webjsdev/core"
+version: 0.7.12
+date: 2026-06-08T07:00:13.945Z
+commit_count: 2
+---
+## Fixes
+
+- **type notFound/redirect as never so they narrow as terminators** ([#390](https://github.com/webjsdev/webjs/pull/390)) [`2fc9c007`](https://github.com/webjsdev/webjs/commit/2fc9c007)
+  * Type nav sentinels as never
+  
+  * test: add type fixture proving notFound/redirect narrow as never (#390)
+- **add types conditions + declarations for @webjsdev/core subpaths** ([#389](https://github.com/webjsdev/webjs/pull/389)) [`a44ceb46`](https://github.com/webjsdev/webjs/commit/a44ceb46)
+  * Add types conditions for core subpaths
+  
+  * Add types conditions for core subpaths

--- a/package-lock.json
+++ b/package-lock.json
@@ -1715,6 +1715,72 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
@@ -6720,7 +6786,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.12",
+      "version": "0.10.13",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -6736,7 +6802,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.11",
+      "version": "0.7.12",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.24.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.12",
+  "version": "0.10.13",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",


### PR DESCRIPTION
Releases the unreleased work accumulated this session on two published packages.

## @webjsdev/core 0.7.11 -> 0.7.12 (patch)
- fix: type `notFound()`/`redirect()` as `never` so they narrow as control-flow terminators (#390)
- fix: add `types` conditions + `.d.ts` declarations for every `@webjsdev/core` subpath (#389)

## @webjsdev/cli 0.10.12 -> 0.10.13 (patch)
- feat: extract the MCP server into the standalone `@webjsdev/mcp` package; `webjs mcp` delegates to it (#417)
- feat: self-contained editor plugins + drop the `@webjsdev/ui` scaffold pin (#401), Phase 3 standalone plugin (#393)
- fix: scaffold `@types/node` so `node:` builtins resolve in apps (#392)

## Notes
- Both are patch bumps to stay within dependents' `^0.7.x` / `^0.10.x` ranges (single-minor-line convention), so no in-repo dependent range changes are needed.
- Changelogs auto-generated by the pre-commit hook; `package-lock.json` regenerated.
- On merge, the release workflow publishes both to npm + GitHub Packages, creates GH Releases, and lockstep-publishes the `create-webjs` / `webjsdev` wrappers to match cli 0.10.13 (the #419 path fix makes that work).