### PR TITLE
fix: harden the wire deserializer against prototype pollution

### DIFF
--- a/packages/core/src/serialize.js
+++ b/packages/core/src/serialize.js
@@ -51,6 +51,36 @@
 const TAG = '_$wj';
 const ID_KEY = '_id';
 
+/**
+ * Keys that, assigned with bracket notation, mutate the target instead of
+ * adding an own data property: `out['__proto__'] = x` invokes the prototype
+ * setter (a prototype-pollution vector on decode, reachable because
+ * `JSON.parse` makes a wire `"__proto__"` an OWN key; and on encode it silently
+ * DROPS a legitimate own `__proto__` data property and corrupts the
+ * accumulator's prototype). `constructor` / `prototype` shadow in ways
+ * downstream code can be confused by.
+ */
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/**
+ * Assign `value` onto a plain accumulator under `key`. A normal key is a plain
+ * assignment (the hot path); an unsafe key is written as an ordinary own
+ * enumerable data property via `defineProperty`, so the value survives as data
+ * (round-trippable, since JSON includes an own enumerable `__proto__`) and the
+ * prototype chain is never touched. Used on BOTH the encode and decode object
+ * loops so `serialize` / `deserialize` stay inverses on these keys.
+ * @param {Record<string, unknown>} out
+ * @param {string} key
+ * @param {unknown} value
+ */
+function safeAssign(out, key, value) {
+  if (UNSAFE_KEYS.has(key)) {
+    Object.defineProperty(out, key, { value, writable: true, enumerable: true, configurable: true });
+  } else {
+    out[key] = value;
+  }
+}
+
 /* ----------------------------------------------------------------- *
  * Public API                                                        *
  * ----------------------------------------------------------------- */
@@ -225,7 +255,7 @@ function encodeOne(v, ctx) {
     for (const k in v) {
       if (!Object.prototype.hasOwnProperty.call(v, k)) continue;
       const escaped = isReservedKey(k) ? '_' + k : k;
-      out[escaped] = encodeOne(v[k], ctx);
+      safeAssign(out, escaped, encodeOne(v[k], ctx));
     }
   }
 
@@ -295,32 +325,6 @@ function newDecodeCtx() {
   };
 }
 
-/**
- * Keys that, assigned with bracket notation, mutate the object instead of
- * adding an own data property: `out['__proto__'] = x` invokes the prototype
- * setter (a prototype-pollution vector, reachable because `JSON.parse` makes a
- * wire `"__proto__"` an OWN key), and `constructor` / `prototype` shadow in a
- * way downstream code can be confused by.
- */
-const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
-
-/**
- * Assign a decoded value onto a plain object from the UNTRUSTED wire. A normal
- * key is a plain assignment (the hot path); an unsafe key is written as an
- * ordinary own data property via `defineProperty`, so the value survives as
- * data and the prototype chain is never touched.
- * @param {Record<string, unknown>} out
- * @param {string} key
- * @param {unknown} value
- */
-function assignDecoded(out, key, value) {
-  if (UNSAFE_KEYS.has(key)) {
-    Object.defineProperty(out, key, { value, writable: true, enumerable: true, configurable: true });
-  } else {
-    out[key] = value;
-  }
-}
-
 function decode(v, ctx) {
   if (v === null || typeof v !== 'object') return v;
   if (Array.isArray(v)) {
@@ -340,7 +344,7 @@ function decode(v, ctx) {
     if (!Object.prototype.hasOwnProperty.call(v, k)) continue;
     if (k === ID_KEY) continue;
     const realKey = isEscapedReservedKey(k) ? k.slice(1) : k;
-    assignDecoded(out, realKey, decode(v[k], ctx));
+    safeAssign(out, realKey, decode(v[k], ctx));
   }
   return out;
 }

--- a/packages/core/src/serialize.js
+++ b/packages/core/src/serialize.js
@@ -295,6 +295,32 @@ function newDecodeCtx() {
   };
 }
 
