### PR TITLE
chore: release core 0.7.19, server 0.8.25

### DIFF
--- a/changelog/core/0.7.19.md
+++ b/changelog/core/0.7.19.md
@@ -1,0 +1,26 @@
+---
+package: "@webjsdev/core"
+version: 0.7.19
+date: 2026-06-13T21:41:39.591Z
+commit_count: 3
+---
+## Features
+
+- **HTTP-verb server actions via config exports (#488)** ([#494](https://github.com/webjsdev/webjs/pull/494)) [`2785cd90`](https://github.com/webjsdev/webjs/commit/2785cd90)
+  * feat: action config-export reader for HTTP-verb actions (#488)
+  
+  The foundation: read the reserved sibling config exports (method/cache/
+  tags/invalidates/validate) from a 'use server' action module, with verb
+- **AbortSignal cancellation for RPC, wired to async-render supersede (#492)** ([#496](https://github.com/webjsdev/webjs/pull/496)) [`fcfcfe5f`](https://github.com/webjsdev/webjs/commit/fcfcfe5f)
+  * feat: AbortSignal cancellation for RPC, wired to async-render supersede (#492)
+  
+  Server: the RPC endpoint runs the action inside runWithActionSignal(req.signal),
+  so an action reads the request's AbortSignal via actionSignal() (from
+
+## Fixes
+
+- **harden the wire deserializer against prototype pollution** ([#493](https://github.com/webjsdev/webjs/pull/493)) [`ea1b88a3`](https://github.com/webjsdev/webjs/commit/ea1b88a3)
+  * fix: harden the wire deserializer against prototype pollution (#491)
+  
+  JSON.parse turns a literal "__proto__" wire key into an own property, so
+  the plain-object decode loop's out[key]=value invoked the prototype setter

--- a/changelog/server/0.8.25.md
+++ b/changelog/server/0.8.25.md
@@ -1,0 +1,23 @@
+---
+package: "@webjsdev/server"
+version: 0.8.25
+date: 2026-06-13T21:41:39.616Z
+commit_count: 3
+---
+## Features
+
+- **HTTP-verb server actions via config exports (#488)** ([#494](https://github.com/webjsdev/webjs/pull/494)) [`2785cd90`](https://github.com/webjsdev/webjs/commit/2785cd90)
+  * feat: action config-export reader for HTTP-verb actions (#488)
+  
+  The foundation: read the reserved sibling config exports (method/cache/
+  tags/invalidates/validate) from a 'use server' action module, with verb
+- **AbortSignal cancellation for RPC, wired to async-render supersede (#492)** ([#496](https://github.com/webjsdev/webjs/pull/496)) [`fcfcfe5f`](https://github.com/webjsdev/webjs/commit/fcfcfe5f)
+  * feat: AbortSignal cancellation for RPC, wired to async-render supersede (#492)
+  
+  Server: the RPC endpoint runs the action inside runWithActionSignal(req.signal),
+  so an action reads the request's AbortSignal via actionSignal() (from
+- **per-action middleware with shared context (#490)** ([#497](https://github.com/webjsdev/webjs/pull/497)) [`fdcf056d`](https://github.com/webjsdev/webjs/commit/fdcf056d)
+  * feat: per-action middleware with shared context (#490)
+  
+  A 'use server' action declares export const middleware = [mw1, mw2], each
+  async (ctx, next) => result, run around the action on BOTH the RPC endpoint

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Release the RPC epic work merged so far.

- **@webjsdev/core** 0.7.18 -> 0.7.19: the HTTP-verb action client surface (#488), AbortSignal/abort plumbing + async-render auto-abort (#492), and the deserializer prototype-pollution fix (#491).
- **@webjsdev/server** 0.8.24 -> 0.8.25: the verb-aware action dispatch + caching/invalidation (#488), actionSignal() (#492), and per-action middleware + actionContext() (#490).

Changelogs auto-generated by the pre-commit hook from the conventional-commit history. Patch bumps, consistent with the prior releases. Merging publishes both packages to npm and cuts the GitHub Releases.

Remaining epic work (#489 streaming RPC, the expose()-removal follow-up, #495) will ride a later release.