### PR TITLE
fix: load .env before resolving the dev/start port

### DIFF
--- a/docs/app/docs/configuration/page.ts
+++ b/docs/app/docs/configuration/page.ts
@@ -11,7 +11,7 @@ export default function Configuration() {
     <h3>webjs dev</h3>
     <pre>webjs dev [--port 8080]</pre>
     <ul>
-      <li><code>--port</code>: dev server port (default: <code>8080</code>, or <code>PORT</code> env var)</li>
+      <li><code>--port</code>: dev server port. Precedence is <code>--port</code> &gt; <code>PORT</code> (a real env var <em>or</em> a <code>PORT</code> in the app's <code>.env</code>) &gt; <code>8080</code>. A real exported <code>PORT</code> still wins over the <code>.env</code> value, matching the auto-load's shell-wins-over-file rule.</li>
       <li>File watching via Node's built-in <code>fs.watch</code> (automatic)</li>
       <li>Live reload via SSE (<code>/__webjs/events</code>)</li>
       <li>TypeScript files transformed on the fly</li>
@@ -21,7 +21,7 @@ export default function Configuration() {
     <h3>webjs start</h3>
     <pre>webjs start [--port 8080]</pre>
     <ul>
-      <li><code>--port</code>: production server port (also honors the <code>PORT</code> env var, default 8080)</li>
+      <li><code>--port</code>: production server port. Same precedence as <code>dev</code>: <code>--port</code> &gt; <code>PORT</code> (real env var or <code>.env</code>) &gt; <code>8080</code>.</li>
       <li>Speaks plain HTTP/1.1. TLS termination + HTTP/2 to the browser is the proxy's job (PaaS edges or nginx/Caddy/Traefik)</li>
       <li>gzip/brotli compression enabled by default</li>
       <li>Static file ETag + Cache-Control headers</li>

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -46,6 +46,15 @@ lib/
                          `{ hasVendorPin, findOutdated }` pair (offline tests).
                          The bin renders + owns the non-zero exit on a hard fail.
                          Tests: `test/cli/doctor.test.mjs`.
+  port.js                Port resolution for `webjs dev` / `start` (#447).
+                         `loadAppEnv(appDir)` loads `<appDir>/.env` into
+                         `process.env` (same guard + shell-wins semantics as the
+                         server's own load); `resolvePort(portFlag, env?)` is the
+                         PURE resolver with precedence `--port` > `PORT` (real env
+                         or `.env`) > 8080. The bin calls `loadAppEnv` BEFORE
+                         `resolvePort` so a `.env` PORT is in `process.env` at
+                         resolution time; the server loads `.env` too but too late
+                         to affect the port the CLI computes. Tests: `test/port/`.
   create.js              `webjs create <name>` scaffold logic. Copies
                          `templates/` into the new app, writes
                          package.json + tsconfig + Prisma schema,

--- a/packages/cli/bin/webjs.js
+++ b/packages/cli/bin/webjs.js
@@ -3,6 +3,7 @@ import { resolve, join, dirname } from 'node:path';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { checkNodeInline, nodeInlineMessage } from '../lib/node-preflight.js';
+import { loadAppEnv, resolvePort } from '../lib/port.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const [cmd, ...rest] = process.argv.slice(2);
@@ -85,7 +86,11 @@ async function main() {
       // If we're already inside the --watch child, start the server directly.
       if (process.env.__WEBJS_DEV_CHILD === '1') {
         const { startServer } = await import('@webjsdev/server');
-        const port = Number(flag(rest, '--port', process.env.PORT || 8080));
+        // Load `.env` BEFORE resolving the port so a `PORT` set there is in
+        // process.env at resolution time (#447). The server loads `.env`
+        // too, but that runs too late to affect the port the CLI computes.
+        loadAppEnv(process.cwd());
+        const port = resolvePort(flag(rest, '--port'));
         await startServer({ appDir: process.cwd(), port, dev: true });
         break;
       }
@@ -125,7 +130,10 @@ async function main() {
     }
     case 'start': {
       const { startServer } = await import('@webjsdev/server');
-      const port = Number(flag(rest, '--port', process.env.PORT || 8080));
+      // Load `.env` BEFORE resolving the port so a `PORT` set there wins over
+      // the 8080 default (#447), same as for `dev`.
+      loadAppEnv(process.cwd());
+      const port = resolvePort(flag(rest, '--port'));
       await startServer({ appDir: process.cwd(), port, dev: false });
       break;
     }

--- a/packages/cli/lib/port.js
+++ b/packages/cli/lib/port.js
@@ -1,0 +1,60 @@
+/**
+ * Port resolution for `webjs dev` / `webjs start` (issue #447).
+ *
+ * The bug this fixes: the CLI read `process.env.PORT || 8080` BEFORE the
+ * server's bootstrap ran `process.loadEnvFile('.env')`, so a `PORT` set in
+ * the project's `.env` never reached the port comparison and the server
+ * always came up on 8080. Every OTHER `.env` var worked, because the server
+ * loads `.env` early enough for everything IT reads; only the port, computed
+ * one layer up in the CLI, missed the load.
+ *
+ * The fix loads `.env` into `process.env` here, in the CLI, before the port
+ * is computed. Both functions live in this module so `dev` and `start` share
+ * one implementation and the logic is unit-testable without spawning a
+ * server.
+ */
+import { join } from 'node:path';
+
+/**
+ * Load `<appDir>/.env` into `process.env`, guarded exactly like the server's
+ * own `loadAppEnv` (`packages/server/src/dev.js`): only on a Node with the
+ * built-in `process.loadEnvFile`, and swallowing a missing or malformed file.
+ *
+ * Node's `loadEnvFile` does NOT override a var already present in
+ * `process.env`, so a real shell-exported `PORT=NNNN npm run dev` still wins
+ * over the file. That "shell beats file" precedence is intentional and
+ * matches what the server does after its own load.
+ *
+ * @param {string} appDir
+ */
+export function loadAppEnv(appDir) {
+  try {
+    if (typeof process.loadEnvFile === 'function') {
+      process.loadEnvFile(join(appDir, '.env'));
+    }
+  } catch {
+    // No .env, malformed file, or a Node without loadEnvFile. Fall through
+    // silently: the app may not need any env vars, or they may be set via
+    // the shell.
+  }
+}
+
+/**
+ * Resolve the server port with precedence `--port` flag > `PORT` (shell env
+ * or `.env`, whichever landed in `process.env`) > 8080.
+ *
+ * Kept pure (no `.env` loading, no `process.env` mutation) so it is trivially
+ * testable: the caller loads `.env` first via `loadAppEnv`, then passes the
+ * resulting `process.env` in. A non-numeric or empty `--port` / `PORT`
+ * surfaces as `NaN`, same as the previous inline `Number(...)`, so behaviour
+ * for bad input is unchanged.
+ *
+ * @param {string | undefined} portFlag  The `--port` value, or undefined.
+ * @param {NodeJS.ProcessEnv} [env]      Defaults to `process.env`.
+ * @returns {number}
+ */
+export function resolvePort(portFlag, env = process.env) {
+  if (portFlag !== undefined) return Number(portFlag);
+  if (env.PORT) return Number(env.PORT);
+  return 8080;
+}

--- a/packages/cli/test/port/port.test.js
+++ b/packages/cli/test/port/port.test.js
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for the CLI's port resolution + `.env` loading (issue #447).
+ *
+ * The bug: the CLI read `process.env.PORT || 8080` BEFORE the server ran
+ * `process.loadEnvFile('.env')`, so a `PORT` in the project's `.env` never
+ * reached the port comparison and the server always bound 8080. These tests
+ * prove the precedence `--port` > `PORT` (shell env or `.env`) > 8080, that a
+ * `.env` `PORT` is honored for BOTH dev and start, that a real shell `PORT`
+ * still works, and the counterfactual: with `.env` NOT loaded (the old
+ * ordering) the `.env` port is lost and 8080 wins.
+ *
+ * Note: `process.loadEnvFile` writes to the REAL native environment, not to a
+ * reassigned `process.env` object, so the load-based tests snapshot and
+ * restore the specific keys they touch (PORT, DATABASE_URL) rather than
+ * swapping `process.env`. They run serially (node:test runs tests in a file
+ * sequentially) so the snapshot/restore is safe.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { loadAppEnv, resolvePort } from '../../lib/port.js';
+
+/** Make a throwaway app dir containing a `.env` with the given body. */
+function appWithEnvFile(body) {
+  const dir = mkdtempSync(join(tmpdir(), 'webjs-port-'));
+  if (body !== null) writeFileSync(join(dir, '.env'), body);
+  return dir;
+}
+
+/**
+ * Snapshot the given env keys, run `fn`, then restore them to their exact
+ * prior state (including "was unset"). loadEnvFile mutates the real
+ * process.env, so this keeps a test from leaking PORT into its neighbors.
+ */
+function withRealEnv(keys, fn) {
+  const snapshot = {};
+  for (const k of keys) snapshot[k] = Object.prototype.hasOwnProperty.call(process.env, k) ? process.env[k] : undefined;
+  try {
+    return fn();
+  } finally {
+    for (const k of keys) {
+      if (snapshot[k] === undefined) delete process.env[k];
+      else process.env[k] = snapshot[k];
+    }
+  }
+}
+
+test('resolvePort: precedence --port > PORT > 8080', () => {
+  // --port wins over everything.
+  assert.equal(resolvePort('9000', { PORT: '8090' }), 9000);
+  assert.equal(resolvePort('9000', {}), 9000);
+  // PORT (env or .env, both land in process.env) beats the default.
+  assert.equal(resolvePort(undefined, { PORT: '8090' }), 8090);
+  // Nothing set falls back to 8080.
+  assert.equal(resolvePort(undefined, {}), 8080);
+});
+
+test('resolvePort: bad input surfaces as NaN, matching the old Number(...)', () => {
+  assert.ok(Number.isNaN(resolvePort('not-a-port', {})));
+  assert.ok(Number.isNaN(resolvePort(undefined, { PORT: 'abc' })));
+});
+
+test('loadAppEnv: a PORT in .env lands in process.env and resolves (the dev + start path)', () => {
+  const dir = appWithEnvFile('PORT=8090\nDATABASE_URL=file:./dev.db\n');
+  withRealEnv(['PORT', 'DATABASE_URL'], () => {
+    delete process.env.PORT; // ensure no shell PORT shadows the .env value
+    loadAppEnv(dir);
+    assert.equal(process.env.PORT, '8090', '.env PORT loaded into process.env');
+    // Both `dev` and `start` resolve the port the same way after the load.
+    assert.equal(resolvePort(undefined), 8090, 'dev/start honor .env PORT');
+    // --port still overrides the .env value.
+    assert.equal(resolvePort('9000'), 9000, '--port overrides .env PORT');
+  });
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('loadAppEnv: a real shell PORT is NOT clobbered by .env (loadEnvFile semantics)', () => {
+  const dir = appWithEnvFile('PORT=8090\n');
+  withRealEnv(['PORT'], () => {
+    // Shell already exported PORT=7000; the .env value must not override it.
+    process.env.PORT = '7000';
+    loadAppEnv(dir);
+    assert.equal(process.env.PORT, '7000', 'shell PORT wins over .env PORT');
+    assert.equal(resolvePort(undefined), 7000);
+  });
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('loadAppEnv: no .env present is a silent no-op (port falls back to 8080)', () => {
+  const dir = appWithEnvFile(null); // dir with NO .env file
+  withRealEnv(['PORT'], () => {
+    delete process.env.PORT;
+    loadAppEnv(dir); // must not throw
+    assert.equal(process.env.PORT, undefined);
+    assert.equal(resolvePort(undefined), 8080);
+  });
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('webjs.js loads .env before resolving the port, for BOTH dev and start', async () => {
+  // Structural pin against the #447 regression: if a future edit moves the
+  // port read back ahead of loadAppEnv (or drops the load), the .env PORT is
+  // lost again. Assert both code paths call loadAppEnv() before resolvePort()
+  // and that neither still reads the pre-load `process.env.PORT || 8080`.
+  const { readFile } = await import('node:fs/promises');
+  const binPath = new URL('../../bin/webjs.js', import.meta.url);
+  const src = await readFile(binPath, 'utf8');
+
+  // The old buggy expression must be gone from both branches.
+  assert.ok(
+    !/process\.env\.PORT\s*\|\|\s*8080/.test(src),
+    'the pre-load `process.env.PORT || 8080` read must not return',
+  );
+  // Both commands resolve via the shared helper.
+  const resolveCount = (src.match(/resolvePort\(/g) || []).length;
+  assert.equal(resolveCount, 2, 'dev + start both call resolvePort');
+  // Each resolvePort call is preceded by a loadAppEnv call (ordering matters).
+  for (const m of src.matchAll(/resolvePort\(/g)) {
+    const before = src.slice(0, m.index);
+    assert.ok(
+      before.lastIndexOf('loadAppEnv(') !== -1,
+      'loadAppEnv must run before resolvePort',
+    );
+  }
+});
+
+test('COUNTERFACTUAL: the old ordering (resolve before loading .env) loses the .env PORT', () => {
+  // This pins the actual bug. With the fix REVERTED, the CLI resolved the
+  // port from process.env BEFORE .env was loaded, so a .env-only PORT was
+  // invisible and 8080 won. Simulate that ordering: resolve first (against an
+  // env without PORT), load second. The buggy order yields 8080; the fixed
+  // order (load then resolve) yields 8090 from the same .env.
+  const dir = appWithEnvFile('PORT=8090\n');
+  withRealEnv(['PORT'], () => {
+    delete process.env.PORT;
+    const buggyPort = resolvePort(undefined); // resolved BEFORE the load
+    assert.equal(buggyPort, 8080, 'old order: .env PORT not yet visible -> 8080');
+    loadAppEnv(dir);
+    assert.equal(resolvePort(undefined), 8090, 'fixed order: .env PORT honored');
+  });
+  rmSync(dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary

Closes #447

`PORT` set in a project's `.env` was silently ignored: the dev/start server always bound `8080` no matter what `.env` said, even though every other `.env` var (DATABASE_URL and friends) worked. A real exported `PORT=8090 npm run dev` bound 8090, but the same value in `.env` did not. That asymmetry is the bug.

The cause is load ordering. `bin/webjs.js` computed the port with `Number(flag(rest, '--port', process.env.PORT || 8080))` BEFORE the server's bootstrap ran `process.loadEnvFile('.env')`. At the moment the CLI read `process.env.PORT` the file had not been loaded yet, so it fell back to `8080`. The server loads `.env` early enough for everything IT reads; only the port, computed one layer up in the CLI, missed the load.

The fix loads `.env` in the CLI before resolving the port. A new `packages/cli/lib/port.js` holds two functions so `dev` and `start` share one implementation and the logic is unit-testable without spawning a server:

- `loadAppEnv(appDir)` loads `<appDir>/.env` into `process.env`, with the exact same guard and shell-wins-over-file semantics as the server's own `loadAppEnv` (only when `process.loadEnvFile` exists, swallows a missing/malformed file, never clobbers an already-set var).
- `resolvePort(portFlag, env)` is a pure resolver with precedence `--port` > `PORT` (a real env var or a `PORT` in `.env`, whichever is in `process.env`) > `8080`. Bad input surfaces as `NaN`, same as the old inline `Number(...)`.

Both `dev` and `start` call `loadAppEnv` before `resolvePort`. A real exported `PORT` still wins over the `.env` value because `loadEnvFile` does not override an already-present var, matching the auto-load's documented shell-beats-file rule.

## Test plan

- Unit (`packages/cli/test/port/port.test.js`, run via `npm test`): precedence `--port` > `PORT` > 8080; bad input -> NaN; a `.env` PORT lands in `process.env` and resolves for the dev + start path; a real shell PORT is not clobbered by `.env`; no `.env` is a silent no-op falling back to 8080; a structural pin that both `dev` and `start` call `loadAppEnv` before `resolvePort` and neither still reads the pre-load `process.env.PORT || 8080`.
- Counterfactual: committed the fix, then reverted the `bin/webjs.js` ordering back to the old `Number(flag(rest, '--port', process.env.PORT || 8080))`. The structural test went red (it caught both the returned old expression and the missing `loadAppEnv`/`resolvePort` calls); restoring the fix made it green again.
- `npm test`: 2264 pass. The only failures are the `examples/blog` smoke suite timing out ("blog dev server did not become ready within 15s") which is a pre-existing boot-time flake on this machine, not from this change: it fails identically with my changes stashed out, and a CLI port resolver does not touch the served wire.

## Definition-of-done surfaces

- Docs site: **Updated** `docs/app/docs/configuration/page.ts` (the `webjs dev` and `webjs start` CLI-options bullets now state the full precedence `--port` > `PORT` (real env or `.env`) > `8080`, and that a real shell PORT wins over the file).
- AGENTS: **Updated** `packages/cli/AGENTS.md` (added the `lib/port.js` entry to the lib inventory with the precedence and the load-before-resolve ordering).
- Tests: **Updated** new `packages/cli/test/port/` covering dev + start, `--port` override, real env PORT, no-`.env`, and the counterfactual.
- Dogfood gate: **Ran.** `website` / `docs` / `ui-website` boot 200/307 in dist mode with zero broken modulepreload hints (the edited `/docs/configuration` page renders 200). `examples/blog` e2e is the pre-existing 15s boot flake noted above; a CLI port change does not alter the served wire.
- Scaffold templates: **N/A** because the fix is in the CLI's own runtime port resolution, not in anything `webjs create` generates; no template references the port read.
- MCP server: **N/A** because the change touches neither the introspection projections (routes/actions/components/check) nor the agent-docs knowledge corpus.
- Editor plugins / intellisense: **N/A** because nothing in the template grammar, completions, diagnostics, or snippets changed.
- Marketing copy: **N/A** because no landing-page claim is affected.
- Version bump / changelog: **N/A** in this PR; the squash-merge subject carries the `fix:` prefix so the changelog is generated on the next release bump.
- Deployment docs (`docs/app/docs/deployment/page.ts`): **N/A** because its `--port` mentions are example invocations, not precedence claims; the canonical precedence lives on the configuration page.