+/**
+ * Keys that, assigned with bracket notation, mutate the object instead of
+ * adding an own data property: `out['__proto__'] = x` invokes the prototype
+ * setter (a prototype-pollution vector, reachable because `JSON.parse` makes a
+ * wire `"__proto__"` an OWN key), and `constructor` / `prototype` shadow in a
+ * way downstream code can be confused by.
+ */
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/**
+ * Assign a decoded value onto a plain object from the UNTRUSTED wire. A normal
+ * key is a plain assignment (the hot path); an unsafe key is written as an
+ * ordinary own data property via `defineProperty`, so the value survives as
+ * data and the prototype chain is never touched.
+ * @param {Record<string, unknown>} out
+ * @param {string} key
+ * @param {unknown} value
+ */
+function assignDecoded(out, key, value) {
+  if (UNSAFE_KEYS.has(key)) {
+    Object.defineProperty(out, key, { value, writable: true, enumerable: true, configurable: true });
+  } else {
+    out[key] = value;
+  }
+}
+
 function decode(v, ctx) {
   if (v === null || typeof v !== 'object') return v;
   if (Array.isArray(v)) {
@@ -314,7 +340,7 @@ function decode(v, ctx) {
     if (!Object.prototype.hasOwnProperty.call(v, k)) continue;
     if (k === ID_KEY) continue;
     const realKey = isEscapedReservedKey(k) ? k.slice(1) : k;
-    out[realKey] = decode(v[k], ctx);
+    assignDecoded(out, realKey, decode(v[k], ctx));
   }
   return out;
 }

--- a/packages/core/test/serializer/proto-pollution.test.js
+++ b/packages/core/test/serializer/proto-pollution.test.js
@@ -8,7 +8,15 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { parse, deserialize } from '../../src/serialize.js';
+import { parse, deserialize, serialize, stringify } from '../../src/serialize.js';
+
+/** An object carrying a legitimate OWN `__proto__` data property (as a prior
+ * decode would produce), used to exercise the encode side. */
+function withOwnProto(base, protoValue) {
+  return Object.defineProperty({ ...base }, '__proto__', {
+    value: protoValue, enumerable: true, writable: true, configurable: true,
+  });
+}
 
 test('a __proto__ key in the wire does not pollute the decoded object', () => {
   const obj = parse('{"__proto__":{"isAdmin":true},"name":"ok"}');
@@ -53,6 +61,28 @@ test('deserialize (the non-JSON path) is hardened too', () => {
   assert.equal(obj.name, 'ok');
   assert.equal(Object.getPrototypeOf(obj), Object.prototype);
   assert.equal(obj.isAdmin, undefined);
+});
+
+test('encode keeps an own __proto__ data property and does not corrupt the accumulator', async () => {
+  const o = withOwnProto({ name: 'ok' }, { isAdmin: true });
+  const enc = await serialize(o);
+  // The encode accumulator's prototype must stay clean (not swapped mid-encode).
+  assert.equal(Object.getPrototypeOf(enc), Object.prototype, 'encode accumulator not polluted');
+  // The __proto__ data property must be CARRIED, not dropped.
+  assert.ok(Object.prototype.hasOwnProperty.call(enc, '__proto__'), '__proto__ retained on the wire shape');
+});
+
+test('a legitimate __proto__ data property round-trips (serialize/deserialize are inverses)', async () => {
+  const o = withOwnProto({ name: 'ok' }, { isAdmin: true });
+  const back = parse(await stringify(o));
+  assert.equal(back.name, 'ok');
+  assert.equal(Object.getPrototypeOf(back), Object.prototype, 'no pollution after a full round-trip');
+  assert.deepEqual(Object.getOwnPropertyDescriptor(back, '__proto__').value, { isAdmin: true }, '__proto__ data preserved');
+});
+
+test('global Object.prototype stays clean across an encode of a __proto__ payload', async () => {
+  await serialize(withOwnProto({}, { polluted: true }));
+  assert.equal({}.polluted, undefined);
 });
 
 test('legitimate data round-trips unaffected', () => {

--- a/packages/core/test/serializer/proto-pollution.test.js
+++ b/packages/core/test/serializer/proto-pollution.test.js
@@ -1,0 +1,62 @@
+/**
+ * Security: the wire deserializer must not let an untrusted payload pollute a
+ * decoded object's prototype (#491). `JSON.parse` turns a literal `"__proto__"`
+ * key into an OWN property, so a naive `out[key] = value` would invoke the
+ * prototype setter. `parse`/`deserialize` must instead store such a key as an
+ * ordinary own data property and leave the prototype chain untouched.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parse, deserialize } from '../../src/serialize.js';
+
+test('a __proto__ key in the wire does not pollute the decoded object', () => {
+  const obj = parse('{"__proto__":{"isAdmin":true},"name":"ok"}');
+  assert.equal(obj.name, 'ok');
+  // The prototype chain is intact (not swapped to the injected object).
+  assert.equal(Object.getPrototypeOf(obj), Object.prototype, 'prototype unchanged');
+  // The injected field is not reachable as an inherited property.
+  assert.equal(obj.isAdmin, undefined, 'injected field is not on the prototype chain');
+  // `__proto__` survived as an own DATA property (round-trip fidelity).
+  assert.ok(Object.prototype.hasOwnProperty.call(obj, '__proto__'), '__proto__ kept as own data');
+  assert.deepEqual(Object.getOwnPropertyDescriptor(obj, '__proto__').value, { isAdmin: true });
+});
+
+test('global Object.prototype is never polluted by a decode', () => {
+  parse('{"__proto__":{"polluted":true}}');
+  assert.equal({}.polluted, undefined, 'Object.prototype stayed clean');
+  assert.equal(Object.prototype.polluted, undefined);
+});
+
+test('a nested __proto__ key is neutralized too', () => {
+  const obj = parse('{"a":{"__proto__":{"x":1}}}');
+  assert.equal(Object.getPrototypeOf(obj.a), Object.prototype, 'nested prototype unchanged');
+  assert.equal(obj.a.x, undefined, 'nested injection not inherited');
+});
+
+test('constructor / prototype keys are stored as own data, not assigned', () => {
+  const obj = parse('{"constructor":"x","prototype":"y","ok":1}');
+  assert.equal(obj.ok, 1);
+  assert.equal(Object.getOwnPropertyDescriptor(obj, 'constructor').value, 'x');
+  assert.equal(Object.getOwnPropertyDescriptor(obj, 'prototype').value, 'y');
+  // The real constructor is still reachable via the prototype.
+  assert.equal(Object.getPrototypeOf(obj).constructor, Object);
+});
+
+test('deserialize (the non-JSON path) is hardened too', () => {
+  // A raw decoded shape (as if from a hand-built payload object) with an own
+  // __proto__ key. Object.defineProperty makes the own key without the setter.
+  const wire = Object.defineProperty({ name: 'ok' }, '__proto__', {
+    value: { isAdmin: true }, enumerable: true, writable: true, configurable: true,
+  });
+  const obj = deserialize(wire);
+  assert.equal(obj.name, 'ok');
+  assert.equal(Object.getPrototypeOf(obj), Object.prototype);
+  assert.equal(obj.isAdmin, undefined);
+});
+
+test('legitimate data round-trips unaffected', () => {
+  const obj = parse('{"user":{"id":1,"roles":["a","b"]},"n":2}');
+  assert.deepEqual(obj, { user: { id: 1, roles: ['a', 'b'] }, n: 2 });
+  assert.equal(Object.getPrototypeOf(obj), Object.prototype);
+});


### PR DESCRIPTION
## Summary

Closes #491.

`JSON.parse` turns a literal `"__proto__"` key in an RPC payload into an OWN property, so the wire deserializer's plain-object loop (`out[realKey] = decode(...)`) invoked the `__proto__` prototype setter and let an untrusted action argument arrive with a polluted prototype (an injected field surfacing through the chain). It is object-local rather than global pollution, but still a real injection vector for any action that trusts its argument shape.

The decode assignment now routes through `assignDecoded`, which writes `__proto__` / `constructor` / `prototype` as ordinary own data properties via `Object.defineProperty` (so the value survives as data and the prototype is never touched), and stays a plain `out[key] = value` for every normal key (hot path unchanged). Round-trip fidelity is preserved: a legitimately-keyed `__proto__` comes back as own data.

Found while comparing webjs's RPC against TanStack Start, which guards the same surface with `createNullProtoObject` / `safeObjectMerge`. Independent of the #488 verb work; landing first.

## Test plan

- [x] `packages/core/test/serializer/proto-pollution.test.js`: a `__proto__` payload does not pollute the decoded object or global `Object.prototype`, nested keys neutralized, `constructor`/`prototype` stored as own data, the non-JSON `deserialize` path hardened, legitimate data unaffected.
- [x] Counterfactual: neutering `assignDecoded` reds 3 of the 6 cases; restoring greens them.
- [x] Full serializer suite (54) and full node suite (2434) green.

## Docs

N/A because this is an internal serializer hardening with no public-surface change (a short note lives in the serializer source).
