### PR TITLE
chore: release @webjsdev/core 0.7.13

### DIFF
--- a/changelog/core/0.7.13.md
+++ b/changelog/core/0.7.13.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/core"
+version: 0.7.13
+date: 2026-06-08T07:14:51.657Z
+commit_count: 1
+---
+## Fixes
+
+- **declare drifted @webjsdev/core exports in index.d.ts + add a coverage guard** ([#428](https://github.com/webjsdev/webjs/pull/428)) [`0cd345fc`](https://github.com/webjsdev/webjs/commit/0cd345fc)
+  * fix: declare the 35 drifted @webjsdev/core exports in index.d.ts (#388)
+  
+  The hand-maintained index.d.ts overlay had drifted from index.js: 35 runtime
+  named exports (signal/computed/effect/batch/isSignal/Signal, the full directive

--- a/package-lock.json
+++ b/package-lock.json
@@ -6802,7 +6802,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.12",
+      "version": "0.7.13",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.24.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",


### PR DESCRIPTION
Releases the #388 type fix so the published `@webjsdev/core` types stop drifting from runtime.

## @webjsdev/core 0.7.12 -> 0.7.13 (patch)
- fix: declare the 35 drifted `index.d.ts` exports (signal/computed, the directive set, the serializer, WebjsFrame/Stream, revalidate, ...) + a self-maintaining coverage guard (#388)

Patch bump stays within dependents' `^0.7.x`, so no in-repo range changes. Changelog auto-generated; lockfile regenerated. On merge the release workflow publishes to npm + GitHub Packages and creates the GH Release.