### PR TITLE
fix: give in-repo apps @types/node so node: builtins resolve

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -18,5 +18,8 @@
   },
   "engines": {
     "node": ">=24.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0"
   }
 }

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "NodeNext",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "strict": true,
+    "types": ["node"],
     "noEmit": true,
     "allowJs": true,
     "checkJs": true,

--- a/examples/blog/package.json
+++ b/examples/blog/package.json
@@ -27,6 +27,7 @@
     "dayjs": "^1.11.21"
   },
   "devDependencies": {
+    "@types/node": "^24.0.0",
     "@webjsdev/intellisense": "^0.5.0",
     "prisma": "^5.22.0",
     "typescript": "^6.0.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,9 +39,29 @@
         "@webjsdev/core": "^0.7.0",
         "@webjsdev/server": "^0.8.0"
       },
+      "devDependencies": {
+        "@types/node": "^24.0.0"
+      },
       "engines": {
         "node": ">=24.0.0"
       }
+    },
+    "docs/node_modules/@types/node": {
+      "version": "24.13.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.1.tgz",
+      "integrity": "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "docs/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "examples/blog": {
       "name": "@webjsdev/example-blog",
@@ -54,6 +74,7 @@
         "dayjs": "^1.11.21"
       },
       "devDependencies": {
+        "@types/node": "^24.0.0",
         "@webjsdev/intellisense": "^0.5.0",
         "prisma": "^5.22.0",
         "typescript": "^6.0.3"
@@ -61,6 +82,23 @@
       "engines": {
         "node": ">=24.0.0"
       }
+    },
+    "examples/blog/node_modules/@types/node": {
+      "version": "24.13.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.1.tgz",
+      "integrity": "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "examples/blog/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -6895,6 +6933,23 @@
         "webjsui": "bin/webjsui.js"
       }
     },
+    "packages/ui/node_modules/@types/node": {
+      "version": "24.13.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.1.tgz",
+      "integrity": "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "packages/ui/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/ui/packages/registry": {
       "name": "@webjsdev/ui-registry",
       "version": "0.1.0"
@@ -6910,6 +6965,7 @@
       },
       "devDependencies": {
         "@tailwindcss/cli": "^4.2.2",
+        "@types/node": "^24.0.0",
         "concurrently": "^9.2.1"
       }
     },
@@ -6948,6 +7004,7 @@
         "@webjsdev/server": "^0.8.0"
       },
       "devDependencies": {
+        "@types/node": "^24.0.0",
         "@web/test-runner": "^0.20.0",
         "@web/test-runner-playwright": "^0.11.0",
         "playwright": "^1.59.0"
@@ -6955,6 +7012,23 @@
       "engines": {
         "node": ">=24.0.0"
       }
+    },
+    "website/node_modules/@types/node": {
+      "version": "24.13.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.1.tgz",
+      "integrity": "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "website/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/packages/ui/packages/website/package.json
+++ b/packages/ui/packages/website/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@tailwindcss/cli": "^4.2.2",
+    "@types/node": "^24.0.0",
     "concurrently": "^9.2.1"
   }
 }

--- a/packages/ui/packages/website/tsconfig.json
+++ b/packages/ui/packages/website/tsconfig.json
@@ -11,7 +11,7 @@
     "strict": true,
     "types": ["node"],
     "noEmit": true,
-    "checkJs": true,
+    "checkJs": false,
     "allowJs": true,
     "allowImportingTsExtensions": true,
     "skipLibCheck": true,
@@ -28,14 +28,12 @@
   "include": [
     "app/**/*",
     "components/**/*",
-    "modules/**/*",
     "lib/**/*",
     "middleware.js",
     "middleware.ts"
   ],
   "exclude": [
     "node_modules",
-    ".webjs",
-    "prisma/migrations"
+    ".webjs"
   ]
 }

--- a/website/package.json
+++ b/website/package.json
@@ -19,6 +19,7 @@
     "@webjsdev/server": "^0.8.0"
   },
   "devDependencies": {
+    "@types/node": "^24.0.0",
     "@web/test-runner": "^0.20.0",
     "@web/test-runner-playwright": "^0.11.0",
     "playwright": "^1.59.0"

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "NodeNext",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "strict": true,
+    "types": ["node"],
     "noEmit": true,
     "allowImportingTsExtensions": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Closes #436

## Problem

A `.server.ts` importing `node:fs/promises` in an in-repo app showed in VS Code: *Cannot find name 'node:fs/promises'*. #403 fixed this for freshly **scaffolded** apps (added `@types/node` + `types: ['node']` to the generator), but the four existing in-repo apps were never updated. `@types/node` is only hoisted at the monorepo root, which the CLI `tsc` resolves but VS Code's tsserver does not reliably pick up for a workspace app.

## Fix

- **examples/blog, website, docs**: add `@types/node` devDep + `types: ['node']` to the tsconfig.
- **ui-website**: had NO tsconfig at all; add one mirroring the others, with `checkJs: false` (it has no own `.js`, so this avoids surfacing implicit-any in the framework/registry `.js` it imports, which is a separate missing-`.d.ts` gap). Its `components/` is gitignored/generated, so only the app-root tsconfig + package.json are tracked.

node: builtins now resolve in all four (0 `node:` errors). Verified the blog has the same 11 pre-existing errors with and without this change (a `WebSocket` default-import style, a stale `@prisma/client` generate, some implicit-anys), so this introduces no regressions.

## Test plan

- [x] `tsc --noEmit` per app: `node:` errors 0/0/0/0 (was erroring in VS Code).
- [x] No new errors introduced (blog 11 before == 11 after).
- [x] N/A CI: none of the apps have a typecheck gate; this is editor/tsserver resolution.