### PR TITLE
feat: report action verb/cache/config in MCP list_actions

### DIFF
--- a/packages/mcp/AGENTS.md
+++ b/packages/mcp/AGENTS.md
@@ -36,10 +36,13 @@ src/
                          INTROSPECTION tools (read-only, appDir-scoped), each
                          projecting a @webjsdev/server function: list_routes
                          (buildRouteTable), list_actions (buildActionIndex +
-                         hashFile), list_components (scanComponents), check
-                         (checkConventions via projectCheck). Export names are
-                         extracted LEXICALLY (extractExportNames /
-                         extractRouteMethods) so no app module is loaded.
+                         hashFile, now reports verb/cache/tags/invalidates per
+                         #488 and excludes reserved config exports from the
+                         callable-action list), list_components (scanComponents),
+                         check (checkConventions via projectCheck). Export names
+                         are extracted LEXICALLY (extractExportNames /
+                         extractRouteMethods / extractActionConfig) so no app
+                         module is loaded.
                          `deps` / `docsDeps` / `sourceDeps` are injectable for
                          in-process tests.
   mcp-docs.js            KNOWLEDGE layer (#376): resolveDocsLocation (bundled

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -25,9 +25,11 @@ subcommand) delegates to this same server, so both routes run identical code.
 ## What it exposes
 
 - **Introspection tools** (read-only, scoped to an `appDir`): `list_routes`,
-  `list_actions` (with the `/__webjs/action/<hash>/<fn>` RPC endpoints),
-  `list_components`, `check` (the structured `webjs check` violations). Each
-  projects an existing `@webjsdev/server` data function and mutates nothing.
+  `list_actions` (RPC endpoints plus the full data contract: HTTP verb, cache
+  config, and boolean flags for tags/invalidates/validate/middleware; reserved
+  config exports are excluded from the callable-action list), `list_components`,
+  `check` (the structured `webjs check` violations). Each projects an existing
+  `@webjsdev/server` data function and mutates nothing.
 - **Knowledge layer**: an `init` mental-model primer, a `docs` retrieval tool,
   MCP `resources` (the `agent-docs/*` corpus + `AGENTS.md` as `webjs-docs://*`),
   and `prompts` (the recipes as guided workflows).

--- a/packages/mcp/src/mcp.js
+++ b/packages/mcp/src/mcp.js
@@ -36,6 +36,13 @@ import { resolveFrameworkRoots, runSourceTool } from './mcp-source.js';
 
 const PROTOCOL_VERSION = '2024-11-05';
 
