### PR TITLE
chore: release core 0.7.20, server 0.8.26, cli 0.10.15, mcp 0.1.2

### DIFF
--- a/changelog/cli/0.10.15.md
+++ b/changelog/cli/0.10.15.md
@@ -1,0 +1,18 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.15
+date: 2026-06-13T23:58:13.106Z
+commit_count: 2
+---
+## Features
+
+- **async render() + component-level Suspense (bare-await data fetch)** ([#470](https://github.com/webjsdev/webjs/pull/470)) [`5443ec9a`](https://github.com/webjsdev/webjs/commit/5443ec9a)
+  * feat(server): treat async render() components as interactive in elision
+  
+  An async (promise-returning) render() suspends on the client: it awaits
+  data, re-renders with the resolved value, reads the SSR seed, and may
+- **elide bare async-render components (#474)** ([#480](https://github.com/webjsdev/webjs/pull/480)) [`63ca566d`](https://github.com/webjsdev/webjs/commit/63ca566d)
+  * feat(elision): elide bare async-render components
+  
+  #470 made async render() a blanket interactivity signal, shipping every
+  async component plus a redundant on-hydration re-fetch. A BARE async leaf

--- a/changelog/core/0.7.20.md
+++ b/changelog/core/0.7.20.md
@@ -1,0 +1,18 @@
+---
+package: "@webjsdev/core"
+version: 0.7.20
+date: 2026-06-13T23:58:13.052Z
+commit_count: 2
+---
+## Features
+
+- **streaming RPC results (return a ReadableStream/async-iterable from an action)** ([#499](https://github.com/webjsdev/webjs/pull/499)) [`b82ce614`](https://github.com/webjsdev/webjs/commit/b82ce614)
+  * feat: stream a ReadableStream/async-iterable action result over RPC (#489)
+  
+  An action that returns a ReadableStream, async iterable, async generator,
+  or Node Readable now streams its chunks over the single RPC response
+- **add opt-in compile-time serializability types for actions (#488)** ([#502](https://github.com/webjsdev/webjs/pull/502)) [`20a99175`](https://github.com/webjsdev/webjs/commit/20a99175)
+  A server action's args/return cross the RPC wire through the webjs
+  serializer, which drops functions and a class instance's methods silently.
+  `Serializable<T>` maps a fully serializable type to itself and a function /
+  method position to a branded NonSerializable marker; SerializableArgs /

--- a/changelog/core/0.7.20.md
+++ b/changelog/core/0.7.20.md
@@ -4,6 +4,16 @@ version: 0.7.20
 date: 2026-06-13T23:58:13.052Z
 commit_count: 2
 ---
+## Breaking
+
+- **remove `expose()` / `validateInput()` / `getExposed()`; REST endpoints move to `route.ts`** ([#503](https://github.com/webjsdev/webjs/pull/503)) [`c0561758`](https://github.com/webjsdev/webjs/commit/c0561758)
+  `expose()`, `validateInput()`, and `getExposed()` are removed from
+  `@webjsdev/core`. A server action stays a plain `'use server'` function; to
+  reach it over plain HTTP, put it behind a `route.ts` handler (import the
+  action and call it), optionally via the new `route()` adapter from
+  `@webjsdev/server`. The per-action validator is the `export const validate`
+  config export. webjs has no users yet, so there is no deprecation shim.
+
 ## Features
 
 - **streaming RPC results (return a ReadableStream/async-iterable from an action)** ([#499](https://github.com/webjsdev/webjs/pull/499)) [`b82ce614`](https://github.com/webjsdev/webjs/commit/b82ce614)

--- a/changelog/mcp/0.1.2.md
+++ b/changelog/mcp/0.1.2.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/mcp"
+version: 0.1.2
+date: 2026-06-13T23:58:13.168Z
+commit_count: 1
+---
+## Features
+
+- **report action verb/cache/config in MCP list_actions** ([#501](https://github.com/webjsdev/webjs/pull/501)) [`9f2e5418`](https://github.com/webjsdev/webjs/commit/9f2e5418)
+  * feat: report action verb/cache/config in MCP list_actions (#488)
+  
+  Add extractActionConfig (lexical, no module load) to mcp.js that reads
+  the reserved config exports (method, cache, tags, invalidates, validate,

--- a/changelog/server/0.8.26.md
+++ b/changelog/server/0.8.26.md
@@ -1,0 +1,21 @@
+---
+package: "@webjsdev/server"
+version: 0.8.26
+date: 2026-06-13T23:58:13.078Z
+commit_count: 2
+---
+## Features
+
+- **streaming RPC results (return a ReadableStream/async-iterable from an action)** ([#499](https://github.com/webjsdev/webjs/pull/499)) [`b82ce614`](https://github.com/webjsdev/webjs/commit/b82ce614)
+  * feat: stream a ReadableStream/async-iterable action result over RPC (#489)
+  
+  An action that returns a ReadableStream, async iterable, async generator,
+  or Node Readable now streams its chunks over the single RPC response
+
+## Fixes
+
+- **count a type-annotated arrow action in the one-action check rule (#495)** ([#500](https://github.com/webjsdev/webjs/pull/500)) [`81b7cd7a`](https://github.com/webjsdev/webjs/commit/81b7cd7a)
+  The one-action-per-configured-file rule's arrow matcher did not allow a
+  `: Type` annotation between the const name and the `=`, so an annotated
+  arrow action (`export const getA: Handler = (id) => ...`) slipped past the
+  lint, letting a configured file ship two callable actions. Broaden the

--- a/changelog/server/0.8.26.md
+++ b/changelog/server/0.8.26.md
@@ -4,6 +4,20 @@ version: 0.8.26
 date: 2026-06-13T23:58:13.078Z
 commit_count: 2
 ---
+## Breaking
+
+- **REST endpoints move from `expose()` to `route.ts`; new `route()` adapter** ([#503](https://github.com/webjsdev/webjs/pull/503)) [`c0561758`](https://github.com/webjsdev/webjs/commit/c0561758)
+  The REST-via-`expose()` machinery is removed (`expose()` / `validateInput()` /
+  `getExposed()` are gone from `@webjsdev/core`). A REST endpoint is now a
+  `route.ts` that imports and calls a `'use server'` action. The new
+  `route(action, opts?)` export from `@webjsdev/server` is the optional one-liner
+  for that pattern: it merges the URL query, route params, and JSON body into one
+  input, runs an optional `{ validate }` boundary validator, dispatches through
+  the request `AbortSignal` and per-action middleware, and JSON-responds the
+  result (a returned `Response` passes through). The per-action validator is the
+  `export const validate` config export. `buildActionIndex` no longer loads any
+  module.
+
 ## Features
 
 - **streaming RPC results (return a ReadableStream/async-iterable from an action)** ([#499](https://github.com/webjsdev/webjs/pull/499)) [`b82ce614`](https://github.com/webjsdev/webjs/commit/b82ce614)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.14",
+  "version": "0.10.15",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/mcp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "description": "The webjs Model Context Protocol server: live app introspection (routes / actions / components / check) plus the framework knowledge layer (docs, recipes, source) for AI coding agents",
   "bin": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.25",
+  "version": "0.8.26",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Release the accumulated work from the **RPC epic (#488)** and prior unreleased debt.

## Bumps

| Package | From | To | Highlights |
|---|---|---|---|
| `@webjsdev/core` | 0.7.19 | 0.7.20 | streaming RPC results (#499), opt-in serializability types (#502), **breaking:** `expose()`/`validateInput()`/`getExposed()` removed (#503) |
| `@webjsdev/server` | 0.8.25 | 0.8.26 | streaming RPC (#499), one-action check fix (#500), **breaking:** REST via `route.ts` + new `route()` adapter (#503) |
| `@webjsdev/cli` | 0.10.14 | 0.10.15 | accumulated unreleased debt (async render + elision template touches) |
| `@webjsdev/mcp` | 0.1.1 | 0.1.2 | `list_actions` reports verb/cache/tags/invalidates (#501) |

## Breaking change

`expose()` / `validateInput()` / `getExposed()` are removed from `@webjsdev/core`. REST endpoints now go through `route.ts` (import the action and call it, or use the new `route()` adapter from `@webjsdev/server`). The per-action validator is the `export const validate` config export. webjs has no users yet, so there is no deprecation shim. The breaking note was hand-added to the core + server changelogs because the #503 PR merged with a `refactor:` prefix, which the changelog backfill (feat/fix/breaking/perf only) does not pick up.

## Notes

Changelogs auto-generated by the pre-commit hook from the conventional-commit history, with the breaking #503 entry added manually (see above). Patch bumps, consistent with the project's pre-1.0 convention. Merging triggers `release.yml` (npm publish + GitHub Releases).