### PR TITLE
chore: release core 0.7.21, server 0.8.28, cli 0.10.16

### DIFF
--- a/changelog/cli/0.10.16.md
+++ b/changelog/cli/0.10.16.md
@@ -1,0 +1,12 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.16
+date: 2026-06-14T13:42:31.489Z
+commit_count: 2
+---
+## Scaffold templates
+
+The scaffold templates shipped into every new app gain Bun coverage and shed stale claims:
+
+- **Bun runtime guidance.** The scaffolded `AGENTS.md` documents running an app on Bun (`bun --bun run dev` / `start`) and that TypeScript stripping comes from `amaro` there ([#510](https://github.com/webjsdev/webjs/pull/510)) [`2c6d9599`](https://github.com/webjsdev/webjs/commit/2c6d9599).
+- **Corrected runtime framing** ([#515](https://github.com/webjsdev/webjs/pull/515)) [`ed558949`](https://github.com/webjsdev/webjs/commit/ed558949): the scaffold `Dockerfile` no longer claims a removed esbuild fallback (webjs is buildless; `node:24-alpine` default with an `oven/bun` option), and the `AGENTS.md` invariant + `CONVENTIONS.md` code-style section now say types are stripped at the runtime layer (Node's built-in or `amaro` on Bun) rather than Node-only.

--- a/changelog/core/0.7.21.md
+++ b/changelog/core/0.7.21.md
@@ -1,0 +1,12 @@
+---
+package: "@webjsdev/core"
+version: 0.7.21
+date: 2026-06-14T13:42:31.433Z
+commit_count: 1
+---
+## Fixes
+
+The Bun test matrix ([#515](https://github.com/webjsdev/webjs/pull/515)) surfaced two genuine cross-runtime serializer / SSR bugs in core, now fixed:
+
+- **Serialize FormData reliably on Bun.** Bun returns a fresh `Blob`/`File` identity on every `FormData.entries()` / `get()` call (Node returns a stable one), so the serializer's two-pass design (precompute Blob bytes by identity, then re-iterate to encode) missed its identity-keyed lookup and threw `undefined is not an object (u8.buffer)`. Each FormData's entries are now captured once and reused across both passes, so a `FormData` with mixed string + `Blob` entries round-trips on every runtime. [`ed558949`](https://github.com/webjsdev/webjs/commit/ed558949)
+- **Name the offending browser member in the SSR error hint on Bun.** `browserMemberHint` anchored its `TypeError` / `ReferenceError` regexes to end-of-string, but JSC (Bun) appends a detail clause that V8 (Node) does not, so the actionable "this is a browser-only API touched during SSR" hint never fired on Bun. The match is now on a word boundary, so the hint fires on both engines. [`ed558949`](https://github.com/webjsdev/webjs/commit/ed558949)

--- a/changelog/server/0.8.28.md
+++ b/changelog/server/0.8.28.md
@@ -1,0 +1,24 @@
+---
+package: "@webjsdev/server"
+version: 0.8.28
+date: 2026-06-14T13:42:31.459Z
+commit_count: 4
+---
+## Features
+
+- **Brotli compression on the Bun listener via `node:zlib`** ([#518](https://github.com/webjsdev/webjs/pull/518)) [`b905b34f`](https://github.com/webjsdev/webjs/commit/b905b34f)
+  * The `Bun.serve` shell compressed via the web `CompressionStream` (gzip only); it now uses `node:zlib` (native on Bun) for **brotli on Bun**, reaching full compression parity with the Node shell. The negotiation (`br` > `gzip` > `deflate`) + compressor factory are shared in `listener-core.js` so the two shells compress identically, and the body is bridged through a reader-loop generator + `pipeline` so a mid-stream error tears the chain down instead of hanging.
+- **run on both Bun and Node via a pluggable TS stripper** ([#510](https://github.com/webjsdev/webjs/pull/510)) [`2c6d9599`](https://github.com/webjsdev/webjs/commit/2c6d9599)
+  * feat: make the TS stripper pluggable so webjs runs on Bun and Node (#508)
+  
+  * test: cross-runtime smoke (SSR + TS strip + action RPC) for Node and Bun (#508)
+- **Bun.serve listener adapter behind a runtime-neutral shell seam** ([#512](https://github.com/webjsdev/webjs/pull/512)) [`c562ac70`](https://github.com/webjsdev/webjs/commit/c562ac70)
+  * feat: add Bun.serve listener adapter behind a runtime-neutral shell seam
+  
+  startServer now detects the host runtime and selects a listener shell:
+  the existing node:http path on Node, a new Bun.serve path on Bun. Bun is
+- **Bun test matrix in CI, fixing the cross-runtime bugs it found** ([#515](https://github.com/webjsdev/webjs/pull/515)) [`ed558949`](https://github.com/webjsdev/webjs/commit/ed558949)
+  * fix: normalize amaro's non-erasable TS error code to Node's (#509)
+  
+  The Bun test matrix surfaced a genuine cross-runtime bug: the dev-error
+  overlay classifies a TypeScript strip failure by err.code ===

--- a/package-lock.json
+++ b/package-lock.json
@@ -6852,7 +6852,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.15",
+      "version": "0.10.16",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -6868,7 +6868,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.20",
+      "version": "0.7.21",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.25.0"
@@ -6916,7 +6916,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.27",
+      "version": "0.8.28",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.20",
+  "version": "0.7.21",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.27",
+  "version": "0.8.28",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Release the merged Bun work to npm. Rebased onto the latest main and refreshed to include #518.

| Package | From | To | What |
|---|---|---|---|
| `@webjsdev/server` | 0.8.27 | **0.8.28** | feat: pluggable TS stripper (#510), the `Bun.serve` listener adapter (#512), the cross-runtime fixes the Bun matrix found (#515), and **brotli compression on the Bun listener via node:zlib** (#518) |
| `@webjsdev/core` | 0.7.20 | **0.7.21** | fix: FormData serializer crash on Bun + the SSR browser-member error hint on Bun (#515) |
| `@webjsdev/cli` | 0.10.15 | **0.10.16** | scaffold-template Bun guidance (#510) + corrected runtime framing in the Dockerfile / AGENTS / CONVENTIONS (#515) |

`@webjsdev/mcp` is untouched, so it is not bumped. `package-lock.json` regenerated to match the bumps (so `npm ci` stays in sync).

Changelogs were auto-generated by the pre-commit backfill, then hand-curated for per-package accuracy (the squash subjects are `feat:`, but core's changes were fixes and cli's were template docs).

Merging this publishes the three packages to npm via `release.yml`.
