### PR TITLE
chore: release core 0.7.16, server 0.8.22, mcp 0.1.1

### DIFF
--- a/changelog/core/0.7.16.md
+++ b/changelog/core/0.7.16.md
@@ -1,0 +1,18 @@
+---
+package: "@webjsdev/core"
+version: 0.7.16
+date: 2026-06-12T07:41:12.912Z
+commit_count: 2
+---
+## Features
+
+- **async render() + component-level Suspense (bare-await data fetch)** ([#470](https://github.com/webjsdev/webjs/pull/470)) [`5443ec9a`](https://github.com/webjsdev/webjs/commit/5443ec9a)
+  * feat(server): treat async render() components as interactive in elision
+  
+  An async (promise-returning) render() suspends on the client: it awaits
+  data, re-renders with the resolved value, reads the SSR seed, and may
+- **elide bare async-render components (#474)** ([#480](https://github.com/webjsdev/webjs/pull/480)) [`63ca566d`](https://github.com/webjsdev/webjs/commit/63ca566d)
+  * feat(elision): elide bare async-render components
+  
+  #470 made async render() a blanket interactivity signal, shipping every
+  async component plus a redundant on-hydration re-fetch. A BARE async leaf

--- a/changelog/mcp/0.1.1.md
+++ b/changelog/mcp/0.1.1.md
@@ -1,0 +1,18 @@
+---
+package: "@webjsdev/mcp"
+version: 0.1.1
+date: 2026-06-12T07:41:13.132Z
+commit_count: 2
+---
+## Features
+
+- **extract the MCP server into a standalone @webjsdev/mcp package** ([#417](https://github.com/webjsdev/webjs/pull/417)) [`b4c86b67`](https://github.com/webjsdev/webjs/commit/b4c86b67)
+  * feat: extract the MCP server into a standalone @webjsdev/mcp package (#415)
+  
+  The MCP server lived inside @webjsdev/cli (lib/mcp.js + mcp-docs.js +
+  mcp-source.js + check-json.js), reachable ONLY as `webjs mcp`. Following
+- **async render() + component-level Suspense (bare-await data fetch)** ([#470](https://github.com/webjsdev/webjs/pull/470)) [`5443ec9a`](https://github.com/webjsdev/webjs/commit/5443ec9a)
+  * feat(server): treat async render() components as interactive in elision
+  
+  An async (promise-returning) render() suspends on the client: it awaits
+  data, re-renders with the resolved value, reads the SSR seed, and may

--- a/changelog/server/0.8.22.md
+++ b/changelog/server/0.8.22.md
@@ -1,0 +1,18 @@
+---
+package: "@webjsdev/server"
+version: 0.8.22
+date: 2026-06-12T07:41:12.962Z
+commit_count: 2
+---
+## Features
+
+- **async render() + component-level Suspense (bare-await data fetch)** ([#470](https://github.com/webjsdev/webjs/pull/470)) [`5443ec9a`](https://github.com/webjsdev/webjs/commit/5443ec9a)
+  * feat(server): treat async render() components as interactive in elision
+  
+  An async (promise-returning) render() suspends on the client: it awaits
+  data, re-renders with the resolved value, reads the SSR seed, and may
+- **elide bare async-render components (#474)** ([#480](https://github.com/webjsdev/webjs/pull/480)) [`63ca566d`](https://github.com/webjsdev/webjs/commit/63ca566d)
+  * feat(elision): elide bare async-render components
+  
+  #470 made async render() a blanket interactivity signal, shipping every
+  async component plus a redundant on-hydration re-fetch. A BARE async leaf

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "The webjs Model Context Protocol server: live app introspection (routes / actions / components / check) plus the framework knowledge layer (docs, recipes, source) for AI coding agents",
   "bin": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.21",
+  "version": "0.8.22",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Release of the async-render / elision work merged to main (#470, #480).

| Package | Bump | Notes |
|---|---|---|
| `@webjsdev/core` | 0.7.15 → 0.7.16 | feat: async render(), `<webjs-suspense>`, bare-async elision |
| `@webjsdev/server` | 0.8.21 → 0.8.22 | feat: Suspense SSR streaming, elision analyser |
| `@webjsdev/mcp` | 0.1.0 → 0.1.1 | refreshed bundled docs corpus + the `fetch_data_in_component` prompt |

Patch bumps within the `0.MAJOR.x` line so every dependent's `^0.7`/`^0.8` caret range stays valid (no cascade). Changelog files auto-generated by the `.hooks/pre-commit` backfill from the conventional squash subjects. cli is untouched in code (only template docs changed), so it is not bumped.
