### PR TITLE
fix: hot-reload webjs dev under Bun via bun --hot (#514)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,13 @@ jobs:
       # Readable.fromWeb, which hangs on Bun).
       - name: webjs compression on Bun
         run: bun test/bun/compression.mjs
+      # Dev hot reload on Bun (#514): start `webjs dev` under Bun, edit a
+      # re-imported route module, and assert the response updates with NO manual
+      # restart. The CLI re-execs under `bun --hot` on Bun (vs `node --watch` on
+      # Node); without it Bun ignores the dev `?t=` cache-bust and the edit stays
+      # stale. The same script proves no Node regression under `npm test`.
+      - name: webjs dev hot reload on Bun
+        run: bun test/bun/dev-hot-reload.mjs
       # The Bun test MATRIX (#509): run the runtime-sensitive node:test suite
       # (core + server + cross-package test/) under Bun, file by file, classifying
       # each result. Documented Node-only files + Bun-test-runner-quirk files are

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -320,7 +320,7 @@ Rules: **always scaffold via `webjs create`** (never hand-roll). **Default to a 
 ## CLI reference
 
 ```sh
-webjs dev    [--port N]            # dev server with live reload
+webjs dev    [--port N] [--no-hot] # dev server with live reload (node --watch on Node, bun --hot on Bun). --no-hot runs in-process
 webjs start  [--port N]            # prod server; source IS the runtime, plain HTTP/1.1 (reverse-proxy for TLS + HTTP/2)
 webjs test   [--server] [--browser] [--watch]
 webjs check  [--rules] [--json]    # correctness validator (report-only, no autofix); --json for an agent loop

--- a/agent-docs/testing.md
+++ b/agent-docs/testing.md
@@ -134,15 +134,24 @@ edge case, an error-message-format quirk).
   (`startServer` over a real socket: SSR + route + SSE + WebSocket). Plain assert
   scripts (not `node:test`) so the same file runs identically on each runtime.
 
-**Known Bun limitation (dev hot-reload of server modules).** webjs's dev server
+**Dev hot-reload of server modules (cross-runtime, #514).** webjs's dev server
 re-imports a `route.ts` / `.server.ts` / page module per request with a
-`?t=<timestamp>` query cache-bust to pick up edits. Bun's ESM loader IGNORES the
-query string (Node honors it and re-imports), and Bun exposes no module-eviction
-API, so on Bun a server-side module edit is not reflected until a dev-server
-restart. Component / page / layout SOURCE edits hot-reload fine on Bun (the
-served `.ts`/`.js` is read from disk per request, not imported). This is a Bun
-runtime gap, not a webjs bug; the `api` dev-cache-bust test is skipped under the
-Bun matrix for this reason.
+`?t=<timestamp>` query cache-bust to pick up edits. Node honors that query and
+re-imports, so under `node --watch` an edit is picked up live. Bun's ESM loader
+IGNORES the query string and exposes no module-eviction API, so that mechanism
+alone leaves a server-side edit stale on Bun. The CLI closes the gap by
+re-execing `webjs dev` under `bun --hot` on Bun (vs `node --watch` on Node),
+whose file-watching cache invalidation makes the next re-import fresh with no
+restart (`Bun.serve` is reused across hot reloads, so the listener is not
+duplicated). The cross-runtime test `test/bun/dev-hot-reload.mjs` proves the
+edit-picked-up behaviour on BOTH runtimes (and runs as a dedicated CI step on
+Bun). The `api` dev-cache-bust UNIT test asserts the bare server-level `?t=`
+mechanism directly (no supervisor), which Bun ignores by design, so it stays on
+the Bun-matrix denylist; the user-facing hot reload it underpins is covered on
+Bun by the dev-hot-reload script instead. A `--no-hot` flag opts out of the
+supervisor on either runtime (run the server in-process, edits need a manual
+restart). Component / page / layout SOURCE edits already hot-reload on both
+runtimes (the served `.ts`/`.js` is read from disk per request, not imported).
 
 ### In-repo app tests in CI (#342)
 

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -55,6 +55,17 @@ lib/
                          `resolvePort` so a `.env` PORT is in `process.env` at
                          resolution time; the server loads `.env` too but too late
                          to affect the port the CLI computes. Tests: `test/port/`.
+  dev-supervisor.js      `webjs dev` reload-supervisor planner (#514). PURE
+                         `planDevSupervisor({ isBun, argv, noHot, exists })`
+                         returns the spawn decision: `bun --hot` on Bun (Bun
+                         ignores the dev `?t=` cache-bust, so `node --watch`
+                         would leave a server-module edit stale), `node --watch`
+                         + the existing `--watch-path` set on Node, or `inline`
+                         (run in-process) when `--no-hot` is passed. Kept pure so
+                         the branch logic is unit-testable without spawning a
+                         process; the bin owns the actual spawn + the
+                         `__WEBJS_DEV_CHILD` re-entry. Tests: `test/dev-supervisor/`
+                         (unit) + `test/bun/dev-hot-reload.mjs` (cross-runtime).
   create.js              `webjs create <name>` scaffold logic. Copies
                          `templates/` into the new app, writes
                          package.json + tsconfig + Prisma schema,
@@ -77,7 +88,7 @@ README.md                npm-facing package readme.
 
 | Command | Implementation |
 |---|---|
-| `webjs dev` | Spawns `node --watch` re-entry, then `startServer({ dev: true })`. In the parent (pre-spawn) it runs the Prisma-client preflight (`lib/prisma-preflight.js`, #452): for a Prisma app (a `prisma/schema.prisma` or an `@prisma/client` dep) whose generated client is missing/stale, it prints a hint pointing at `npm run dev` (the canonical command, which runs the `predev` `prisma generate` hook) or `webjs db generate`. A bare `webjs dev` skips `predev`; the hint replaces the raw crash. Non-Prisma apps get nothing. A hint only, never an auto-run. |
+| `webjs dev` | Re-execs itself under the host runtime's hot-reload supervisor, then `startServer({ dev: true })` in the child. The supervisor is runtime-specific (#514, `lib/dev-supervisor.js`): `node --watch` on Node (restart-on-change, fresh ESM cache, plus the dev re-import's `?t=` query); `bun --hot` on Bun (in-place module invalidation, since Bun keys its cache by path and ignores `?t=`, so `node --watch` would leave a server-module edit stale). `--no-hot` opts out and runs the server in-process on either runtime. In the parent (pre-spawn) it runs the Prisma-client preflight (`lib/prisma-preflight.js`, #452): for a Prisma app (a `prisma/schema.prisma` or an `@prisma/client` dep) whose generated client is missing/stale, it prints a hint pointing at `npm run dev` (the canonical command, which runs the `predev` `prisma generate` hook) or `webjs db generate`. A bare `webjs dev` skips `predev`; the hint replaces the raw crash. Non-Prisma apps get nothing. A hint only, never an auto-run. |
 | `webjs start` | `startServer({ dev: false })`, plain HTTP/1.1 (front a reverse proxy for TLS + HTTP/2) |
 | `webjs test [--server\|--browser]` | `node --test` for server tests, `wtr` for browser tests |
 | `webjs check [--rules] [--json]` | `checkConventions()` from `@webjsdev/server/check`. `--rules` lists the checks. `--json` emits the structured violations + a summary count as JSON (via `projectCheck` from `@webjsdev/mcp/check-report`, the same projector the MCP `check` tool uses, #415), so an agent in a loop consumes structured data instead of regex-scraping stdout; the non-zero exit on violations is preserved. Report-only: each violation carries a prose `fix` hint, but there is no `--fix` autofix flag (the rules either rewrite code or rename files, so an automatic codemod is not safe) |

--- a/packages/cli/bin/webjs.js
+++ b/packages/cli/bin/webjs.js
@@ -4,6 +4,7 @@ import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { checkNodeInline, nodeInlineMessage } from '../lib/node-preflight.js';
 import { loadAppEnv, resolvePort } from '../lib/port.js';
+import { planDevSupervisor } from '../lib/dev-supervisor.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const [cmd, ...rest] = process.argv.slice(2);
@@ -83,7 +84,8 @@ async function main() {
   }
   switch (cmd) {
     case 'dev': {
-      // If we're already inside the --watch child, start the server directly.
+      // If we're already inside the reload child (node --watch or bun --hot),
+      // start the server directly.
       if (process.env.__WEBJS_DEV_CHILD === '1') {
         const { startServer } = await import('@webjsdev/server');
         // Load `.env` BEFORE resolving the port so a `PORT` set there is in
@@ -104,36 +106,31 @@ async function main() {
       const hint = prismaDevHint(process.cwd());
       if (hint) console.error(hint);
 
-      // Otherwise, spawn ourselves as a child with node --watch.
-      // This restarts the process on file changes, guaranteeing a fresh
-      // Node ESM module cache. Without this, edits to transitively-imported
-      // modules (actions, queries, components, utils) don't take effect
-      // because Node caches ESM by URL with no public invalidation API.
-      // Build watch paths from directories that exist in the project.
+      // Decide how to run: in-process (`--no-hot`), or re-exec'd under the host
+      // runtime's hot-reload supervisor (`node --watch` on Node, `bun --hot` on
+      // Bun, #514). The branch logic lives in the pure `planDevSupervisor` so it
+      // is unit-testable without spawning a process.
       const { existsSync } = await import('node:fs');
-      const watchPaths = [];
-      for (const dir of ['app', 'components', 'modules', 'lib', 'actions']) {
-        if (existsSync(dir)) watchPaths.push('--watch-path', dir);
-      }
-      // Watch root middleware/config if present
-      for (const f of ['middleware.ts', 'middleware.js']) {
-        if (existsSync(f)) watchPaths.push('--watch-path', f);
+      const plan = planDevSupervisor({
+        isBun: !!process.versions.bun,
+        argv: process.argv.slice(1),
+        noHot: rest.includes('--no-hot'),
+        exists: (p) => existsSync(p),
+      });
+
+      if (plan.mode === 'inline') {
+        const { startServer } = await import('@webjsdev/server');
+        loadAppEnv(process.cwd());
+        const port = resolvePort(flag(rest, '--port'));
+        await startServer({ appDir: process.cwd(), port, dev: true });
+        break;
       }
 
-      const child = spawn(
-        process.execPath,
-        [
-          '--watch',
-          '--watch-preserve-output',
-          ...watchPaths,
-          ...process.argv.slice(1),
-        ],
-        {
-          stdio: 'inherit',
-          cwd: process.cwd(),
-          env: { ...process.env, __WEBJS_DEV_CHILD: '1' },
-        },
-      );
+      const child = spawn(process.execPath, plan.args, {
+        stdio: 'inherit',
+        cwd: process.cwd(),
+        env: { ...process.env, __WEBJS_DEV_CHILD: '1' },
+      });
       child.on('exit', (code) => process.exit(code ?? 0));
       break;
     }

--- a/packages/cli/bin/webjs.js
+++ b/packages/cli/bin/webjs.js
@@ -40,7 +40,8 @@ if (cmd !== 'help' && cmd !== undefined) {
 const TEMPLATES = ['full-stack', 'api', 'saas'];
 
 const USAGE = `webjs commands:
-  webjs dev   [--port 8080]                       Start dev server with live reload
+  webjs dev   [--port 8080] [--no-hot]            Start dev server with live reload
+                                                  (--no-hot: run in-process, no hot-reload supervisor)
   webjs start [--port 8080]                       Start production server (serves source directly, no build step)
   webjs test  [--server|--browser]                 Run server + browser tests
   webjs check [--json]                            Run correctness checks on the app (--json emits structured violations)

--- a/packages/cli/lib/dev-supervisor.js
+++ b/packages/cli/lib/dev-supervisor.js
@@ -1,0 +1,61 @@
+/**
+ * Dev-server reload supervisor planning for `webjs dev` (issue #514).
+ *
+ * `webjs dev` re-execs itself under the host runtime's hot-reload supervisor so
+ * an edit to a transitively-imported module (an action, query, component, util)
+ * takes effect without a manual restart. Both runtimes cache ES modules by
+ * resolved URL with no public invalidation API, so the dev re-import in
+ * `@webjsdev/server`'s `dev.js` relies on the runtime's own file-watching cache
+ * invalidation:
+ *
+ * - **Node** has no in-place module-cache eviction, so it re-execs under
+ *   `node --watch`, which RESTARTS the process on a file change (a fresh ESM
+ *   cache each time). The dev re-import additionally appends a `?t=` cache-bust
+ *   query that Node honours between restarts.
+ * - **Bun** keys its module cache by path and IGNORES that `?t=` query, so the
+ *   `node --watch` model does not transfer: without help a re-imported module
+ *   stays STALE on Bun (the #514 bug). Bun's `--hot` invalidates loaded modules
+ *   on a file change WITHOUT restarting the process, which is exactly what the
+ *   dev re-import needs; `Bun.serve` is reused across hot reloads, so the
+ *   listener is not duplicated. `--hot` auto-watches every loaded file, so the
+ *   node `--watch-path` flags do not apply (and are not Bun flags).
+ *
+ * This pure planner returns the spawn decision so the bin stays a thin shell and
+ * the branch logic is unit-testable without spawning a process.
+ */
+
+/**
+ * Plan how `webjs dev` runs its server.
+ *
+ * @param {object} opts
+ * @param {boolean} opts.isBun  Whether the host runtime is Bun (`process.versions.bun`).
+ * @param {string[]} opts.argv  `process.argv.slice(1)` (the script path followed by its args), forwarded to the child verbatim.
+ * @param {boolean} opts.noHot  Whether `--no-hot` was passed (opt out of the supervisor entirely).
+ * @param {(path: string) => boolean} opts.exists  Existence check for the Node `--watch-path` targets (relative to cwd). Unused on Bun.
+ * @returns {{ mode: 'inline' } | { mode: 'spawn', args: string[] }}
+ *   `inline` runs the server in this process (no reload watcher); `spawn`
+ *   re-execs `process.execPath` with `args` and `__WEBJS_DEV_CHILD=1`.
+ */
+export function planDevSupervisor({ isBun, argv, noHot, exists }) {
+  // `--no-hot` opts out of the reload supervisor on either runtime: run the dev
+  // server in THIS process with no watcher. Degraded dev (a deep-import edit
+  // needs a manual restart) but useful under an external process manager or a
+  // debugger that wants a single, un-re-exec'd process.
+  if (noHot) return { mode: 'inline' };
+
+  if (isBun) return { mode: 'spawn', args: ['--hot', ...argv] };
+
+  // Node: re-exec under `node --watch`, watching the project dirs/files that
+  // exist. `--watch-preserve-output` keeps prior logs across a restart.
+  const watchPaths = [];
+  for (const dir of ['app', 'components', 'modules', 'lib', 'actions']) {
+    if (exists(dir)) watchPaths.push('--watch-path', dir);
+  }
+  for (const f of ['middleware.ts', 'middleware.js']) {
+    if (exists(f)) watchPaths.push('--watch-path', f);
+  }
+  return {
+    mode: 'spawn',
+    args: ['--watch', '--watch-preserve-output', ...watchPaths, ...argv],
+  };
+}

--- a/packages/cli/test/dev-supervisor/dev-supervisor.test.js
+++ b/packages/cli/test/dev-supervisor/dev-supervisor.test.js
@@ -1,0 +1,84 @@
+/**
+ * Unit tests for the `webjs dev` reload-supervisor planner (issue #514).
+ *
+ * The bug: on Bun, `webjs dev` re-exec'd under `node --watch` (a Node-only
+ * flag) and relied on the dev re-import's `?t=` cache-bust query, which Bun
+ * ignores (it keys its module cache by path), so an edit to a re-imported
+ * module stayed STALE on Bun. The fix re-execs under `bun --hot` on Bun, whose
+ * file-watching cache invalidation makes the dev re-import pick up the edit.
+ *
+ * These tests prove the planner's branch logic: Bun yields `bun --hot`, Node
+ * yields `node --watch` with the existing watch-path set, `--no-hot` opts out
+ * on either runtime, and the counterfactual that the Bun branch never emits the
+ * Node-only `--watch` flags.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { planDevSupervisor } from '../../lib/dev-supervisor.js';
+
+const ARGV = ['/path/to/webjs.js', 'dev', '--port', '8080'];
+const allExist = () => true;
+const noneExist = () => false;
+
+test('Bun re-execs under `bun --hot`, forwarding argv verbatim', () => {
+  const plan = planDevSupervisor({ isBun: true, argv: ARGV, noHot: false, exists: allExist });
+  assert.deepEqual(plan, { mode: 'spawn', args: ['--hot', ...ARGV] });
+});
+
+test('Bun branch NEVER emits the Node-only watch flags (the #514 mismatch)', () => {
+  // The counterfactual: the old code passed `--watch` / `--watch-path` to Bun,
+  // which Bun does not understand. The fix must use ONLY `--hot`.
+  const plan = planDevSupervisor({ isBun: true, argv: ARGV, noHot: false, exists: allExist });
+  assert.ok(plan.mode === 'spawn');
+  for (const flag of ['--watch', '--watch-preserve-output', '--watch-path']) {
+    assert.ok(!plan.args.includes(flag), `Bun args must not include ${flag}`);
+  }
+});
+
+test('Node re-execs under `node --watch` with the project watch paths', () => {
+  const plan = planDevSupervisor({ isBun: false, argv: ARGV, noHot: false, exists: allExist });
+  assert.deepEqual(plan, {
+    mode: 'spawn',
+    args: [
+      '--watch',
+      '--watch-preserve-output',
+      '--watch-path', 'app',
+      '--watch-path', 'components',
+      '--watch-path', 'modules',
+      '--watch-path', 'lib',
+      '--watch-path', 'actions',
+      '--watch-path', 'middleware.ts',
+      '--watch-path', 'middleware.js',
+      ...ARGV,
+    ],
+  });
+});
+
+test('Node watch paths include only the dirs/files that exist', () => {
+  // Only `app` exists in this project.
+  const exists = (p) => p === 'app';
+  const plan = planDevSupervisor({ isBun: false, argv: ARGV, noHot: false, exists });
+  assert.deepEqual(plan, {
+    mode: 'spawn',
+    args: ['--watch', '--watch-preserve-output', '--watch-path', 'app', ...ARGV],
+  });
+});
+
+test('Node with no project dirs still watches (no --watch-path entries)', () => {
+  const plan = planDevSupervisor({ isBun: false, argv: ARGV, noHot: false, exists: noneExist });
+  assert.deepEqual(plan, {
+    mode: 'spawn',
+    args: ['--watch', '--watch-preserve-output', ...ARGV],
+  });
+});
+
+test('`--no-hot` opts out of the supervisor on Bun (run in-process)', () => {
+  const plan = planDevSupervisor({ isBun: true, argv: ARGV, noHot: true, exists: allExist });
+  assert.deepEqual(plan, { mode: 'inline' });
+});
+
+test('`--no-hot` opts out of the supervisor on Node (run in-process)', () => {
+  const plan = planDevSupervisor({ isBun: false, argv: ARGV, noHot: true, exists: allExist });
+  assert.deepEqual(plan, { mode: 'inline' });
+});

--- a/packages/cli/test/port/port.test.js
+++ b/packages/cli/test/port/port.test.js
@@ -114,9 +114,10 @@ test('webjs.js loads .env before resolving the port, for BOTH dev and start', as
     !/process\.env\.PORT\s*\|\|\s*8080/.test(src),
     'the pre-load `process.env.PORT || 8080` read must not return',
   );
-  // Both commands resolve via the shared helper.
+  // Every command resolves via the shared helper: `start`, the `dev` reload
+  // child (`__WEBJS_DEV_CHILD`), and the `dev --no-hot` in-process path (#514).
   const resolveCount = (src.match(/resolvePort\(/g) || []).length;
-  assert.equal(resolveCount, 2, 'dev + start both call resolvePort');
+  assert.equal(resolveCount, 3, 'start + dev-child + dev --no-hot all call resolvePort');
   // Each resolvePort call is preceded by a loadAppEnv call (ordering matters).
   for (const m of src.matchAll(/resolvePort\(/g)) {
     const before = src.slice(0, m.index);

--- a/packages/server/test/api/dev-cache-bust.test.js
+++ b/packages/server/test/api/dev-cache-bust.test.js
@@ -6,8 +6,11 @@
  * is NODE-ONLY: Bun's ESM loader ignores the query cache-bust (and exposes no
  * module-eviction API), so this assertion cannot hold on Bun. It is denylisted in
  * the Bun matrix (see scripts/run-bun-tests.js); the rest of handleApi (routing,
- * 405, params, Response.json) stays in api.test.js and DOES run under Bun. Bun
- * dev-reload limitation tracked in #514.
+ * 405, params, Response.json) stays in api.test.js and DOES run under Bun. This
+ * test exercises the bare server-level `?t=` mechanism directly (no supervisor),
+ * which Bun ignores by design. The USER-FACING dev hot reload it underpins IS
+ * fixed for Bun at the CLI level via `bun --hot` (#514), proven cross-runtime by
+ * test/bun/dev-hot-reload.mjs.
  */
 import { test, before, after } from 'node:test';
 import assert from 'node:assert/strict';

--- a/scripts/run-bun-tests.js
+++ b/scripts/run-bun-tests.js
@@ -37,7 +37,7 @@ const PER_FILE_TIMEOUT_MS = Number(process.env.WEBJS_BUN_TEST_TIMEOUT_MS || 120_
  * the exact repo-relative path (normalized to `/`).
  */
 const DENYLIST = [
-  { match: 'packages/server/test/api/dev-cache-bust.test.js', reason: 'asserts the dev ?t= import cache-bust, which Bun ignores (a documented Bun limitation, #514; see agent-docs/testing.md). The rest of handleApi runs on Bun via api.test.js.' },
+  { match: 'packages/server/test/api/dev-cache-bust.test.js', reason: 'asserts the bare server-level dev ?t= import cache-bust directly (no supervisor), which Bun ignores by keying its module cache on path. The USER-FACING hot reload is fixed for Bun at the CLI level via `bun --hot` (#514), proven cross-runtime by test/bun/dev-hot-reload.mjs; this unit test exercises the Node-only `?t=` mechanism. The rest of handleApi runs on Bun via api.test.js.' },
   { match: 'packages/server/test/body-limit/server-timeouts.test.js', reason: 'asserts node:http server.requestTimeout/headersTimeout/keepAliveTimeout; the Bun shell uses Bun.serve idleTimeout instead (#511). The runtime-agnostic 413 body-limit tests run on Bun via integration.test.js.' },
   { match: 'packages/server/test/seed/seed-hook.test.js', reason: 'SSR action-result seeding needs module.registerHooks, unavailable on Bun (no-ops by design, #508).' },
   { match: 'packages/server/test/seed/seed-ssr.test.js', reason: 'SSR action-result seeding needs module.registerHooks, unavailable on Bun (no-ops by design, #508).' },

--- a/test/bun/dev-hot-reload.mjs
+++ b/test/bun/dev-hot-reload.mjs
@@ -29,7 +29,9 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '../..');
 const CLI = join(ROOT, 'packages/cli/bin/webjs.js');
 const runtime = process.versions.bun ? `bun ${process.versions.bun}` : `node ${process.versions.node}`;
-// A per-pid port keeps parallel runs (the node + bun jobs) from colliding.
+// The node (`npm test`) and bun (`bun ...mjs`) runs are SEQUENTIAL CI steps, so
+// they do not race for a port; the per-pid offset is only defensive against a
+// leftover socket from a prior run lingering in TIME_WAIT.
 const PORT = 9700 + (process.pid % 250);
 const BASE = `http://localhost:${PORT}`;
 

--- a/test/bun/dev-hot-reload.mjs
+++ b/test/bun/dev-hot-reload.mjs
@@ -1,0 +1,97 @@
+/**
+ * Cross-runtime dev hot-reload test (#514): start `webjs dev` under WHICHEVER
+ * runtime executes this file, edit a re-imported route module while the server
+ * runs, and assert the response reflects the edit WITHOUT a manual restart. Run
+ * it under both:
+ *
+ *   node test/bun/dev-hot-reload.mjs
+ *   bun  test/bun/dev-hot-reload.mjs
+ *
+ * This is the HEADLINE behaviour for #514. On Node the CLI re-execs under
+ * `node --watch` (the process restarts, fresh ESM cache); on Bun it re-execs
+ * under `bun --hot` (loaded modules are invalidated in place). Before the fix
+ * the CLI used `node --watch` on Bun too, and since Bun ignores the dev
+ * re-import's `?t=` cache-bust query, the edited module stayed STALE on Bun.
+ *
+ * A plain assert script (not node:test) so the SAME file runs identically on
+ * both runtimes; it exits non-zero on failure. It spawns the real CLI via the
+ * current runtime's `process.execPath`, so the runtime selects its own
+ * supervisor exactly as a user's `webjs dev` / `bun --bun run dev` would.
+ */
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '../..');
+const CLI = join(ROOT, 'packages/cli/bin/webjs.js');
+const runtime = process.versions.bun ? `bun ${process.versions.bun}` : `node ${process.versions.node}`;
+// A per-pid port keeps parallel runs (the node + bun jobs) from colliding.
+const PORT = 9700 + (process.pid % 250);
+const BASE = `http://localhost:${PORT}`;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** Poll `fn` until it returns truthy or the deadline passes. */
+async function until(fn, { timeoutMs, stepMs = 200 }) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try { if (await fn()) return true; } catch { /* keep polling */ }
+    if (Date.now() > deadline) return false;
+    await sleep(stepMs);
+  }
+}
+
+const dir = mkdtempSync(join(tmpdir(), 'webjs-dev-hot-'));
+const routeFile = join(dir, 'app/api/ping/route.ts');
+const writeRoute = (body) => writeFileSync(routeFile, `export async function GET() { return new Response(${JSON.stringify(body)}); }\n`);
+
+let child;
+try {
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'dev-hot', type: 'module', webjs: {} }));
+  // Resolve @webjsdev/* from the workspace so the spawned CLI's server import
+  // and (later) any app import resolve regardless of the temp-dir location.
+  mkdirSync(join(dir, 'node_modules/@webjsdev'), { recursive: true });
+  symlinkSync(join(ROOT, 'packages/core'), join(dir, 'node_modules/@webjsdev/core'));
+  symlinkSync(join(ROOT, 'packages/server'), join(dir, 'node_modules/@webjsdev/server'));
+  mkdirSync(dirname(routeFile), { recursive: true });
+  writeRoute('VERSION_ONE');
+
+  // Spawn the REAL CLI under the current runtime, detached so we can signal the
+  // whole process group (the CLI re-execs a supervisor child, which on Node
+  // spawns the server as a further child).
+  child = spawn(process.execPath, [CLI, 'dev', '--port', String(PORT)], {
+    cwd: dir,
+    detached: true,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, NODE_ENV: 'development' },
+  });
+  let log = '';
+  child.stdout.on('data', (d) => { log += d; });
+  child.stderr.on('data', (d) => { log += d; });
+
+  const ready = await until(async () => (await fetch(`${BASE}/__webjs/health`)).ok, { timeoutMs: 30_000 });
+  assert.ok(ready, `dev server did not become ready on ${runtime}\n--- server log ---\n${log}`);
+
+  const first = await (await fetch(`${BASE}/api/ping`)).text();
+  assert.equal(first, 'VERSION_ONE', `first fetch should serve the original module on ${runtime}`);
+
+  // Edit the re-imported module and wait for the edit to take effect. No manual
+  // restart: the runtime's supervisor (node --watch / bun --hot) must pick it up.
+  writeRoute('VERSION_TWO');
+  const updated = await until(async () => (await (await fetch(`${BASE}/api/ping`)).text()) === 'VERSION_TWO', { timeoutMs: 20_000 });
+  assert.ok(updated, `edited module stayed STALE on ${runtime} (hot reload did not pick up the edit)\n--- server log ---\n${log}`);
+
+  console.log(`OK  webjs dev hot-reload picked up a re-imported module edit on ${runtime} (#514)`);
+} finally {
+  if (child && child.pid) {
+    try { process.kill(-child.pid, 'SIGTERM'); } catch { try { child.kill('SIGTERM'); } catch {} }
+    // Give the group a moment to exit, then hard-kill any stragglers.
+    await sleep(500);
+    try { process.kill(-child.pid, 'SIGKILL'); } catch {}
+  }
+  rmSync(dir, { recursive: true, force: true });
+}

