### PR TITLE
fix: type WebComponent base lifecycle callbacks as non-optional

### DIFF
--- a/packages/core/src/component.d.ts
+++ b/packages/core/src/component.d.ts
@@ -114,7 +114,11 @@ export abstract class WebComponent extends HTMLElement {
   /** Optional render-error boundary inside the component. */
   renderError?(error: Error): TemplateResult | void;
 
-  connectedCallback?(): void;
-  disconnectedCallback?(): void;
-  attributeChangedCallback?(name: string, oldValue: string | null, newValue: string | null): void;
+  // Concrete on the base (component.js implements all three), so a subclass
+  // override can call `super.connectedCallback()` etc. without a
+  // possibly-undefined error (#433). NOT optional, unlike the subclass-only
+  // hooks above (firstUpdated / renderError).
+  connectedCallback(): void;
+  disconnectedCallback(): void;
+  attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null): void;
 }

--- a/test/types/component-lifecycle.test-d.ts
+++ b/test/types/component-lifecycle.test-d.ts
@@ -1,0 +1,27 @@
+/**
+ * Compile-time type test for #433: the base-implemented WebComponent lifecycle
+ * callbacks (`connectedCallback` / `disconnectedCallback` /
+ * `attributeChangedCallback`) are declared NON-optional, so a subclass override
+ * can call `super.X()` without a "possibly undefined" error. The scaffold's own
+ * `components/theme-toggle.ts` relies on `super.connectedCallback()`.
+ *
+ * Run by `test/types/type-fixtures.test.mjs` via `tsc --noEmit --strict`. This
+ * fixture IS the counterfactual: re-add the `?` to those declarations in
+ * `packages/core/src/component.d.ts` and the `super.X()` calls below fail to
+ * compile, so the harness goes red.
+ */
+import { WebComponent } from '@webjsdev/core';
+
+class ThemeToggleLike extends WebComponent {
+  connectedCallback(): void {
+    super.connectedCallback(); // base implements it; not possibly-undefined
+  }
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+  }
+  attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null): void {
+    super.attributeChangedCallback(name, oldValue, newValue);
+  }
+}
+
+export { ThemeToggleLike };


### PR DESCRIPTION
Closes #433

## Problem

`packages/core/src/component.d.ts` declared `connectedCallback` / `disconnectedCallback` / `attributeChangedCallback` as OPTIONAL (`?`), but `component.js` concretely implements all three. So a subclass override calling `super.connectedCallback()` (the documented required pattern, used by the scaffold's own `theme-toggle.ts`) errored: `Cannot invoke an object which is possibly 'undefined'`.

## Fix

Drop the `?` from the three base-implemented callbacks (concrete, like the `updated()` declaration right above). `adoptedCallback` stays out (the base does not implement it).

## Test plan

- [x] `test/types/component-lifecycle.test-d.ts`: a `WebComponent` subclass calling `super.{connected,disconnected,attributeChanged}Callback()` compiles. Counterfactual verified (re-adding `?` makes the fixture fail).
- [x] type-fixtures suite green (7).
- [x] `website` + `examples/blog` `theme-toggle.ts` (both use `super.connectedCallback()`) type-check with no possibly-undefined error.

Ships to users on the next `@webjsdev/core` release.