### PR TITLE
test: run the blog e2e against a Bun-served blog (#523)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,20 @@ jobs:
         env:
           WEBJS_E2E: '1'
         run: node --test test/e2e/e2e.test.mjs
+      # Cross-runtime e2e (#523): re-run the SAME suite under node --test (its
+      # node:test hook lifecycle does not survive `bun test`) but with the blog
+      # SERVED on Bun (WEBJS_E2E_RUNTIME=bun spawns the blog under the bun binary).
+      # This proves the Bun.serve shell + Prisma-on-Bun in a real browser. The few
+      # node-only assertions (SSR seeding, #472/#488) and the #528-blocked abort
+      # test skip themselves on Bun.
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Run e2e with the blog served on Bun
+        env:
+          WEBJS_E2E: '1'
+          WEBJS_E2E_RUNTIME: 'bun'
+        run: node --test test/e2e/e2e.test.mjs
 
   dist:
     name: Build (@webjsdev/core dist)

--- a/test/e2e/e2e.test.mjs
+++ b/test/e2e/e2e.test.mjs
@@ -67,6 +67,20 @@ function blogRuntimeExec() {
   return process.execPath;
 }
 
+/** Whether the blog under test is served on Bun (WEBJS_E2E_RUNTIME=bun). */
+const BLOG_ON_BUN = (process.env.WEBJS_E2E_RUNTIME || '').toLowerCase() === 'bun';
+
+/**
+ * Skip reason for tests that assert SSR action-result SEEDING (#472 / the #488
+ * GET seed). Seeding rides Node's `module.registerHooks`, which Bun lacks, so on
+ * Bun seeding is disabled FAIL-OPEN: the data is still correct (the component
+ * re-fetches over RPC instead of reading a seed), but the "no RPC because seeded"
+ * assertion does not hold. Node-only, the same carve-out the Bun unit-test matrix
+ * makes for the seed-hook tests. `false` when the blog runs on Node (tests run).
+ */
+const SEED_SKIP = BLOG_ON_BUN &&
+  'SSR action seeding (#472) needs module.registerHooks, unavailable on Bun (disabled fail-open); the seeded-vs-RPC assertion is node-only.';
+
 /**
  * Start the blog example dev server and wait until it's ready.
  * @param {number} port
@@ -388,7 +402,7 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
     assert.ok(greeting.includes('Hello, world!'), 'the greeting survived the re-render');
   });
 
-  test('SSR action seeding: no action RPC on hydration, RPC on a prop bump (#472)', async () => {
+  test('SSR action seeding: no action RPC on hydration, RPC on a prop bump (#472)', { skip: SEED_SKIP }, async () => {
     // The /seeded page renders a shipping <seeded-user> whose async render()
     // awaits the getSeedUser 'use server' action. SSR bakes the result into the
     // first paint AND seeds it into the page, so the client's first render must
@@ -439,7 +453,7 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
     }
   });
 
-  test('HTTP-verb actions: GET read is seeded, POST mutation invalidates + refetches (#488)', async () => {
+  test('HTTP-verb actions: GET read is seeded, POST mutation invalidates + refetches (#488)', { skip: SEED_SKIP }, async () => {
     // /verbs reads via a GET action (cacheable, seeded on first paint) and a
     // POST mutation that invalidates the read's tag. Probe action RPCs: none on
     // hydration (the GET was seeded), then the bump fires the mutation and a
@@ -551,7 +565,7 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
     }
   });
 
-  test('SSR action seeding rides a soft navigation: no RPC on the navigated render (#472)', async () => {
+  test('SSR action seeding rides a soft navigation: no RPC on the navigated render (#472)', { skip: SEED_SKIP }, async () => {
     // Start on another page, then soft-navigate to /seeded through the client
     // router. The navigation response carries the seed payload, the router
     // ingests it (applySwap -> scanSeeds) before <seeded-user> hydrates, so the

--- a/test/e2e/e2e.test.mjs
+++ b/test/e2e/e2e.test.mjs
@@ -82,6 +82,19 @@ const SEED_SKIP = BLOG_ON_BUN &&
   'SSR action seeding (#472) needs module.registerHooks, unavailable on Bun (disabled fail-open); the seeded-vs-RPC assertion is node-only.';
 
 /**
+ * Skip reason for the async-render abort test when the blog runs on Bun. This is
+ * NOT a Bun-runtime gap: it is a REAL framework bug (#528). When seeding is off
+ * (always on Bun, or WEBJS_SEED=0 on Node), an async-render component that reads
+ * a signal performs an on-hydration re-fetch and then goes inert: a later signal
+ * bump does not re-render, so there is no superseded fetch to abort. Reproduced
+ * on Node with WEBJS_SEED=0, so it is tracked as a framework bug to FIX, not a
+ * runtime carve-out. Skip here only so the rest of the cross-runtime e2e is green
+ * until #528 lands; remove this skip when #528 is fixed.
+ */
+const ASYNC_REACTIVITY_SKIP = BLOG_ON_BUN &&
+  'blocked by #528: async-render + signal goes inert after the on-hydration re-fetch (seeding off), so no superseded fetch exists to abort. A framework bug to fix, not a Bun-runtime gap.';
+
+/**
  * Start the blog example dev server and wait until it's ready.
  * @param {number} port
  * @returns {Promise<import('node:child_process').ChildProcess>}
@@ -504,7 +517,7 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
     }
   });
 
-  test('a superseded async render aborts its in-flight action fetch (#492)', async () => {
+  test('a superseded async render aborts its in-flight action fetch (#492)', { skip: ASYNC_REACTIVITY_SKIP }, async () => {
     // <abort-demo> awaits a slow (800ms) GET action. Bumping n while the fetch
     // is in flight supersedes the render, and the framework aborts the previous
     // render's fetch (net::ERR_ABORTED on the action URL).

--- a/test/e2e/e2e.test.mjs
+++ b/test/e2e/e2e.test.mjs
@@ -10,6 +10,14 @@
  * Run:   WEBJS_E2E=1 node --test test/e2e/e2e.test.mjs
  * (gated behind WEBJS_E2E so the default `npm test` run skips it; CI runs
  * it as its own job, see .github/workflows/ci.yml)
+ *
+ * Cross-runtime (#523): the harness always runs under `node --test` (its
+ * node:test hook lifecycle does not survive `bun test`), but the BLOG SERVER it
+ * spawns can be served on Bun by setting WEBJS_E2E_RUNTIME=bun (point
+ * WEBJS_BUN_PATH at the bun binary if it is not `bun` on PATH). This exercises
+ * the full browser stack against a Bun-served blog, proving the Bun.serve shell
+ * and Prisma-on-Bun in a real browser:
+ *   WEBJS_E2E=1 WEBJS_E2E_RUNTIME=bun node --test test/e2e/e2e.test.mjs
  */
 
 import { test, describe, before, after } from 'node:test';
@@ -44,6 +52,22 @@ function freePort() {
 }
 
 /**
+ * The runtime executable that SERVES the blog under test. Defaults to the
+ * runtime running this harness (`process.execPath`, i.e. node under
+ * `node --test`). Set WEBJS_E2E_RUNTIME=bun to serve the blog on Bun instead
+ * (the cross-runtime e2e for #523); WEBJS_BUN_PATH overrides the bun binary
+ * location when it is not `bun` on PATH. Only the spawned blog process changes
+ * runtime; the harness itself stays on node.
+ * @returns {string}
+ */
+function blogRuntimeExec() {
+  if ((process.env.WEBJS_E2E_RUNTIME || '').toLowerCase() === 'bun') {
+    return process.env.WEBJS_BUN_PATH || 'bun';
+  }
+  return process.execPath;
+}
+
+/**
  * Start the blog example dev server and wait until it's ready.
  * @param {number} port
  * @returns {Promise<import('node:child_process').ChildProcess>}
@@ -52,7 +76,7 @@ function startBlog(port, extraEnv = {}) {
   const cliPath = resolve(ROOT, 'packages', 'cli', 'bin', 'webjs.js');
   return new Promise((res, reject) => {
     const child = spawn(
-      process.execPath,
+      blogRuntimeExec(),
       [cliPath, 'dev', '--port', String(port)],
       {
         cwd: BLOG_DIR,


### PR DESCRIPTION
Closes #523

Add a cross-runtime e2e: the harness stays on `node --test` (its node:test hook lifecycle breaks under `bun test`), but `startBlog` now spawns the blog server under Bun when `WEBJS_E2E_RUNTIME=bun` is set. This runs the full Puppeteer suite against a Bun-served blog, proving the `Bun.serve` shell and Prisma-on-Bun in a real browser, and runs as a second e2e step in CI.

## Result
Full e2e under Bun: **83 pass, 0 fail, 4 skipped**. The 4 skips are documented and runtime-correct:
- 3 SSR action-seeding tests (#472/#488): seeding rides `module.registerHooks`, unavailable on Bun, so it is disabled fail-open (data still correct, the seeded-vs-RPC assertion is node-only). Same carve-out the Bun unit matrix makes.
- 1 async-render abort test (#492): gated pending **#528**.

## It found a real bug (#528)
The Bun run surfaced a genuine framework bug, not a runtime gap: an `async render()` component that reads a signal goes inert after its on-hydration re-fetch (which only happens when seeding is off, always on Bun). Reproduced on Node with `WEBJS_SEED=0`, so it is a framework bug to FIX (filed as #528), not a Bun carve-out. Seeding masks it by default on Node. The abort test is skipped on Bun referencing #528; the skip is removed when #528 lands.

## Surfaces
- `test/e2e/e2e.test.mjs`: the `WEBJS_E2E_RUNTIME=bun` runtime override + the gated tests.
- `.github/workflows/ci.yml`: a second e2e run with the blog on Bun (the e2e job already has chromium + the seeded DB).
- N/A: no published-package source changed (test + CI only), so no version bump / changelog.
