### PR TITLE
docs: update file-based-routing blog post from expose() to route.ts

### DIFF
--- a/blog/file-based-routing.md
+++ b/blog/file-based-routing.md
@@ -128,7 +128,7 @@ Two.
 
 `<webjs-frame>` is an escape hatch for partial-swap regions not tied to a folder structure. Wrap a chunk of your page in `<webjs-frame id="cart-summary">`, and you can use `revalidate('/cart-summary')` to refresh just that fragment without a full navigation. It is for cases where you want to re-fetch data in place without leaving the page. Implementation is at `packages/core/src/webjs-frame.js`.
 
-`expose()` lets a server action also live at a REST URL. The same function powers both call paths. From a client component: `import { createPost }` and call it as RPC. From curl: `POST /api/posts`. One implementation, two protocols. The function lives in `packages/core/src/expose.js`.
+A server action can also live at a REST URL. The same function powers both call paths. From a client component: `import { createPost }` and call it as RPC. From curl: drop it into a `route.ts` (`export const POST = route(createPost)`), so `POST /api/posts` hits the same implementation. One function, two protocols. The `route()` helper lives in `packages/server/src/action-route.js`.
 
 
 # What I am still figuring out


### PR DESCRIPTION
Doc-drift cleanup found during a post-#503 audit. The dated blog post `blog/file-based-routing.md` (served on the website via `website/app/blog/[slug]/page.ts`) still described `expose()` as a live feature and pointed at `packages/core/src/expose.js`, which was deleted when `expose()` was removed in #503 (core 0.7.20).

Rewrote the one paragraph to the current `route.ts` + `route()` pattern, preserving the post's voice and date, and pointed it at the real `packages/server/src/action-route.js`. The top-level `blog/` directory was outside the #503 migration's grep scope; the rest of the docs/AGENTS/templates/apps were already clean (verified repo-wide).