### PR TITLE
chore: release core 0.7.18, server 0.8.24

### DIFF
--- a/changelog/core/0.7.18.md
+++ b/changelog/core/0.7.18.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/core"
+version: 0.7.18
+date: 2026-06-13T10:14:58.956Z
+commit_count: 1
+---
+## Features
+
+- **seed SSR action results into hydration so async render does not re-fetch (#472)** ([#486](https://github.com/webjsdev/webjs/pull/486)) [`86bd5a5a`](https://github.com/webjsdev/webjs/commit/86bd5a5a)
+  * feat: add SSR action-seed capture + client consumer modules (#472)
+  
+  The server module installs a synchronous module.registerHooks facade that
+  wraps each 'use server' export in a Proxy recording (file, fn, args) ->

--- a/changelog/server/0.8.24.md
+++ b/changelog/server/0.8.24.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/server"
+version: 0.8.24
+date: 2026-06-13T10:14:59.007Z
+commit_count: 1
+---
+## Features
+
+- **seed SSR action results into hydration so async render does not re-fetch (#472)** ([#486](https://github.com/webjsdev/webjs/pull/486)) [`86bd5a5a`](https://github.com/webjsdev/webjs/commit/86bd5a5a)
+  * feat: add SSR action-seed capture + client consumer modules (#472)
+  
+  The server module installs a synchronous module.registerHooks facade that
+  wraps each 'use server' export in a Proxy recording (file, fn, args) ->

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.17",
+  "version": "0.7.18",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Release the SSR action-seeding feature (#472, PR #486).

- **@webjsdev/core** 0.7.17 -> 0.7.18: `takeSeed` / `scanSeeds` / `SEED_MISS` client seed consumer, the seed-aware RPC stub path, soft-nav seed ingestion in the client router.
- **@webjsdev/server** 0.8.23 -> 0.8.24: the `action-seed.js` capture (registerHooks facade + ALS collector), ssr.js seed emission, the `webjs.seed` / `WEBJS_SEED` switch.

Changelogs auto-generated by the pre-commit hook from the conventional-commit history. Patch bumps, consistent with the recent releases (#485 / #466) pre-1.0.

Merging publishes both packages to npm and creates the GitHub Releases (release.yml).