--- a/test/bun/dev-hot-reload.test.mjs
+++ b/test/bun/dev-hot-reload.test.mjs
@@ -1,0 +1,15 @@
+/**
+ * Run the cross-runtime dev hot-reload check (#514) under WHICHEVER runtime
+ * executes the test suite. Picked up by the root `node --test` runner, so
+ * `npm test` exercises the `node --watch` supervisor; CI runs
+ * `bun test/bun/dev-hot-reload.mjs` separately for the `bun --hot` supervisor
+ * (the path that #514 actually fixes). The behaviour script is a plain assert
+ * file (`dev-hot-reload.mjs`, not `*.test.mjs`, so the runner does not
+ * double-run it); importing it spawns the real CLI, edits a module, and throws
+ * on any failure.
+ */
+import { test } from 'node:test';
+
+test('webjs dev hot-reloads a re-imported module edit on this runtime (#514)', async () => {
+  await import('./dev-hot-reload.mjs');
+});


### PR DESCRIPTION
Closes #514

## Problem

On Bun, `webjs dev` re-exec'd itself under `node --watch` (a Node-only flag) and relied on the dev re-import's `?t=<timestamp>` cache-bust query to pick up edits. Bun keys its module cache by path and IGNORES that query, with no module-eviction API, so an edit to a re-imported server module (a `route.ts`, a `.server.ts`, a page, a layout) stayed STALE until a manual dev-server restart. Node honours `?t=` and additionally restarts under `--watch`, so Node was unaffected.

