### PR TITLE
chore: release @webjsdev/core 0.7.14

### DIFF
--- a/changelog/core/0.7.14.md
+++ b/changelog/core/0.7.14.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/core"
+version: 0.7.14
+date: 2026-06-08T07:43:01.675Z
+commit_count: 1
+---
+## Fixes
+
+- **type WebComponent base lifecycle callbacks as non-optional (#433)** ([#434](https://github.com/webjsdev/webjs/pull/434)) [`e73895c7`](https://github.com/webjsdev/webjs/commit/e73895c7)
+  component.d.ts declared connectedCallback / disconnectedCallback /
+  attributeChangedCallback as OPTIONAL, but component.js concretely implements
+  all three. So an override calling super.connectedCallback() (the documented,
+  required pattern, used by the scaffold's own theme-toggle.ts) errored with

--- a/package-lock.json
+++ b/package-lock.json
@@ -6802,7 +6802,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.13",
+      "version": "0.7.14",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.24.0"
@@ -6818,7 +6818,7 @@
     },
     "packages/editors/nvim": {
       "name": "webjs.nvim",
-      "version": "0.1.0"
+      "version": "0.2.0"
     },
     "packages/editors/vscode": {
       "name": "webjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",


### PR DESCRIPTION
Releases the #433 fix: `@webjsdev/core` 0.7.13 -> 0.7.14 (patch).

- fix: type the WebComponent base lifecycle callbacks (`connectedCallback` / `disconnectedCallback` / `attributeChangedCallback`) as non-optional so `super.connectedCallback()` type-checks (#433/#434).

Patch bump stays within dependents' `^0.7.x`. Changelog auto-generated; lockfile regenerated. On merge the release workflow publishes to npm + GitHub Packages and creates the GH Release.