### PR TITLE
feat: add a vtsls/LazyVim LSP helper to webjs.nvim

### DIFF
--- a/packages/editors/nvim/AGENTS.md
+++ b/packages/editors/nvim/AGENTS.md
@@ -18,7 +18,8 @@ specific to the Neovim plugin.
    auto-loads any `queries/<lang>/<kind>.scm` on the runtimepath, so no Lua
    wires this up.
 2. **Lua** (`lua/webjs/`): `init.lua` (`setup()`, the `:WebjsCheck` command,
-   the `with_tsserver_plugin()` LSP helper), `check.lua` (`webjs check --json`
+   the `with_tsserver_plugin()` LSP helper for ts_ls AND `with_vtsls_plugin()`
+   for vtsls/LazyVim, #405), `check.lua` (`webjs check --json`
    to `vim.diagnostic` + quickfix), `health.lua` (`:checkhealth webjs`).
    `plugin/webjs.lua` registers `:WebjsCheck` so it works without an explicit
    `setup()`.

--- a/packages/editors/nvim/README.md
+++ b/packages/editors/nvim/README.md
@@ -48,9 +48,44 @@ queries auto-load). `setup()` is only needed to register `:WebjsCheck`.
 
 ## Language-service intelligence
 
-webjs.nvim **bundles** `@webjsdev/intellisense` (standalone, no Lit dependency).
-Wire it into your `ts_ls` setup with the helper, which points `tsserver` at the
-bundled copy via its plugin probe location:
+webjs.nvim **bundles** `@webjsdev/intellisense` (standalone, no Lit dependency)
+and exposes it to your TypeScript LSP, pointing the plugin probe location at the
+bundled copy. That works with **nothing in the app** (no `@webjsdev/intellisense`
+dependency, no `tsconfig.json` edit). If the app DOES wire the plugin via
+`tsconfig.json` `plugins` (the `webjs create` scaffold does), that is fine too:
+`tsserver` dedupes by name, so there is no double-load.
+
+**Two LSPs load tsserver plugins differently, so pick the helper for yours.**
+
+### vtsls (LazyVim's default TypeScript LSP)
+
+vtsls loads plugins via `settings.vtsls.tsserver.globalPlugins`. With LazyVim,
+configure the `vtsls` server through `nvim-lspconfig` `opts.servers`:
+
+```lua
+-- ~/.config/nvim/lua/plugins/webjs.lua
+return {
+  { 'webjsdev/webjs.nvim', ft = { 'typescript', 'javascript' }, opts = {} },
+
+  -- treesitter parsers the html/css template injections need
+  { 'nvim-treesitter/nvim-treesitter', opts = function(_, o)
+      o.ensure_installed = o.ensure_installed or {}
+      vim.list_extend(o.ensure_installed, { 'html', 'css' })
+    end },
+
+  -- the webjs intelligence plugin, into vtsls
+  { 'neovim/nvim-lspconfig', opts = { servers = { vtsls = {
+      settings = require('webjs').with_vtsls_plugin(),
+  } } } },
+}
+```
+
+`with_vtsls_plugin(settings?)` merges `{ name, location, enableForWorkspaceTypeScriptVersions = true }`
+into an existing (or new) `settings` table, idempotently.
+
+### ts_ls (a.k.a. `tsserver`) / typescript-tools.nvim
+
+ts_ls loads plugins via `init_options.plugins`:
 
 ```lua
 require('lspconfig').ts_ls.setup({
@@ -58,11 +93,10 @@ require('lspconfig').ts_ls.setup({
 })
 ```
 
-That works with **nothing in the app** (no `@webjsdev/intellisense` dependency, no
-`tsconfig.json` edit). If the app DOES wire the plugin via `tsconfig.json`
-`plugins` (the `webjs create` scaffold does), that's fine too: `tsserver`
-dedupes by name, so there is no double-load. Point your LSP at the
-**workspace's** `node_modules/typescript`, and `:LspRestart` after install.
+After either, point your LSP at the **workspace's** `node_modules/typescript`
+and `:LspRestart` once. Highlighting (the treesitter injection) is **independent**
+of this LSP wiring and works as soon as the plugin loads, given the `html` / `css`
+parsers above.
 
 ## Commands
 

