### PR TITLE
chore: release cli 0.10.17

### DIFF
--- a/changelog/cli/0.10.17.md
+++ b/changelog/cli/0.10.17.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.17
+date: 2026-06-14T19:33:51.322Z
+commit_count: 1
+---
+## Fixes
+
+- **hot-reload webjs dev under Bun via bun --hot (#514)** ([#519](https://github.com/webjsdev/webjs/pull/519)) [`5aceb8b0`](https://github.com/webjsdev/webjs/commit/5aceb8b0)
+  * fix: hot-reload webjs dev under bun via bun --hot (#514)
+  
+  On Bun, webjs dev re-exec'd under node --watch (a Node-only flag) and relied
+  on the dev re-import's ?t= cache-bust query. Bun keys its module cache by path

--- a/package-lock.json
+++ b/package-lock.json
@@ -6852,7 +6852,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.16",
+      "version": "0.10.17",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.16",
+  "version": "0.10.17",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {


### PR DESCRIPTION
Release `@webjsdev/cli` 0.10.17.

Ships the #514 fix: `webjs dev` now hot-reloads server modules under Bun by re-execing under `bun --hot` (vs `node --watch` on Node), since Bun ignores the dev `?t=` cache-bust. Merged in #519.

All dependents pin `@webjsdev/cli: ^0.10.0`, so this patch bump needs no range changes. Lockfile regenerated; changelog auto-generated from the conventional commit.