+// Mirrors packages/server/src/action-config.js. A drift test in
+// packages/mcp/test/mcp.test.mjs asserts these stay in sync with the source.
+/** HTTP verbs an action may declare (mirrors RPC_VERBS in action-config.js). */
+const RPC_VERBS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']);
+/** Reserved config export names in a 'use server' file (mirrors RESERVED_CONFIG in action-config.js). */
+const RESERVED_CONFIG = new Set(['method', 'cache', 'tags', 'invalidates', 'validate', 'middleware']);
+
 /**
  * The four read-only tools. Each takes an optional `{ appDir }` (default the
  * server's cwd) and projects an EXISTING `@webjsdev/server` function's output
@@ -128,7 +135,7 @@ const TOOL_DEFS = [
   {
     name: 'list_actions',
     description:
-      'List registered server actions (the .server.{js,ts} files with "use server"): file, exported function name, and the /__webjs/action/<hash>/<fn> RPC endpoint. Read-only.',
+      'List registered server actions (the .server.{js,ts} files with "use server"): file, exported function name, the /__webjs/action/<hash>/<fn> RPC endpoint, HTTP verb (method), cache config, and boolean flags for tags/invalidates/validate/middleware. Config-only exports (method, cache, tags, invalidates, validate, middleware) are NOT listed as actions. Read-only.',
     inputSchema: APPDIR_SCHEMA,
   },
   {
@@ -207,6 +214,67 @@ export function extractRouteMethods(src) {
 }
 
 /**
+ * Lexically extract the HTTP-verb action config declared as reserved sibling
+ * exports in a `'use server'` file (#488). Reads source text only (no module
+ * load) so there are no DB-init or Prisma side effects.
+ *
+ * Returned shape:
+ *   {
+ *     method: 'GET'|'POST'|'PUT'|'PATCH'|'DELETE',  // default 'POST'
+ *     cache: string | null,    // raw RHS literal when present, else null
+ *     tags: boolean,           // whether the tags export is declared
+ *     invalidates: boolean,    // whether the invalidates export is declared
+ *     validate: boolean,       // whether the validate export is declared
+ *     middleware: boolean,     // whether the middleware export is declared
+ *   }
+ *
+ * @param {string} src
+ * @returns {{ method: string, cache: string|null, tags: boolean, invalidates: boolean, validate: boolean, middleware: boolean }}
+ */
+export function extractActionConfig(src) {
+  // Extract `method` from: export const method = 'GET'  (single/double/backtick)
+  const methodMatch = /\bexport\s+const\s+method\s*=\s*(['"`])([A-Za-z]+)\1/.exec(src);
+  let method = 'POST';
+  if (methodMatch) {
+    const upper = methodMatch[2].toUpperCase();
+    if (RPC_VERBS.has(upper)) method = upper;
+  }
+
+  // Extract `cache` RHS. Single-line: `export const cache = 60` -> '60'
+  // Multi-line object: capture balanced braces across lines.
+  let cache = null;
+  const cacheMatch = /\bexport\s+const\s+cache\s*=\s*/.exec(src);
+  if (cacheMatch) {
+    const rest = src.slice(cacheMatch.index + cacheMatch[0].length);
+    if (rest.startsWith('{')) {
+      // Capture the balanced-brace object (may span lines).
+      let depth = 0;
+      let end = 0;
+      for (let i = 0; i < rest.length; i++) {
+        if (rest[i] === '{') depth++;
+        else if (rest[i] === '}') { depth--; if (depth === 0) { end = i; break; } }
+      }
+      cache = rest.slice(0, end + 1).trim();
+    } else {
+      // Single-line: read up to the first newline or semicolon.
+      const lineMatch = /^([^\n;]+)/.exec(rest);
+      if (lineMatch) cache = lineMatch[1].trim();
+    }
+  }
+
+  // Boolean presence of the remaining config names.
+  const exported = new Set(extractExportNames(src));
+  return {
+    method,
+    cache,
+    tags: exported.has('tags'),
+    invalidates: exported.has('invalidates'),
+    validate: exported.has('validate'),
+    middleware: exported.has('middleware'),
+  };
+}
+
+/**
  * The literal URL path for a page/api directory: `blog/[slug]` -> `/blog/[slug]`,
  * the root `.` -> `/`. Route groups `(group)` and `_private` segments drop, the
  * same normalization `buildRouteTable` uses for matching.
@@ -279,18 +347,28 @@ export function makeToolRunners(deps) {
       // no stray stdout from a loaded module corrupting the JSON-RPC channel).
       // The RPC hash is over the file path only, so no module load is needed.
       const idx = await buildActionIndex(appDir, false, { skipExposeLoad: true });
-      /** @type {Array<{ file: string, fn: string, endpoint: string }>} */
+      /** @type {Array<{ file: string, fn: string, endpoint: string, method: string, cache: string|null, tags: boolean, invalidates: boolean, validate: boolean, middleware: boolean }>} */
       const actions = [];
       for (const [file, hash] of idx.fileToHash) {
-        let names = [];
+        let src = '';
         try {
-          names = extractExportNames(await readFile(file, 'utf8'));
+          src = await readFile(file, 'utf8');
         } catch {}
+        const names = extractExportNames(src);
+        const config = extractActionConfig(src);
         for (const fn of names) {
+          // Skip reserved config export names: they are config, not callable actions.
+          if (RESERVED_CONFIG.has(fn)) continue;
           actions.push({
             file: relative(appDir, file),
             fn,
             endpoint: `/__webjs/action/${hash}/${fn}`,
+            method: config.method,
+            cache: config.cache,
+            tags: config.tags,
+            invalidates: config.invalidates,
+            validate: config.validate,
+            middleware: config.middleware,
           });
         }
       }

--- a/packages/mcp/test/mcp.test.mjs
+++ b/packages/mcp/test/mcp.test.mjs
@@ -619,22 +619,31 @@ test('drift guard: MCP RESERVED_CONFIG and RPC_VERBS match action-config.js expo
     assert.equal(cfg.method, verb, `RPC verb ${verb} must be recognized by extractActionConfig`);
   }
 
-  // Verify all RESERVED_CONFIG names from action-config.js are excluded from callable actions.
-  // We do this by building a file that exports one of each reserved name as a const,
-  // plus a real callable function, and checking only the function appears.
-  const reservedDecls = [...srcReserved].map((name) => {
-    if (name === 'middleware') return `export const ${name} = [];`;
-    return `export const ${name} = () => [];`;
-  }).join('\n');
-  const src = `'use server';\n${reservedDecls}\nexport async function myAction() {}\n`;
-  const names = extractExportNames(src);
+  // Verify EVERY RESERVED_CONFIG name from action-config.js is excluded from the
+  // callable-action list by the REAL list_actions runner. A reserved name added
+  // to action-config.js but missing from the MCP's local set would surface here
+  // as a wrongly-listed action (each reserved name is declared as a function-
+  // valued const, the shape that would otherwise count as a callable action).
+  const reservedDecls = [...srcReserved].map((name) =>
+    name === 'middleware' ? `export const ${name} = [];` : `export const ${name} = () => [];`,
+  ).join('\n');
+  // First confirm the lexical extractor SEES them all (so the filter is the gate,
+  // not a parse miss), then confirm the runner excludes them.
+  const probe = `'use server';\n${reservedDecls}\nexport async function myAction() {}\n`;
+  const names = extractExportNames(probe);
   for (const name of srcReserved) {
-    // extractActionConfig should exclude all of these when building the action list.
-    // We verify they ARE in extractExportNames (so the filter logic is what excludes them).
-    assert.ok(names.includes(name), `reserved name '${name}' must appear in extractExportNames so the RESERVED_CONFIG filter is the gate`);
+    assert.ok(names.includes(name), `reserved name '${name}' must be visible to extractExportNames`);
   }
-  // And that the non-reserved action function IS present.
-  assert.ok(names.includes('myAction'), 'the callable action is present in export names');
+  const dir = tmpDir();
+  write(dir, 'modules/x/cfg.server.ts', probe);
+  const { frames } = await driveMcp(dir, [
+    { jsonrpc: '2.0', id: 77, method: 'tools/call', params: { name: 'list_actions', arguments: {} } },
+  ]);
+  const listed = JSON.parse(frames[0].result.content[0].text).map((a) => a.fn);
+  assert.deepEqual(listed, ['myAction'], 'only the callable action is listed; every reserved config name is excluded');
+  for (const name of srcReserved) {
+    assert.ok(!listed.includes(name), `reserved name '${name}' must be excluded from the action list (MCP RESERVED_CONFIG drift)`);
+  }
 });
 
 test('mcp: a request split across stdin chunks (mid-line) still parses', async () => {

--- a/packages/mcp/test/mcp.test.mjs
+++ b/packages/mcp/test/mcp.test.mjs
@@ -24,7 +24,7 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO = resolve(__dirname, '..', '..', '..');
-const { runMcpServer, extractExportNames, extractRouteMethods } = await import(
+const { runMcpServer, extractExportNames, extractRouteMethods, extractActionConfig } = await import(
   resolve(REPO, 'packages', 'mcp', 'src', 'mcp.js')
 );
 
@@ -420,6 +420,221 @@ test('mcp: prompts/list + prompts/get serve the recipe workflows; unknown prompt
   ]));
   assert.equal(frames[0].error.code, -32602, 'unknown prompt is a -32602');
   assert.ok(frames[1].result.prompts, 'the loop kept serving after the error');
+});
+
+/* ---------- extractActionConfig unit tests (#488) ---------- */
+
+test('extractActionConfig: GET action with cache + tags reports correct config', () => {
+  const src = `
+    'use server';
+    export const method = 'GET';
+    export const cache = 60;
+    export const tags = (id) => [\`user:\${id}\`];
+    export async function getUser(id) { return {}; }
+  `;
+  const cfg = extractActionConfig(src);
+  assert.equal(cfg.method, 'GET');
+  assert.equal(cfg.cache, '60');
+  assert.equal(cfg.tags, true);
+  assert.equal(cfg.invalidates, false);
+  assert.equal(cfg.validate, false);
+  assert.equal(cfg.middleware, false);
+});
+
+test('extractActionConfig: object cache value is captured across lines', () => {
+  const src = `
+    'use server';
+    export const method = 'GET';
+    export const cache = { maxAge: 300, swr: 60, public: true };
+    export async function getPosts() { return []; }
+  `;
+  const cfg = extractActionConfig(src);
+  assert.equal(cfg.method, 'GET');
+  assert.ok(cfg.cache && cfg.cache.startsWith('{') && cfg.cache.endsWith('}'), 'object cache captured');
+  assert.ok(cfg.cache.includes('maxAge'), 'object cache includes maxAge');
+});
+
+test('extractActionConfig: POST mutation with invalidates', () => {
+  const src = `
+    'use server';
+    export const invalidates = (id) => [\`user:\${id}\`];
+    export async function updateUser(input) { return { success: true }; }
+  `;
+  const cfg = extractActionConfig(src);
+  assert.equal(cfg.method, 'POST');
+  assert.equal(cfg.cache, null);
+  assert.equal(cfg.tags, false);
+  assert.equal(cfg.invalidates, true);
+  assert.equal(cfg.validate, false);
+  assert.equal(cfg.middleware, false);
+});
+
+test('extractActionConfig: plain legacy action has POST + all config flags false', () => {
+  const src = `
+    'use server';
+    export async function createPost(input) { return { success: true }; }
+  `;
+  const cfg = extractActionConfig(src);
+  assert.equal(cfg.method, 'POST');
+  assert.equal(cfg.cache, null);
+  assert.equal(cfg.tags, false);
+  assert.equal(cfg.invalidates, false);
+  assert.equal(cfg.validate, false);
+  assert.equal(cfg.middleware, false);
+});
+
+test('extractActionConfig: validate + middleware flags', () => {
+  const src = `
+    'use server';
+    export const validate = (input) => ({ success: true });
+    export const middleware = [authMw, logMw];
+    export async function doThing(input) { return { success: true }; }
+  `;
+  const cfg = extractActionConfig(src);
+  assert.equal(cfg.validate, true);
+  assert.equal(cfg.middleware, true);
+});
+
+test('extractActionConfig: unrecognized method falls back to POST', () => {
+  const src = `
+    'use server';
+    export const method = 'OPTIONS';
+    export async function doThing() {}
+  `;
+  const cfg = extractActionConfig(src);
+  assert.equal(cfg.method, 'POST', 'unrecognized verb defaults to POST');
+});
+
+test('extractActionConfig: method with double-quote and uppercase matches', () => {
+  const src = `
+    'use server';
+    export const method = "DELETE";
+    export async function removeItem(id) {}
+  `;
+  const cfg = extractActionConfig(src);
+  assert.equal(cfg.method, 'DELETE');
+});
+
+/* ---------- list_actions: config fields + config exports excluded (#488) ---------- */
+
+test('mcp: list_actions GET action reports method/cache/tags and excludes config exports', async () => {
+  const dir = tmpDir();
+  write(
+    dir,
+    'modules/users/queries/get-user.server.ts',
+    [
+      `'use server';`,
+      `export const method = 'GET';`,
+      `export const cache = 60;`,
+      `export const tags = (id) => [\`user:\${id}\`];`,
+      `export async function getUser(id) { return {}; }`,
+    ].join('\n') + '\n',
+  );
+  const { frames } = await driveMcp(dir, [
+    { jsonrpc: '2.0', id: 50, method: 'tools/call', params: { name: 'list_actions', arguments: {} } },
+  ]);
+  const actions = JSON.parse(frames[0].result.content[0].text);
+
+  // Only the callable function is listed; config exports are NOT actions.
+  const fns = actions.map((a) => a.fn);
+  assert.ok(fns.includes('getUser'), 'getUser is listed');
+  assert.ok(!fns.includes('method'), 'method config export is NOT listed as an action');
+  assert.ok(!fns.includes('cache'), 'cache config export is NOT listed as an action');
+  assert.ok(!fns.includes('tags'), 'tags config export is NOT listed as an action');
+
+  const a = actions.find((x) => x.fn === 'getUser');
+  assert.ok(a, 'getUser action found');
+  assert.equal(a.method, 'GET');
+  assert.equal(a.cache, '60');
+  assert.equal(a.tags, true);
+  assert.equal(a.invalidates, false);
+  assert.equal(a.validate, false);
+  assert.equal(a.middleware, false);
+  assert.match(a.endpoint, /^\/__webjs\/action\/[0-9a-f]+\/getUser$/);
+});
+
+test('mcp: list_actions POST mutation with invalidates reports correct config', async () => {
+  const dir = tmpDir();
+  write(
+    dir,
+    'modules/users/actions/update-user.server.ts',
+    [
+      `'use server';`,
+      `export const invalidates = (id) => [\`user:\${id}\`];`,
+      `export async function updateUser(input) { return { success: true }; }`,
+    ].join('\n') + '\n',
+  );
+  const { frames } = await driveMcp(dir, [
+    { jsonrpc: '2.0', id: 51, method: 'tools/call', params: { name: 'list_actions', arguments: {} } },
+  ]);
+  const actions = JSON.parse(frames[0].result.content[0].text);
+  const a = actions.find((x) => x.fn === 'updateUser');
+  assert.ok(a, 'updateUser action found');
+  assert.equal(a.method, 'POST');
+  assert.equal(a.cache, null);
+  assert.equal(a.invalidates, true);
+
+  // invalidates config export must NOT appear as a separate action.
+  const fns = actions.map((x) => x.fn);
+  assert.ok(!fns.includes('invalidates'), 'invalidates config export is NOT listed as an action');
+});
+
+test('mcp: list_actions legacy action (no config) reports POST and all config flags false/null', async () => {
+  const dir = tmpDir();
+  write(
+    dir,
+    'modules/posts/actions/create.server.ts',
+    `'use server';\nexport async function createPost(input) { return { success: true }; }\n`,
+  );
+  const { frames } = await driveMcp(dir, [
+    { jsonrpc: '2.0', id: 52, method: 'tools/call', params: { name: 'list_actions', arguments: {} } },
+  ]);
+  const actions = JSON.parse(frames[0].result.content[0].text);
+  const a = actions.find((x) => x.fn === 'createPost');
+  assert.ok(a, 'createPost action found');
+  assert.equal(a.method, 'POST');
+  assert.equal(a.cache, null);
+  assert.equal(a.tags, false);
+  assert.equal(a.invalidates, false);
+  assert.equal(a.validate, false);
+  assert.equal(a.middleware, false);
+});
+
+/* ---------- drift guard: MCP local copies match action-config.js ---------- */
+
+test('drift guard: MCP RESERVED_CONFIG and RPC_VERBS match action-config.js exports', async () => {
+  const actionConfigPath = resolve(REPO, 'packages', 'server', 'src', 'action-config.js');
+  const { RESERVED_CONFIG: srcReserved, RPC_VERBS: srcVerbs } = await import(actionConfigPath);
+
+  // Re-read the MCP source to extract the local set literals lexically.
+  // The simplest approach: import the module and introspect via extractActionConfig
+  // coverage. But the sets are module-private constants. Test via behavior: verify
+  // that every entry in the authoritative sets is handled the same way by
+  // extractActionConfig (config names are not listed as actions, verbs are recognized).
+
+  // Verify all RPC_VERBS from action-config.js are recognized by extractActionConfig.
+  for (const verb of srcVerbs) {
+    const src = `'use server';\nexport const method = '${verb}';\nexport async function fn() {}\n`;
+    const cfg = extractActionConfig(src);
+    assert.equal(cfg.method, verb, `RPC verb ${verb} must be recognized by extractActionConfig`);
+  }
+
+  // Verify all RESERVED_CONFIG names from action-config.js are excluded from callable actions.
+  // We do this by building a file that exports one of each reserved name as a const,
+  // plus a real callable function, and checking only the function appears.
+  const reservedDecls = [...srcReserved].map((name) => {
+    if (name === 'middleware') return `export const ${name} = [];`;
+    return `export const ${name} = () => [];`;
+  }).join('\n');
+  const src = `'use server';\n${reservedDecls}\nexport async function myAction() {}\n`;
+  const names = extractExportNames(src);
+  for (const name of srcReserved) {
+    // extractActionConfig should exclude all of these when building the action list.
+    // We verify they ARE in extractExportNames (so the filter logic is what excludes them).
+    assert.ok(names.includes(name), `reserved name '${name}' must appear in extractExportNames so the RESERVED_CONFIG filter is the gate`);
+  }
+  // And that the non-reserved action function IS present.
+  assert.ok(names.includes('myAction'), 'the callable action is present in export names');
 });
 
 test('mcp: a request split across stdin chunks (mid-line) still parses', async () => {


### PR DESCRIPTION
Part of the #488 epic acceptance criteria: "MCP `list_actions` reports verb + cache + tags + invalidates so an agent sees the full data contract."

## What

`list_actions` now reports each action's HTTP verb and cache/config contract, and stops listing the reserved config exports (`method`/`cache`/`tags`/`invalidates`/`validate`/`middleware`) as if they were callable actions.

Each action entry gains: `method` (the verb, default `POST`), `cache` (the raw RHS literal, or `null`), and boolean flags `tags` / `invalidates` / `validate` / `middleware`.

## How

A new lexical `extractActionConfig(src)` reads the reserved sibling exports from source text only (no module load, so invariant 2 holds: read-only, no Prisma/DB side effects, no stray stdout). `list_actions` filters the reserved names out of the callable-action list and attaches the config. Local `RPC_VERBS` / `RESERVED_CONFIG` sets mirror `packages/server/src/action-config.js`, guarded by a drift test.

## Tests

`packages/mcp/test/mcp.test.mjs`: unit cases for `extractActionConfig` (GET with cache/tags, multi-line object cache, POST + invalidates, legacy no-config, validate/middleware flags, unknown-method fallback, double-quote method), three integration cases driving the full server (config exports excluded, POST mutation, legacy action), and a **drift guard** that imports the real `RESERVED_CONFIG` / `RPC_VERBS` from `action-config.js` and drives the real `list_actions` runner so a reserved name added upstream but missing from the MCP copy surfaces as a wrongly-listed action. 31 MCP tests + 55 action-verbs green in the main checkout.

## Docs

`packages/mcp/AGENTS.md` + `packages/mcp/README.md` updated to describe the new `list_actions` output shape and the reserved-export exclusion.

## Surfaces N/A

No runtime/public-API change (introspection projection only), no scaffold, editor, or marketing surface affected.