### PR TITLE
feat: Bun test matrix in CI, fixing the cross-runtime bugs it found

### DIFF
--- a/.claude/hooks/require-tests-with-src.sh
+++ b/.claude/hooks/require-tests-with-src.sh
@@ -74,6 +74,8 @@ Walk the layers the change can affect, do NOT stop at unit:
   browser: */test/**/browser/*   (hydration, client render, DOM, router)
   e2e:     test/e2e/*.test.mjs    (full stack, network probes, navigation)
   smoke:   test/examples/*/smoke/*   (example apps still serve)
+  bun:     node scripts/run-bun-tests.js + test/bun/*.mjs   (cross-runtime;
+           required for serializer / listener / streams / crypto / node:* changes)
 
 For a client-router / component / browser-facing change a unit test is
 necessary but NOT sufficient. Add the browser and/or e2e coverage that
@@ -109,10 +111,29 @@ EOF
   fi
 fi
 
+# Accumulate non-blocking layer reminders, then emit ONE additionalContext (two
+# jq objects would be invalid hook output).
+reminder=""
+
 client_facing=$(printf '%s\n' "$src_touched" | grep -E 'router-client|render-client|component\.js|slot\.js|lazy-loader|websocket-client|client-router|directives' || true)
 if [ -n "$client_facing" ]; then
   list=$(printf '%s' "$client_facing" | tr '\n' ' ')
-  jq -n --arg ctx "Reminder: this commit changes client/browser-facing source ($list). A unit test alone is not sufficient. Confirm browser and/or e2e coverage (network probes, navigation, hydration) asserts the real behaviour, and run a test-audit review before declaring the PR ready." '{
+  reminder="${reminder}Client/browser-facing source changed ($list). A unit test alone is not sufficient; confirm browser and/or e2e coverage (network probes, navigation, hydration) asserts the real behaviour. "
+fi
+
+# Runtime-sensitive source: webjs runs on Node 24+ AND Bun (#508), and these
+# surfaces are where the two runtimes diverge (the serializer's Blob/File/FormData
+# identity, the node:http vs Bun.serve listener shells, node stream/fs error
+# propagation, the TS stripper's error shape, JSC vs V8 error messages). A change
+# here MUST be proven on Bun, not just Node. The Bun matrix is a separate runner.
+runtime_sensitive=$(printf '%s\n' "$src_touched" | grep -E 'serialize|file-storage|listener-core|listener-bun|ts-strip|action-stream|render-server|websocket|node-version' || true)
+if [ -n "$runtime_sensitive" ]; then
+  rlist=$(printf '%s' "$runtime_sensitive" | tr '\n' ' ')
+  reminder="${reminder}Runtime-sensitive source changed ($rlist). webjs runs on Node AND Bun: run \`node scripts/run-bun-tests.js\` (needs bun installed) plus the test/bun/*.mjs scripts under Bun, and treat any divergence as a real framework bug to fix (not a skip). Add a test/bun/<feature>.mjs cross-runtime script for a new listener/serializer/streaming surface. See agent-docs/testing.md. "
+fi
+
+if [ -n "$reminder" ]; then
+  jq -n --arg ctx "Reminder: ${reminder}Run a test-audit review before declaring the PR ready." '{
     hookSpecificOutput: { hookEventName: "PreToolUse", additionalContext: $ctx }
   }'
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       - run: npm test
 
   bun:
-    name: Bun runtime smoke (#508, #511)
+    name: Bun runtime smoke + test matrix (#508, #509, #511)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -106,6 +106,13 @@ jobs:
       # so this is the cross-shell parity proof.
       - name: webjs listener parity on Bun
         run: bun test/bun/listener.mjs
+      # The Bun test MATRIX (#509): run the runtime-sensitive node:test suite
+      # (core + server + cross-package test/) under Bun, file by file, classifying
+      # each result. Documented Node-only files + Bun-test-runner-quirk files are
+      # skipped with a reason; genuine Bun failures fail the job. This is what
+      # catches the long tail of cross-runtime incompatibilities.
+      - name: webjs Bun test matrix
+        run: node scripts/run-bun-tests.js
 
   browser:
     name: Browser (web-test-runner / Playwright)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,11 @@ jobs:
       # so this is the cross-shell parity proof.
       - name: webjs listener parity on Bun
         run: bun test/bun/listener.mjs
+      # FileStore streaming on Bun (#509): put/get round-trip + the
+      # no-orphan-on-mid-stream-error invariant (the Readable.fromWeb->reader-loop
+      # fix, which Readable.fromWeb hangs on under Bun).
+      - name: webjs FileStore streaming on Bun
+        run: bun test/bun/file-storage.mjs
       # The Bun test MATRIX (#509): run the runtime-sensitive node:test suite
       # (core + server + cross-package test/) under Bun, file by file, classifying
       # each result. Documented Node-only files + Bun-test-runner-quirk files are

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,17 @@
 # same image with a different start command. Locally:
 # `docker compose up --build` runs all three via compose.yaml.
 #
-# No build step for JS. webjs serves .ts directly via Node's built-in
-# `module.stripTypeScriptTypes` (position-preserving whitespace
-# replacement, no sourcemap shipped to the browser).
+# No build step for JS. webjs serves .ts directly by stripping types at the
+# runtime layer (position-preserving whitespace replacement, no sourcemap shipped
+# to the browser). webjs is buildless end to end; there is NO bundler or esbuild
+# fallback.
 #
-# **Node 24+ is REQUIRED** for that path. On Node 22, the runtime falls
-# back to esbuild for every .ts file. esbuild's class-declaration
-# transformation has been observed to break webjs's SSR walker for
-# multi-class component files: Tier-2 components (dialog, tooltip,
-# dropdown-menu, etc.) all rendered with the wrong shell because the
-# first class's render() was being invoked for every sub-tag. Pinning
-# Node 24 here pairs with the AGENTS.md "Node 24+ required" invariant.
+# This image runs on Node, where the strip is the built-in
+# `module.stripTypeScriptTypes`. **Node 24+ is REQUIRED** on the Node path (the
+# built-in stripper and recursive fs.watch need it), which is why the base below
+# pins a current Node major. webjs ALSO runs on Bun (where the strip comes from
+# `amaro`); to deploy on Bun, swap the base for an `oven/bun` image and start with
+# `bun --bun run start`.
 #
 # Tailwind CSS IS built at image time (CLI, no browser runtime). The
 # blog runs `prisma generate` at build and `prisma migrate deploy` at

--- a/agent-docs/testing.md
+++ b/agent-docs/testing.md
@@ -108,6 +108,42 @@ cross-package suite (`packages/*/test/` + `test/`). They do NOT walk the in-repo
 apps' own test dirs (`website/test/`, `examples/blog/test/`), so those run from
 each app's OWN `webjs test` script, not the root runner.
 
+### The Bun test matrix (#509)
+
+webjs runs on Node 24+ or Bun (#508). The **Node suite (`npm test`) is the
+source of truth**; a separate, additive **Bun matrix** re-runs the
+runtime-sensitive suite under Bun to catch the long tail of cross-runtime
+incompatibilities (a `node:*` API Bun implements differently, a crypto/stream
+edge case, an error-message-format quirk).
+
+- `node scripts/run-bun-tests.js` (needs `bun` on PATH; `BUN=…` overrides) runs
+  the `node:test` files under `test/`, `packages/core/test/`, and
+  `packages/server/test/` (excluding `browser/`, `e2e/`, the network-bound
+  `vendor/`) file by file via `bun test <file>`, and CLASSIFIES each result:
+  **pass**, **skip(node-only)** (a documented file that asserts Node-only
+  behavior or trips a Bun-test-runner quirk, listed with a reason in the
+  script's `DENYLIST`, its Bun behavior covered elsewhere), **skip(harness)**
+  (a Bun `node:test` compat gap, auto-detected by error signature),
+  **skip(env)** (needs Redis / a DOM), and **genuine fail** (a real Bun
+  failure, which fails the job). Set `WEBJS_BUN_TESTS=<substr,…>` to scope a
+  local run.
+- CI runs it in the `bun` job alongside `test/bun/smoke.mjs` (#508) and
+  `test/bun/listener.mjs` (#511, the listener-shell parity).
+- Two cross-runtime test scripts also run under BOTH runtimes: `test/bun/smoke.mjs`
+  (boot + SSR + TS strip + a server-action RPC) and `test/bun/listener.mjs`
+  (`startServer` over a real socket: SSR + route + SSE + WebSocket). Plain assert
+  scripts (not `node:test`) so the same file runs identically on each runtime.
+
+**Known Bun limitation (dev hot-reload of server modules).** webjs's dev server
+re-imports a `route.ts` / `.server.ts` / page module per request with a
+`?t=<timestamp>` query cache-bust to pick up edits. Bun's ESM loader IGNORES the
+query string (Node honors it and re-imports), and Bun exposes no module-eviction
+API, so on Bun a server-side module edit is not reflected until a dev-server
+restart. Component / page / layout SOURCE edits hot-reload fine on Bun (the
+served `.ts`/`.js` is read from disk per request, not imported). This is a Bun
+runtime gap, not a webjs bug; the `api` dev-cache-bust test is skipped under the
+Bun matrix for this reason.
+
 ### In-repo app tests in CI (#342)
 
 Each in-repo app (`website`, `examples/blog`) carries its own test suite under

--- a/docs/app/docs/editor-setup/page.ts
+++ b/docs/app/docs/editor-setup/page.ts
@@ -59,7 +59,7 @@ export default function EditorSetup() {
     <ul>
       <li><code>moduleResolution: "NodeNext"</code>: required for the framework's <code>exports</code> map to resolve correctly.</li>
       <li><code>allowImportingTsExtensions: true</code>: lets you write <code>import { x } from './foo.ts'</code>, matching how webjs serves them.</li>
-      <li><code>noEmit: true</code>: TypeScript type-checks only. webjs strips types via Node's built-in stripper at import / request time.</li>
+      <li><code>noEmit: true</code>: TypeScript type-checks only. webjs strips types at the runtime layer at import / request time (Node's built-in stripper, or <code>amaro</code> on Bun).</li>
       <li><code>erasableSyntaxOnly: true</code>: rejects non-erasable TypeScript (<code>enum</code>, <code>namespace</code> with values, parameter properties, legacy decorators). Required because Node's stripper only supports erasable TS. See the <a href="/docs/typescript">TypeScript</a> page for the erasable equivalents.</li>
       <li><code>plugins</code>: one entry. <code>@webjsdev/intellisense</code> is standalone (no separate <code>ts-lit-plugin</code> entry).</li>
     </ul>

--- a/examples/blog/CONVENTIONS.md
+++ b/examples/blog/CONVENTIONS.md
@@ -785,7 +785,7 @@ export async function createPost(input: {
 
 <!-- OVERRIDE -->
 - TypeScript with explicit `.ts` extensions in imports
-- **Erasable TypeScript only.** The framework strips types via Node 24+'s built-in `module.stripTypeScriptTypes` (whitespace replacement, byte-exact line + column preservation, no sourcemap shipped). Your `tsconfig.json` sets `erasableSyntaxOnly: true`, so the compiler rejects: `enum`, `namespace` with values, constructor parameter properties, legacy decorators with `emitDecoratorMetadata`, and `import = require`. Write the erasable equivalents:
+- **Erasable TypeScript only.** The runtime strips types at the runtime layer (Node 24+'s built-in `module.stripTypeScriptTypes`, or `amaro` on Bun, byte-identical) with whitespace replacement, so line + column positions are byte-exact and no sourcemap ships. Your `tsconfig.json` sets `erasableSyntaxOnly: true`, so the compiler rejects: `enum`, `namespace` with values, constructor parameter properties, legacy decorators with `emitDecoratorMetadata`, and `import = require`. Write the erasable equivalents:
   ```ts
   // Not allowed
   enum Color { Red, Green, Blue }

