### PR TITLE
feat: opt-in compile-time serializability types for server actions

### DIFF
--- a/agent-docs/typescript.md
+++ b/agent-docs/typescript.md
@@ -128,6 +128,31 @@ Supported: `Date`, `Map`, `Set`, `BigInt`, `Error`, `undefined`,
 instances come through as plain objects, with prototypes lost and methods
 gone (matches React Server Actions).
 
+#### Catching a non-serializable signature at compile time (`SerializableActionFn`)
+
+The class-instance / function caveat above is a silent runtime surprise: a
+method-valued field or a function argument typechecks fine but vanishes on the
+wire. The opt-in `SerializableActionFn` annotation turns it into a compile-time
+error. webjs actions stay plain `export async function`s (the framework rewrites
+the client import to an RPC stub at runtime, it does not wrap the authored
+function), so the guard is an OPTIONAL type annotation the author applies when
+they want it:
+
+```ts
+import type { SerializableActionFn } from '@webjsdev/core';
+
+export const getUser: SerializableActionFn<(id: number) => Promise<User>> =
+  async (id) => db.user.find(id);
+//  ^ if User carries a method (or any arg is a function), this is a type error
+//    pointing at the offending member, instead of a value that silently loses
+//    it on the wire.
+```
+
+`Serializable<T>` (also exported) maps a fully serializable `T` to itself and a
+non-serializable position (a function / method) to a branded `NonSerializable`
+marker; `SerializableArgs` / `SerializableResult` apply it across an action's
+parameters and (promise-unwrapped) return. All types-only, erased at runtime.
+
 ### API routes: opt in via content negotiation
 
 `route.ts` handlers use standard JSON by default so external consumers

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -86,7 +86,13 @@ opt-in route union (`PageProps`, `LayoutProps`, `RouteHandlerContext`, `Route`,
 `src/webjs-config.d.ts`; it mirrors the `@webjsdev/server` config readers and
 the companion JSON Schema (`packages/server/webjs-config.schema.json`), and
 those three MUST stay in lockstep (the procedure is documented in
-`packages/server/AGENTS.md`). All are pure declaration files (erased at
+`packages/server/AGENTS.md`). The opt-in server-action serializability guard
+(`Serializable`, `SerializableArgs`, `SerializableResult`, `SerializableActionFn`,
+`NonSerializable`, #488) lives in `src/serializable.d.ts`: it maps a fully
+serializable type to itself and a non-serializable position (a function / method)
+to a branded marker, so an author who annotates an action with
+`SerializableActionFn` gets a compile-time error on a non-serializable arg /
+return instead of a silent wire loss. All are pure declaration files (erased at
 runtime, zero build cost). A page imports them with `import type { Metadata,
 PageProps } from '@webjsdev/core'`. The `Metadata` and `PageProps` /
 `LayoutProps` shapes MUST stay in lockstep with what

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -54,6 +54,16 @@ export type {
   WebjsCspConfig,
 } from './src/webjs-config.d.ts';
 
+// Compile-time serializability typing for server actions (#488): the opt-in
+// guard that makes a non-serializable action arg / return a type error.
+export type {
+  Serializable,
+  SerializableArgs,
+  SerializableResult,
+  SerializableActionFn,
+  NonSerializable,
+} from './src/serializable.d.ts';
+
 export { html, isTemplate, MARKER } from './src/html.js';
 export { css, isCSS, adoptStyles, stylesToString } from './src/css.js';
 export { register, lookup, lookupModuleUrl, isLazy, allTags, primeModuleUrl, tagOf } from './src/registry.js';

--- a/packages/core/src/serializable.d.ts
+++ b/packages/core/src/serializable.d.ts
@@ -1,0 +1,104 @@
+/**
+ * Compile-time serializability typing for server actions (#488).
+ *
+ * A `'use server'` action's arguments and result cross the RPC wire through the
+ * webjs serializer, which round-trips a SPECIFIC set of rich types (`Date`,
+ * `Map`, `Set`, `BigInt`, `Error`, `RegExp`, `URL`, typed arrays, `ArrayBuffer`,
+ * `Blob`, `File`, `FormData`, registered `Symbol`s, plain objects / arrays, and
+ * cycles). It does NOT round-trip a FUNCTION or a class instance's METHODS: a
+ * function silently vanishes from the wire, and a class instance arrives as a
+ * plain object with its prototype (so its methods) gone. That is a runtime
+ * surprise the author never asked for.
+ *
+ * `Serializable<T>` makes it a TYPE error instead. It maps a fully serializable
+ * `T` to itself, and a `T` that carries a function (a method, a callback prop)
+ * to a branded `NonSerializable<...>` marker, so assigning the offending value
+ * fails to typecheck with a message that names the problem. `SerializableArgs`
+ * / `SerializableResult` apply it across an action's parameter tuple and its
+ * (possibly promised) return.
+ *
+ * This is OPT-IN by design: webjs actions stay plain `export async function`s
+ * with no wrapper (the framework rewrites the client import to an RPC stub at
+ * runtime, it does not wrap the authored function). An author who wants the
+ * guard annotates the action with `SerializableActionFn`, e.g.
+ *
+ *   import type { SerializableActionFn } from '@webjsdev/core';
+ *   export const getUser: SerializableActionFn<(id: number) => Promise<User>> =
+ *     async (id) => db.user.find(id);
+ *
+ * If `User` (or any arg) is not serializable, the annotation is a compile-time
+ * error pointing at the offending member. Types only, erased at runtime, zero
+ * cost.
+ */
+
+/** A branded marker a non-serializable position resolves to, so the error names it. */
+export type NonSerializable<Reason extends string = 'this value is not serializable over the webjs RPC wire'> = {
+  readonly __webjsNonSerializable: Reason;
+};
+
+/** Primitives the wire carries verbatim. */
+type SerializablePrimitive = string | number | boolean | bigint | null | undefined;
+
+/**
+ * Built-in rich types the webjs serializer round-trips as themselves (their
+ * identity / methods survive because the serializer reconstructs the instance).
+ * `Map` / `Set` recurse into their members via the top-level mapper.
+ */
+type SerializableBuiltin =
+  | Date
+  | RegExp
+  | URL
+  | Error
+  | ArrayBuffer
+  | Int8Array | Uint8Array | Uint8ClampedArray
+  | Int16Array | Uint16Array
+  | Int32Array | Uint32Array
+  | Float32Array | Float64Array
+  | BigInt64Array | BigUint64Array
+  | Blob
+  | File
+  | FormData;
+
+/**
+ * Map `T` to itself when it is fully serializable, else to a `NonSerializable`
+ * marker at the offending position. A function (a method or a callback-valued
+ * property) is the canonical non-serializable case. Objects and arrays recurse;
+ * `Map` / `Set` recurse into their type parameters.
+ */
+export type Serializable<T> =
+  T extends SerializablePrimitive ? T :
+  // A function never survives the wire (it just disappears).
+  T extends (...args: any[]) => any ? NonSerializable<'a function is not serializable over the webjs RPC wire'> :
+  T extends SerializableBuiltin ? T :
+  T extends Map<infer K, infer V> ? Map<Serializable<K>, Serializable<V>> :
+  T extends Set<infer U> ? Set<Serializable<U>> :
+  T extends Promise<infer U> ? Promise<Serializable<U>> :
+  T extends ReadonlyArray<infer U> ? (T extends Array<infer _W> ? Array<Serializable<U>> : ReadonlyArray<Serializable<U>>) :
+  T extends object ? { [K in keyof T]: Serializable<T[K]> } :
+  T;
+
+/** Apply {@link Serializable} across an action's parameter tuple. */
+export type SerializableArgs<A extends readonly unknown[]> = {
+  [K in keyof A]: Serializable<A[K]>;
+};
+
+/**
+ * Apply {@link Serializable} to an action's return, unwrapping a `Promise` so an
+ * async action is checked against its resolved value (the wire carries the
+ * resolved value, never the promise).
+ */
+export type SerializableResult<R> =
+  R extends Promise<infer U> ? Promise<Serializable<U>> : Serializable<R>;
+
+/**
+ * The opt-in annotation type for a server action: it preserves the function's
+ * exact call signature while constraining every argument and the result to be
+ * serializable. A non-serializable arg or return makes the annotation a
+ * compile-time error.
+ *
+ * @example
+ *   export const getUser: SerializableActionFn<(id: number) => Promise<User>> =
+ *     async (id) => db.user.find(id);
+ */
+export type SerializableActionFn<F extends (...args: any[]) => any> =
+  (...args: SerializableArgs<Parameters<F>>) => SerializableResult<ReturnType<F>>;

--- a/test/types/serializable.test-d.ts
+++ b/test/types/serializable.test-d.ts
@@ -1,0 +1,87 @@
+/**
+ * Compile-time type fixture for the serializability guard (#488).
+ *
+ * NOT executed by node:test directly. The runner `type-fixtures.test.mjs`
+ * compiles it with `tsc --noEmit --strict`, so every `// @ts-expect-error` line
+ * is a self-checking counterfactual: tsc reports an "unused @ts-expect-error" if
+ * the type ever widens to accept a non-serializable value.
+ */
+
+import type {
+  Serializable,
+  SerializableActionFn,
+  NonSerializable,
+} from '@webjsdev/core';
+
+// --- A fully serializable shape round-trips through Serializable<T> ---
+
+type User = {
+  id: number;
+  name: string;
+  created: Date;
+  scores: number[];
+  tags: Set<string>;
+  meta: Map<string, number>;
+  nested: { active: boolean; big: bigint };
+};
+
+// Serializable<User> === User (assignable both directions).
+const toWire: Serializable<User> = {} as User;
+const fromWire: User = {} as Serializable<User>;
+void toWire;
+void fromWire;
+
+// The rich built-ins survive as themselves.
+const d: Serializable<Date> = new Date();
+const m: Serializable<Map<string, number>> = new Map();
+const bytes: Serializable<Uint8Array> = new Uint8Array();
+void d; void m; void bytes;
+
+// --- A serializable action annotation preserves the call signature ---
+
+const getUser: SerializableActionFn<(id: number) => Promise<User>> = async (id) => ({
+  id,
+  name: 'u' + id,
+  created: new Date(),
+  scores: [1, 2],
+  tags: new Set<string>(),
+  meta: new Map<string, number>(),
+  nested: { active: true, big: 1n },
+});
+// The annotated action is still callable with its real argument types.
+const p: Promise<User> = getUser(7);
+void p;
+
+// --- Negative: a METHOD on the result is not serializable ---
+
+type WithMethod = { id: number; greet: () => string };
+// @ts-expect-error a method-valued property cannot round-trip the RPC wire
+const badResult: SerializableActionFn<() => Promise<WithMethod>> = async () => ({
+  id: 1,
+  greet: () => 'hi',
+});
+void badResult;
+
+// --- Negative: a bare function return is not serializable ---
+
+// @ts-expect-error a function return cannot round-trip the RPC wire
+const badFnReturn: SerializableActionFn<() => Promise<() => void>> = async () => () => {};
+void badFnReturn;
+
+// --- Negative: passing a function ARGUMENT to a serializable action ---
+
+const takesData: SerializableActionFn<(input: { n: number }) => Promise<number>> = async () => 1;
+// @ts-expect-error a function is not assignable to the serializable arg position
+takesData(() => {});
+// A plain serializable arg is accepted.
+const okCall: Promise<number> = takesData({ n: 5 });
+void okCall;
+
+// --- Negative: Serializable<T> brands a function field as NonSerializable ---
+
+// The mapped field is the branded marker, never the original function type.
+const brandedField: Serializable<WithMethod>['greet'] = {} as NonSerializable<'a function is not serializable over the webjs RPC wire'>;
+void brandedField;
+// @ts-expect-error a real function is not assignable to the branded field
+const badField: Serializable<WithMethod> = { id: 1, greet: () => 'hi' };
+void badField;


### PR DESCRIPTION
Part of the #488 epic acceptance criteria: "non-serializable input/output is a compile-time error".

## What

A server action's args and result cross the RPC wire through the webjs serializer, which round-trips a specific rich-type set but **silently drops a function or a class instance's methods** (a method-valued field typechecks fine, then vanishes on the wire). This adds the type machinery to catch that at compile time.

- `Serializable<T>` maps a fully serializable type to itself and a non-serializable position (a function / method) to a branded `NonSerializable` marker.
- `SerializableArgs<A>` / `SerializableResult<R>` apply it across an action's parameter tuple and its promise-unwrapped return.
- `SerializableActionFn<F>` is the opt-in annotation:
  ```ts
  export const getUser: SerializableActionFn<(id: number) => Promise<User>> =
    async (id) => db.user.find(id);
  // ^ a method on User (or a function arg) is now a type error, not a wire loss
  ```

## Why opt-in

webjs actions stay plain `export async function`s. The framework rewrites the client import to an RPC stub at runtime; it does **not** wrap the authored function, so there is no automatic insertion point to force the check (forcing it would require an authoring wrapper webjs deliberately avoids). The guard is therefore an optional type annotation the author applies when they want it. Types-only, erased at runtime, zero cost.

## Tests

`test/types/serializable.test-d.ts` (compiled by the `type-fixtures` runner under `tsc --strict`): the positive case (a `User` with `Date` / `Set` / `Map` / `bigint` round-trips) plus four self-checking `@ts-expect-error` counterfactuals (a method on the result, a function return, a function argument at a call site, a branded field). dts-export-coverage + server-types green.

## Docs

`agent-docs/typescript.md` (a subsection under "Server actions: type-safe automatically") and `packages/core/AGENTS.md` (the type-overlay list).

## Surfaces N/A

Types-only (`packages/core/src/serializable.d.ts` + index.d.ts export): no runtime, scaffold, MCP, or editor-grammar change.