### PR TITLE
chore: release core 0.7.15, server 0.8.21, cli 0.10.14

### DIFF
--- a/changelog/cli/0.10.14.md
+++ b/changelog/cli/0.10.14.md
@@ -1,0 +1,31 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.14
+date: 2026-06-10T10:05:59.634Z
+commit_count: 4
+---
+## Features
+
+- **convention-pick redirect() status + hint bare webjs dev's missing prisma client** ([#456](https://github.com/webjsdev/webjs/pull/456)) [`5d5cd76b`](https://github.com/webjsdev/webjs/commit/5d5cd76b)
+  * feat: convention-pick redirect() status (302 GET gate, 307 action)
+  
+  redirect('/login') baked in 307 unconditionally, so a GET-to-GET gate
+  (an auth bounce) returned the method-preserving 307 where 302 Found is
+- **make the opt-in webjs vendor pin output committable** ([#455](https://github.com/webjsdev/webjs/pull/455)) [`3e125a1f`](https://github.com/webjsdev/webjs/commit/3e125a1f)
+  * feat: make committable the opt-in webjs vendor pin output
+  
+  Vendoring is an optional opt-in: the no-build default resolves bare
+  specifiers at runtime via jspm.io and commits nothing. But when a user
+- **flag an incoherent importmap dependency graph in webjs doctor** ([#460](https://github.com/webjsdev/webjs/pull/460)) [`06c10efa`](https://github.com/webjsdev/webjs/commit/06c10efa)
+  * feat(server): importmap coherence check over the resolved dep graph
+  
+  Add checkImportmapCoherence: given a produced importmap, for each resolved
+  package it verifies that the version pinned for every OTHER resolved package it
+
+## Fixes
+
+- **load .env before resolving the dev/start port (#447)** ([#453](https://github.com/webjsdev/webjs/pull/453)) [`4f7f7abe`](https://github.com/webjsdev/webjs/commit/4f7f7abe)
+  PORT set in a project's .env was ignored: the CLI computed the port from
+  process.env.PORT || 8080 in bin/webjs.js BEFORE the server's bootstrap ran
+  process.loadEnvFile('.env'), so the file's PORT never reached the comparison
+  and the server always bound 8080. Every other .env var worked because the

--- a/changelog/core/0.7.15.md
+++ b/changelog/core/0.7.15.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/core"
+version: 0.7.15
+date: 2026-06-10T10:05:59.525Z
+commit_count: 1
+---
+## Features
+
+- **convention-pick redirect() status + hint bare webjs dev's missing prisma client** ([#456](https://github.com/webjsdev/webjs/pull/456)) [`5d5cd76b`](https://github.com/webjsdev/webjs/commit/5d5cd76b)
+  * feat: convention-pick redirect() status (302 GET gate, 307 action)
+  
+  redirect('/login') baked in 307 unconditionally, so a GET-to-GET gate
+  (an auth bounce) returned the method-preserving 307 where 302 Found is

--- a/changelog/server/0.8.21.md
+++ b/changelog/server/0.8.21.md
@@ -1,0 +1,41 @@
+---
+package: "@webjsdev/server"
+version: 0.8.21
+date: 2026-06-10T10:05:59.580Z
+commit_count: 6
+---
+## Features
+
+- **webjs check flags server-only imports that reach the browser** ([#457](https://github.com/webjsdev/webjs/pull/457)) [`471531fc`](https://github.com/webjsdev/webjs/commit/471531fc)
+  * feat: webjs check flags server-only imports that reach the browser
+  
+  A page/layout/component that ships to the browser but transitively
+  imports a server-only .server.{ts,js} module crashes at runtime (the
+- **convention-pick redirect() status + hint bare webjs dev's missing prisma client** ([#456](https://github.com/webjsdev/webjs/pull/456)) [`5d5cd76b`](https://github.com/webjsdev/webjs/commit/5d5cd76b)
+  * feat: convention-pick redirect() status (302 GET gate, 307 action)
+  
+  redirect('/login') baked in 307 unconditionally, so a GET-to-GET gate
+  (an auth bounce) returned the method-preserving 307 where 302 Found is
+- **type the auth() session user (augmentable + generic)** ([#454](https://github.com/webjsdev/webjs/pull/454)) [`5298fbe4`](https://github.com/webjsdev/webjs/commit/5298fbe4)
+  * feat: type the auth() session user (augmentable + generic)
+  
+  auth() resolved { user: Record<string, unknown> }, so reading a custom
+  field the session/jwt callbacks set (e.g. session.user.id, which crisp
+- **make the opt-in webjs vendor pin output committable** ([#455](https://github.com/webjsdev/webjs/pull/455)) [`3e125a1f`](https://github.com/webjsdev/webjs/commit/3e125a1f)
+  * feat: make committable the opt-in webjs vendor pin output
+  
+  Vendoring is an optional opt-in: the no-build default resolves bare
+  specifiers at runtime via jspm.io and commits nothing. But when a user
+- **flag an incoherent importmap dependency graph in webjs doctor** ([#460](https://github.com/webjsdev/webjs/pull/460)) [`06c10efa`](https://github.com/webjsdev/webjs/commit/06c10efa)
+  * feat(server): importmap coherence check over the resolved dep graph
+  
+  Add checkImportmapCoherence: given a produced importmap, for each resolved
+  package it verifies that the version pinned for every OTHER resolved package it
+
+## Fixes
+
+- **resolve the whole bare-import set in one jspm generate call** ([#459](https://github.com/webjsdev/webjs/pull/459)) [`105cb8d7`](https://github.com/webjsdev/webjs/commit/105cb8d7)
+  * fix: resolve the whole bare-import set in one jspm generate call
+  
+  Per-package-in-isolation resolution pinned a directly-imported package
+  to its local node_modules version while a transitive floated to

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.13",
+  "version": "0.10.14",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.20",
+  "version": "0.8.21",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
## Release

Cuts the npm release for the crisp dogfood batch.

| Package | From | To | Commits |
|---|---|---|---|
| `@webjsdev/core` | 0.7.14 | **0.7.15** | 1 (feat) |
| `@webjsdev/server` | 0.8.20 | **0.8.21** | 6 (5 feat, 1 fix) |
| `@webjsdev/cli` | 0.10.13 | **0.10.14** | 4 (3 feat, 1 fix) |

The unscoped wrappers (`create-webjs`, `webjsdev`) are lockstep-published at the `@webjsdev/cli` version by the workflow; they carry no changelog file by design.

## What's in it

The seven dogfood PRs surfaced while building crisp on webjs, plus the two follow-ups:

- **#449** `webjs check` flags server-only imports reaching the browser (server)
- **#452** convention-pick `redirect()` status (302 GET gate / 307 action) + bare-`webjs dev` prisma hint (core, server, cli)
- **#451** typed `auth()` session user (augmentable + generic) (server)
- **#446** resolve the whole bare-import set in one jspm generate call (server)
- **#448** committable `webjs vendor pin` output (server, cli)
- **#450** importmap-coherence check in `webjs doctor` (server, cli)
- **#447** load `.env` before resolving the dev/start port (cli)
- **#461** move `gitignore-vendor` check from `webjs check` to `webjs doctor` (server, cli) — a `refactor:`, so not headlined in the changelog by convention, but its code ships in this bump
- **#463** doc sweep closing the gaps from the above (cli templates/README; docs site + agent-docs)

## How it publishes

Changelog files were generated by `scripts/backfill-changelog.js` from the conventional-commit history. **Merging this PR** triggers `.github/workflows/release.yml` → npm.com + GitHub Packages + GitHub Releases (all idempotent). Nothing publishes until merge.