--- a/packages/cli/templates/AGENTS.md
+++ b/packages/cli/templates/AGENTS.md
@@ -1143,10 +1143,11 @@ composition, so a nested shell ends up dropped by the HTML parser.
    browser-only). Never fetch initial data in `connectedCallback` /
    `firstUpdated`. Fetch in the page function (server) and pass it as
    a prop. See *Component pattern* above.
-8. **Erasable TypeScript only.** The runtime (Node 24+ or Bun) strips types via
-   `module.stripTypeScriptTypes` (whitespace replacement, byte-exact
-   line and column position preservation, no sourcemap shipped to the
-   browser). Your `tsconfig.json` sets `erasableSyntaxOnly: true`, so
+8. **Erasable TypeScript only.** The runtime strips types at the runtime
+   layer (Node 24+'s built-in `module.stripTypeScriptTypes`, or `amaro`
+   on Bun, which is byte-identical), with whitespace replacement so
+   line and column positions are byte-exact and no sourcemap ships to
+   the browser. Your `tsconfig.json` sets `erasableSyntaxOnly: true`, so
    the TS compiler rejects: `enum`, `namespace` with values,
    constructor parameter properties, legacy decorators with
    `emitDecoratorMetadata`, and `import = require`. Use the erasable

--- a/packages/cli/templates/CONVENTIONS.md
+++ b/packages/cli/templates/CONVENTIONS.md
@@ -1054,7 +1054,7 @@ export async function createPost(input: {
 
 <!-- OVERRIDE -->
 - TypeScript with explicit `.ts` extensions in imports
-- **Erasable TypeScript only.** The framework strips types via Node 24+'s built-in `module.stripTypeScriptTypes` (whitespace replacement, byte-exact line + column preservation, no sourcemap shipped). Your `tsconfig.json` sets `erasableSyntaxOnly: true`, so the compiler rejects: `enum`, `namespace` with values, constructor parameter properties, legacy decorators with `emitDecoratorMetadata`, and `import = require`. Write the erasable equivalents:
+- **Erasable TypeScript only.** The runtime strips types at the runtime layer (Node 24+'s built-in `module.stripTypeScriptTypes`, or `amaro` on Bun, byte-identical) with whitespace replacement, so line + column positions are byte-exact and no sourcemap ships. Your `tsconfig.json` sets `erasableSyntaxOnly: true`, so the compiler rejects: `enum`, `namespace` with values, constructor parameter properties, legacy decorators with `emitDecoratorMetadata`, and `import = require`. Write the erasable equivalents:
   ```ts
   // Not allowed
   enum Color { Red, Green, Blue }

--- a/packages/cli/templates/Dockerfile
+++ b/packages/cli/templates/Dockerfile
@@ -3,11 +3,14 @@
 # Works with a plain `docker build` / `docker compose up`, and is the same
 # artifact the webdeploy hosting tool (ubicloud + uncloud) builds and ships.
 #
-# webjs serves .ts directly via Node's built-in type-stripping, so there is
-# NO JavaScript build step. **Node 24+ is REQUIRED**: on older Node the runtime
-# falls back to esbuild, whose class-declaration transform breaks webjs's SSR
-# walker for multi-class component files. Do not lower this base image
-# below 24 (the same version the CI workflow and the framework pin).
+# webjs serves .ts directly by stripping types at the runtime layer, so there is
+# NO JavaScript build step (webjs is buildless end to end; there is no bundler or
+# esbuild fallback). This image runs the app on **Node 24+**, where the strip is
+# the built-in `module.stripTypeScriptTypes`. webjs ALSO runs on **Bun** (where
+# the strip comes from `amaro` automatically), so you can swap this base for an
+# `oven/bun` image and start the app with `bun --bun run start`. Do not lower the
+# Node base below 24 (the floor the CI workflow and the framework pin enforce),
+# since the built-in stripper and recursive fs.watch need it.
 #
 # Security headers are set by the framework, not the proxy. webjs emits
 # X-Content-Type-Options, X-Frame-Options, Referrer-Policy, and

--- a/packages/core/src/render-server.js
+++ b/packages/core/src/render-server.js
@@ -361,11 +361,15 @@ const SSR_HTMLELEMENT_METHODS = new Set([
  */
 function browserMemberHint(e) {
   const msg = e && typeof (/** @type any */ (e).message) === 'string' ? /** @type any */ (e).message : '';
-  let m = /^(\w+) is not defined$/.exec(msg);
+  // Match on a word boundary, NOT end-of-string: V8 (Node) ends the message at
+  // "is not defined" / "is not a function", but JSC (Bun) appends a detail
+  // clause (e.g. ". (In '({}).querySelector(\"p\")', '...' is undefined)"), so an
+  // anchored `$` would miss the Bun message and drop the actionable hint.
+  let m = /^(\w+) is not defined\b/.exec(msg);
   if (e instanceof ReferenceError && m && SSR_BROWSER_GLOBALS.has(m[1])) {
     return `\`${m[1]}\` is a browser-only global and is undefined during SSR.`;
   }
-  m = /\.(\w+) is not a function$/.exec(msg);
+  m = /\.(\w+) is not a function\b/.exec(msg);
   if (e instanceof TypeError && m && SSR_HTMLELEMENT_METHODS.has(m[1])) {
     return `\`${m[1]}\` is an HTMLElement method that does not exist on the server-side component instance during SSR.`;
   }

--- a/packages/core/src/serialize.js
+++ b/packages/core/src/serialize.js
@@ -142,6 +142,12 @@ function newEncodeCtx() {
     emitted: new Set(),   // ids already emitted as the canonical encoding
     nextId: 0,
     blobBytes: new Map(), // Blob → Uint8Array (precomputed during countRefs)
+    // FormData → its entries captured ONCE. Bun returns a FRESH Blob/File
+    // identity on every FormData.entries()/get() call (Node returns a stable
+    // one), so countRefs and encode must iterate the SAME captured array or the
+    // identity-keyed blobBytes lookup misses on Bun (crash). Captured here so
+    // both passes see the same Blob objects on every runtime.
+    fdEntries: new Map(),
   };
 }
 
@@ -164,7 +170,11 @@ async function countRefs(value, ctx) {
       continue;
     }
     if (typeof FormData !== 'undefined' && v instanceof FormData) {
-      for (const [, val] of v.entries()) {
+      // Capture entries ONCE (see fdEntries note) and traverse THOSE Blob
+      // objects, so encode reuses the exact instances whose bytes we precompute.
+      const captured = ctx.fdEntries.get(v) || [...v.entries()];
+      ctx.fdEntries.set(v, captured);
+      for (const [, val] of captured) {
         if (typeof val !== 'string') stack.push(val);
       }
       continue;
@@ -233,8 +243,12 @@ function encodeOne(v, ctx) {
       out = { [TAG]: 'Blob', v: bytesToB64(bytes), t: v.type || '' };
     }
   } else if (typeof FormData !== 'undefined' && v instanceof FormData) {
+    // Reuse the entries captured in countRefs so the Blob/File instances match
+    // the ones whose bytes were precomputed (Bun yields fresh identities per
+    // entries() call; see the fdEntries note in newEncodeCtx).
+    const captured = ctx.fdEntries.get(v) || [...v.entries()];
     const entries = [];
-    for (const [k, val] of v.entries()) entries.push([k, encodeOne(val, ctx)]);
+    for (const [k, val] of captured) entries.push([k, encodeOne(val, ctx)]);
     out = { [TAG]: 'FD', v: entries };
   } else if (ArrayBuffer.isView(v) || v instanceof ArrayBuffer) {
     out = encodeBinary(v);

--- a/packages/server/src/file-storage.js
+++ b/packages/server/src/file-storage.js
@@ -19,8 +19,10 @@
  * Design notes:
  *
  *   - **Streaming write.** `put` never buffers the whole file. It pipes
- *     `file.stream()` -> `Readable.fromWeb` -> `createWriteStream` via
- *     `node:stream/promises.pipeline`, so a large upload uses constant memory.
+ *     `file.stream()` -> a reader-loop async generator (`webStreamChunks`) ->
+ *     `createWriteStream` via `node:stream/promises.pipeline`, so a large upload
+ *     uses constant memory (the reader loop instead of `Readable.fromWeb` so a
+ *     mid-stream source error propagates through `pipeline` on Bun too, #509).
  *     The upstream body-size cap (#237, `maxMultipartBytes`) bounds the size
  *     BEFORE the bytes ever reach the store, so the store does not re-implement
  *     a limit; it only stays streaming.
@@ -181,15 +183,19 @@ export function assertSafeKey(dir, key) {
  * @returns {{ stream: import('node:stream').Readable, contentType: string | null }}
  */
 function toNodeStream(file) {
-  // A Blob / File exposes a web ReadableStream via `.stream()`; converting it
-  // with Readable.fromWeb keeps it streaming (no `.arrayBuffer()`).
+  // A Blob / File exposes a web ReadableStream via `.stream()`; consuming it
+  // through a reader-loop async generator (NOT `Readable.fromWeb`) keeps it
+  // streaming AND propagates a mid-stream source error reliably on both Node and
+  // Bun. `Readable.fromWeb` does NOT forward a web-stream error through
+  // `stream/promises.pipeline` on Bun (the `pipeline` promise never settles, so
+  // `put` would hang instead of rejecting + cleaning up the partial file, #509).
   if (file && typeof file.stream === 'function' && typeof file.size === 'number') {
     const contentType = typeof file.type === 'string' && file.type ? file.type : null;
-    return { stream: Readable.fromWeb(file.stream()), contentType };
+    return { stream: Readable.from(webStreamChunks(file.stream())), contentType };
   }
   // A web ReadableStream directly.
   if (file && typeof file.getReader === 'function') {
-    return { stream: Readable.fromWeb(/** @type {ReadableStream} */ (file)), contentType: null };
+    return { stream: Readable.from(webStreamChunks(/** @type {ReadableStream} */ (file))), contentType: null };
   }
   // A Uint8Array / Buffer: wrap as a single-chunk readable. This DOES hold the
   // bytes the caller already has in memory, but it does not COPY-buffer them
@@ -198,6 +204,27 @@ function toNodeStream(file) {
     return { stream: Readable.from([Buffer.from(file.buffer, file.byteOffset, file.byteLength)]), contentType: null };
   }
   throw new Error('file-storage: put() expects a Blob, File, ReadableStream, or Uint8Array');
+}
+
+/**
+ * Read a web `ReadableStream` chunk by chunk as an async iterable. A read error
+ * (a source that errors mid-stream) throws OUT of the generator, which
+ * `Readable.from` surfaces as a stream `error` that `pipeline` rejects on. This
+ * is the cross-runtime-reliable alternative to `Readable.fromWeb`, whose error
+ * does not propagate through `pipeline` on Bun (#509).
+ * @param {ReadableStream} web
+ */
+async function* webStreamChunks(web) {
+  const reader = web.getReader();
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) return;
+      yield value;
+    }
+  } finally {
+    try { reader.releaseLock(); } catch {}
+  }
 }
 
 /**

--- a/packages/server/src/file-storage.js
+++ b/packages/server/src/file-storage.js
@@ -216,13 +216,19 @@ function toNodeStream(file) {
  */
 async function* webStreamChunks(web) {
   const reader = web.getReader();
+  let finished = false;
   try {
     for (;;) {
       const { done, value } = await reader.read();
-      if (done) return;
+      if (done) { finished = true; return; }
       yield value;
     }
   } finally {
+    // On EARLY termination (the consumer errored / aborted before the source
+    // finished, e.g. a disk-write failure mid-upload), cancel the source so an
+    // upstream producer (a request body) stops sending, matching the behavior
+    // `Readable.fromWeb` gave. Skip cancel on normal completion.
+    if (!finished) { try { await reader.cancel(); } catch {} }
     try { reader.releaseLock(); } catch {}
   }
 }

--- a/packages/server/src/ts-strip.js
+++ b/packages/server/src/ts-strip.js
@@ -94,7 +94,25 @@ async function resolve() {
   if (typeof tx !== 'function') {
     throw new Error('webjs: the resolved `amaro` module has no `transformSync` export.');
   }
-  return { fn: (source) => tx(source, { mode: 'strip-only' }).code, name: 'amaro' };
+  return {
+    fn: (source) => {
+      try {
+        return tx(source, { mode: 'strip-only' }).code;
+      } catch (e) {
+        // Normalize amaro's non-erasable-syntax error code to Node's, so a
+        // single downstream check (`err.code === 'ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX'`
+        // in dev.js's tsResponse) classifies the failure identically on both
+        // runtimes (amaro reports `code: 'UnsupportedSyntax'` for an enum /
+        // namespace-with-values / parameter-property / legacy-decorator). The
+        // strip-error contract is part of this seam, like the strip itself.
+        if (e && e.code === 'UnsupportedSyntax') {
+          try { e.code = 'ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX'; } catch {}
+        }
+        throw e;
+      }
+    },
+    name: 'amaro',
+  };
 }
 
 /**

--- a/packages/server/test/api/api.test.js
+++ b/packages/server/test/api/api.test.js
@@ -104,17 +104,6 @@ test('handleApi: params are also attached to the Request object', async () => {
   assert.deepEqual(body, { params: { id: '42', slug: 'hello' } });
 });
 
-test('handleApi: dev=true cache-busts the import (re-reads the module from disk)', async () => {
-  const file = join(dir, 'live.js');
-  await writeFile(file, `export async function GET() { return new Response('v1'); }`);
-
-  const route = { file };
-  const r1 = await handleApi(route, {}, new Request('http://x/api/live'), true);
-  assert.equal(await r1.text(), 'v1');
-
-  // Overwrite module and call again with dev=true; cache-busting query should
-  // force re-import.
-  await writeFile(file, `export async function GET() { return new Response('v2'); }`);
-  const r2 = await handleApi(route, {}, new Request('http://x/api/live'), true);
-  assert.equal(await r2.text(), 'v2');
-});
+// The dev cache-bust test moved to dev-cache-bust.test.js (#509): it is the one
+// handleApi behavior that is Node-only (Bun ignores the ?t= import cache-bust),
+// so it is denylisted in the Bun matrix while the rest of this file runs on Bun.

--- a/packages/server/test/api/dev-cache-bust.test.js
+++ b/packages/server/test/api/dev-cache-bust.test.js
@@ -1,0 +1,38 @@
+/**
+ * handleApi() dev cache-bust: in dev, a route module is re-imported per request
+ * with a `?t=<timestamp>` query so an edit is picked up without a restart.
+ *
+ * SPLIT OUT of api.test.js (#509) because this is the ONE handleApi behavior that
+ * is NODE-ONLY: Bun's ESM loader ignores the query cache-bust (and exposes no
+ * module-eviction API), so this assertion cannot hold on Bun. It is denylisted in
+ * the Bun matrix (see scripts/run-bun-tests.js); the rest of handleApi (routing,
+ * 405, params, Response.json) stays in api.test.js and DOES run under Bun. Bun
+ * dev-reload limitation tracked in #514.
+ */
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { writeFile, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { handleApi } from '../../src/api.js';
+
+let dir;
+
+before(async () => { dir = await mkdtemp(join(tmpdir(), 'webjs-api-cachebust-')); });
+after(async () => { if (dir) await rm(dir, { recursive: true, force: true }); });
+
+test('handleApi: dev=true cache-busts the import (re-reads the module from disk)', async () => {
+  const file = join(dir, 'live.js');
+  await writeFile(file, `export async function GET() { return new Response('v1'); }`);
+
+  const route = { file };
+  const r1 = await handleApi(route, {}, new Request('http://x/api/live'), true);
+  assert.equal(await r1.text(), 'v1');
+
+  // Overwrite module and call again with dev=true; cache-busting query should
+  // force re-import.
+  await writeFile(file, `export async function GET() { return new Response('v2'); }`);
+  const r2 = await handleApi(route, {}, new Request('http://x/api/live'), true);
+  assert.equal(await r2.text(), 'v2');
+});

--- a/packages/server/test/body-limit/integration.test.js
+++ b/packages/server/test/body-limit/integration.test.js
@@ -3,8 +3,10 @@
  *   - the action RPC endpoint returns 413 for an over-limit body, driven through
  *     `createRequestHandler` (the real handle pipeline);
  *   - the `route.{js,ts}` `readBody` path returns 413 via `handleApi`, exercised
- *     with the per-request limit stamped in the request context;
- *   - a real ephemeral `startServer` carries the configured node:http timeouts.
+ *     with the per-request limit stamped in the request context.
+ *
+ * The node:http server-timeout assertions moved to server-timeouts.test.js (#509),
+ * leaving this file's 413 body-limit tests runtime-agnostic (they run under Bun).
  *
  * tmpdir app fixtures, like dev-handler.test.js. Route fixtures that need the
  * `html` tag import it from core's source by absolute file URL (a random tmpdir

--- a/packages/server/test/body-limit/integration.test.js
+++ b/packages/server/test/body-limit/integration.test.js
@@ -17,15 +17,10 @@ import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
-import { createRequestHandler, startServer } from '../../src/dev.js';
+import { createRequestHandler } from '../../src/dev.js';
 import { handleApi } from '../../src/api.js';
 import { readBody } from '../../src/json.js';
 import { withRequest, setBodyLimits } from '../../src/context.js';
-import {
-  DEFAULT_REQUEST_TIMEOUT_MS,
-  DEFAULT_HEADERS_TIMEOUT_MS,
-  DEFAULT_KEEP_ALIVE_TIMEOUT_MS,
-} from '../../src/body-limit.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const HTML_URL = pathToFileURL(resolve(__dirname, '../../../core/src/html.js')).toString();
@@ -222,34 +217,7 @@ test('page action form: over-limit multipart/urlencoded body is 413, under-limit
   assert.equal(big.status, 413);
 });
 
-/* --------------- server timeouts on the real node:http server --------------- */
-
-test('startServer applies node:http timeouts (secure defaults)', async () => {
-  const appDir = makeApp({ 'app/page.js': `export default () => 'home';` });
-  const { server, close } = await startServer({ appDir, port: 0, dev: false });
-  try {
-    assert.equal(server.requestTimeout, DEFAULT_REQUEST_TIMEOUT_MS);
-    assert.equal(server.headersTimeout, DEFAULT_HEADERS_TIMEOUT_MS);
-    assert.equal(server.keepAliveTimeout, DEFAULT_KEEP_ALIVE_TIMEOUT_MS);
-    assert.ok(server.headersTimeout < server.requestTimeout, 'headersTimeout must be under requestTimeout');
-  } finally {
-    await close();
-  }
-});
-
-test('startServer honors webjs.* timeout config', async () => {
-  const appDir = makeApp({
-    'app/page.js': `export default () => 'home';`,
-    'package.json': JSON.stringify({
-      webjs: { requestTimeoutMs: 45000, headersTimeoutMs: 12000, keepAliveTimeoutMs: 8000 },
-    }),
-  });
-  const { server, close } = await startServer({ appDir, port: 0, dev: false });
-  try {
-    assert.equal(server.requestTimeout, 45000);
-    assert.equal(server.headersTimeout, 12000);
-    assert.equal(server.keepAliveTimeout, 8000);
-  } finally {
-    await close();
-  }
-});
+// The node:http server-timeout tests moved to server-timeouts.test.js (#509):
+// they assert node:http-only `server.*Timeout` properties (the Bun shell uses
+// Bun.serve's idleTimeout), so they are denylisted in the Bun matrix while the
+// runtime-agnostic 413 body-limit tests above DO run under Bun.

--- a/packages/server/test/body-limit/server-timeouts.test.js
+++ b/packages/server/test/body-limit/server-timeouts.test.js
@@ -1,0 +1,67 @@
+/**
+ * node:http server timeouts on the real ephemeral server (issue #237).
+ *
+ * SPLIT OUT of body-limit/integration.test.js (#509): these assert
+ * `server.requestTimeout` / `headersTimeout` / `keepAliveTimeout`, node:http
+ * properties that the Node listener shell sets. On Bun the listener is
+ * `Bun.serve`, which has a single `idleTimeout` instead (the node `requestTimeout`
+ * is mapped to it, covered by the #511 listener docs), so these node-shell
+ * assertions are denylisted in the Bun matrix while the runtime-agnostic 413
+ * body-limit tests in integration.test.js DO run under Bun.
+ */
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { startServer } from '../../src/dev.js';
+import {
+  DEFAULT_REQUEST_TIMEOUT_MS,
+  DEFAULT_HEADERS_TIMEOUT_MS,
+  DEFAULT_KEEP_ALIVE_TIMEOUT_MS,
+} from '../../src/body-limit.js';
+
+let tmpRoot;
+before(() => { tmpRoot = mkdtempSync(join(tmpdir(), 'webjs-timeouts-')); });
+after(() => { rmSync(tmpRoot, { recursive: true, force: true }); });
+
+function makeApp(files) {
+  const appDir = mkdtempSync(join(tmpRoot, 'app-'));
+  for (const [rel, body] of Object.entries(files)) {
+    const abs = join(appDir, rel);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, body);
+  }
+  return appDir;
+}
+
+test('startServer applies node:http timeouts (secure defaults)', async () => {
+  const appDir = makeApp({ 'app/page.js': `export default () => 'home';` });
+  const { server, close } = await startServer({ appDir, port: 0, dev: false });
+  try {
+    assert.equal(server.requestTimeout, DEFAULT_REQUEST_TIMEOUT_MS);
+    assert.equal(server.headersTimeout, DEFAULT_HEADERS_TIMEOUT_MS);
+    assert.equal(server.keepAliveTimeout, DEFAULT_KEEP_ALIVE_TIMEOUT_MS);
+    assert.ok(server.headersTimeout < server.requestTimeout, 'headersTimeout must be under requestTimeout');
+  } finally {
+    await close();
+  }
+});
+
+test('startServer honors webjs.* timeout config', async () => {
+  const appDir = makeApp({
+    'app/page.js': `export default () => 'home';`,
+    'package.json': JSON.stringify({
+      webjs: { requestTimeoutMs: 45000, headersTimeoutMs: 12000, keepAliveTimeoutMs: 8000 },
+    }),
+  });
+  const { server, close } = await startServer({ appDir, port: 0, dev: false });
+  try {
+    assert.equal(server.requestTimeout, 45000);
+    assert.equal(server.headersTimeout, 12000);
+    assert.equal(server.keepAliveTimeout, 8000);
+  } finally {
+    await close();
+  }
+});

--- a/packages/server/test/file-storage/disk-store.test.js
+++ b/packages/server/test/file-storage/disk-store.test.js
@@ -163,7 +163,11 @@ test('STRUCTURAL: put streams (createWriteStream + pipeline, no arrayBuffer)', a
     .replace(/(^|[^:])\/\/.*$/gm, '$1');
   assert.match(src, /createWriteStream/, 'uses createWriteStream');
   assert.match(src, /pipeline\(/, 'uses stream pipeline');
-  assert.match(src, /Readable\.fromWeb/, 'converts the web stream without buffering');
+  // Converts the web stream without buffering via a reader-loop async generator
+  // (`Readable.from(webStreamChunks(...))`), NOT `Readable.fromWeb` (whose error
+  // does not propagate through `pipeline` on Bun, #509).
+  assert.match(src, /Readable\.from\(webStreamChunks\(/, 'converts the web stream chunk-by-chunk without buffering');
+  assert.doesNotMatch(src, /Readable\.fromWeb/, 'avoids Readable.fromWeb on the put path (Bun error-propagation gap)');
   assert.doesNotMatch(src, /\.arrayBuffer\(\)/, 'never calls arrayBuffer() on the put path');
   assert.doesNotMatch(src, /writeFile\(/, 'never uses writeFile for the object body');
 });

--- a/packages/server/test/listener/compression-parity.test.js
+++ b/packages/server/test/listener/compression-parity.test.js
@@ -37,7 +37,11 @@ before(async () => {
   w('app/api/sse/route.ts', `export async function GET() {\n  const body = new ReadableStream({ start(c) { c.enqueue(new TextEncoder().encode('data: hi\\n\\n')); c.close(); } });\n  return new Response(body, { headers: { 'content-type': 'text/event-stream' } });\n}\n`);
 
   ({ server, close } = await startServer({ appDir: dir, dev: true, compress: true, port: 0, logger: quiet }));
-  base = `http://localhost:${server.address().port}`;
+  // The node shell exposes the port via server.address(); the Bun shell via
+  // server.port. Support both so this runs on either runtime (it then exercises
+  // each shell's own compression negotiation).
+  const port = typeof server.port === 'number' ? server.port : server.address().port;
+  base = `http://localhost:${port}`;
 });
 
 after(async () => {

--- a/packages/server/test/ts-strip/ts-strip.test.js
+++ b/packages/server/test/ts-strip/ts-strip.test.js
@@ -82,3 +82,39 @@ test('stripperName is null before resolution', () => {
   __resetStripper();
   assert.equal(stripperName(), null);
 });
+
+/* ---------------- non-erasable error parity (#509) ---------------- */
+
+// A non-erasable construct must fail strip on BOTH backends with the SAME error
+// code, so the one downstream classifier (dev.js's tsResponse ts-strip frame +
+// 500) fires identically on Node and Bun. Node's built-in throws
+// `ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX`; amaro reports `UnsupportedSyntax`, which
+// the seam normalizes to the same code. Found by the Bun test matrix: without
+// the normalization the dev-error overlay never classified the failure on Bun.
+const NON_ERASABLE = 'export enum Color { Red, Green }\n';
+
+test('the amaro backend tags a non-erasable error with Node\'s code (#509)', async () => {
+  process.env.WEBJS_TS_STRIPPER = 'amaro';
+  __resetStripper();
+  await assert.rejects(
+    () => stripTypeScript(NON_ERASABLE),
+    (err) => {
+      assert.equal(err.code, 'ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX', 'amaro error normalized to the Node code');
+      return true;
+    },
+  );
+  delete process.env.WEBJS_TS_STRIPPER;
+});
+
+test('the built-in backend throws the same code for the same construct', async () => {
+  process.env.WEBJS_TS_STRIPPER = 'builtin';
+  __resetStripper();
+  await assert.rejects(
+    () => stripTypeScript(NON_ERASABLE),
+    (err) => {
+      assert.equal(err.code, 'ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX', 'built-in uses the Node code');
+      return true;
+    },
+  );
+  delete process.env.WEBJS_TS_STRIPPER;
+});

--- a/packages/ui/test/cn-helper.test.js
+++ b/packages/ui/test/cn-helper.test.js
@@ -16,7 +16,10 @@ import { readFileSync, writeFileSync, mkdtempSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import { stripTypeScriptTypes } from 'node:module';
+// Framework's runtime-portable stripper (built-in on Node, amaro on Bun), NOT a
+// named `import { stripTypeScriptTypes } from 'node:module'` (a LINK-TIME error
+// on Bun, where the export is absent).
+import { stripTypeScript } from '../../server/src/ts-strip.js';
 
 const UTILS_SRC = join(
   dirname(fileURLToPath(import.meta.url)),
@@ -28,7 +31,7 @@ const UTILS_SRC = join(
 );
 
 const ts = readFileSync(UTILS_SRC, 'utf8');
-const js = stripTypeScriptTypes(ts);
+const js = await stripTypeScript(ts);
 const dir = mkdtempSync(join(tmpdir(), 'webjs-ui-cn-'));
 const file = join(dir, 'utils.mjs');
 writeFileSync(file, js);

--- a/scripts/run-bun-tests.js
+++ b/scripts/run-bun-tests.js
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/**
+ * Bun test matrix driver (#509).
+ *
+ * Runs the runtime-sensitive `node:test` files (under `test/`, `packages/core/test/`,
+ * and `packages/server/test/`, excluding `browser/`, the `e2e/` gate, and the
+ * network-bound `vendor/` suite) under Bun, file by file via `bun test <file>`,
+ * and CLASSIFIES each result so the matrix is meaningful rather than a wall of red:
+ *
+ *   - **pass**: ran green under Bun.
+ *   - **denylist-skip**: a file KNOWN to assert Node-only behavior (a node:http
+ *     shell internal, the built-in TS stripper as a reference, `module.registerHooks`
+ *     seeding, the node `ws`-library subsystem) or to trip a Bun test-runner quirk
+ *     (async-error attribution, source-order coupling). Each entry carries a reason;
+ *     the Bun-relevant behavior of these surfaces is covered elsewhere (noted per
+ *     entry), so skipping them loses no Bun coverage. See `agent-docs/testing.md`.
+ *   - **harness-skip**: failed ONLY because Bun's `node:test` compat is incomplete
+ *     (nested `test()`, `suite()`), an upstream Bun gap, auto-detected by the error
+ *     signature so it self-heals as Bun improves.
+ *   - **env-skip**: needs an environment this matrix does not provision (Redis, a DOM).
+ *   - **genuine-fail**: a real failure under Bun. THESE fail the job; they are the
+ *     valuable finds (a `node:*` API Bun implements differently, a crypto/stream
+ *     edge case, a timing quirk).
+ *
+ * The Node suite (`npm test`) stays the source of truth; this matrix is additive.
+ * Exit non-zero only on a genuine failure (or a timeout). Set `WEBJS_BUN_TESTS=…`
+ * to a comma-separated path-substring filter to scope a local run.
+ */
+import { spawnSync } from 'node:child_process';
+import { readdirSync } from 'node:fs';
+import { join, sep, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const BUN = process.env.BUN || 'bun';
+const PER_FILE_TIMEOUT_MS = Number(process.env.WEBJS_BUN_TEST_TIMEOUT_MS || 120_000);
+
+/**
+ * Files that assert Node-only behavior or trip a Bun test-runner quirk. Each is
+ * skipped with a documented reason; the Bun-relevant behavior is covered by the
+ * test named in the reason, so no Bun coverage is lost. Match is by path suffix.
+ */
+const DENYLIST = [
+  { match: 'packages/server/test/websocket/websocket.test.js', reason: 'exercises the node `ws`-library upgrade subsystem directly (createServer + attachWebSocket); the Bun WebSocket path is covered by test/bun/listener.mjs' },
+  { match: 'packages/server/test/seed/seed-hook.test.js', reason: 'SSR action-result seeding needs module.registerHooks, unavailable on Bun (no-ops by design, #508)' },
+  { match: 'packages/server/test/seed/seed-ssr.test.js', reason: 'SSR action-result seeding needs module.registerHooks, unavailable on Bun (no-ops by design, #508)' },
+  { match: 'packages/server/test/body-limit/integration.test.js', reason: 'asserts node:http server.requestTimeout/headersTimeout/keepAliveTimeout; the Bun shell maps these to idleTimeout (covered by the deployment docs + listener)' },
+  { match: 'packages/server/test/dev/dev-handler.test.js', reason: 'node:http shell internals (brotli preference, toWebRequest/sendWebResponse, server.address); the Bun shell is covered by test/bun/listener.mjs + compression-parity' },
+  { match: 'packages/server/test/ts-strip/ts-strip.test.js', reason: 'uses the node built-in stripper as the byte-identity reference; the amaro path (Bun backend) is covered under Bun by test/bun/smoke.mjs + dev-error-overlay' },
+  { match: 'packages/server/test/api/api.test.js', reason: 'the dev ?t= import cache-bust relies on node query module-cache eviction, which Bun ignores (documented Bun limitation, see agent-docs/testing.md); the rest of api is covered' },
+  { match: 'packages/server/test/importmap/importmap.test.js', reason: 'relies on node:test source-order for the shared importmap module singleton; Bun orders/isolates tests differently (the functions themselves are runtime-agnostic)' },
+  { match: 'packages/server/test/file-storage/disk-store.test.js', reason: "Bun's test runner mis-attributes the intentional mid-stream ReadableStream error across streaming tests; FileStore streaming is verified runtime-agnostic on Bun standalone" },
+  { match: 'test/cli/typecheck.test.mjs', reason: 'spawns process.execPath (the webjs CLI typecheck, a Node tsc tool); under the matrix process.execPath is bun, which resolves TypeScript differently, so the Node-tooling assertion does not hold' },
+];
+
+/** @param {string} dir @param {string[]} out */
+function walk(dir, out) {
+  let entries;
+  try { entries = readdirSync(dir, { withFileTypes: true }); }
+  catch { return; }
+  for (const e of entries) {
+    if (e.name === 'node_modules' || e.name === '.git') continue;
+    const full = join(dir, e.name);
+    if (e.isDirectory()) walk(full, out);
+    else if (e.isFile() && (e.name.endsWith('.test.js') || e.name.endsWith('.test.mjs'))) out.push(full);
+  }
+}
+
+// Runtime-sensitive roots only (the issue's "server + core" scope, plus the
+// cross-package SSR/scaffold tests under the repo-root test/). The dev-tooling
+// packages (cli, mcp, editors, ui) are exercised on Node.
+const all = [];
+walk(join(ROOT, 'test'), all);
+walk(join(ROOT, 'packages', 'core', 'test'), all);
+walk(join(ROOT, 'packages', 'server', 'test'), all);
+
+const SEP = sep;
+const excludeSegs = [`${SEP}browser${SEP}`, `${SEP}e2e${SEP}`, `${SEP}vendor${SEP}`];
+const filter = (process.env.WEBJS_BUN_TESTS || '').split(',').map((s) => s.trim()).filter(Boolean);
+const rel = (f) => f.slice(ROOT.length + 1);
+const onDenylist = (f) => DENYLIST.find((d) => rel(f) === d.match);
+
+let files = all
+  .filter((f) => !excludeSegs.some((s) => f.includes(s)))
+  .filter((f) => filter.length === 0 || filter.some((q) => f.includes(q)))
+  .sort();
+
+const HARNESS_SIGNATURES = [
+  'is not yet implemented in Bun', // nested test() inside test()
+  'outside of the test runner',
+  'suite is not defined',
+  'describe is not defined',
+];
+const ENV_SIGNATURES = [
+  'Install a Redis client',
+  'document is not defined',
+  'window is not defined',
+  'HTMLElement is not defined',
+  'customElements is not defined',
+];
+
+const results = { pass: [], deny: [], harness: [], env: [], fail: [] };
+
+console.log(`[bun-matrix] running ${files.length} test files under ${BUN}\n`);
+
+for (const f of files) {
+  const deny = onDenylist(f);
+  if (deny) {
+    results.deny.push({ f, why: deny.reason });
+    console.log(`SKIP(node-only) ${rel(f)}`);
+    continue;
+  }
+  const r = spawnSync(BUN, ['test', f], {
+    cwd: ROOT, encoding: 'utf8', timeout: PER_FILE_TIMEOUT_MS,
+    env: { ...process.env, FORCE_COLOR: '0' },
+  });
+  const out = `${r.stdout || ''}\n${r.stderr || ''}`;
+  if (r.error && r.error.code === 'ETIMEDOUT') {
+    results.fail.push({ f, why: `timed out after ${PER_FILE_TIMEOUT_MS}ms` });
+    console.log(`TIMEOUT  ${rel(f)}`);
+    continue;
+  }
+  if (r.status === 0) { results.pass.push(f); continue; }
+  const harnessHit = HARNESS_SIGNATURES.find((s) => out.includes(s));
+  const envHit = ENV_SIGNATURES.find((s) => out.includes(s));
+  const hasAssertion = /AssertionError|Expected .* to (?:be|equal|deeply)/.test(out);
+  if (harnessHit && !hasAssertion) {
+    results.harness.push({ f, why: harnessHit });
+    console.log(`SKIP(harness) ${rel(f)}  [${harnessHit}]`);
+  } else if (envHit && !hasAssertion) {
+    results.env.push({ f, why: envHit });
+    console.log(`SKIP(env)     ${rel(f)}  [${envHit}]`);
+  } else {
+    results.fail.push({ f, why: firstFailure(out) });
+    console.log(`FAIL     ${rel(f)}`);
+  }
+}
+
+function firstFailure(out) {
+  const line = out.split('\n').find((l) => /AssertionError|error:|\(fail\)/.test(l));
+  return (line || 'non-zero exit').trim().slice(0, 200);
+}
+
+console.log('\n[bun-matrix] summary');
+console.log(`  pass:            ${results.pass.length}`);
+console.log(`  skip(node-only): ${results.deny.length}  (documented Node-only / Bun-runner-quirk; Bun behavior covered elsewhere)`);
+console.log(`  skip(harness):   ${results.harness.length}  (Bun node:test compat gaps; tracked upstream)`);
+console.log(`  skip(env):       ${results.env.length}  (needs Redis / DOM; not provisioned)`);
+console.log(`  genuine fail:    ${results.fail.length}`);
+
+if (results.fail.length) {
+  console.log('\n[bun-matrix] GENUINE FAILURES (these fail the job):');
+  for (const { f, why } of results.fail) console.log(`  - ${rel(f)}: ${why}`);
+  process.exit(1);
+}
+console.log('\n[bun-matrix] OK: no genuine Bun failures.');

--- a/scripts/run-bun-tests.js
+++ b/scripts/run-bun-tests.js
@@ -4,27 +4,20 @@
  *
  * Runs the runtime-sensitive `node:test` files (under `test/`, `packages/core/test/`,
  * and `packages/server/test/`, excluding `browser/`, the `e2e/` gate, and the
- * network-bound `vendor/` suite) under Bun, file by file via `bun test <file>`,
- * and CLASSIFIES each result so the matrix is meaningful rather than a wall of red:
+ * network-bound `vendor/` suite) under Bun, file by file via `bun test <file>`.
  *
- *   - **pass**: ran green under Bun.
- *   - **denylist-skip**: a file KNOWN to assert Node-only behavior (a node:http
- *     shell internal, the built-in TS stripper as a reference, `module.registerHooks`
- *     seeding, the node `ws`-library subsystem) or to trip a Bun test-runner quirk
- *     (async-error attribution, source-order coupling). Each entry carries a reason;
- *     the Bun-relevant behavior of these surfaces is covered elsewhere (noted per
- *     entry), so skipping them loses no Bun coverage. See `agent-docs/testing.md`.
- *   - **harness-skip**: failed ONLY because Bun's `node:test` compat is incomplete
- *     (nested `test()`, `suite()`), an upstream Bun gap, auto-detected by the error
- *     signature so it self-heals as Bun improves.
- *   - **env-skip**: needs an environment this matrix does not provision (Redis, a DOM).
- *   - **genuine-fail**: a real failure under Bun. THESE fail the job; they are the
- *     valuable finds (a `node:*` API Bun implements differently, a crypto/stream
- *     edge case, a timing quirk).
+ * SOUNDNESS: the runner does NOT classify failures into skips (a self-classifying
+ * runner can silently hide a real bug behind a "skip", which defeats the purpose).
+ * The ONLY skips are an EXPLICIT, documented `DENYLIST` of files that assert
+ * Node-only behavior or trip a Bun test-runner quirk, each with a reason and a
+ * note of where the Bun-relevant behavior IS covered. Every other file MUST pass:
+ * a non-zero exit, ANY failed test, or zero tests run (a silent compat gap) is a
+ * genuine failure that fails the job. So a real cross-runtime bug can only ever
+ * surface as a failure, never be auto-skipped.
  *
  * The Node suite (`npm test`) stays the source of truth; this matrix is additive.
- * Exit non-zero only on a genuine failure (or a timeout). Set `WEBJS_BUN_TESTS=…`
- * to a comma-separated path-substring filter to scope a local run.
+ * Set `WEBJS_BUN_TESTS=…` to a comma-separated path-substring filter to scope a
+ * local run.
  */
 import { spawnSync } from 'node:child_process';
 import { readdirSync } from 'node:fs';
@@ -37,21 +30,24 @@ const BUN = process.env.BUN || 'bun';
 const PER_FILE_TIMEOUT_MS = Number(process.env.WEBJS_BUN_TEST_TIMEOUT_MS || 120_000);
 
 /**
- * Files that assert Node-only behavior or trip a Bun test-runner quirk. Each is
- * skipped with a documented reason; the Bun-relevant behavior is covered by the
- * test named in the reason, so no Bun coverage is lost. Match is by path suffix.
+ * Files SKIPPED under Bun, each with a reason and where the Bun-relevant behavior
+ * is otherwise covered. A file-level skip is coarse, so node-only behavior is
+ * SPLIT into its own file (api dev-cache-bust, body-limit server-timeouts) rather
+ * than denylisting a file that also carries runtime-agnostic tests. Match is by
+ * the exact repo-relative path (normalized to `/`).
  */
 const DENYLIST = [
-  { match: 'packages/server/test/websocket/websocket.test.js', reason: 'exercises the node `ws`-library upgrade subsystem directly (createServer + attachWebSocket); the Bun WebSocket path is covered by test/bun/listener.mjs' },
-  { match: 'packages/server/test/seed/seed-hook.test.js', reason: 'SSR action-result seeding needs module.registerHooks, unavailable on Bun (no-ops by design, #508)' },
-  { match: 'packages/server/test/seed/seed-ssr.test.js', reason: 'SSR action-result seeding needs module.registerHooks, unavailable on Bun (no-ops by design, #508)' },
-  { match: 'packages/server/test/body-limit/integration.test.js', reason: 'asserts node:http server.requestTimeout/headersTimeout/keepAliveTimeout; the Bun shell maps these to idleTimeout (covered by the deployment docs + listener)' },
-  { match: 'packages/server/test/dev/dev-handler.test.js', reason: 'node:http shell internals (brotli preference, toWebRequest/sendWebResponse, server.address); the Bun shell is covered by test/bun/listener.mjs + compression-parity' },
-  { match: 'packages/server/test/ts-strip/ts-strip.test.js', reason: 'uses the node built-in stripper as the byte-identity reference; the amaro path (Bun backend) is covered under Bun by test/bun/smoke.mjs + dev-error-overlay' },
-  { match: 'packages/server/test/api/api.test.js', reason: 'the dev ?t= import cache-bust relies on node query module-cache eviction, which Bun ignores (documented Bun limitation, see agent-docs/testing.md); the rest of api is covered' },
-  { match: 'packages/server/test/importmap/importmap.test.js', reason: 'relies on node:test source-order for the shared importmap module singleton; Bun orders/isolates tests differently (the functions themselves are runtime-agnostic)' },
-  { match: 'packages/server/test/file-storage/disk-store.test.js', reason: "Bun's test runner mis-attributes the intentional mid-stream ReadableStream error across streaming tests; FileStore streaming is verified runtime-agnostic on Bun standalone" },
-  { match: 'test/cli/typecheck.test.mjs', reason: 'spawns process.execPath (the webjs CLI typecheck, a Node tsc tool); under the matrix process.execPath is bun, which resolves TypeScript differently, so the Node-tooling assertion does not hold' },
+  { match: 'packages/server/test/api/dev-cache-bust.test.js', reason: 'asserts the dev ?t= import cache-bust, which Bun ignores (a documented Bun limitation, #514; see agent-docs/testing.md). The rest of handleApi runs on Bun via api.test.js.' },
+  { match: 'packages/server/test/body-limit/server-timeouts.test.js', reason: 'asserts node:http server.requestTimeout/headersTimeout/keepAliveTimeout; the Bun shell uses Bun.serve idleTimeout instead (#511). The runtime-agnostic 413 body-limit tests run on Bun via integration.test.js.' },
+  { match: 'packages/server/test/seed/seed-hook.test.js', reason: 'SSR action-result seeding needs module.registerHooks, unavailable on Bun (no-ops by design, #508).' },
+  { match: 'packages/server/test/seed/seed-ssr.test.js', reason: 'SSR action-result seeding needs module.registerHooks, unavailable on Bun (no-ops by design, #508).' },
+  { match: 'packages/server/test/dev/dev-handler.test.js', reason: 'node:http shell internals (brotli preference, which Bun has no CompressionStream equivalent for; toWebRequest/sendWebResponse; server.address). The Bun shell is covered by test/bun/listener.mjs + listener/compression-parity.test.js (gzip on the Bun shell).' },
+  { match: 'packages/server/test/ts-strip/ts-strip.test.js', reason: 'uses the node built-in stripper as the byte-identity reference (absent on Bun). The amaro path (Bun backend) is covered on Bun by test/bun/smoke.mjs + dev/dev-error-overlay.test.js, and a forced-amaro parity test runs on Node.' },
+  { match: 'packages/server/test/importmap/importmap.test.js', reason: 'relies on node:test source-order for the shared importmap module singleton; Bun orders/isolates tests differently (the importmap functions themselves are runtime-agnostic).' },
+  { match: 'packages/server/test/file-storage/disk-store.test.js', reason: "Bun's test runner mis-attributes the intentional mid-stream ReadableStream error across this file's tests. The FileStore streaming behavior (put/get round-trip AND the no-orphan-on-mid-stream-error invariant) is now proven on Bun by test/bun/file-storage.mjs (the #509 Readable.fromWeb->reader-loop fix)." },
+  { match: 'packages/server/test/cache/cache-redis.test.js', reason: 'needs a running Redis + an ioredis/redis client, not provisioned in the matrix (skipped on Node too).' },
+  { match: 'packages/server/test/websocket/websocket.test.js', reason: 'exercises the node `ws`-library upgrade subsystem directly (node:http createServer + attachWebSocket, which do not interoperate on Bun). The Bun WebSocket path (Bun.serve + the BunWsAdapter, #511) is covered by test/bun/listener.mjs.' },
+  { match: 'test/cli/typecheck.test.mjs', reason: 'spawns process.execPath (the webjs CLI typecheck, a Node tsc tool); under the matrix process.execPath is bun, which resolves TypeScript differently, so the Node-tooling assertion does not hold.' },
 ];
 
 /** @param {string} dir @param {string[]} out */
@@ -78,34 +74,21 @@ walk(join(ROOT, 'packages', 'server', 'test'), all);
 const SEP = sep;
 const excludeSegs = [`${SEP}browser${SEP}`, `${SEP}e2e${SEP}`, `${SEP}vendor${SEP}`];
 const filter = (process.env.WEBJS_BUN_TESTS || '').split(',').map((s) => s.trim()).filter(Boolean);
-const rel = (f) => f.slice(ROOT.length + 1);
-const onDenylist = (f) => DENYLIST.find((d) => rel(f) === d.match);
+// Repo-relative path, always forward-slashed so DENYLIST matching is OS-stable.
+const rel = (f) => f.slice(ROOT.length + 1).split(sep).join('/');
+const denyOf = (f) => DENYLIST.find((d) => rel(f) === d.match);
 
-let files = all
+const files = all
   .filter((f) => !excludeSegs.some((s) => f.includes(s)))
   .filter((f) => filter.length === 0 || filter.some((q) => f.includes(q)))
   .sort();
 
-const HARNESS_SIGNATURES = [
-  'is not yet implemented in Bun', // nested test() inside test()
-  'outside of the test runner',
-  'suite is not defined',
-  'describe is not defined',
-];
-const ENV_SIGNATURES = [
-  'Install a Redis client',
-  'document is not defined',
-  'window is not defined',
-  'HTMLElement is not defined',
-  'customElements is not defined',
-];
-
-const results = { pass: [], deny: [], harness: [], env: [], fail: [] };
+const results = { pass: [], deny: [], fail: [] };
 
 console.log(`[bun-matrix] running ${files.length} test files under ${BUN}\n`);
 
 for (const f of files) {
-  const deny = onDenylist(f);
+  const deny = denyOf(f);
   if (deny) {
     results.deny.push({ f, why: deny.reason });
     console.log(`SKIP(node-only) ${rel(f)}`);
@@ -117,36 +100,45 @@ for (const f of files) {
   });
   const out = `${r.stdout || ''}\n${r.stderr || ''}`;
   if (r.error && r.error.code === 'ETIMEDOUT') {
-    results.fail.push({ f, why: `timed out after ${PER_FILE_TIMEOUT_MS}ms` });
+    results.fail.push({ f, why: `timed out after ${PER_FILE_TIMEOUT_MS}ms (a hang is a genuine Bun failure)` });
     console.log(`TIMEOUT  ${rel(f)}`);
     continue;
   }
-  if (r.status === 0) { results.pass.push(f); continue; }
-  const harnessHit = HARNESS_SIGNATURES.find((s) => out.includes(s));
-  const envHit = ENV_SIGNATURES.find((s) => out.includes(s));
-  const hasAssertion = /AssertionError|Expected .* to (?:be|equal|deeply)/.test(out);
-  if (harnessHit && !hasAssertion) {
-    results.harness.push({ f, why: harnessHit });
-    console.log(`SKIP(harness) ${rel(f)}  [${harnessHit}]`);
-  } else if (envHit && !hasAssertion) {
-    results.env.push({ f, why: envHit });
-    console.log(`SKIP(env)     ${rel(f)}  [${envHit}]`);
+  const verdict = classify(r.status, out);
+  if (verdict.ok) {
+    results.pass.push(f);
   } else {
-    results.fail.push({ f, why: firstFailure(out) });
-    console.log(`FAIL     ${rel(f)}`);
+    results.fail.push({ f, why: verdict.why });
+    console.log(`FAIL     ${rel(f)}  [${verdict.why}]`);
   }
 }
 
-function firstFailure(out) {
+/**
+ * A file PASSES only if Bun exited 0, reported NO failed tests, and actually RAN
+ * at least one test (a zero-test run is a silent compat gap, not a pass).
+ * @param {number|null} status
+ * @param {string} out
+ */
+function classify(status, out) {
+  const passN = num(out, /(\d+)\s+pass\b/);
+  const failN = num(out, /(\d+)\s+fail\b/);
+  const ranN = num(out, /Ran\s+(\d+)\s+test/);
+  if (status !== 0) return { ok: false, why: `non-zero exit (${status}); ${failN} failed` + firstFail(out) };
+  if (failN > 0) return { ok: false, why: `${failN} test(s) failed` + firstFail(out) };
+  const executed = ranN || passN;
+  if (executed === 0) return { ok: false, why: 'zero tests ran (a silent Bun node:test compat gap)' };
+  return { ok: true };
+}
+
+function num(out, re) { const m = re.exec(out); return m ? Number(m[1]) : 0; }
+function firstFail(out) {
   const line = out.split('\n').find((l) => /AssertionError|error:|\(fail\)/.test(l));
-  return (line || 'non-zero exit').trim().slice(0, 200);
+  return line ? `: ${line.trim().slice(0, 160)}` : '';
 }
 
 console.log('\n[bun-matrix] summary');
 console.log(`  pass:            ${results.pass.length}`);
-console.log(`  skip(node-only): ${results.deny.length}  (documented Node-only / Bun-runner-quirk; Bun behavior covered elsewhere)`);
-console.log(`  skip(harness):   ${results.harness.length}  (Bun node:test compat gaps; tracked upstream)`);
-console.log(`  skip(env):       ${results.env.length}  (needs Redis / DOM; not provisioned)`);
+console.log(`  skip(node-only): ${results.deny.length}  (explicit DENYLIST; each documented, Bun behavior covered elsewhere)`);
 console.log(`  genuine fail:    ${results.fail.length}`);
 
 if (results.fail.length) {

--- a/scripts/run-bun-tests.js
+++ b/scripts/run-bun-tests.js
@@ -83,6 +83,14 @@ const files = all
   .filter((f) => filter.length === 0 || filter.some((q) => f.includes(q)))
   .sort();
 
+// Guard against a silent green from validating nothing: if discovery found no
+// files (a moved test root or a broken walk) and no explicit filter was given,
+// that is a failure, not a pass.
+if (files.length === 0 && filter.length === 0) {
+  console.error('[bun-matrix] FAIL: discovered 0 test files (the test roots moved or the walk broke).');
+  process.exit(1);
+}
+
 const results = { pass: [], deny: [], fail: [] };
 
 console.log(`[bun-matrix] running ${files.length} test files under ${BUN}\n`);

--- a/scripts/run-bun-tests.js
+++ b/scripts/run-bun-tests.js
@@ -48,6 +48,7 @@ const DENYLIST = [
   { match: 'packages/server/test/cache/cache-redis.test.js', reason: 'needs a running Redis + an ioredis/redis client, not provisioned in the matrix (skipped on Node too).' },
   { match: 'packages/server/test/websocket/websocket.test.js', reason: 'exercises the node `ws`-library upgrade subsystem directly (node:http createServer + attachWebSocket, which do not interoperate on Bun). The Bun WebSocket path (Bun.serve + the BunWsAdapter, #511) is covered by test/bun/listener.mjs.' },
   { match: 'test/cli/typecheck.test.mjs', reason: 'spawns process.execPath (the webjs CLI typecheck, a Node tsc tool); under the matrix process.execPath is bun, which resolves TypeScript differently, so the Node-tooling assertion does not hold.' },
+  { match: 'packages/server/test/elision/differential-elision.test.js', reason: 'boots the examples/blog app and renders its DB-backed home page, which needs a migrated Prisma dev.db + jspm vendor resolution the matrix job does not provision (only the e2e / in-repo-app jobs do). The elision LOGIC is covered by the other unit tests in elision/; a real app boot on Bun is covered deterministically by test/bun/listener.mjs.' },
 ];
 
 /** @param {string} dir @param {string[]} out */
@@ -72,7 +73,12 @@ walk(join(ROOT, 'packages', 'core', 'test'), all);
 walk(join(ROOT, 'packages', 'server', 'test'), all);
 
 const SEP = sep;
-const excludeSegs = [`${SEP}browser${SEP}`, `${SEP}e2e${SEP}`, `${SEP}vendor${SEP}`];
+// Exclude browser (needs wtr), e2e (gated), the network-bound vendor suite, and
+// the example-app smoke/probe tests (test/examples/**), which boot a real app
+// that needs a migrated Prisma DB + jspm vendor resolution the matrix job does
+// not provision (the dedicated e2e / in-repo-app CI jobs do; on Bun a real app
+// boot is covered deterministically by the test/bun/*.mjs scripts).
+const excludeSegs = [`${SEP}browser${SEP}`, `${SEP}e2e${SEP}`, `${SEP}vendor${SEP}`, `${SEP}examples${SEP}`];
 const filter = (process.env.WEBJS_BUN_TESTS || '').split(',').map((s) => s.trim()).filter(Boolean);
 // Repo-relative path, always forward-slashed so DENYLIST matching is OS-stable.
 const rel = (f) => f.slice(ROOT.length + 1).split(sep).join('/');

--- a/test/bun/file-storage.mjs
+++ b/test/bun/file-storage.mjs
@@ -1,0 +1,56 @@
+/**
+ * Cross-runtime FileStore streaming proof (#509). The full `diskStore` suite
+ * (packages/server/test/file-storage/disk-store.test.js) is denylisted in the
+ * Bun matrix because Bun's `node:test` runner mis-attributes the intentional
+ * mid-stream ReadableStream error across its tests. So that the streaming
+ * behavior is NOT actually unverified on Bun, this standalone assert script
+ * exercises the two invariants that depend on the `Readable.fromWeb` ->
+ * `createWriteStream` -> `pipeline` path (the stream/fs surface most likely to
+ * diverge across runtimes) under WHICHEVER runtime runs it:
+ *
+ *   node test/bun/file-storage.mjs
+ *   bun  test/bun/file-storage.mjs
+ *
+ * (1) a Blob put/get round-trips identical bytes + size + content type, and
+ * (2) a mid-stream write failure rejects AND leaves NO orphan partial file.
+ * Run from the repo root so the bare `@webjsdev/server` specifier resolves to
+ * the workspace package.
+ */
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { diskStore } from '@webjsdev/server';
+
+const runtime = process.versions.bun ? `bun ${process.versions.bun}` : `node ${process.versions.node}`;
+const dir = mkdtempSync(join(tmpdir(), 'webjs-filestore-x-'));
+try {
+  const store = diskStore({ dir });
+
+  // 1. Blob put/get round-trip through the streaming write + read path.
+  await store.put('x.bin', new Blob([new Uint8Array([1, 2, 3, 4, 5])], { type: 'application/octet-stream' }));
+  const handle = await store.get('x.bin');
+  assert.ok(handle, 'get returns a handle');
+  assert.equal(handle.size, 5, 'size is reported');
+  assert.equal(handle.contentType, 'application/octet-stream', 'content type is preserved');
+  const chunks = [];
+  for await (const c of handle.body) chunks.push(Buffer.from(c));
+  const bytes = Buffer.concat(chunks);
+  assert.deepEqual([...bytes], [1, 2, 3, 4, 5], 'bytes round-trip identically');
+
+  // 2. A mid-stream write failure rejects and leaves no orphan partial file.
+  let pulls = 0;
+  const failing = new ReadableStream({
+    pull(controller) {
+      if (pulls++ === 0) controller.enqueue(new Uint8Array([1, 2, 3]));
+      else controller.error(new Error('boom mid-stream'));
+    },
+  });
+  await assert.rejects(() => store.put('partial.bin', failing), /boom/, 'put rejects on a mid-stream error');
+  assert.equal(await store.has('partial.bin'), false, 'the truncated partial file was cleaned up');
+  assert.equal(await store.get('partial.bin'), null, 'get returns null (no partial bytes)');
+
+  console.log(`OK  webjs FileStore streaming passed on ${runtime} (put/get round-trip + no-orphan-on-mid-stream-error)`);
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}

--- a/test/bun/file-storage.test.mjs
+++ b/test/bun/file-storage.test.mjs
@@ -1,0 +1,13 @@
+/**
+ * Run the cross-runtime FileStore streaming proof (#509) under WHICHEVER runtime
+ * executes the suite. Picked up by the root `node --test` runner (so `npm test`
+ * exercises the Node path); CI also runs `bun test/bun/file-storage.mjs` for the
+ * Bun path. The proof is a plain assert script (`file-storage.mjs`, not
+ * `*.test.mjs`, so the runner does not double-run it); importing it runs it and
+ * throws on any failure.
+ */
+import { test } from 'node:test';
+
+test('FileStore put/get round-trips and cleans up a mid-stream failure on this runtime (#509)', async () => {
+  await import('./file-storage.mjs');
+});

--- a/test/source-fidelity/source-fidelity.test.mjs
+++ b/test/source-fidelity/source-fidelity.test.mjs
@@ -27,7 +27,12 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { stripTypeScriptTypes } from 'node:module';
+// Use the framework's OWN runtime-portable stripper (Node's built-in on Node,
+// amaro on Bun), NOT a named `import { stripTypeScriptTypes } from 'node:module'`
+// (which is a LINK-TIME SyntaxError on Bun, where that export is absent). This
+// also pins the served bytes against the EXACT stripper the server used on this
+// runtime, so the byte-identity assertion holds on both.
+import { stripTypeScript } from '../../packages/server/src/ts-strip.js';
 
 import { createRequestHandler } from '@webjsdev/server';
 
@@ -80,7 +85,7 @@ test('TS type-strip is position-preserving: served line/column equals authored',
   // shift a line or column). This also closes the gap where positionPreserved
   // alone would tolerate a real code character being blanked to a space: only
   // genuine type syntax is blanked here.
-  assert.equal(s, stripTypeScriptTypes(a),
+  assert.equal(s, await stripTypeScript(a),
     'served bytes must equal the position-preserving type-strip of the authored source, nothing more');
   // Sampled column fidelity: a code line with no types is byte-identical and
   // at the same line index.


### PR DESCRIPTION
Closes #509. (Supersedes #513, which GitHub auto-closed when its stacked base branch `feat/bun-serve-listener-adapter` was deleted on the #512 squash-merge; this branch is the same work rebased cleanly onto main.)

## What

A sound Bun test matrix (`scripts/run-bun-tests.js` + CI job) that re-runs the runtime-sensitive `node:test` suite under Bun: **175 pass, 11 documented node-only skips, 0 genuine failures**. The runner cannot hide a failure behind a skip (no auto-classifier; only an explicit, documented denylist; a zero-tests-ran guard and an empty-discovery guard). The Node suite stays the source of truth; this is additive.

## 5 genuine cross-runtime bugs the matrix found and fixed

1. **FormData serializer crash** (Bun returns fresh Blob identities per `entries()`).
2. **FileStore `put()` hang** (`Readable.fromWeb` doesn't propagate a mid-stream error through `pipeline` on Bun; switched to a reader-loop generator; proven by `test/bun/file-storage.mjs`).
3. **amaro error code** (`UnsupportedSyntax` vs Node's `ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX`; the dev-error overlay never classified it on Bun).
4. **SSR error hint** (JSC appends a detail clause V8 doesn't; the browser-member hint never fired on Bun).
5. **link-unsafe imports** (two test files still named `import { stripTypeScriptTypes } from 'node:module'`).

## Self-review

3 rounds, converged clean (round 1 itself surfaced bug #2 when a reviewer challenged a denylist coverage claim). Also wires the matrix into the `require-tests-with-src` test-gate hook, and corrects residual Node-only TS-strip framing across the scaffold + apps + the deploy Dockerfiles.

## Evidence

Node suite 2548 pass / 0 fail; Bun matrix 0 genuine failures; blog e2e 87 pass; website/docs/ui-website boot clean. One documented Bun limitation tracked in #514 (dev hot-reload of server modules; Bun ignores the `?t=` import cache-bust).
