### PR TITLE
fix: silence streamed Suspense boundary error message in prod

### DIFF
--- a/packages/server/src/ssr.js
+++ b/packages/server/src/ssr.js
@@ -1445,8 +1445,9 @@ function deduplicatedPreloads(componentUrls, moduleUrls, graph, entryFiles, appD
  * Build a streaming Response. Degrades to a single-flush response when
  * there are no pending Suspense boundaries.
  *
- * @param {string} headHtml
+ * @param {string} prefix
  * @param {string} bodyHtml
+ * @param {string} closer
  * @param {{ pending: {id: string, promise: Promise<unknown>}[], nextId: number }} ctx
  * @param {number} status
  * @param {Request | undefined} req

--- a/packages/server/src/ssr.js
+++ b/packages/server/src/ssr.js
@@ -183,6 +183,7 @@ export async function ssrPage(route, params, url, opts) {
       url,
       metadata,
       nonce,
+      opts.dev,
     );
     // Server HTML cache write (#241). The page opted in via `revalidate`, so
     // FLAG this candidate for the response funnel rather than writing here: the
@@ -1451,8 +1452,10 @@ function deduplicatedPreloads(componentUrls, moduleUrls, graph, entryFiles, appD
  * @param {Request | undefined} req
  * @param {URL | undefined} url
  * @param {Record<string, any>} [metadata]
+ * @param {string} [nonce]
+ * @param {boolean} [dev]  dev surfaces a streamed-boundary error message; prod stays silent
  */
-function streamingHtmlResponse(prefix, bodyHtml, closer, ctx, status, req, url, metadata, nonce) {
+function streamingHtmlResponse(prefix, bodyHtml, closer, ctx, status, req, url, metadata, nonce, dev) {
   const encoder = new TextEncoder();
   const headers = new Headers({ 'content-type': 'text/html; charset=utf-8' });
   // Default: no caching. Pages are dynamic by default: the developer
@@ -1505,8 +1508,13 @@ function streamingHtmlResponse(prefix, bodyHtml, closer, ctx, status, req, url, 
                 for (const n of sub.pending) ctx.pending.push(n);
                 return { id: p.id, html };
               } catch (e) {
+                // Match the SSR error-isolation policy (render-server.js's
+                // defaultSSRErrorTemplate): dev surfaces the message so the
+                // failure is obvious, prod stays SILENT so no internal detail
+                // (a DB error, a stack-derived path) leaks to the client (#478).
                 const msg = e instanceof Error ? e.message : String(e);
-                return { id: p.id, html: `<p>error: ${escapeHtml(msg)}</p>` };
+                const html = dev ? `<p>error: ${escapeHtml(msg)}</p>` : '';
+                return { id: p.id, html };
               }
             })
           );

--- a/packages/server/test/dev/streaming-error-isolation.test.js
+++ b/packages/server/test/dev/streaming-error-isolation.test.js
@@ -1,0 +1,80 @@
+/**
+ * Streamed Suspense boundary error isolation (#478).
+ *
+ * The page-level streaming path (`ssr.js` `streamingHtmlResponse`) renders each
+ * pending boundary and, when one REJECTS or throws, emits an error placeholder
+ * in its slot. That message must follow the same policy as the rest of SSR
+ * (`render-server.js` `defaultSSRErrorTemplate`): dev surfaces the message so
+ * the failure is obvious, prod stays SILENT so no internal detail (a DB error,
+ * a stack-derived path) leaks to the client.
+ *
+ * Driven through the real `createRequestHandler` pipeline against a fixture
+ * page whose top-level `Suspense` boundary rejects with a recognizable secret.
+ */
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { createRequestHandler } from '../../src/dev.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const HTML_URL = pathToFileURL(resolve(__dirname, '../../../core/src/html.js')).toString();
+const SUSPENSE_URL = pathToFileURL(resolve(__dirname, '../../../core/src/suspense.js')).toString();
+
+const SECRET = 'SECRET-DB-ERROR-7f3a9';
+
+// A page whose only content is a Suspense boundary that rejects after a tick.
+// The deferred rejection (vs an eager `Promise.reject`) keeps it from being an
+// unhandled rejection before the streaming loop awaits it. The streaming loop
+// awaits `p.promise`, the rejection throws into its catch, and the boundary's
+// slot gets the dev/prod-gated error placeholder.
+const REJECTING_PAGE =
+  `import { html } from ${JSON.stringify(HTML_URL)};\n` +
+  `import { Suspense } from ${JSON.stringify(SUSPENSE_URL)};\n` +
+  `export default function P() {\n` +
+  `  const slow = new Promise((_, reject) => setTimeout(() => reject(new Error('${SECRET}')), 5));\n` +
+  `  return html\`<main><h1>page</h1>\${Suspense({ fallback: html\`<p>loading</p>\`, children: slow })}</main>\`;\n` +
+  `}\n`;
+
+let tmpRoot;
+before(() => { tmpRoot = mkdtempSync(join(tmpdir(), 'webjs-stream-err-')); });
+after(() => { rmSync(tmpRoot, { recursive: true, force: true }); });
+
+function makeApp(files) {
+  const appDir = mkdtempSync(join(tmpRoot, 'app-'));
+  for (const [rel, body] of Object.entries(files)) {
+    const abs = join(appDir, rel);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, body);
+  }
+  return appDir;
+}
+
+test('PROD: a rejected streamed boundary does NOT leak the error message', async () => {
+  const appDir = makeApp({ 'app/page.js': REJECTING_PAGE });
+  const app = await createRequestHandler({ appDir, dev: false });
+  const res = await app.handle(new Request('http://x/'));
+  assert.equal(res.status, 200, 'the page still streams a 200 (the boundary is isolated)');
+  const body = await res.text();
+  assert.ok(body.includes('page'), 'the non-suspended content rendered');
+  assert.ok(body.includes('loading'), 'the boundary fallback was flushed');
+  assert.ok(
+    !body.includes(SECRET),
+    `prod must NOT leak the boundary error message; body contained it:\n${body}`,
+  );
+});
+
+test('DEV: a rejected streamed boundary surfaces the error message', async () => {
+  const appDir = makeApp({ 'app/page.js': REJECTING_PAGE });
+  const app = await createRequestHandler({ appDir, dev: true });
+  const res = await app.handle(new Request('http://x/'));
+  assert.equal(res.status, 200, 'the page still streams a 200');
+  const body = await res.text();
+  assert.ok(
+    body.includes(SECRET),
+    `dev must surface the boundary error message for debugging; body:\n${body}`,
+  );
+});


