### PR TITLE
chore: release webjs.nvim 0.2.0 (vtsls/LazyVim helper)

### DIFF
--- a/changelog/nvim/0.2.0.md
+++ b/changelog/nvim/0.2.0.md
@@ -1,0 +1,29 @@
+---
+package: "webjs.nvim"
+version: 0.2.0
+date: 2026-06-08T07:35:42.054Z
+commit_count: 4
+npm: false
+---
+## Features
+
+- **editor plugin Phase 4: webjs.nvim (Neovim highlighting + intelligence)** ([#394](https://github.com/webjsdev/webjs/pull/394)) [`ecedc142`](https://github.com/webjsdev/webjs/commit/ecedc142)
+  * feat: add webjs.nvim, the Neovim editor plugin (Phase 4)
+  
+  Phase 4 of the editor-plugin epic (#381), the Neovim counterpart to the
+  `webjs` VS Code extension. No Lit dependency.
+- **self-contained editor plugins (bundle ts-plugin in nvim too) + drop ui pin** ([#401](https://github.com/webjsdev/webjs/pull/401)) [`42db65ef`](https://github.com/webjsdev/webjs/commit/42db65ef)
+  * feat: bundle @webjsdev/ts-plugin into webjs.nvim (self-contained)
+  
+  #398. webjs.nvim now bundles the language-service plugin, so a Neovim user
+  gets intelligence even when the app has no @webjsdev/ts-plugin in
+- **track vscode + nvim editor packages in the changelog feed** ([#414](https://github.com/webjsdev/webjs/pull/414)) [`5727a075`](https://github.com/webjsdev/webjs/commit/5727a075)
+  * feat: track vscode + nvim editor packages in the changelog (#413)
+  
+  Of the three editor packages only @webjsdev/ts-plugin appeared in the
+  unified /changelog feed; the VS Code extension (private, ships via
+- **add a vtsls/LazyVim LSP helper to webjs.nvim (#405)** ([#430](https://github.com/webjsdev/webjs/pull/430)) [`aa78b1d8`](https://github.com/webjsdev/webjs/commit/aa78b1d8)
+  with_tsserver_plugin() emits the ts_ls init_options.plugins shape, which does
+  nothing under vtsls (LazyVim's default TypeScript LSP). vtsls loads tsserver
+  plugins via settings.vtsls.tsserver.globalPlugins with
+  enableForWorkspaceTypeScriptVersions. Add vtsls_global_plugin() +

--- a/changelog/nvim/0.2.0.md
+++ b/changelog/nvim/0.2.0.md
@@ -1,29 +1,17 @@
 ---
 package: "webjs.nvim"
 version: 0.2.0
-date: 2026-06-08T07:35:42.054Z
-commit_count: 4
+date: 2026-06-08
+commit_count: 1
 npm: false
 ---
 ## Features
 
-- **editor plugin Phase 4: webjs.nvim (Neovim highlighting + intelligence)** ([#394](https://github.com/webjsdev/webjs/pull/394)) [`ecedc142`](https://github.com/webjsdev/webjs/commit/ecedc142)
-  * feat: add webjs.nvim, the Neovim editor plugin (Phase 4)
-  
-  Phase 4 of the editor-plugin epic (#381), the Neovim counterpart to the
-  `webjs` VS Code extension. No Lit dependency.
-- **self-contained editor plugins (bundle ts-plugin in nvim too) + drop ui pin** ([#401](https://github.com/webjsdev/webjs/pull/401)) [`42db65ef`](https://github.com/webjsdev/webjs/commit/42db65ef)
-  * feat: bundle @webjsdev/ts-plugin into webjs.nvim (self-contained)
-  
-  #398. webjs.nvim now bundles the language-service plugin, so a Neovim user
-  gets intelligence even when the app has no @webjsdev/ts-plugin in
-- **track vscode + nvim editor packages in the changelog feed** ([#414](https://github.com/webjsdev/webjs/pull/414)) [`5727a075`](https://github.com/webjsdev/webjs/commit/5727a075)
-  * feat: track vscode + nvim editor packages in the changelog (#413)
-  
-  Of the three editor packages only @webjsdev/ts-plugin appeared in the
-  unified /changelog feed; the VS Code extension (private, ships via
-- **add a vtsls/LazyVim LSP helper to webjs.nvim (#405)** ([#430](https://github.com/webjsdev/webjs/pull/430)) [`aa78b1d8`](https://github.com/webjsdev/webjs/commit/aa78b1d8)
-  with_tsserver_plugin() emits the ts_ls init_options.plugins shape, which does
-  nothing under vtsls (LazyVim's default TypeScript LSP). vtsls loads tsserver
-  plugins via settings.vtsls.tsserver.globalPlugins with
-  enableForWorkspaceTypeScriptVersions. Add vtsls_global_plugin() +
+- **add a vtsls/LazyVim LSP helper** ([#430](https://github.com/webjsdev/webjs/pull/430)) [`aa78b1d8`](https://github.com/webjsdev/webjs/commit/aa78b1d8)
+  `with_tsserver_plugin()` emits the `ts_ls` `init_options.plugins` shape, which
+  does nothing under vtsls (LazyVim's default TypeScript LSP). Adds
+  `vtsls_global_plugin()` + `with_vtsls_plugin(settings)` (idempotent, pointing
+  at the bundled `@webjsdev/intellisense`), so a LazyVim user wires intelligence
+  with a one-line helper instead of hand-writing `globalPlugins`. README gets a
+  LazyVim recipe alongside the ts_ls one; the vimdoc + selftest cover both
+  shapes (#405).

--- a/packages/editors/nvim/package.json
+++ b/packages/editors/nvim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webjs.nvim",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Neovim editor support for webjs apps (html/css/svg template highlighting + in-template intelligence via the bundled @webjsdev/intellisense). NOT an npm package: ships to the webjsdev/webjs.nvim git repo via subtree split, installed by lazy.nvim. This manifest exists only as the version source for the unified changelog (changelog/nvim/<version>.md); see PUBLISHING.md."
 }


### PR DESCRIPTION
Cuts webjs.nvim 0.2.0 so version-pinning lazy.nvim users get the vtsls/LazyVim helper (#405/#430).

- Bumps `packages/editors/nvim/package.json` 0.1.0 -> 0.2.0 (the changelog version source).
- `changelog/nvim/0.2.0.md`: hand-trimmed to the actual change (the vtsls helper); backfill had dumped the full history because the 0.1.0 package.json was an Add, not a Modify.
- `npm: false`, so the release workflow skips the registry (webjs.nvim ships via the git subtree mirror, not npm). After merge I will re-split the mirror and tag `v0.2.0` on `webjsdev/webjs.nvim`.