### PR TITLE
docs: when-to-use guide for webjs-frame + webjs-stream (Turbo lineage)

### DIFF
--- a/agent-docs/advanced.md
+++ b/agent-docs/advanced.md
@@ -867,8 +867,8 @@ component JS. A frame's route can itself use `<webjs-suspense>`, so a deferred
 (`loading="lazy"`) frame whose data is slow streams that data behind a fallback
 inside the frame (one caveat: a streamed framed route skips the byte-saving
 subtree extraction, so the full page renders and the client slices out the
-region). See `data-fetching.md` / the data-fetching doc page for the
-async-render vs `<webjs-suspense>` vs `<webjs-frame>` vs `<webjs-stream>`
+region). See the data-fetching doc page (`docs/app/docs/data-fetching/page.ts`)
+for the async-render vs `<webjs-suspense>` vs `<webjs-frame>` vs `<webjs-stream>`
 decision boundary.
 
 For partial-swap regions NOT tied to a folder layout (a marketing-page

--- a/agent-docs/advanced.md
+++ b/agent-docs/advanced.md
@@ -857,6 +857,20 @@ mounted across nav and keep their `scrollTop` natively.
 
 ### `<webjs-frame>` escape hatch
 
+`<webjs-frame>` is webjs's take on **Turbo Frames** (Hotwire Turbo), so the
+mental model and most `<turbo-frame>` muscle memory transfer directly: a lazy,
+URL-addressable region that swaps on its own, driven by a link or form
+targeting its id. It is the unit for a region that loads or refreshes
+INDEPENDENTLY of a full-page navigation (something a page/layout, which
+re-renders only at the route level, cannot express), and it ships zero
+component JS. A frame's route can itself use `<webjs-suspense>`, so a deferred
+(`loading="lazy"`) frame whose data is slow streams that data behind a fallback
+inside the frame (one caveat: a streamed framed route skips the byte-saving
+subtree extraction, so the full page renders and the client slices out the
+region). See `data-fetching.md` / the data-fetching doc page for the
+async-render vs `<webjs-suspense>` vs `<webjs-frame>` vs `<webjs-stream>`
+decision boundary.
+
 For partial-swap regions NOT tied to a folder layout (a marketing-page
 widget, tabbed UI, etc.), wrap the region in a frame:
 
@@ -1008,6 +1022,13 @@ server-side into the frame instead of using `src` (the self-load then replaces
 those fallback children).
 
 ### Stream actions: surgical element-level updates (#248)
+
+`<webjs-stream>` is webjs's take on **Turbo Streams** (Hotwire Turbo); the
+action set (`append` / `prepend` / `before` / `after` / `replace` / `update` /
+`remove`) mirrors `<turbo-stream>`, so that muscle memory transfers directly. It
+is the ONLY surgical single-element update primitive (and the live-channel
+applier); a region swap or a `<webjs-frame>` reload redraws a whole region, and
+`<webjs-suspense>` is for streaming, so none of them cover "append one row".
 
 A region swap (a layout marker or a `<webjs-frame>`) is the right tool for "this
 part of the page changed". It is too coarse for "append ONE comment", "remove

--- a/docs/app/docs/client-router/page.ts
+++ b/docs/app/docs/client-router/page.ts
@@ -64,6 +64,7 @@ export default function ClientRouter() {
 });</pre>
 
     <h2><code>&lt;webjs-frame&gt;</code>: escape hatch for non-layout regions</h2>
