### PR TITLE
chore: release @webjsdev/server 0.8.20 + @webjsdev/intellisense 0.5.1

### DIFF
--- a/changelog/intellisense/0.5.1.md
+++ b/changelog/intellisense/0.5.1.md
@@ -1,0 +1,12 @@
+---
+package: "@webjsdev/intellisense"
+version: 0.5.1
+date: 2026-06-08T09:27:18.197Z
+commit_count: 1
+---
+## Features
+
+- **flag duplicate custom-element tag registrations (check rule + editor 9004)** ([#444](https://github.com/webjsdev/webjs/pull/444)) [`5ff76b63`](https://github.com/webjsdev/webjs/commit/5ff76b63)
+  * feat: add no-duplicate-tag webjs check rule (#364)
+  
+  * feat: flag duplicate custom-element tag registrations in editor (#364)

--- a/changelog/server/0.8.20.md
+++ b/changelog/server/0.8.20.md
@@ -1,0 +1,12 @@
+---
+package: "@webjsdev/server"
+version: 0.8.20
+date: 2026-06-08T09:27:18.104Z
+commit_count: 1
+---
+## Features
+
+- **flag duplicate custom-element tag registrations (check rule + editor 9004)** ([#444](https://github.com/webjsdev/webjs/pull/444)) [`5ff76b63`](https://github.com/webjsdev/webjs/commit/5ff76b63)
+  * feat: add no-duplicate-tag webjs check rule (#364)
+  
+  * feat: flag duplicate custom-element tag registrations in editor (#364)

--- a/package-lock.json
+++ b/package-lock.json
@@ -6866,7 +6866,7 @@
     },
     "packages/editors/intellisense": {
       "name": "@webjsdev/intellisense",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "peerDependencies": {
         "typescript": ">=5.0.0"
@@ -6906,7 +6906,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.19",
+      "version": "0.8.20",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/editors/intellisense/package.json
+++ b/packages/editors/intellisense/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/intellisense",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "commonjs",
   "description": "Standalone TypeScript language-service plugin for webjs (no Lit dependency). Adds in-template intelligence inside html`` templates: go-to-definition on tags / attributes / CSS classes, binding-aware completions, value/binding diagnostics, and hover, all driven by its own template parser and gated on import-graph reachability.",
   "main": "src/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.19",
+  "version": "0.8.20",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Release the two packages that gained a feature in #444 (the duplicate custom-element tag detection).

## Bumps

- `@webjsdev/server` 0.8.19 -> **0.8.20** (the `no-duplicate-tag` `webjs check` rule)
- `@webjsdev/intellisense` 0.5.0 -> **0.5.1** (the editor 9004 duplicate-tag diagnostic)

Both are patch bumps. Every in-repo dependent pins `^0.8.0` / `^0.5.0`, so the bumps stay in range; no dependent range edits needed, only the `package-lock.json` regen (included).

## Changelog

Auto-generated by the pre-commit hook (`scripts/backfill-changelog.js`) from the #444 `feat:` squash commit: `changelog/server/0.8.20.md` + `changelog/intellisense/0.5.1.md`.

No other accumulated release debt: each package had exactly one unreleased functional commit (#444).