### PR TITLE
fix: stop a long unbroken token scrolling the changelog page on mobile

### DIFF
--- a/website/app/changelog/page.ts
+++ b/website/app/changelog/page.ts
@@ -47,7 +47,7 @@ export default async function Changelog() {
                 <time class="font-mono text-[11.5px] text-fg-subtle tracking-tight">${e.date.slice(0, 10)}</time>
                 <span class="text-[11.5px] text-fg-subtle">${e.commitCount} change${e.commitCount === 1 ? '' : 's'}</span>
               </header>
-              <div>${unsafeHTML(renderEntryBody(e.body))}</div>
+              <div class="[overflow-wrap:anywhere]">${unsafeHTML(renderEntryBody(e.body))}</div>
             </article>
           `)}
     </main>


### PR DESCRIPTION
## Problem

On the `/changelog` page in mobile view, the **whole page** scrolled horizontally. The cause is a changelog entry (server 0.8.1) carrying a slash-delimited token with no whitespace:

```
(graph/scan/gate/actions/middleware/elision/vendor)
```

A `/` is not a default line-break opportunity, so the token can't wrap — it forced the rendered `<p>` wider than a phone viewport, and that overflow propagated to the page.

## Fix

Set `overflow-wrap: anywhere` on the changelog entry's body container (`website/app/changelog/page.ts`). The property is **inherited**, so a single class cascades to every rendered paragraph, list item, and inline `code` span, breaking any otherwise-unbreakable token to fit the column. This fixes it at the layout level — for all historical and future entries — rather than editing the (historical) changelog content.

## Verification

Loaded `/changelog` at a 375px (iPhone-class) viewport via Playwright:

- `document.documentElement.scrollWidth == clientWidth == 375` → **0px horizontal overflow** (page no longer scrolls sideways).
- The entry containing the token now computes `overflow-wrap: anywhere`.
- Widest element on the page == the viewport (375px); nothing exceeds it.