+    <p><code>&lt;webjs-frame&gt;</code> is webjs's take on <strong>Turbo Frames</strong> (from Hotwire Turbo), so if you know <code>&lt;turbo-frame&gt;</code> the model transfers directly: a lazy, URL-addressable region that swaps on its own, driven by a link or form that targets its id. See <a href="/docs/data-fetching">Data fetching</a> for when to reach for a frame versus async render, <code>&lt;webjs-suspense&gt;</code>, or <code>&lt;webjs-stream&gt;</code>, and for combining a lazy frame with streamed content inside it.</p>
     <p>The marker mechanism scopes swaps to the deepest shared <strong>layout</strong>. When you need a swap region <em>smaller</em> than the deepest layout (typically a widget inside a page that should swap independently of the rest of the page) wrap it in <code>&lt;webjs-frame id="..."&gt;</code>.</p>
     <pre>// app/posts/[slug]/page.ts
 export default async function PostPage({ params }) {
@@ -103,6 +104,7 @@ export default async function PostPage({ params }) {
     <p><strong>Progressive-enhancement caveat:</strong> a <code>src</code>-driven frame is JS-dependent. The browser does not natively fetch a <code>&lt;webjs-frame src&gt;</code> (unlike an <code>&lt;iframe&gt;</code>), so with JS off the frame shows only whatever children were server-rendered into it. Use <code>src</code> / <code>loading</code> for deferred content (comments, a recommendations rail, an expensive card) where a JS-off placeholder is acceptable; for content that must exist without JS, render it server-side into the frame instead.</p>
 
     <h2>Stream actions (surgical element updates)</h2>
+    <p><code>&lt;webjs-stream&gt;</code> is webjs's take on <strong>Turbo Streams</strong> (from Hotwire Turbo); the action set (<code>append</code> / <code>prepend</code> / <code>before</code> / <code>after</code> / <code>replace</code> / <code>update</code> / <code>remove</code>) mirrors <code>&lt;turbo-stream&gt;</code>, so that knowledge transfers directly.</p>
     <p>A region swap is the right tool for "this part of the page changed". It is too coarse for "append ONE comment", "remove ONE row", or "bump a count". For those, a server response declares per-element actions as plain HTML, a <code>&lt;webjs-stream action target&gt;</code> wrapping one <code>&lt;template&gt;</code>:</p>
     <pre>&lt;webjs-stream action="append" target="comments"&gt;
   &lt;template&gt;&lt;li&gt;Nice post!&lt;/li&gt;&lt;/template&gt;

--- a/docs/app/docs/data-fetching/page.ts
+++ b/docs/app/docs/data-fetching/page.ts
@@ -75,6 +75,52 @@ class Report extends WebComponent {
       <li><strong>Errors.</strong> Do nothing by default. The framework isolates a failed async component automatically. Add <code>renderError()</code> ONLY to customize the error UI.</li>
     </ol>
 
+    <h2>Deferred or self-refreshing regions: webjs-frame with webjs-suspense</h2>
+    <p>Everything above puts data in the FIRST response (blocking or streamed). Some regions instead need to load or refresh <strong>independently of a full-page navigation</strong>, which is the one thing a page or layout cannot do, because a page/layout re-renders only at the route level (the whole route, on navigation). The unit for an independent region is <code>&lt;webjs-frame&gt;</code>, a server-rendered, URL-addressable sub-region that loads and reloads on its own and ships <strong>zero component JS</strong> (its content is server HTML, swapped in by the framework). It is the webjs answer to a leaf that behaves like an RSC server component, re-rendering through a server round-trip rather than shipping a module.</p>
+    <p><strong>webjs-frame is webjs's take on Turbo Frames</strong> (from Hotwire Turbo), so the mental model and most muscle memory transfer directly. A frame is a lazy, URL-addressable region; a link or form targeting it swaps only that region; <code>loading="lazy"</code> defers it to viewport entry. If you know <code>&lt;turbo-frame&gt;</code>, you already know <code>&lt;webjs-frame&gt;</code>.</p>
+    <p>Reach for a frame, not a page/layout, when the region:</p>
+    <ol>
+      <li><strong>Refreshes on its own</strong> (a dashboard widget, a "load more", a filtered list) without reloading the page. Drive it with a <code>data-webjs-frame="&lt;id&gt;"</code> link or form, or by changing its <code>src</code>; the server re-renders just that route and the frame swaps the result in. No component module ships.</li>
+      <li><strong>Is below the fold or expensive and should NOT hold the first response open.</strong> Use <code>&lt;webjs-frame id src loading="lazy"&gt;</code>, so the first response ships fast and small and the frame self-loads its URL on viewport entry (a second request). This is the deliberately-deferred case, distinct from streaming.</li>
+      <li><strong>Is URL-addressable</strong> (a tab panel, a detail pane) that maps to a route.</li>
+    </ol>
+    <p><strong>Combining the two.</strong> A frame defers a region to a SECOND request; <code>&lt;webjs-suspense&gt;</code> streams slow data WITHIN a response. They compose: a frame whose route is itself slow can wrap that data in <code>&lt;webjs-suspense&gt;</code>, so the frame defers the load (lazy, on viewport) and the slow data then streams in behind a fallback inside the frame. A comments section that is both below the fold AND slow is the canonical case.</p>
+    <pre>// app/post/[id]/page.ts, defer the comments to a lazy frame
+html\`
+  &lt;article&gt;...the post (in the first paint)...&lt;/article&gt;
+  &lt;webjs-frame id="comments" src=${'${`/post/${id}/comments`}'} loading="lazy"&gt;&lt;/webjs-frame&gt;
+\`;
+
+// app/post/[id]/comments/page.ts, the frame's route streams its slow data
+html\`
+  &lt;webjs-frame id="comments"&gt;
+    &lt;webjs-suspense .fallback=${'${html`<p>Loading comments…</p>`}'}&gt;
+      &lt;comment-list post-id=${'${id}'}&gt;&lt;/comment-list&gt;
+    &lt;/webjs-suspense&gt;
+  &lt;/webjs-frame&gt;
+\`;</pre>
+    <p>The right way: point the frame's <code>src</code> / <code>data-webjs-frame</code> at a <code>route.ts</code> or page that renders the region server-side; wrap genuinely-slow data inside it in <code>&lt;webjs-suspense&gt;</code>; use <code>loading="lazy"</code> for below-the-fold; and keep PE-critical content in the first paint (a frame <code>src</code> is JS-dependent, so a no-JS client sees only what was rendered into the frame). One caveat: when a framed route streams, the frame's byte-saving subtree extraction is skipped (the full page renders server-side and the client slices out the region), so you trade some wire bytes for the streaming.</p>
+    <h2>Surgical single-element updates and live channels: webjs-stream</h2>
+    <p>A frame or a region swap redraws a whole region. That is too coarse for "append ONE comment", "remove ONE row", "bump a count", or "insert a toast". For those, <code>&lt;webjs-stream&gt;</code> applies a per-element update declared as plain HTML: a <code>&lt;webjs-stream action target&gt;</code> wrapping a single <code>&lt;template&gt;</code>, where <code>action</code> is one of <code>append</code> / <code>prepend</code> / <code>before</code> / <code>after</code> / <code>replace</code> / <code>update</code> / <code>remove</code> and <code>target</code> is an element id. The element self-applies on connect and removes itself, so it needs no per-app DOM code.</p>
+    <p><strong>webjs-stream is webjs's take on Turbo Streams</strong> (from Hotwire Turbo); the action set mirrors <code>&lt;turbo-stream&gt;</code>, so that muscle memory transfers directly. The same applier serves two delivery paths: a content-negotiated <code>&lt;form&gt;</code> response (the client router asks for the stream MIME only on a JS-driven submit, so a JS-off form still gets a normal render), and a <strong>live channel</strong>, where <code>renderStream(message)</code> in a <code>connectWS</code> handler applies a <code>broadcast()</code>ed payload. So chat, notifications, and presence reuse the same grammar.</p>
+    <pre>// server: append one comment, fan it out to other viewers, degrade for no-JS
+import { stream, streamResponse, acceptsStream, broadcast } from '@webjsdev/server';
+export async function POST(req, { params }) {
+  const c = await addComment(params.id, await req.formData());
+  const html = stream.append('comments', ${'${`<li>${escapeHtml(c.text)}</li>`}'});
+  broadcast(${'${`post:${params.id}`}'}, html);
+  return acceptsStream(req) ? streamResponse(html) : Response.redirect(${'${`/post/${params.id}`}'}, 303);
+}</pre>
+    <p>Reach for <code>&lt;webjs-stream&gt;</code> when the change is a single element inside an otherwise-unchanged region, or when a live channel pushes incremental updates. Use a region swap or a <code>&lt;webjs-frame&gt;</code> reload when a whole region changes; those are not the tool for one row.</p>
+
+    <h2>Which primitive when (the decision boundary)</h2>
+    <ul>
+      <li><strong>async render</strong>: co-located server data in the FIRST paint (the default).</li>
+      <li><strong>webjs-suspense</strong>: slow data that should still be in the first response, streamed behind a fallback.</li>
+      <li><strong>webjs-frame</strong>: a region that loads / refreshes INDEPENDENTLY of a full navigation (self-refresh, lazy below-the-fold, URL-addressable), server-rendered, zero component JS. Turbo Frames.</li>
+      <li><strong>webjs-stream</strong>: a SURGICAL single-element update (append / remove / replace one node) or a live-channel push. Turbo Streams.</li>
+    </ul>
+
     <h2>Anti-patterns</h2>
     <ul>
       <li>Do NOT prop-drill server data through layers when the leaf component can fetch it itself.</li>

--- a/packages/cli/templates/AGENTS.md
+++ b/packages/cli/templates/AGENTS.md
@@ -813,6 +813,14 @@ here is for the "submit → server processes → render new page" flow.)
 
 ### 4. `<webjs-frame id="...">` for non-layout swap regions
 
+`<webjs-frame>` is webjs's take on **Turbo Frames** (Hotwire Turbo), so
+`<turbo-frame>` muscle memory transfers directly: a lazy, URL-addressable
+region that swaps on its own, driven by a link/form targeting its id. Use it
+for a region that loads or refreshes INDEPENDENTLY of a full navigation
+(a self-refreshing widget, a `loading="lazy"` below-the-fold region, a
+URL-addressable panel); it ships zero component JS. Its route can itself use
+`<webjs-suspense>` so a lazy frame's slow data streams in behind a fallback.
+
 For a widget that should swap on click but isn't a route boundary
 (e.g. a tab strip inside a page), wrap it:
 
@@ -880,6 +888,14 @@ rather than silently swapping the whole page; call `preventDefault()` to take
 over the outcome (e.g. `location.assign(e.detail.url)`).
 
 ### 5. Stream actions for surgical element-level updates
+
+`<webjs-stream>` is webjs's take on **Turbo Streams** (Hotwire Turbo); the
+action set (`append` / `prepend` / `before` / `after` / `replace` / `update` /
+`remove`) mirrors `<turbo-stream>`, so that muscle memory transfers directly.
+It is the ONLY surgical single-element update primitive AND the live-channel
+applier (`connectWS` / `broadcast` -> `renderStream`); a region swap or a
+`<webjs-frame>` reload redraws a whole region, so reach for `<webjs-stream>`
+when only one element changes.
 
 When a region swap is too coarse (append ONE comment, remove ONE row, bump a
 count, insert a toast), a server response can declare per-element actions as


### PR DESCRIPTION
Region-primitives when-to-use guide (originally #476, reopened against main after the #470 base branch was merged + deleted).

A single "which one when" guide for the four data / region primitives (async `render()`, `<webjs-suspense>`, `<webjs-frame>`, `<webjs-stream>`), plus the Turbo lineage so agents can transfer Hotwire muscle memory.

- `<webjs-frame>`: a server-rendered, URL-addressable sub-region that loads / reloads INDEPENDENTLY of a full-page navigation and ships zero component JS (self-refreshing widgets, below-the-fold lazy regions, URL-addressable panels). Truly inspired by Turbo Frames.
- `<webjs-frame>` + `<webjs-suspense>`: a deferred frame whose route is itself slow wraps that data in `<webjs-suspense>`, so the frame defers the load and the slow data streams in behind a fallback inside the frame. Caveat documented: a streamed framed route skips the frame's byte-saving subtree extraction.
- `<webjs-stream>`: the only SURGICAL element-level update primitive (append / prepend / before / after / replace / update / remove) AND the live-channel applier (`connectWS` / `broadcast` to `renderStream`). Truly inspired by Turbo Streams.

Surfaces updated: the data-fetching doc page (decision boundary + the frame/stream sections), the client-router doc page, `agent-docs/advanced.md`, and the scaffold `AGENTS.md`. Docs only, no code changes. Fresh-context reviewed; fixed a dead `data-fetching.md` cross-reference found in review.
