### PR TITLE
chore: release core 0.7.17, server 0.8.23

### DIFF
--- a/changelog/core/0.7.17.md
+++ b/changelog/core/0.7.17.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/core"
+version: 0.7.17
+date: 2026-06-12T19:17:40.395Z
+commit_count: 1
+---
+## Fixes
+
+- **SSR error prod-silence keys on the dev flag, not NODE_ENV** ([#484](https://github.com/webjsdev/webjs/pull/484)) [`e0d27191`](https://github.com/webjsdev/webjs/commit/e0d27191)
+  * fix: SSR error prod-silence keys on the dev flag, not NODE_ENV
+  
+  defaultSSRErrorTemplate (the per-component SSR error isolation) and the
+  renderToStream boundary catch gated prod-silence on NODE_ENV. But webjs

--- a/changelog/server/0.8.23.md
+++ b/changelog/server/0.8.23.md
@@ -1,0 +1,18 @@
+---
+package: "@webjsdev/server"
+version: 0.8.23
+date: 2026-06-12T19:17:40.449Z
+commit_count: 2
+---
+## Fixes
+
+- **silence streamed Suspense boundary error message in prod** ([#482](https://github.com/webjsdev/webjs/pull/482)) [`ff84dd63`](https://github.com/webjsdev/webjs/commit/ff84dd63)
+  * fix: silence streamed Suspense boundary error message in prod
+  
+  The page-level streaming path (streamingHtmlResponse) emitted the raw
+  boundary error message in BOTH dev and prod, leaking internal detail (a
+- **SSR error prod-silence keys on the dev flag, not NODE_ENV** ([#484](https://github.com/webjsdev/webjs/pull/484)) [`e0d27191`](https://github.com/webjsdev/webjs/commit/e0d27191)
+  * fix: SSR error prod-silence keys on the dev flag, not NODE_ENV
+  
+  defaultSSRErrorTemplate (the per-component SSR error isolation) and the
+  renderToStream boundary catch gated prod-silence on NODE_ENV. But webjs

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Release of the SSR error-isolation fixes merged to main (#482, #484).

| Package | Bump | Notes |
|---|---|---|
| `@webjsdev/server` | 0.8.22 → 0.8.23 | fix: streamed Suspense boundary message silenced in prod (#482); SSR error prod-silence keyed on the dev flag, not NODE_ENV (#484) |
| `@webjsdev/core` | 0.7.16 → 0.7.17 | fix: SSR error prod-silence keyed on the dev flag (the render-context threading, #484) |

Patch bumps within the `0.MAJOR.x` line so every dependent caret range stays valid. Changelogs auto-generated from the conventional `fix:` PR titles. Merging adds the `changelog/**.md` files, which triggers the release workflow to publish npm + cut GitHub Releases.
