### PR TITLE
chore: release server 0.8.29

### DIFF
--- a/changelog/server/0.8.29.md
+++ b/changelog/server/0.8.29.md
@@ -1,0 +1,26 @@
+---
+package: "@webjsdev/server"
+version: 0.8.29
+date: 2026-06-15T15:31:43.991Z
+commit_count: 3
+---
+## Features
+
+- **make SSR action-result seeding work on Bun (#529)** ([#534](https://github.com/webjsdev/webjs/pull/534)) [`e2c7c7a1`](https://github.com/webjsdev/webjs/commit/e2c7c7a1)
+  * feat: install SSR action seeding on Bun via Bun.plugin
+  
+  Seeding (#472) rode Node's module.registerHooks, which Bun lacks, so it was off
+  on Bun and every shipping async-render component re-fetched on hydration. Extract
+
+## Fixes
+
+- **hot-reload webjs dev under Bun via bun --hot (#514)** ([#519](https://github.com/webjsdev/webjs/pull/519)) [`5aceb8b0`](https://github.com/webjsdev/webjs/commit/5aceb8b0)
+  * fix: hot-reload webjs dev under bun via bun --hot (#514)
+  
+  On Bun, webjs dev re-exec'd under node --watch (a Node-only flag) and relied
+  on the dev re-import's ?t= cache-bust query. Bun keys its module cache by path
+- **make the seed facade fail-open on an export-enumeration miss** ([#538](https://github.com/webjsdev/webjs/pull/538)) [`d5f545f5`](https://github.com/webjsdev/webjs/commit/d5f545f5)
+  * fix: make the seed facade fail-open on an export-enumeration miss
+  
+  The facade enumerates a 'use server' module's named exports with a regex
+  (extractExportNames) to emit one wrapped `export const NAME` per export. A

--- a/package-lock.json
+++ b/package-lock.json
@@ -6916,7 +6916,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.28",
+      "version": "0.8.29",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.28",
+  "version": "0.8.29",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Releases `@webjsdev/server` 0.8.29 (patch). All in-repo dependents pin `^0.8.0`, so the patch stays in range with no dependent edits; `package-lock.json` is resynced.

Covers the unreleased server commits since 0.8.28:
- feat: SSR action-result seeding on Bun (#534, closes #529)
- fix: hot-reload `webjs dev` under Bun via `bun --hot` (#519, #514)
- fix: seed facade fail-open on an export-enumeration miss (#538, closes #535)

Merging this adds `changelog/server/0.8.29.md` to `main`, which triggers `release.yml` to `npm publish` the package and cut its GitHub Release (idempotent). No other published package is owed a bump: core/mcp/intellisense have no unreleased shipped-code commits, and the cli/ui touches since their last releases were a template doc (#534), a test (#515), and the ui-website app config (#437), none of which ship in the package.

Verification: the changelog was auto-generated by the pre-commit hook from the conventional squash subjects (commit_count 3, correctly split into 1 feature + 2 fixes). Version-bump-only diff (one version line + lockfile + generated changelog).