--- a/packages/editors/nvim/doc/webjs.txt
+++ b/packages/editors/nvim/doc/webjs.txt
@@ -55,24 +55,41 @@ no setup() call.
 ==============================================================================
 5. LSP INTELLIGENCE                                                    *webjs-lsp*
 
-webjs.nvim BUNDLES @webjsdev/intellisense (standalone, no Lit dependency). Wire it
-into ts_ls with the helper, which points tsserver at the bundled copy via its
-plugin probe location:
+webjs.nvim BUNDLES @webjsdev/intellisense (standalone, no Lit dependency) and
+points the tsserver plugin probe location at the bundled copy, so it works with
+no @webjsdev/intellisense in the app. If the app also wires it via tsconfig.json
+`plugins`, tsserver dedupes by name, so there is no double-load.
 
+Two LSPs load tsserver plugins via DIFFERENT keys; pick the helper for yours.
+
+vtsls (LazyVim's default) uses `settings.vtsls.tsserver.globalPlugins`:
+>lua
+  -- in nvim-lspconfig opts.servers
+  vtsls = { settings = require('webjs').with_vtsls_plugin() }
+<
+ts_ls / typescript-tools.nvim use `init_options.plugins`:
 >lua
   require('lspconfig').ts_ls.setup({
     init_options = require('webjs').with_tsserver_plugin(),
   })
 <
-That works with no @webjsdev/intellisense in the app. If the app also wires it via
-tsconfig.json `plugins`, tsserver dedupes by name, so there is no double-load.
+Add the `html` and `css` treesitter parsers (`ensure_installed`) for the
+template injection highlighting, which is independent of the LSP wiring.
 
                                                   *webjs.with_tsserver_plugin()*
 require('webjs').with_tsserver_plugin({init_options})
                         Return {init_options} with the bundled
                         @webjsdev/intellisense merged into `plugins` (idempotent),
                         its `location` set to the copy vendored inside
-                        webjs.nvim. No app dependency required.
+                        webjs.nvim. For ts_ls / typescript-tools.nvim.
+
+                                                     *webjs.with_vtsls_plugin()*
+require('webjs').with_vtsls_plugin({settings})
+                        Return {settings} with the bundled
+                        @webjsdev/intellisense merged into
+                        `vtsls.tsserver.globalPlugins` (idempotent), with
+                        `enableForWorkspaceTypeScriptVersions = true`. For vtsls
+                        (LazyVim). No app dependency required.
 
 ==============================================================================
 6. HEALTH                                                           *webjs-health*

--- a/packages/editors/nvim/lua/webjs/init.lua
+++ b/packages/editors/nvim/lua/webjs/init.lua
@@ -59,6 +59,41 @@ function M.with_tsserver_plugin(init_options)
   return init_options
 end
 
+--- The vtsls-shaped globalPlugin spec. vtsls (the LSP LazyVim's TypeScript
+--- extra and many modern setups use) loads tsserver plugins via
+--- `settings.vtsls.tsserver.globalPlugins`, a DIFFERENT key from ts_ls's
+--- `init_options.plugins`, and needs `enableForWorkspaceTypeScriptVersions` so
+--- the plugin loads against the workspace's own TypeScript too. Points at the
+--- BUNDLED copy, so it works with no @webjsdev/intellisense in the app and no
+--- tsconfig edit (#405).
+--- @return table { name, location, enableForWorkspaceTypeScriptVersions, languages }
+function M.vtsls_global_plugin()
+  return {
+    name = '@webjsdev/intellisense',
+    location = M.bundled_location(),
+    enableForWorkspaceTypeScriptVersions = true,
+    languages = { 'javascript', 'typescript' },
+  }
+end
+
+--- Convenience: merge the webjs tsserver plugin into a vtsls `settings` table
+--- (creating `vtsls.tsserver.globalPlugins` if absent), idempotently. Use this
+--- with the `vtsls` language server (LazyVim's default TypeScript LSP), where
+--- `with_tsserver_plugin`'s `init_options.plugins` shape does nothing.
+--- @param settings table|nil
+--- @return table the same (or a new) settings with the globalPlugin present
+function M.with_vtsls_plugin(settings)
+  settings = settings or {}
+  settings.vtsls = settings.vtsls or {}
+  settings.vtsls.tsserver = settings.vtsls.tsserver or {}
+  settings.vtsls.tsserver.globalPlugins = settings.vtsls.tsserver.globalPlugins or {}
+  for _, p in ipairs(settings.vtsls.tsserver.globalPlugins) do
+    if p.name == '@webjsdev/intellisense' then return settings end
+  end
+  table.insert(settings.vtsls.tsserver.globalPlugins, M.vtsls_global_plugin())
+  return settings
+end
+
 --- Register user commands. Safe to call multiple times.
 function M.setup(opts)
   M.config = vim.tbl_deep_extend('force', M.config, opts or {})

--- a/packages/editors/nvim/test/selftest.lua
+++ b/packages/editors/nvim/test/selftest.lua
@@ -33,6 +33,20 @@ ok(vim.fn.isdirectory(loc .. '/node_modules/@webjsdev/intellisense') == 1,
 ok(vim.fn.filereadable(loc .. '/node_modules/@webjsdev/intellisense/src/index.js') == 1,
   'bundled intellisense entry is present')
 
+-- 3b. vtsls helper (#405): the globalPlugins shape LazyVim/vtsls uses, also
+-- pointing at the BUNDLED copy.
+local gp = webjs.vtsls_global_plugin()
+ok(gp.name == '@webjsdev/intellisense', 'vtsls_global_plugin names the plugin')
+ok(gp.location == webjs.bundled_location(), 'vtsls_global_plugin points at the bundled location')
+ok(gp.enableForWorkspaceTypeScriptVersions == true,
+  'vtsls_global_plugin enables for workspace TypeScript versions')
+local st = webjs.with_vtsls_plugin({})
+local injected = st.vtsls.tsserver.globalPlugins
+ok(injected[1].name == '@webjsdev/intellisense', 'with_vtsls_plugin injects into settings.vtsls.tsserver.globalPlugins')
+ok(vim.fn.isdirectory(injected[1].location .. '/node_modules/@webjsdev/intellisense') == 1,
+  'vtsls globalPlugin location points at the vendored bundle')
+ok(#webjs.with_vtsls_plugin(st).vtsls.tsserver.globalPlugins == 1, 'with_vtsls_plugin is idempotent')
+
 -- 4. check.project maps a violation to a quickfix entry
 local _, qf = check.project({
   violations = { { rule = 'no-foo', message = 'bad', file = '/tmp/x.ts', line = 3, column = 5 } },


### PR DESCRIPTION
Closes #405

## Problem

webjs.nvim's `with_tsserver_plugin()` returns the **ts_ls** shape (`init_options.plugins`). But LazyVim's default TypeScript LSP is **vtsls**, which loads tsserver plugins via a different key (`settings.vtsls.tsserver.globalPlugins`, with `enableForWorkspaceTypeScriptVersions`). So the helper does nothing under vtsls, and a LazyVim user has to hand-write the `globalPlugins` block.

## Fix (`packages/editors/nvim`)

- `vtsls_global_plugin()` + `with_vtsls_plugin(settings?)`: the vtsls-shaped helper, idempotent, pointing `location` at the bundled `@webjsdev/intellisense` (so it works with nothing in the app).
- **README**: a LazyVim/vtsls recipe alongside the ts_ls one, plus the `html`/`css` treesitter parsers and a note that highlighting is independent of the LSP wiring.
- **vimdoc** (`doc/webjs.txt`) + **selftest** cover both helper shapes (the selftest asserts the vtsls globalPlugin carries the bundled location + is idempotent).

> Note: the plugin name is `@webjsdev/intellisense` (the issue predates the #416 ts-plugin->intellisense rename; the bundled vendor + helpers already use the new name).

## Test plan

- [x] Headless nvim selftest: ALL PASS, including 6 new vtsls assertions.
- [x] Node wrapper (`test/nvim.test.mjs`) + vendor-sync green (3/3).

## After merge

Re-publish the `webjsdev/webjs.nvim` mirror via the subtree split (the #397 publish flow) so lazy.nvim users get the new helper.