### PR TITLE
docs: footer reads 'Built with WebJs'

### DIFF
--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -354,7 +354,7 @@ lib/session.server.ts</pre>
           <a class="text-fg-muted no-underline text-[13.5px] hover:text-accent" href="/changelog">Changelog</a>
         </nav>
       </div>
-      <div class="w-full text-center mt-6 md:mt-0 text-fg-subtle text-sm">Built with webjs <svg class="heart" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg></div>
+      <div class="w-full text-center mt-6 md:mt-0 text-fg-subtle text-sm">Built with WebJs <svg class="heart" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg></div>
     </footer>
   `;
 }


### PR DESCRIPTION
Closes #439

Capitalizes the brand in the landing-page footer ('Built with webjs' -> 'Built with WebJs'), matching the WebJs capitalization (#431). Copy-only, one line.