### PR TITLE
fix: count a type-annotated arrow action in the one-action check rule

### DIFF
--- a/packages/server/src/check.js
+++ b/packages/server/src/check.js
@@ -749,7 +749,13 @@ export async function checkConventions(appDir) {
       // An arrow-const action: `export const x = (...) => ...`, the paren-less
       // `export const x = id => ...`, or a function expression. The `=>` /
       // `function` anchor keeps a plain `export const N = 5` from counting.
-      const reArrow = /\bexport\s+const\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s+)?(?:function\b|(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*=>)/g;
+      // An OPTIONAL `: Type` annotation may sit between the name and the `=`
+      // (#495); the type itself can contain a function-type `=>`, so the
+      // annotation matcher consumes any non-`=` char OR a literal `=>`, and the
+      // assignment is the first `=` NOT followed by `>` (`=(?!>)`). The
+      // alternation is unambiguous at each position (a `=` can only start `=>`),
+      // so there is no catastrophic backtracking.
+      const reArrow = /\bexport\s+const\s+([A-Za-z_$][\w$]*)\s*(?::(?:[^=]|=>)*?)?=(?!>)\s*(?:async\s+)?(?:function\b|(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*=>)/g;
       while ((m = reArrow.exec(scan))) names.add(m[1]);
       if (/\bexport\s+default\b/.test(scan)) names.add('default');
       const actions = [...names].filter((n) => !RESERVED_CONFIG.has(n));

--- a/packages/server/test/action-verbs/check-one-action.test.js
+++ b/packages/server/test/action-verbs/check-one-action.test.js
@@ -54,3 +54,21 @@ test('a plain non-function const export is not counted as an action', async () =
   assert.equal(has(await checkConventions(dir)), false, 'a value const is not an action');
   rmSync(dir, { recursive: true, force: true });
 });
+
+test('counts a TYPE-ANNOTATED arrow action (#495)', async () => {
+  const dir = app({ 'a.server.ts': `'use server';\nexport const method='GET';\nexport const getA: (id: number) => Promise<number> = async (id) => id;\nexport async function getB(){return 1}\n` });
+  assert.ok(has(await checkConventions(dir)), 'annotated arrow + fn => two actions');
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('a function-type annotation does not break the parse (single annotated action is fine)', async () => {
+  const dir = app({ 'a.server.ts': `'use server';\nexport const method='GET';\nexport const getA: (n: number) => string = (n) => String(n);\n` });
+  assert.equal(has(await checkConventions(dir)), false, 'one annotated action only => not flagged');
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('a plain annotated value const is still NOT counted (#495)', async () => {
+  const dir = app({ 'a.server.ts': `'use server';\nexport const method='GET';\nexport const MAX: number = 5;\nexport async function getA(id){return id+MAX}\n` });
+  assert.equal(has(await checkConventions(dir)), false, 'an annotated value const is not an action');
+  rmSync(dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
Closes #495. A #488-epic follow-up surfaced in the #494 review.

## Problem

The `one-action-per-configured-file` `webjs check` rule under-counted a **type-annotated arrow action**: `export const getA: Handler = (id) => ...`. The arrow matcher allowed `export const NAME = ... =>` but not a `: Type` annotation between the name and the `=`, so a configured file with one `export async function` plus one annotated-arrow action slipped past the lint and silently shipped two callable actions sharing the file-level verb config.

## Fix

Broaden the arrow matcher to consume an optional `: Type` annotation. The type itself may contain a function-type `=>`, so the annotation matcher accepts any non-`=` char OR a literal `=>`, and the assignment is the first `=` NOT followed by `>` (`=(?!>)`). The alternation is unambiguous at every position (a `=` can only begin `=>`), so there is no catastrophic backtracking.

Counterfactual verified: the old regex returns no match on the annotated arrow; the new one matches `getA`; a plain `export const MAX: number = 5` stays uncounted.

## Tests

`packages/server/test/action-verbs/check-one-action.test.js` adds three cases (acceptance criteria of the issue):
- a type-annotated arrow action IS counted (so a file with it + another action is flagged),
- a function-type annotation (`(n: number) => string`) does not break the parse (a single annotated action is not flagged),
- a plain annotated value const (`: number = 5`) is still NOT counted.

Full `check` + `action-verbs` suites green (86 tests).

## Surfaces N/A

Advisory check-rule fix only: no public API, runtime, docs, scaffold, MCP, or editor surface changes (a false negative missed a flag, never a crash).