### PR TITLE
chore: release server 0.8.27

### DIFF
--- a/changelog/server/0.8.27.md
+++ b/changelog/server/0.8.27.md
@@ -1,0 +1,12 @@
+---
+package: "@webjsdev/server"
+version: 0.8.27
+date: 2026-06-14T06:26:35.324Z
+commit_count: 1
+---
+## Features
+
+- **flag a 'use server' file that exports no callable action** ([#506](https://github.com/webjsdev/webjs/pull/506)) [`c74f63db`](https://github.com/webjsdev/webjs/commit/c74f63db)
+  * feat: flag a 'use server' file that exports no callable action (#464)
+  
+  * docs: document the use-server-exports-callable check rule (#464)

--- a/package-lock.json
+++ b/package-lock.json
@@ -6842,7 +6842,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.13",
+      "version": "0.10.15",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -6858,7 +6858,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.14",
+      "version": "0.7.20",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.25.0"
@@ -6892,7 +6892,7 @@
     },
     "packages/mcp": {
       "name": "@webjsdev/mcp",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/server": "^0.8.0"
@@ -6906,7 +6906,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.20",
+      "version": "0.8.27",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.26",
+  "version": "0.8.27",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
## Summary

Release `@webjsdev/server` 0.8.26 -> 0.8.27 to ship the new `webjs check` rule.

| Package | From | To | What |
|---|---|---|---|
| `@webjsdev/server` | 0.8.26 | 0.8.27 | `use-server-exports-callable` (#464): flag a `'use server'` `.server.{js,ts}` file that exports no callable action |

Only `@webjsdev/server` has unreleased work since the last release (core / cli / mcp are unchanged). The changelog `changelog/server/0.8.27.md` was auto-generated by the pre-commit hook from the conventional-commit history.

Also syncs `package-lock.json`, which had drifted behind the published workspace versions over the last few releases (it lagged at core 0.7.14 / server 0.8.20); the diff is only the four workspace version fields catching up to their real `package.json` versions, no dependency-tree change. All dependents pin `^0.8.0`, which `0.8.27` satisfies, so no range edits.

Merging adds the changelog file to `main`, which triggers `release.yml` to `npm publish` and cut the GitHub Release (idempotent).

## Test plan

The feature itself (the rule + its 19 unit tests, the counterfactual, the four-app `webjs check` pass) shipped and was reviewed in #506; this PR is the version bump + changelog + lockfile sync only.