### PR DESCRIPTION
## Summary

Closes #478.

The page-level streaming path (`ssr.js` `streamingHtmlResponse`) emitted the raw boundary error message in BOTH dev and prod when a streamed `Suspense` boundary rejects, leaking internal detail (a DB error, a stack-derived path) to the client. The fix threads the `dev` flag into `streamingHtmlResponse` and gates the placeholder: dev surfaces `error: <msg>` for debugging, prod emits an empty (isolated) boundary.

`dev` is webjs's authoritative prod signal: the deployment model uses the CLI `dev` flag, not `NODE_ENV` (`docs/app/docs/deployment/page.ts`), and the Dockerfile sets `NODE_ENV=production` for app code / deps but the server itself keys on `dev`. So under `webjs start` (`dev: false`) this is silent regardless of whether `NODE_ENV` was exported.

Pre-existing on main (not a regression from #470); narrow to trigger (per-component async-render throws are already isolated, so this catch only fires on a top-level boundary rejection or a non-isolated `renderToString` throw).

Scope note: this fixes the page-streaming BOUNDARY path. The per-component SSR isolation (`render-server.js` `defaultSSRErrorTemplate`) and the core `renderToStream` boundary catch still key on `NODE_ENV` (`isProd()`), so under a bare `webjs start` with `NODE_ENV` unset those paths still leak a component error. That broader inconsistency (align all SSR error paths on the `dev` flag) is tracked separately as #483.

## Test plan

- **Integration** (`packages/server/test/dev/streaming-error-isolation.test.js`): a fixture page whose top-level `Suspense` boundary rejects with a recognizable secret, driven through `createRequestHandler`. PROD asserts the body does NOT contain the message (still 200, fallback flushed, content rendered); DEV asserts it DOES. Counterfactual verified: neutering the gate fails the PROD case.
- `dev/` + `test/ssr/` suites: 346 pass.

## Definition of done

- **Tests**: integration above. Browser/e2e: N/A because the change is a server-side SSR streaming error path; the only observable difference is the ABSENCE of a leaked message in prod, which the integration test asserts. The blog e2e streaming tests cover the happy path, which is byte-identical (the change is a catch block).
- **Docs / AGENTS / MCP / editor plugins**: N/A because no public surface changed.
- **Dogfood**: website / docs / ui-website boot 200 in dist mode, no broken preloads. The change cannot affect the happy path (rejection-only catch).
- **Version bump**: server is owed a follow-up patch (0.8.22 → 0.8.23) at the next release; not in this PR.
- **Self-review**: ran the loop; the one finding (the `dev`-vs-`NODE_ENV` inconsistency with the component path) is filed as #483, since aligning the component-isolation path is a separate pre-existing surface.