## Fix

`webjs dev` now re-execs under the host runtime's own hot-reload supervisor:

- **Node**: `node --watch` (unchanged): restart on change, fresh ESM cache, plus the `?t=` re-import.
- **Bun**: `bun --hot`: in-place module-cache invalidation on a file change, no process restart. `Bun.serve` is reused across hot reloads, so the listener is never duplicated (verified: a page AND a layout edit both apply with no `EADDRINUSE`).

A `--no-hot` flag opts out of the supervisor on either runtime and runs the server in-process (a deep-import edit then needs a manual restart), useful under an external process manager or a debugger.

The branch logic is extracted into a pure `planDevSupervisor` (`packages/cli/lib/dev-supervisor.js`) so it is unit-testable without spawning a process; the bin keeps the `__WEBJS_DEV_CHILD` re-entry and the actual spawn.

## Tests

- **Unit** (`packages/cli/test/dev-supervisor/`): `planDevSupervisor` yields `bun --hot` on Bun, `node --watch` + the existing `--watch-path` set on Node, `inline` for `--no-hot`, and the counterfactual that the Bun branch never emits the Node-only `--watch` flags.
- **Cross-runtime integration** (`test/bun/dev-hot-reload.mjs` + wrapper): starts the REAL CLI under the current runtime, edits a re-imported route while the server runs, and asserts the response updates with no restart. Run under BOTH runtimes (Node proves no regression; Bun proves the fix). Wired as a dedicated CI step `bun test/bun/dev-hot-reload.mjs`, and picked up by the Bun matrix.
- **Counterfactual (manual)**: with `--no-hot` on Bun the edited module stays stale (the #514 bug); with the new `--hot` default it updates.
- Updated the `port.test.js` structural pin (the `--no-hot` inline path adds a third `resolvePort` site, all three still preceded by `loadAppEnv`, so the #447 ordering invariant holds).
- Refreshed the `api/dev-cache-bust.test.js` Bun-matrix denylist note: that unit test asserts the bare server-level `?t=` mechanism directly (still Node-only), while the user-facing hot reload it underpins is now covered on Bun by the dev-hot-reload script.

Browser / e2e: N/A for new assertions (this is a CLI process-supervision change, not a render/serve change), but the full dogfood gate was run as a regression check (below).

## Definition of done

- `npm test`: 2565 pass, 0 fail.
- Bun matrix (`node scripts/run-bun-tests.js`): 175 pass, 12 documented node-only skips, 0 genuine fail.
- Blog e2e (`WEBJS_E2E=1`): 87 pass, 0 fail.
- Dogfood boot-check (prod mode): website `/` 200, docs `/` 302 + `/docs/testing` 200, ui-website `/` 200, no broken modulepreloads. The jspm 401 warnings are pre-existing fail-open vendor noise, unrelated.
- Docs: `agent-docs/testing.md` rewritten from a known-limitation note to the cross-runtime behaviour; `packages/cli/AGENTS.md` module map + `webjs dev` row + USAGE updated. MCP knowledge layer auto-bundles `agent-docs`, so it picks the change up; no new agent-docs file / invariant / recipe, so MCP tooling + editor plugins are N/A.
