### PR TITLE
chore: commit .claude skills to the repo for a portable agent setup

### DIFF
--- a/.claude/skills/use-railway/SKILL.md
+++ b/.claude/skills/use-railway/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: use-railway
+description: >
+  Operate Railway infrastructure: create projects, provision services and
+  databases, manage object storage buckets, deploy code, configure environments
+  and variables, manage domains, troubleshoot failures, check status and metrics,
+  and query Railway docs. Use this skill whenever the user mentions Railway,
+  deployments, services, environments, buckets, object storage, build failures,
+  or infrastructure operations, even if they don't say "Railway" explicitly.
+allowed-tools: Bash(railway:*), Bash(which:*), Bash(command:*), Bash(npm:*), Bash(npx:*), Bash(curl:*), Bash(python3:*)
+---
+
+# Use Railway
+
+## Railway resource model
+
+Railway organizes infrastructure in a hierarchy:
+
+- **Workspace** is the billing and team scope. A user belongs to one or more workspaces.
+- **Project** is a collection of services under one workspace. It maps to one deployable unit of work.
+- **Environment** is an isolated configuration plane inside a project (for example, `production`, `staging`). Each environment has its own variables, config, and deployment history.
+- **Service** is a single deployable unit inside a project. It can be an app from a repo, a Docker image, or a managed database.
+- **Bucket** is an S3-compatible object storage resource inside a project. Buckets are created at the project level and deployed to environments. Each bucket has credentials (endpoint, access key, secret key) for S3-compatible access.
+- **Deployment** is a point-in-time release of a service in an environment. It has build logs, runtime logs, and a status lifecycle.
+
+Most CLI commands operate on the linked project/environment/service context. Use `railway status --json` to see the context, and `--project`, `--environment`, `--service` flags to override.
+
+## Parsing Railway URLs
+
+Users often paste Railway dashboard URLs. Extract IDs before doing anything else:
+
+```
+https://railway.com/project/<PROJECT_ID>/service/<SERVICE_ID>?environmentId=<ENV_ID>
+https://railway.com/project/<PROJECT_ID>/service/<SERVICE_ID>
+```
+
+The URL always contains `projectId` and `serviceId`. It may contain `environmentId` as a query parameter. If the environment ID is missing and the user specifies an environment by name (e.g., "production"), resolve it:
+
+```bash
+scripts/railway-api.sh \
+  'query getProject($id: String!) {
+    project(id: $id) {
+      environments { edges { node { id name } } }
+    }
+  }' \
+  '{"id": "<PROJECT_ID>"}'
+```
+
+Match the environment name (case-insensitive) to get the `environmentId`.
+
+**Prefer passing explicit IDs** to CLI commands (`--project`, `--environment`, `--service`) and scripts (`--project-id`, `--environment-id`, `--service-id`) instead of running `railway link`. This avoids modifying global state and is faster.
+
+## Preflight
+
+Before any mutation, verify context:
+
+```bash
+command -v railway                # CLI installed
+RAILWAY_CALLER="skill:use-railway@1.2.0" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
+railway --version                 # check CLI version
+```
+
+For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.2.0` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight just for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
+
+**Context resolution — URL IDs always win:**
+- If the user provides a Railway URL, extract IDs from it. Do NOT run `railway status --json` — it returns the locally linked project, which is usually unrelated.
+- If no URL is given, fall back to `railway status --json` for the linked project/environment/service.
+
+If the CLI is missing, guide the user to install it.
+
+```bash
+bash <(curl -fsSL cli.new) # Shell script (macOS, Linux, Windows via WSL)
+brew install railway # Homebrew (macOS)
+npm i -g @railway/cli # npm (macOS, Linux, Windows). Requires Node.js version 16 or higher.
+```
+
+If not authenticated, run `railway login`. If not linked and no URL was provided, run `railway link --project <id-or-name>`.
+
+If a command is not recognized (for example, `railway environment edit`), the CLI may be outdated. Upgrade with:
+
+```bash
+railway upgrade
+```
+
+## Common quick operations
+
+These are frequent enough to handle without loading a reference:
+
+```bash
+railway status --json                                    # current context
+railway whoami --json                                    # auth and workspace info
+railway project list --json                              # list projects
+railway service status --all --json                      # all services in current context
+railway variable list --service <svc> --json             # list variables
+railway variable set KEY=value --service <svc>           # set a variable
+railway logs --service <svc> --lines 200 --json          # recent logs
+railway up --detach -m "<summary>"                       # deploy current directory
+railway bucket list --json                               # list buckets in current environment
+railway bucket info --bucket <name> --json               # bucket storage and object count
+railway bucket credentials --bucket <name> --json        # S3-compatible credentials
+```
+
+When using these commands from the skill, keep the command shape but prefix the Railway invocation with the telemetry env, for example:
+
+```bash
+RAILWAY_CALLER="skill:use-railway@1.2.0" RAILWAY_AGENT_SESSION="railway-skill-20260508-1234" railway status --json
+```
+
+## Routing
+
+For anything beyond quick operations, load the reference that matches the user's intent. Load only what you need, one reference is usually enough, two at most.
+
+| Intent | Reference | Use for |
+|---|---|---|
+| **Analyze a database** ("analyze \<url\>", "analyze db", "analyze database", "analyze service", "introspect", "check my postgres/redis/mysql/mongo") | [analyze-db.md](references/analyze-db.md) | Database introspection and performance analysis. analyze-db.md directs you to the DB-specific reference. **This takes priority over the status/operate routes when a Railway URL to a database service is provided alongside "analyze".** |
+| Create or connect resources | [setup.md](references/setup.md) | Projects, services, databases, buckets, templates, workspaces |
+| Ship code or manage releases | [deploy.md](references/deploy.md) | Deploy, redeploy, restart, build config, monorepo, Dockerfile |
+| Change configuration | [configure.md](references/configure.md) | Environments, variables, config patches, domains, networking |
+| Check health or debug failures | [operate.md](references/operate.md) | Status, logs, metrics, build/runtime triage, recovery |
+| Request from API, docs, or community | [request.md](references/request.md) | Railway GraphQL API queries/mutations, metrics queries, Central Station, official docs |
+
+If the request spans two areas (for example, "deploy and then check if it's healthy"), load both references and compose one response.
+
+## Execution rules
+
+1. Prefer Railway CLI. Fall back to `scripts/railway-api.sh` for operations the CLI doesn't expose.
+2. Use `--json` output where available for reliable parsing.
+3. Resolve context before mutation. Know which project, environment, and service you're acting on.
+4. For destructive actions (delete service, remove deployment, drop database), confirm intent and state impact before executing.
+5. After mutations, verify the result with a read-back command.
+
+## User-only commands (NEVER execute directly)
+
+These commands modify database state and require the user to run them directly in their terminal. **Do NOT execute these with Bash. Instead, show the command and ask the user to run it.**
+
+| Command | Why user-only |
+|---------|---------------|
+| `python3 scripts/enable-pg-stats.py --service <name>` | Modifies shared_preload_libraries, may restart database |
+| `python3 scripts/pg-extensions.py --service <name> install <ext>` | Installs database extension |
+| `python3 scripts/pg-extensions.py --service <name> uninstall <ext>` | Removes database extension |
+| `ALTER SYSTEM SET ...` | Changes PostgreSQL configuration |
+| `DROP EXTENSION ...` | Removes database extension |
+| `CREATE EXTENSION ...` | Installs database extension |
+
+When these operations are needed:
+1. Explain what the command does and any side effects (e.g., restart required)
+2. Show the exact command the user should run
+3. Wait for user confirmation that they ran it
+4. Verify the result with a read-only query
+
+## Composition patterns
+
+Multi-step workflows follow natural chains:
+
+- **Add object storage**: setup (create bucket), setup (get credentials), configure (set S3 variables on app service)
+- **First deploy**: setup (create project + service), configure (set variables and source), deploy, operate (verify healthy)
+- **Fix a failure**: operate (triage logs), configure (fix config/variables), deploy (redeploy), operate (verify recovery)
+- **Add a domain**: configure (add domain + set port), operate (verify DNS and service health)
+- **Docs to action**: request (fetch docs answer), route to the relevant operational reference
+
+When composing, return one unified response covering all steps. Don't ask the user to invoke each step separately.
+
+## Setup decision flow
+
+When the user wants to create or deploy something, determine the right action from current context:
+
+1. Run `railway status --json` in the current directory.
+2. **If linked**: add a service to the existing project (`railway add --service <name>`). Do not create a new project unless the user explicitly says "new project" or "separate project".
+3. **If not linked**: check the parent directory (`cd .. && railway status --json`).
+   - **Parent linked**: this is likely a monorepo sub-app. Add a service and set `rootDirectory` to the sub-app path.
+   - **Parent not linked**: run `railway list --json` and look for a project matching the directory name.
+     - **Match found**: link to it (`railway link --project <name>`).
+     - **No match**: create a new project (`railway init --name <name>`).
+4. When multiple workspaces exist, match by name from `railway whoami --json`.
+
+**Naming heuristic**: app names like "flappy-bird" or "my-api" are service names, not project names. Use the directory or repo name for the project.
+
+## Response format
+
+For all operational responses, return:
+1. What was done (action and scope).
+2. The result (IDs, status, key output).
+3. What to do next (or confirmation that the task is complete).
+
+Keep output concise. Include command evidence only when it helps the user understand what happened.

--- a/.claude/skills/use-railway/references/analyze-db-mongo.md
+++ b/.claude/skills/use-railway/references/analyze-db-mongo.md
@@ -1,0 +1,84 @@
+# MongoDB Analysis
+
+This reference covers MongoDB-specific metrics, tuning, and analysis guidance.
+For common analysis patterns (output structure, collection status handling, performance thinking), see [analyze-db.md](analyze-db.md).
+
+### What the Script Collects
+
+**Via SSH (mongosh):**
+- **Server Status:** version, storage engine, uptime, connections, opcounters, latency, memory, network, WiredTiger cache/checkpoint/tickets, global lock queues, document operations, query efficiency, cursors, TTL, asserts
+- **DB Stats:** dataSize, storageSize, indexSize, object count, collection count
+- **Collection Stats:** per-collection document count, size, storage size, index size, index count
+- **Current Operations:** active ops with type, namespace, duration
+- **Slow Queries:** from system.profile (if profiling enabled) — op, namespace, duration, plan summary
+- **Replication Info:** oplog size, usage, time window
+- **Top Collections:** per-collection read/write counts and time from `top` admin command
+
+**Via Railway API:** Same infrastructure metrics.
+
+### MongoDB Performance Patterns
+
+**WiredTiger Cache Pressure Pattern:**
+- Cache usage > 80% + app thread evictions > 0 = cache too small for working set
+- Dirty cache > 20% of total = checkpoint falling behind, writes accumulating
+- Read/write tickets depleted = operations queueing at storage engine level
+- Fix: increase service RAM (WiredTiger uses ~50% of available RAM for cache)
+
+**Query Efficiency Pattern:**
+- `scannedObjects >> docsReturned` = collection scans, missing indexes
+- Plan cache misses >> hits = frequent query re-planning, add indexes
+- Sort spill to disk > 0 = sorts exceeding 100MB memory limit, needs index
+
+**Connection Saturation Pattern:**
+- `connectionsCurrent` approaching `connectionsAvailable` = connection pool exhaustion
+- Many active ops with high microsecs_running = slow queries holding connections
+- Queued readers/writers > 0 = global lock contention
+
+**Oplog Pressure Pattern:**
+- Oplog usage > 80% = replication window shrinking
+- High write rate + small oplog = replicas may fall out of sync
+- timeDiffHours < 1 on busy systems = risk of replica resync
+
+### MongoDB Thresholds
+
+| Metric | Healthy | Warning | Critical |
+|--------|---------|---------|----------|
+| WT cache usage | <70% | 70-85% | >85% |
+| WT dirty % | <5% | 5-20% | >20% |
+| App thread evictions | 0 | 1-100 | >100 |
+| Connection usage | <70% | 70-85% | >85% |
+| Queued operations | 0 | 1-10 | >10 |
+| Scan-to-return ratio | <2x | 2-10x | >10x |
+
+## Infrastructure (7d + 24h)
+
+Show both windows side by side to compare trends:
+
+**7-Day Trends**
+| Metric | Current | Avg | Min | Max | Trend |
+|--------|---------|-----|-----|-----|-------|
+| CPU | 0.02 vCPU | 0.02 | 0.00 | 0.12 | stable |
+| Memory | 210 MB | 200 MB | 180 MB | 240 MB | stable |
+| Disk | 1.5 GB | 1.48 GB | 1.42 GB | 1.55 GB | increasing (+6%) |
+
+**Last 24 Hours**
+| Metric | Current | Avg | Min | Max | Trend |
+|--------|---------|-----|-----|-----|-------|
+| CPU | 0.03 vCPU | 0.02 | 0.00 | 0.12 | stable |
+| Memory | 210 MB | 205 MB | 195 MB | 240 MB | stable |
+| Disk | 1.5 GB | 1.49 GB | 1.48 GB | 1.51 GB | stable |
+
+Compare windows to distinguish sustained vs transient trends.
+
+Do NOT show cpu_limit/memory_limit columns or utilization %. Railway auto-scales — these limits are just the ceiling. See [analyze-db.md](analyze-db.md) autoscale rules.
+
+## MongoDB Autoscale Note
+
+See [analyze-db.md](analyze-db.md) for full autoscale rules. For MongoDB specifically:
+- WiredTiger uses ~50% of available RAM for cache by default. As Railway auto-scales the container, the cache ceiling grows automatically.
+- Do NOT recommend limiting WiredTiger cache to a fraction of the Railway memory limit — the limit is the autoscale ceiling, not fixed allocation.
+- If cache usage is consistently >80%, this indicates working set pressure — note it but do not tell the user to increase RAM manually.
+
+## Validated against
+
+- MongoDB serverStatus, db.stats(), system.profile, top admin command

--- a/.claude/skills/use-railway/references/analyze-db-mysql.md
+++ b/.claude/skills/use-railway/references/analyze-db-mysql.md
@@ -1,0 +1,254 @@
+# MySQL Analysis
+
+This reference covers MySQL-specific metrics, tuning, and analysis guidance.
+For common analysis patterns (output structure, collection status handling, performance thinking), see [analyze-db.md](analyze-db.md).
+
+## What the Script Collects
+
+**Via SSH (mysql -B):**
+- **SHOW GLOBAL STATUS:** threads connected/running, max used connections, query counts (select/insert/update/delete), InnoDB buffer pool stats, row lock waits/time, bytes sent/received, temp table stats, handler stats, table lock stats, aborted clients/connects
+- **SHOW VARIABLES:** max_connections, innodb_buffer_pool_size, long_query_time, version
+- **Table Sizes:** per-table rows, data length, index length, total size (top 15)
+- **Processlist:** active queries with user, database, command, time, state
+- **Top Queries (performance_schema):** digest text, call count, avg/total latency, rows examined/sent, temp disk tables, no-index flag
+
+**Via Railway API:** Same infrastructure metrics (CPU, memory, disk, network).
+
+## MySQL Metric Sections — Present ALL of These
+
+When the script returns MySQL data, present **every section below** with its metrics. This matches the full MySQL metrics view. Don't skip sections — if data is present, show it.
+
+### 1. Overview
+
+| Metric | JSON Path | How to Display |
+|--------|-----------|----------------|
+| Version | `overview.version` | As-is |
+| Uptime | `overview.uptime_seconds` | Format as Xd Xh Xm |
+| Connections | `overview.connection_usage_percent` | `XX%` with `threads_connected / max_connections` as sub-value |
+| Threads Running | `overview.threads_running` | As-is |
+| Aborted Clients | `overview.aborted_clients` | Warn if > 0 — apps not closing connections |
+| Aborted Connects | `overview.aborted_connects` | Warn if > 0 — auth failures or limit hits |
+
+**Presentation:**
+```
+| Metric | Value | Status |
+|--------|-------|--------|
+| Version | 9.4.0 | |
+| Uptime | 3d 12h | |
+| Connections | 45% (9 / 20) | OK |
+| Threads Running | 2 | |
+| Aborted Clients | 0 | OK |
+| Aborted Connects | 0 | OK |
+```
+
+### 2. Query Throughput
+
+| Metric | JSON Path | How to Display |
+|--------|-----------|----------------|
+| Total Queries | `query_throughput.questions` | Format with K/M suffix |
+| Slow Queries | `query_throughput.slow_queries` | Warn if > 0, show threshold from `long_query_time` |
+| SELECT | `query_throughput.com_select` | Format with K/M suffix |
+| INSERT | `query_throughput.com_insert` | Format with K/M suffix |
+| UPDATE | `query_throughput.com_update` | Format with K/M suffix |
+| DELETE | `query_throughput.com_delete` | Format with K/M suffix |
+
+Show the query mix distribution. A healthy OLTP workload is SELECT-heavy. INSERT/UPDATE-heavy suggests write pressure.
+
+### 3. InnoDB Row Operations
+
+| Metric | JSON Path |
+|--------|-----------|
+| Rows Read | `innodb_row_ops.rows_read` |
+| Rows Inserted | `innodb_row_ops.rows_inserted` |
+| Rows Updated | `innodb_row_ops.rows_updated` |
+| Rows Deleted | `innodb_row_ops.rows_deleted` |
+
+These are cumulative since server start. Compare read vs write ratios. A read-heavy workload with low row reads may indicate queries returning few results (good) or not using indexes (bad — cross-reference with table scan ratio).
+
+### 4. Query Efficiency
+
+| Metric | JSON Path | How to Interpret |
+|--------|-----------|------------------|
+| Temp Tables to Disk | `query_efficiency.tmp_disk_table_percent` | `XX%` (disk/total). > 10% = queries creating large temp results |
+| Table Scan Ratio | `query_efficiency.table_scan_percent` | `XX%`. > 50% = most reads are full scans — missing indexes |
+| Full Joins | `query_efficiency.select_full_join` | Warn if > 0. Joins without indexes — extremely expensive |
+| Range Selects | `query_efficiency.select_range` | Index range scans (good). Higher is better relative to full scans |
+| Sort Merge Passes | `query_efficiency.sort_merge_passes` | Warn if > 0. Sorts exceeding `sort_buffer_size` |
+
+**This section is critical for identifying missing indexes.** If table scan ratio is high AND specific top queries show `no_index_used > 0`, you can give precise index recommendations.
+
+### 5. InnoDB Buffer Pool
+
+| Metric | JSON Path | How to Display |
+|--------|-----------|----------------|
+| Cache Hit Ratio | `innodb_buffer_pool.hit_ratio` | `XX.X%`. The most important single metric |
+| Pool Usage | `innodb_buffer_pool.usage_percent` | `XX.X%` with `bytes_data / buffer_pool_size` as sub-value |
+| Data | `innodb_buffer_pool.bytes_data` | Format as MB/GB |
+| Dirty | `innodb_buffer_pool.bytes_dirty` | Format as MB/GB. Warn if significant |
+| Free Pages | `innodb_buffer_pool.pages_free` | Format with K/M suffix |
+
+**Analysis guidance:**
+- Hit ratio < 99% + usage > 95% = buffer pool too small for the working set
+- Hit ratio < 95% = severe cache pressure — increase `innodb_buffer_pool_size`
+- Dirty pages are modified pages not yet flushed to disk — high dirty count means heavy writes or slow I/O
+
+### 6. InnoDB I/O
+
+| Metric | JSON Path |
+|--------|-----------|
+| Data Reads | `innodb_io.data_reads` |
+| Data Writes | `innodb_io.data_writes` |
+
+Only show this section if reads or writes > 0. High data reads with low buffer pool hit ratio = cache misses causing disk I/O.
+
+### 7. Network
+
+| Metric | JSON Path |
+|--------|-----------|
+| Bytes Received | `network.bytes_received` |
+| Bytes Sent | `network.bytes_sent` |
+
+Format as KB/MB/GB. High bytes sent relative to received suggests large result sets being returned.
+
+### 8. Locks
+
+| Metric | JSON Path | How to Interpret |
+|--------|-----------|------------------|
+| Row Lock Waits | `locks.row_lock_waits` | Warn if > 0. InnoDB row-level lock contention |
+| Row Lock Time (ms) | `locks.row_lock_time` | Total time spent waiting for row locks |
+| Table Lock Waits | `locks.table_locks_waited` | Warn if > 0. Table-level lock contention |
+| Table Lock Contention | `locks.table_lock_contention` | `XX.X%` (waited / total). > 1% = investigate |
+
+Lock contention + long-running queries in processlist = transactions holding locks too long. Check for MyISAM tables if table lock contention is high.
+
+### 9. Table Cache
+
+| Metric | JSON Path |
+|--------|-----------|
+| Open Tables | `table_cache.open_tables` |
+| Opened Tables | `table_cache.opened_tables` |
+| Cache Hit % | `table_cache.cache_hit_percent` |
+
+Low cache hit = table_open_cache may be too small. Many opened_tables relative to open_tables means tables are being repeatedly opened and closed.
+
+### 10. Top Queries (from performance_schema)
+
+**This is the most actionable section.** Present as a table:
+
+```
+| Query | Calls | Avg Latency | Total Latency | Rows Examined | Rows Sent | Flags |
+|-------|-------|-------------|---------------|---------------|-----------|-------|
+| SELECT ... FROM orders WHERE... | 15.2K | 2.3ms | 35.1s | 1.2M | 15.2K | |
+| SELECT ... FROM users JOIN... | 8.1K | 12.5ms | 101.3s | 890K | 8.1K | ! No Index |
+```
+
+**Per-query analysis:**
+- `no_index_used > 0` → Flag with "! No Index" — these are the biggest optimization targets
+- `tmp_disk_tables > 0` → Query creates on-disk temp tables — needs optimization
+- High `rows_examined / rows_sent` ratio → Scanning many rows to return few — missing or suboptimal index
+- Truncate query text to essential parts (tables, WHERE clauses, JOINs). Don't dump full ORM SQL.
+
+**If `top_queries` is empty or null:** performance_schema is likely disabled — this is the default on Railway. Do not suggest enabling it without caveats: it requires ~400MB+ additional memory and is only advisable on larger instances. Just note that query-level data is unavailable.
+
+### 11. Tables
+
+```
+| Table | Rows | Data | Indexes | Total |
+|-------|------|------|---------|-------|
+| orders | 1.2M | 450 MB | 120 MB | 570 MB |
+| users | 50K | 12 MB | 8 MB | 20 MB |
+```
+
+Flag tables where index size is disproportionately large relative to data (possible unused indexes) or tables with many rows but no indexes (check with top queries).
+
+### 12. Active Queries
+
+Show if any non-Sleep, non-Daemon processes are running:
+
+```
+| User | Database | Command | Time (s) | Query |
+|------|----------|---------|----------|-------|
+| app | mydb | Query | 45 | SELECT ... |
+```
+
+Long-running queries (> 30s) warrant investigation. Cross-reference with lock waits — a long query may be holding locks that block others.
+
+## MySQL Performance Patterns
+
+**Buffer Pool Starvation Pattern:**
+- Hit ratio < 99% + pool usage > 95% = buffer pool too small for working set
+- High `Innodb_data_reads` confirms disk I/O from cache misses
+- Fix: increase `innodb_buffer_pool_size` (target 70-80% of available RAM)
+
+**Query Inefficiency Pattern:**
+- Table scan ratio > 50% = most reads are full scans, missing indexes
+- `Select_full_join` > 0 = joins without indexes, extremely expensive
+- Temp tables to disk > 10% = sorts/groups exceeding `tmp_table_size`
+- Top queries with `no_index_used > 0` = specific queries needing indexes
+
+**Lock Contention Pattern:**
+- `row_lock_waits` high + `row_lock_time` high = write contention
+- Table lock contention > 1% = may have MyISAM tables or DDL locks
+- Long-running queries in processlist holding locks
+
+**Connection Pattern:**
+- `connection_usage_percent > 70%` = approaching limit
+- `aborted_clients > 0` = connections not being closed properly (app bug or timeout)
+- `aborted_connects > 0` = authentication failures or connection limit hits
+
+## MySQL Thresholds
+
+| Metric | Healthy | Warning | Critical |
+|--------|---------|---------|----------|
+| Buffer pool hit ratio | > 99% | 95-99% | < 95% |
+| Buffer pool usage | < 85% | 85-95% | > 95% |
+| Connection usage | < 70% | 70-90% | > 90% |
+| Temp tables to disk | < 10% | 10-25% | > 25% |
+| Table scan ratio | < 50% | 50-75% | > 75% |
+| Table lock contention | < 1% | 1-5% | > 5% |
+| Full joins | 0 | 1-100 | > 100 |
+| Sort merge passes | 0 | > 0 | — |
+
+## MySQL Tuning Knowledge
+
+| Parameter | Default | Target | What It Does |
+|-----------|---------|--------|--------------|
+| `innodb_buffer_pool_size` | 128MB | 70-80% RAM | InnoDB's main cache. Equivalent to PostgreSQL's shared_buffers but should be much larger (70-80% vs 25%). |
+| `max_connections` | 151 | Based on load | Each connection uses memory. Over-provisioning wastes RAM. |
+| `tmp_table_size` / `max_heap_table_size` | 16MB | 64-256MB | Max size for in-memory temp tables. Larger = fewer disk temp tables. Both must be set together. |
+| `sort_buffer_size` | 256KB | 1-4MB | Per-connection sort buffer. Too large wastes memory (multiplied by connections). |
+| `long_query_time` | 10s | 1-2s | Threshold for slow query log. Lower = more visibility but more log volume. |
+| `table_open_cache` | 4000 | Based on tables | Number of open tables cached. Increase if `Opened_tables` grows rapidly. |
+
+## MySQL-Specific Notes
+
+- **`performance_schema=0` in start command** disables query-level metrics. This is the default on Railway. Note it when detected but do not recommend enabling it without caveats — it adds ~400MB+ memory overhead and is only practical on larger instances (2GB+ RAM).
+- **`disable-log-bin` in start command** means no binary logging — point-in-time recovery is not possible. Note if relevant.
+- **`innodb-use-native-aio=0`** is common on Railway (container filesystem limitation). Not a concern.
+- **Cumulative counters**: All SHOW GLOBAL STATUS values are cumulative since server start. Use uptime to compute rates (e.g., questions/uptime = queries per second).
+
+## Infrastructure (7d + 24h)
+
+Show both windows side by side to compare trends:
+
+**7-Day Trends**
+| Metric | Current | Avg | Min | Max | Trend |
+|--------|---------|-----|-----|-----|-------|
+| CPU | 0.03 vCPU | 0.02 | 0.00 | 0.15 | stable |
+| Memory | 480 MB | 460 MB | 420 MB | 510 MB | stable |
+| Disk | 2.8 GB | 2.7 GB | 2.6 GB | 2.9 GB | increasing (+8%) |
+
+**Last 24 Hours**
+| Metric | Current | Avg | Min | Max | Trend |
+|--------|---------|-----|-----|-----|-------|
+| CPU | 0.05 vCPU | 0.03 | 0.00 | 0.15 | stable |
+| Memory | 480 MB | 465 MB | 450 MB | 510 MB | stable |
+| Disk | 2.8 GB | 2.78 GB | 2.75 GB | 2.81 GB | stable |
+
+Compare windows to distinguish sustained vs transient trends.
+
+Do NOT show cpu_limit/memory_limit columns or utilization %. Railway auto-scales — these limits are just the ceiling. See [analyze-db.md](analyze-db.md) autoscale rules.
+
+## Validated against
+
+- MySQL SHOW GLOBAL STATUS, SHOW VARIABLES, information_schema, performance_schema

--- a/.claude/skills/use-railway/references/analyze-db-postgres.md
+++ b/.claude/skills/use-railway/references/analyze-db-postgres.md
@@ -1,0 +1,479 @@
+# PostgreSQL Analysis
+
+This reference covers PostgreSQL-specific metrics, tuning, and analysis guidance.
+For common analysis patterns (output structure, collection status handling, performance thinking), see [analyze-db.md](analyze-db.md).
+
+## What the Script Collects
+
+**`collection_status`** — check this FIRST. Shows what succeeded vs failed:
+- `database_query`: SSH → psql batched query (connections, cache, vacuum, queries, etc.)
+- `metrics_api`: Railway API for disk, CPU, memory
+- `logs_api`: Railway API for recent log lines
+- `ha_cluster`: SSH → Patroni REST API (HA services only)
+
+Each entry has `"status"` (`"success"`, `"error"`, or `"skipped"`) and optional `"error"` or `"reason"` fields.
+
+All in ONE operation (no additional queries needed):
+
+**Connections:**
+- Current/max/available counts
+- States (active, idle, idle_in_transaction)
+- By application name
+- By age (buckets: <1min, 1-5min, 5-60min, 1-24hr, >24hr)
+- Oldest connection age
+
+**Memory & Configuration:**
+- shared_buffers, effective_cache_size, work_mem, maintenance_work_mem
+- WAL settings, parallelism settings, planner settings
+- Autovacuum status
+- track_activity_query_size (tells you if queries are truncated in pg_stat_statements)
+- log_min_duration_statement (tells you if slow query logging is enabled and at what threshold)
+- idle_in_transaction_session_timeout, statement_timeout (safety timeouts)
+- track_io_timing (needed for blk_read_time/blk_write_time in query stats)
+
+**Cache Performance:**
+- Overall table/index hit ratios
+- Per-table: hit %, disk reads, size (this is key for diagnosis)
+
+**Storage:**
+- Database size, WAL size
+- Per-table: total size, data size, index size, row count
+
+**Vacuum Health:**
+- Per-table: dead rows, dead %, vacuum count, last vacuum/analyze, XID age
+- Flags: needs_vacuum, needs_freeze
+
+**Indexes:**
+- Unused indexes (0 scans) with sizes
+- Invalid indexes (failed builds)
+
+**Query Performance (if pg_stat_statements enabled):**
+- Top 100 queries by total execution time
+- Per-query execution: calls, total_min, mean_ms, min_ms, max_ms, stddev_ms
+- Per-query rows: total rows, rows_per_call
+- Per-query planning: total_plan_ms, mean_plan_ms
+- Per-query cache: shared_blks_hit, shared_blks_read, shared_blks_dirtied, shared_blks_written, cache_hit_pct
+- Per-query temp: temp_blks_read, temp_blks_written
+- Per-query I/O timing: blk_read_time_ms, blk_write_time_ms (requires track_io_timing=on)
+- Per-query WAL: wal_records, wal_bytes
+- Per-query local blocks: local_blks_hit, local_blks_read (for temp tables)
+- Temp file stats (cumulative since stats reset, NOT current disk usage)
+
+**Logs & Active Issues:**
+- `recent_logs`: Raw unfiltered logs (1000 lines) - parse these yourself, look for errors, warnings, patterns
+- `recent_errors`: Filtered error-level logs (legacy, for quick reference)
+- `long_running_queries`: Queries running >5s at time of collection
+- `blocked_queries`: Queries waiting on locks
+- `cluster_logs`: HA cluster events (Patroni)
+
+**Important:** Always analyze the raw `recent_logs` array thoroughly. This is 1000 lines of unfiltered database output — treat it as a goldmine.
+
+**Log analysis checklist — go through ALL of these:**
+
+1. **Error/Fatal/Panic messages**: Count them, categorize them, quote the exact messages
+   - `ERROR: deadlock detected` → cross-reference with deadlock count in database_stats
+   - `FATAL: too many connections` → cross-reference with connection usage
+   - `ERROR: canceling statement due to statement timeout` → which queries are timing out?
+   - `FATAL: out of shared memory` → shared_buffers or lock table exhaustion
+   - `ERROR: could not extend file` → disk space issue
+   - `PANIC: ...` → database crash, investigate immediately
+
+2. **Slow query log entries** (if `log_min_duration_statement` is set):
+   - Count how many slow queries appear
+   - Identify which tables/queries are mentioned most often
+   - Cross-reference with top_queries — the same patterns should appear in both
+   - Note the actual durations logged vs mean_ms from pg_stat_statements
+
+3. **Autovacuum activity**:
+   - `LOG: automatic vacuum of table` → is autovacuum running? How often?
+   - `LOG: automatic analyze of table` → statistics being updated
+   - `WARNING: oldest xmin is far in the past` → XID wraparound risk
+   - Absence of autovacuum entries with high dead rows → autovacuum may be blocked or misconfigured
+
+4. **Checkpoint activity**:
+   - `LOG: checkpoint starting` / `LOG: checkpoint complete` → how frequent?
+   - `checkpoint complete: wrote X buffers (Y%)` → high Y% means lots of dirty data
+   - Time between checkpoints — if < 5 minutes, write load is high
+   - `checkpoints are occurring too frequently` → increase max_wal_size
+
+5. **Connection patterns**:
+   - `LOG: connection received` / `LOG: connection authorized` → connection rate
+   - `LOG: disconnection` → normal or unexpected? Check session duration
+   - `FATAL: remaining connection slots are reserved` → max_connections hit
+   - `FATAL: password authentication failed` → unauthorized access attempts
+
+6. **Replication messages**:
+   - `LOG: started streaming WAL` → replica connected
+   - `ERROR: requested WAL segment has already been removed` → replica too far behind
+   - `FATAL: could not receive data from WAL stream` → replication broken
+
+7. **Temporal patterns**:
+   - Are errors clustered in time? (burst vs steady)
+   - Do slow queries correlate with checkpoint times?
+   - Is there a pattern suggesting cron jobs or batch processing?
+
+State what you found with specifics: "Analyzed 1000 log lines covering 2024-01-15 14:00 to 15:30. Found: 23 slow query warnings (all SELECT on UserSession table, 200-800ms), 4 autovacuum runs, 2 checkpoints (normal interval), 0 errors. The slow queries correlate with the UserSession table's 76% cache hit rate."
+
+### Log Interpretation When Only Logs Are Available
+
+When `collection_status.database_query` failed and you only have logs:
+
+**Startup vs steady-state logs:**
+- `LOG: database system is ready to accept connections` — normal startup, NOT evidence of a crash
+- `LOG: started streaming WAL` — normal replication, NOT an error
+- `LOG: checkpoint starting` / `LOG: checkpoint complete` — routine operation
+- `FATAL: the database system is starting up` — transient during restarts, NOT a persistent problem
+
+**What you CAN say from logs alone:**
+- Whether errors or warnings are present and their frequency
+- Whether the database recently restarted (and that this is normal during deploys)
+- Whether there are connection refused errors (possible saturation or startup)
+
+**What you CANNOT say from logs alone:**
+- Whether the database is performing well or poorly
+- Whether cache hit ratios are good
+- Whether vacuum is behind
+- Whether queries are slow
+- Any tuning recommendations
+
+If only logs are available, explicitly state: "No performance conclusions possible — database metrics were not collected."
+
+**Active Issues:**
+- Long-running queries (>5s)
+- Idle in transaction (>30s)
+- Blocked queries (waiting on locks)
+- Lock contention details
+
+**Infrastructure (7d + 24h)** — show both windows so trends can be compared:
+
+**7-Day Trends**
+| Metric | Current | Avg | Min | Max | Trend |
+|--------|---------|-----|-----|-----|-------|
+| CPU | 0.02 vCPU | 0.02 | 0.00 | 0.18 | stable |
+| Memory | 320 MB | 290 MB | 240 MB | 380 MB | stable |
+| Disk | 4.2 GB | 4.1 GB | 3.9 GB | 4.3 GB | increasing (+8%) |
+
+**Last 24 Hours**
+| Metric | Current | Avg | Min | Max | Trend |
+|--------|---------|-----|-----|-----|-------|
+| CPU | 0.04 vCPU | 0.02 | 0.00 | 0.18 | stable |
+| Memory | 320 MB | 295 MB | 270 MB | 340 MB | stable |
+| Disk | 4.2 GB | 4.15 GB | 4.1 GB | 4.2 GB | stable |
+
+Compare: "Disk growing slowly over 7d but stable over 24h → gradual data growth, not an acute event."
+
+Do NOT show cpu_limit/memory_limit columns or utilization %. Railway auto-scales — these limits are just the ceiling. See [analyze-db.md](analyze-db.md) autoscale rules.
+
+**Replication / HA (if applicable):**
+- Replication status
+- HA cluster status (Patroni)
+- Background writer stats
+- WAL archiver status
+
+## PostgreSQL Tuning Knowledge
+
+Use this to reason about configuration issues:
+
+### Memory Parameters
+
+| Parameter | Default | Target | What It Does |
+|-----------|---------|--------|--------------|
+| `shared_buffers` | 128MB | 25% RAM | The database's main cache. Pages read from disk go here. Too small = constant disk I/O. |
+| `effective_cache_size` | 4GB | 75% RAM | NOT memory allocation - a hint to the planner about OS cache. Too low = planner avoids indexes. |
+| `work_mem` | 4MB | 16-64MB | Memory per sort/hash/join operation. Too low = temp files on disk. Caution: multiplied by concurrent operations. |
+| `maintenance_work_mem` | 64MB | 256MB-1GB | Memory for VACUUM, CREATE INDEX. Higher = faster maintenance. |
+
+### Tuning Formulas
+
+```
+shared_buffers = RAM × 0.25 (max 40%)
+  1GB RAM  → 256MB
+  4GB RAM  → 1GB
+  16GB RAM → 4GB
+
+work_mem = (RAM / max_connections) / 4
+  4GB RAM, 100 conns → 10MB
+  8GB RAM, 200 conns → 10MB
+
+effective_cache_size = RAM × 0.75
+  4GB RAM  → 3GB
+  16GB RAM → 12GB
+```
+
+### Settings Requiring Restart vs Immediate
+
+**Restart required:**
+- shared_buffers
+- max_connections
+- max_parallel_workers
+
+**Immediate (SIGHUP):**
+- work_mem
+- effective_cache_size
+- random_page_cost
+- checkpoint_completion_target
+
+### SSD vs HDD
+
+Railway uses SSDs. If `random_page_cost = 4.0` (HDD default), the planner thinks random reads are 4x more expensive than sequential - it avoids index scans. Set to 1.1-2.0 for SSDs.
+
+### Railway auto-scales vertically
+
+See [analyze-db.md](analyze-db.md) for full autoscale rules. For PostgreSQL specifically:
+
+- Tune parameters relative to the **current** RAM from `metrics_history.memory.current`, not `memory_limit`.
+- If shared_buffers is undersized relative to current RAM, recommend increasing it to 25% of current RAM.
+- If the working set far exceeds what 25% of current RAM can hold, note this as a limitation of the current memory footprint — but do NOT tell the user to increase RAM. The platform handles that automatically.
+
+## Thresholds for Reasoning
+
+| Metric | Healthy | Warning | Critical |
+|--------|---------|---------|----------|
+| Cache hit ratio | >99% | 95-99% | <95% |
+| Per-table cache hit | >95% | 80-95% | <80% with high reads |
+| Connection usage | <70% | 70-90% | >90% |
+| Disk usage | <70% | 70-85% | >85% |
+| Dead rows % | <5% | 5-20% | >20% |
+| XID age | <100M | 100-150M | >150M (emergency at 2B) |
+
+### Vacuum Priority Matrix
+
+Dead row percentage alone doesn't determine urgency. Use this matrix:
+
+| Table Size | Dead Rows | Priority |
+|------------|-----------|----------|
+| > 100 MB | > 10,000 | High - real bloat affecting performance |
+| > 50 MB | > 5,000 | Medium - worth addressing |
+| < 10 MB | Any | Low - negligible impact, ignore |
+| Any | < 1,000 | Low - autovacuum will handle it |
+
+A 1 MB table with 25% dead rows has ~250 KB of bloat. Not worth mentioning as "critical".
+
+## Applying Fixes
+
+When recommending changes, include the actual SQL and **always explain side effects** — especially for settings that add overhead or change behavior.
+
+```sql
+-- Memory tuning (example for 4GB RAM)
+ALTER SYSTEM SET shared_buffers = '1GB';
+ALTER SYSTEM SET effective_cache_size = '3GB';
+ALTER SYSTEM SET work_mem = '32MB';
+ALTER SYSTEM SET random_page_cost = 1.5;
+SELECT pg_reload_conf();
+-- Note: shared_buffers requires restart
+```
+
+```sql
+-- Vacuum specific tables
+VACUUM ANALYZE "TableName";
+
+-- Emergency XID freeze
+VACUUM FREEZE "TableName";
+```
+
+### Side effects to document per setting
+
+| Setting | Side Effect to Explain |
+|---------|----------------------|
+| `track_io_timing` | Adds a system call (gettimeofday) per block read/write. On most modern systems the overhead is <1%, but on systems with slow clock sources it can be measurable. Worth it for the diagnostic value in pg_stat_statements (blk_read_time, blk_write_time). |
+| `shared_buffers` | Requires restart. Allocates memory at startup — over-allocating can starve OS cache and other processes. |
+| `work_mem` | Multiplied by concurrent operations (sorts, hashes, joins). 64MB × 50 concurrent ops = 3.2 GB. Recommend conservatively. |
+| `log_min_duration_statement` | Logging slow queries adds I/O. A threshold too low (e.g., 100ms) on a high-throughput DB can generate massive log volume. Start at 1000ms. |
+| `idle_in_transaction_session_timeout` / `statement_timeout` | Will kill queries/transactions that exceed the timeout. Existing application code that relies on long-running transactions or queries will break. Warn the user to verify their application can handle this. |
+
+## Enabling pg_stat_statements
+
+**ONLY suggest this if BOTH conditions are true:**
+1. `pg_stat_statements_installed` is `false` in the JSON output
+2. `top_queries` is empty or missing
+
+If these conditions are met, tell the user to run (do NOT execute with Bash):
+
+```
+python3 scripts/enable-pg-stats.py --service <name>
+```
+
+This may require a brief restart.
+
+**If `pg_stat_statements_installed: true` and `top_queries` has data, DO NOT suggest enabling it.**
+
+---
+
+## PostgreSQL-Specific Guidance
+
+The sections below apply specifically to PostgreSQL analysis via `scripts/analyze-postgres.py`.
+
+## How to Think About PostgreSQL Performance
+
+### The Core Question
+
+When you see a problem, ask: **What is the chain of causation?**
+
+Example chain:
+1. Cache hit is 89% (symptom)
+2. Email table has 6% cache hit with 1.19B disk reads (deeper symptom)
+3. Email table is 1.7GB, shared_buffers is 128MB (root cause)
+4. The table is 13x larger than the buffer pool - it will NEVER fit in cache
+5. Every query touching Email forces disk I/O
+
+**This reasoning is what you provide. The script gives you the data points - you connect them.**
+
+### Patterns to Look For
+
+**Memory Starvation Pattern:**
+- Low cache hit + large tables + small shared_buffers = working set doesn't fit
+- High temp files + low work_mem = sorts/hashes spilling to disk
+- These often occur together - both indicate the database needs more memory
+
+**Important:** Temp file stats (`temp_files`, `temp_bytes`) are **cumulative since the last stats reset**, not current disk usage. When reporting, say "X GB written to temp files since stats reset" - not "X GB on disk right now".
+
+**Vacuum Neglect Pattern:**
+- High dead rows % + "never" vacuum timestamps = autovacuum isn't keeping up
+- Multiple tables with >10% dead rows = systemic issue, not one-off
+- High XID age + vacuum issues = potential wraparound emergency
+
+**Important:** Consider **absolute impact**, not just percentage. A tiny table (< 10 MB) with 20% dead rows has negligible impact - vacuuming it reclaims almost nothing. Prioritize tables with BOTH high dead row counts (thousands+) AND meaningful size (tens of MB+). Don't mark small tables as "critical" just because of a high percentage.
+
+**Missing Index Pattern:**
+- High seq_scan count + 0 idx_scans on large tables = queries scanning full tables
+- Low cache hit on specific tables + high seq_scans = indexes would help AND reduce I/O
+
+**Connection Pressure Pattern:**
+- High connection % + many idle connections = connection pooling needed
+- Old connections (days) + idle_in_transaction = potential connection leaks or stuck transactions
+
+### Slow Query Analysis — Go Deep
+
+The `top_queries` array is the **most valuable data** for customers. This is where you can give the most actionable, specific advice. Don't skim it — analyze every query in the top 10-15 thoroughly.
+
+#### Per-Query Fields and What Each Tells You
+
+| Field | What It Means | How to Interpret |
+|-------|---------------|------------------|
+| `calls` | Number of times this query pattern executed | High calls × even small mean_ms = huge cumulative impact. A 5ms query called 10M times = 833 minutes of DB time |
+| `total_min` | Total execution time in minutes | The primary sort key. This is the query's total footprint on the database |
+| `mean_ms` | Average execution time per call | Compare with stddev — if stddev >> mean, the query has wildly variable performance |
+| `min_ms` / `max_ms` | Fastest and slowest execution | A 2ms min with 30,000ms max means the query sometimes hits pathological cases (lock waits, cache misses, bloated tables) |
+| `stddev_ms` | Standard deviation of execution time | High stddev = unpredictable. The query probably performs well when data is cached but terribly when it's not. This is often the query causing random user-visible latency spikes |
+| `rows_per_call` | Average rows returned per execution | 0.01 rows/call means the query usually returns nothing — might be a polling pattern or existence check that could use EXISTS instead. 50,000 rows/call suggests missing pagination or bulk fetch |
+| `mean_plan_ms` | Average planning time | If plan time is >5ms, the planner is spending significant time. Could indicate: too many partitions, complex joins needing better statistics (`ALTER TABLE SET STATISTICS`), or pg_catalog bloat |
+| `cache_hit_pct` | % of blocks found in shared_buffers | <90% = query is constantly going to disk. Cross-reference with the table it touches in `cache_per_table` |
+| `shared_blks_read` | Blocks read from disk (not cache) | This is the raw I/O cost. Each block = 8KB. 1M blocks read = 8GB of disk I/O |
+| `shared_blks_dirtied` | Blocks this query modified | High dirtied blocks = write-heavy query. These blocks will need to be flushed to disk during checkpoints |
+| `shared_blks_written` | Blocks this query had to flush to disk itself | Should be 0 in a healthy system. >0 means the query was forced to do its own I/O because shared_buffers was full of dirty pages — a sign of severe memory pressure |
+| `temp_blks_read` / `temp_blks_written` | Blocks spilled to temp files | Any nonzero value means the query exceeded work_mem. Each block = 8KB. temp_blks_written of 1M = 8GB spilled to disk for sorts/hashes |
+| `blk_read_time_ms` / `blk_write_time_ms` | Time spent on actual disk I/O (requires `track_io_timing`) | If available and high, this tells you exactly how much time was spent waiting on disk vs CPU. If 0, track_io_timing may be off |
+| `wal_records` / `wal_bytes` | WAL generated by this query | High WAL = write-heavy. If one query generates most WAL, it's driving replication lag and checkpoint pressure |
+| `local_blks_hit` / `local_blks_read` | Blocks for temporary tables | If nonzero, query uses temp tables — common in complex CTEs or materialized subqueries |
+
+#### Red Flags — What Demands Explanation
+
+| Signal | What It Means | Example | What to Tell the Customer |
+|--------|---------------|---------|---------------------------|
+| Low cache_hit_pct (< 90%) | Query hitting disk constantly | `cache_hit_pct: 47.19` | "This query reads X blocks from disk each call. The table it touches (Y) is Z GB but shared_buffers is only W MB — the data physically cannot stay cached" |
+| High temp_blks (any nonzero) | Query spilling sorts/hashes to disk | `temp_blks_written: 39102928` | "This query spills ~X GB to temp files per execution because work_mem (Y MB) is too small for its sort/hash. Each spill means disk I/O instead of memory" |
+| Huge rows_per_call (>1000) | Missing pagination or bulk fetch | `rows_per_call: 12177` | "Each call returns ~12K rows. If this is a user-facing query, it likely needs LIMIT/OFFSET or cursor-based pagination. If it's a batch job, it's expected" |
+| Near-zero rows_per_call with high calls | Polling or existence check pattern | 0.01 rows/call, 500K calls | "This query runs 500K times but almost never finds data. If it's checking for new work, consider LISTEN/NOTIFY instead of polling. If it's an existence check, ensure it uses EXISTS with LIMIT 1" |
+| stddev >> mean | Wildly variable performance | mean=15ms, stddev=2400ms, max=45000ms | "This query averages 15ms but sometimes takes 45 SECONDS. The high stddev means unpredictable latency. Likely causes: lock contention, cache misses on cold data, or table bloat causing variable scan times" |
+| High mean_plan_ms (>5ms) | Expensive query planning | `mean_plan_ms: 23.4` | "The planner spends 23ms just deciding HOW to run this query, before executing it. With X calls, that's Y minutes of pure planning overhead. Consider: PREPARE'd statements, simpler joins, or increasing default_statistics_target for better stats" |
+| shared_blks_written > 0 | Memory pressure forcing query I/O | `shared_blks_written: 50000` | "This query was forced to flush dirty pages to disk itself because shared_buffers was full. This is a sign of severe buffer pool pressure — increase shared_buffers" |
+| High wal_bytes relative to others | Write-heavy query driving replication | `wal_bytes: 5000000000` | "This query generates X GB of WAL, which is Y% of total WAL. It's the primary driver of replication lag and checkpoint I/O" |
+| max_ms >> 10× mean_ms | Pathological worst cases | mean=50ms, max=120000ms | "The worst execution was 2400× slower than average. Investigate: was it blocked by a lock? Did it hit a cold cache after restart? Is there table bloat causing some scans to be much longer?" |
+
+#### How to Present Slow Queries
+
+**Show the full table first** with all available metrics (the report already includes these columns):
+
+```
+| Query (truncated) | Calls | Total (min) | Mean (ms) | Min/Max (ms) | Stddev | Rows/Call | Cache Hit | Temp R/W | Plan (ms) | I/O Time |
+|-------------------|-------|-------------|-----------|--------------|--------|-----------|-----------|----------|-----------|----------|
+| SELECT Email.ccFull... | 78K | 132 | 101 | 0.3/8200 | 340 | 0.05 | 47% | 0/0 | 1.2 | 45000 |
+| SELECT Thread... ORDER BY | 48K | 223 | 279 | 2.1/45000 | 2400 | 12,177 | 98.8% | 0/39M | 0.4 | 800 |
+| SELECT Content... | 1.3K | 12 | 563 | 180/3200 | 420 | 0.65 | 1.8% | 0/0 | 8.3 | 31000 |
+```
+
+**Then analyze EACH query** — this is the most valuable part. For each of the top 10 queries, explain:
+
+1. **What the query does** — identify the tables, the pattern (lookup, join, aggregation, pagination)
+2. **Why it's slow** — connect the specific metrics to a root cause
+3. **The cascading impact** — how this query affects overall database health
+4. **Specific fix** — not generic advice, but targeted to what the metrics show
+
+Example deep analysis:
+
+> **Query 1: Email.ccFull join** (78K calls, 101ms mean, 132 min total)
+> - **Pattern**: Joins Email → EmailThreadKind → Thread → EmailEntry. ORM-generated N+1 or bulk join.
+> - **Root cause**: 47% cache hit means 53% of blocks come from disk. The Email table is 1.7GB but shared_buffers is 128MB — only 7.5% of this table can be cached at once. Every call displaces other data from cache, creating a cascading eviction problem.
+> - **The stddev of 340ms** with max of 8200ms means some calls take 80× longer — likely when the needed pages were just evicted by another query.
+> - **I/O time of 45,000ms** total confirms this: the query has spent 45 seconds just waiting for disk across all calls.
+> - **rows_per_call = 0.05** means it almost never finds a match — it's doing all this I/O for an existence-check pattern. An `EXISTS()` subquery with proper index could eliminate the full table scan.
+> - **Fix**: (a) Increase shared_buffers to 1GB so the hot portion stays cached. (b) Add index on Email(ccFull, threadId) to avoid the sequential scan. (c) Rewrite as EXISTS if the app only needs presence, not the full row.
+
+> **Query 2: Thread pagination** (48K calls, 279ms mean, 223 min total)
+> - **Pattern**: SELECT Thread... ORDER BY with large result set. Pagination query.
+> - **Root cause**: rows_per_call = 12,177 — returning 12K rows per call is a pagination bug (missing LIMIT) or an admin/batch endpoint.
+> - **temp_blks_written = 39M** (312 GB of temp files!) — the ORDER BY creates a sort that exceeds work_mem (4MB), so it spills to disk every single time.
+> - **stddev = 2400ms with max = 45,000ms** — some executions take 45 seconds, likely when disk temp files compete with other I/O.
+> - **Cache hit is 98.8%** — the data itself is cached, but the sort still spills because work_mem is separate from shared_buffers.
+> - **Fix**: (a) Add `LIMIT` if this is user-facing. (b) Create an index matching the ORDER BY clause to eliminate the sort entirely. (c) Increase work_mem to 32-64MB so the sort fits in memory.
+
+#### Truncate Long Queries Intelligently
+- Show the table names and key operations (JOIN, WHERE, ORDER BY)
+- Don't dump 2000-character ORM-generated SQL
+- Identify the pattern: "Thread zone assignment lookup" not the full SQL
+- For ORM queries with `$1, $2, ...` parameters, note that the actual values aren't available — the pattern matters more than specific values
+- **Note on query truncation**: pg_stat_statements stores full query text up to `track_activity_query_size` (default 1024 chars). ORM-generated queries often exceed this — if a query ends abruptly, it was truncated by PostgreSQL, not by our script. The JSON output preserves the full text from pg_stat_statements; only the human-readable text report truncates for display
+
+#### Query Workload Profile
+
+After analyzing individual queries, summarize the overall workload:
+- **Read vs write ratio**: Use tup_returned/tup_fetched vs tup_inserted/tup_updated/tup_deleted from database_stats
+- **Top 3 time consumers**: Which queries dominate total_min? If 3 queries account for 80% of execution time, that's where to focus
+- **Cache pressure sources**: Which queries have the most shared_blks_read? They're driving cache misses for everything else
+- **Temp file culprits**: Which specific queries create temp files? Don't say "increase work_mem" generically — say "Query X creates Y GB of temp files per day"
+- **WAL generators**: If applicable, which queries generate the most WAL bytes? They're driving replication lag
+
+### Correlate Across Sections
+
+The script collects many data points. Look for correlations:
+
+| If you see... | Check also... | Because... |
+|---------------|---------------|------------|
+| Low table cache hit | per-table cache rates, table sizes vs shared_buffers | One large table may be thrashing the cache |
+| High temp files | work_mem value, top queries | Specific queries may be the culprits |
+| Dead rows building up | vacuum health, XID age | Autovacuum may be blocked or misconfigured |
+| Seq scans on large tables | unused indexes, index hit rates | May have indexes but planner isn't using them |
+| High connection usage | connection age, idle_in_transaction | May be leaks, not actual load |
+
+### Synthesize Insights the Script Can't
+
+The script flags individual issues. You should:
+
+1. **Identify the PRIMARY bottleneck** - What's the #1 thing hurting performance right now?
+2. **Explain cascading effects** - How does one problem cause others?
+3. **Prioritize fixes** - What should they do first, second, third?
+4. **Warn about risks** - What happens if they don't fix this?
+
+**Important:** Synthesis is prose that EXPLAINS the data tables you already showed. Don't hide data in prose - the tables make it visible, the prose connects the dots.
+
+Example flow:
+1. Show config table: `shared_buffers = 128 MB` vs recommended `1 GB`
+2. Show cache table: `Email` table at 6% cache hit with 1.19B disk reads
+3. THEN explain: "Your buffer pool (128 MB) is 13x smaller than your Email table (1.7 GB). This single table is dragging down your overall 89% cache hit rate."
+
+The user sees the data, understands the relationship, then gets the explanation. Don't make them trust your conclusions without seeing the evidence first.
+
+## Common Errors to Avoid (PostgreSQL-Specific)
+
+- Saying "enable pg_stat_statements" when `pg_stat_statements_installed: true` and `top_queries` has data
+- Misreporting connection usage (check `percent` field, not just `current`)
+- Ignoring the `oldest_connections` details when flagging old connections
+- Saying "746 GB of temp files on disk" when temp_bytes is cumulative since stats reset
+- Marking tiny tables (< 10 MB) as "critical" for vacuum just because of high dead row percentage
+- Listing slow queries by total_time only without analyzing cache_hit_pct, temp_blks, and rows returned
+- Dumping full ORM-generated SQL instead of summarizing the query pattern
+
+## Validated against
+
+- PostgreSQL system views: pg_stat_activity, pg_stat_statements, pg_statio_user_tables, pg_stat_user_tables
+- Patroni REST API for HA clusters

--- a/.claude/skills/use-railway/references/analyze-db-redis.md
+++ b/.claude/skills/use-railway/references/analyze-db-redis.md
@@ -1,0 +1,208 @@
+# Redis Analysis
+
+This reference covers Redis-specific metrics, tuning, and analysis guidance.
+For common analysis patterns (output structure, collection status handling, performance thinking), see [analyze-db.md](analyze-db.md).
+
+## What the Script Collects
+
+**Via SSH (`INFO ALL`):**
+- **Overview:** version, uptime, connected/blocked clients, rejected connections
+- **Memory:** used/RSS/peak memory, fragmentation ratio, maxmemory, eviction policy
+- **Throughput:** ops/sec, total commands processed, total connections
+- **Cache Performance:** keyspace hits/misses, hit rate, expired/evicted keys
+- **Persistence:** RDB last save time/status, AOF enabled/status
+- **Command Stats:** per-command call count, avg latency, total time (sorted by calls)
+- **Keyspace:** per-database key count, expires, avg TTL
+- **Slow Log:** count via `SLOWLOG LEN` + actual entries via `SLOWLOG GET 20` (command, duration, timestamp)
+- **Biggest Keys:** via `redis-cli --bigkeys` — runs **remotely over SSH** on the Railway service, not locally
+
+**Via Railway API:** Same infrastructure metrics (disk, CPU, memory, network with **7d and 24h trends**).
+
+## Presentation Template
+
+Present Redis analysis using grouped stat cards that mirror the sections below. Each section is a labeled group with key-value stat cards. Flag values with status indicators (healthy/warning/critical) using the thresholds table.
+
+### Full Report (SSH + Metrics + Logs all succeeded)
+
+**Overview**
+| Version | Uptime | Connected Clients | Blocked Clients | Rejected Connections | Total Keys |
+|---------|--------|-------------------|-----------------|----------------------|------------|
+| 7.2.4 | 14d 6h | 23 | 0 | 0 | 48,291 |
+
+Flag: blocked clients > 0 = warning, rejected connections > 0 = critical.
+
+**Memory**
+| Used Memory | RSS Memory | Peak Memory | Fragmentation Ratio | Max Memory | Eviction Policy |
+|-------------|------------|-------------|---------------------|------------|-----------------|
+| 12.4 MB | 18.2 MB | 15.1 MB | 1.47 | Unlimited | noeviction |
+
+Flag: fragmentation > 1.5 = warning, > 2.0 or < 1.0 = critical. Evicted keys > 0 with noeviction = problem.
+
+**Throughput**
+| Ops/sec | Total Commands | Total Connections | Slow Log Entries |
+|---------|----------------|-------------------|------------------|
+| 1,240 | 8.4M | 12,491 | 3 |
+
+Flag: slow log > 100 = warning.
+
+**Cache Performance**
+| Hit Rate | Hits | Misses | Expired Keys | Evicted Keys |
+|----------|------|--------|--------------|--------------|
+| 97.2% | 6.1M | 178K | 892K | 0 |
+
+Flag: hit rate >= 95% = healthy, 80-95% = warning, < 80% = critical. Evicted > 0 = warning.
+
+**Persistence**
+| RDB Last Save | RDB Status | AOF Enabled | AOF Rewrite Status |
+|---------------|------------|-------------|-------------------|
+| 2 min ago | ok | Yes | ok |
+
+Flag: RDB status != ok = critical. AOF rewrite status != ok = critical.
+
+**Command Stats** (top 20 by calls)
+| Command | Calls | Avg Latency | Total Time |
+|---------|-------|-------------|------------|
+| GET | 4.2M | 3.1µs | 13.0s |
+| SET | 2.1M | 4.8µs | 10.1s |
+| HGET | 890K | 5.2µs | 4.6s |
+| EXPIRE | 620K | 2.1µs | 1.3s |
+
+**Slow Log Entries** (if collected — up to 20 most recent)
+| # | Timestamp | Duration | Command |
+|---|-----------|----------|---------|
+| 1 | 2m ago | 12.3ms | GET user:session:abc123... |
+| 2 | 5m ago | 10.1ms | GET cache:render:page/home... |
+| 3 | 12m ago | 8.7ms | HGETALL product:catalog:main |
+
+Analysis: correlate slow commands with command stats and big keys. If slowlog shows GET and bigkeys shows large strings, the diagnosis is "large values causing high GET latency" — confirmed without user intervention.
+
+**Biggest Keys** (if collected — one per type)
+| Type | Key | Size/Count |
+|------|-----|------------|
+| string | cache:render:page/dashboard | 2.1 MB |
+| hash | user:sessions | 14,291 fields |
+| list | queue:notifications | 8,402 items |
+
+Analysis: large keys cause latency spikes on read/write/delete. Cross-reference with slowlog — if the slow commands target these keys, that's the root cause. If bigkeys shows nothing large (all < 1KB), latency issues are likely volume-driven, not value-size-driven.
+
+**Keyspace**
+| Database | Keys | Expires | Avg TTL |
+|----------|------|---------|---------|
+| db0 | 48,291 | 31,204 | 2.4h |
+
+**Infrastructure (7d + 24h)** — show both windows so trends can be compared:
+
+**7-Day Trends**
+| Metric | Current | Avg | Min | Max | Trend |
+|--------|---------|-----|-----|-----|-------|
+| CPU | 0.01 vCPU | 0.01 | 0.00 | 0.10 | stable |
+| Memory | 70 MB | 40 MB | 30 MB | 90 MB | stable |
+| Disk | 1.1 GB | 1.11 GB | 1.07 GB | 1.16 GB | stable |
+
+**Last 24 Hours**
+| Metric | Current | Avg | Min | Max | Trend |
+|--------|---------|-----|-----|-----|-------|
+| CPU | 0.01 vCPU | 0.01 | 0.00 | 0.07 | stable |
+| Memory | 70 MB | 55 MB | 30 MB | 90 MB | increasing (+58%) |
+| Disk | 1.1 GB | 1.11 GB | 1.07 GB | 1.16 GB | stable |
+
+Compare: "Memory increasing in 24h but stable over 7d → temporary spike, not a sustained trend."
+
+Do NOT show cpu_limit/memory_limit columns or utilization %. Railway auto-scales — these limits are just the ceiling. See [analyze-db.md](analyze-db.md) autoscale rules.
+
+### Partial Report (Introspection failed, only Metrics + Logs)
+
+When introspection fails, you have NO Redis INFO data — all overview, memory, throughput, cache, persistence, command stats, and keyspace fields will be null/empty.
+
+**NEVER suggest running `redis-cli` without pointing to the remote Railway service host.** There is no local Redis instance — all redis-cli commands must target the Railway service. If you cannot connect, the fix is to restore remote access (see `analyze-db.md`), not to run commands locally.
+
+**You MUST:**
+1. State clearly: "Redis introspection failed — could not connect to the service"
+2. Show collection status errors
+3. Show ONLY infrastructure metrics and log analysis — do not show empty stat card sections
+4. Do NOT produce recommendations based on null Redis metrics
+
+**Show the infrastructure table** (same as full report).
+
+**Analyze logs thoroughly:**
+- AOF rewrite frequency and growth % triggers
+- fsync warnings ("disk is busy?")
+- OOM warnings
+- Connection errors
+- Startup/restart events (note these are normal during deploys)
+- Summarize with counts: "Analyzed 1000 lines: 18 AOF rewrites, 1 fsync warning, 0 errors"
+
+**State what you cannot determine** without SSH:
+- Connection health (clients, blocked, rejected)
+- Memory usage and fragmentation
+- Cache hit rate
+- Eviction status
+- Command workload profile
+- Keyspace composition
+- Slow log entries and actual slow commands
+- Biggest keys per type
+
+## Redis Performance Patterns
+
+**Memory Fragmentation Pattern:**
+- `mem_fragmentation_ratio > 1.5` = memory is fragmented, RSS much higher than used
+- Caused by frequent small key deletions creating memory holes
+- Fix: restart Redis, or enable `activedefrag yes` (Redis 4.0+)
+- Ratio < 1.0 means Redis is using swap — critical performance issue
+
+**Cache Thrashing Pattern:**
+- Hit rate < 80% + evicted keys > 0 = working set exceeds maxmemory
+- Check maxmemory_policy — `noeviction` will reject writes, `allkeys-lru` will evict
+- If maxmemory is 0 (unlimited), Redis will consume all RAM until OOM killed
+
+**Connection Rejection Pattern:**
+- rejected_connections > 0 = maxclients limit hit
+- Check connected_clients vs maxclients default (10,000)
+- Blocked clients = operations waiting on BLPOP/BRPOP/WAIT
+
+**Persistence Risk Pattern:**
+- RDB last save failed + no AOF = data loss risk on restart
+- Check disk space if saves are failing
+- Long time since last save = more data at risk
+
+**AOF Rewrite Churn Pattern:**
+- Frequent AOF rewrites (every 1-2 hours) with high growth % triggers (100-800%)
+- Indicates high write-to-data-size ratio — small dataset with heavy writes
+- Check Fork CoW size to gauge actual data size vs AOF overhead
+- If rewrites are fast (<1s) and CoW is small (<10 MB), this is noisy but harmless
+- If rewrites are slow or CoW is large, investigate write patterns
+
+**Disk Sawtooth Pattern:**
+- Disk usage oscillating in a regular pattern = AOF growing between rewrites, then compacting
+- Normal behavior — the baseline is volume overhead + AOF base file
+- If the amplitude is growing over time, data size is increasing
+
+## Redis Thresholds
+
+| Metric | Healthy | Warning | Critical |
+|--------|---------|---------|----------|
+| Hit rate | >95% | 80-95% | <80% |
+| Fragmentation ratio | 1.0-1.5 | 1.5-2.0 | >2.0 or <1.0 |
+| Evicted keys | 0 | >0 | Growing rapidly |
+| Blocked clients | 0 | 1-5 | >5 |
+| Connected clients | <80% maxclients | 80-90% | >90% |
+
+## Redis Command Stats Analysis
+
+The top commands by call count reveal the workload pattern:
+- **GET/SET dominant** = simple key-value cache
+- **HGET/HSET dominant** = hash-based data model (sessions, objects)
+- **LPUSH/RPOP dominant** = queue pattern
+- **High KEYS/SCAN** = application iterating keys (potential performance issue at scale)
+- **High latency on simple commands** (>100µs for GET) = memory pressure or CPU saturation
+
+## Redis Autoscale Note
+
+See [analyze-db.md](analyze-db.md) for full autoscale rules. For Redis specifically:
+- If `maxmemory` is set, compare it against actual memory usage — not the Railway memory limit.
+- If `maxmemory` is 0 (unlimited), Redis will grow until the OS kills it. This is the default Railway config and works fine with autoscaling — Redis uses what it needs and Railway scales the container.
+- Do NOT recommend setting maxmemory to a fraction of the Railway memory limit — the limit is the autoscale ceiling, not fixed allocation.
+
+## Validated against
+
+- Redis INFO command, SLOWLOG LEN, SLOWLOG GET, and --bigkeys

--- a/.claude/skills/use-railway/references/analyze-db.md
+++ b/.claude/skills/use-railway/references/analyze-db.md
@@ -1,0 +1,339 @@
+# Database Analysis
+
+## Your Role
+
+You are a database performance expert. The script collects raw data - your job is to **think deeply** about what you see, identify root causes, correlate symptoms, and explain the "why" behind problems.
+
+**Don't just report metrics. Analyze them.**
+
+## Context Resolution
+
+The user's request is the source of truth. Use this decision table:
+
+| What the user provided | Action |
+|------------------------|--------|
+| Railway URL | Extract IDs directly from the URL — do NOT run `railway status --json` |
+| Service name + environment name | Proceed — intent is clear. Resolve IDs via API. |
+| Service name only (no environment) | Find the service by name via API. If multiple matches exist across projects, ask: "Which project do you mean?" Otherwise confirm: "Do you mean `<service>` in `<project>` / `<env>`?" — only proceed on confirmation |
+| Raw UUID(s) | Resolve to human-readable names via API, then confirm before running |
+| Vague request ("analyze my database", "check postgres") | Run `railway status --json` to see what's linked. If it's a database service, confirm: "Do you mean `<service>` in `<project>` / `<env>`?". If it's not a database service or nothing is linked, ask: "Which service and environment should I analyze?" |
+| No context at all | List workspaces (`railway whoami --json`), then projects (`railway project list --json`), then environments and services for the chosen project, narrowing down until you have a specific service and environment |
+
+`railway status --json` is a hint to form a specific question, not a trigger to act without confirmation.
+
+**When the user provides a Railway URL**, extract IDs directly from it:
+
+```
+https://railway.com/project/<PROJECT_ID>/service/<SERVICE_ID>?environmentId=<ENV_ID>
+https://railway.com/project/<PROJECT_ID>/service/<SERVICE_ID>/database?environmentId=<ENV_ID>
+```
+
+Then query the API for the service name and database type in a **single call**:
+
+```bash
+scripts/railway-api.sh \
+  'query getServiceAndConfig($serviceId: String!, $environmentId: String!) {
+    service(id: $serviceId) { name }
+    environment(id: $environmentId) {
+      config(decryptVariables: false)
+    }
+  }' \
+  '{"serviceId": "<SERVICE_ID>", "environmentId": "<ENV_ID>"}'
+```
+
+From the response, get:
+- **Service name**: `data.service.name`
+- **Database image**: `data.environment.config.services.<SERVICE_ID>.source.image`
+
+Then match the image to the database type:
+
+| Image pattern | Database Type |
+|--------------|---------------|
+| `postgres*`, `ghcr.io/railway/postgres*` | PostgreSQL |
+| `mysql*`, `ghcr.io/railway/mysql*` | MySQL |
+| `redis*`, `ghcr.io/railway/redis*`, `railwayapp/redis*` | Redis |
+| `mongo*`, `ghcr.io/railway/mongo*` | MongoDB |
+
+**If `environmentId` is empty in the URL** (e.g., `?environmentId=` or no query param at all), skip the `environment.config` query — it requires a valid ID. Instead, list the project's environments:
+
+```bash
+scripts/railway-api.sh \
+  'query getEnvs($id: String!) { project(id: $id) { environments { edges { node { id name } } } } }' \
+  '{"id": "<PROJECT_ID>"}'
+```
+
+Use the `production` environment by default. If multiple non-PR environments exist and the user hasn't specified one, ask which environment to analyze.
+
+## Database Type Detection and Script Selection
+
+| Database Type | Script |
+|---------------|--------|
+| PostgreSQL | `scripts/analyze-postgres.py` |
+| MySQL | `scripts/analyze-mysql.py` |
+| Redis | `scripts/analyze-redis.py` |
+| MongoDB | `scripts/analyze-mongo.py` |
+
+**All scripts share the same CLI interface** (use the script name from the table above):
+```bash
+python3 scripts/analyze-<script>.py \
+  --service <name> \
+  --json \
+  --project-id <project-id> \
+  --environment-id <env-id> \
+  --service-id <service-id>
+```
+
+Common options across all scripts:
+- `--json` — JSON output for programmatic processing
+- `--quiet` — Suppress progress messages
+- `--skip-logs` — Skip log collection
+- `--metrics-hours <N>` — Hours of metrics history (default: 24, max: 168)
+- `--step <step>` — Debug individual collection steps (ssh-test, query, logs, metrics)
+
+## Before You Analyze: Check Collection Status
+
+**ALWAYS check `collection_status` and `errors[]` FIRST before interpreting any data.** The script collects data from multiple independent sources. Any of them can fail.
+
+### Decision Table
+
+| database_query | metrics_api | logs_api | Report Type |
+|---------------|-------------|----------|-------------|
+| success | success | success | Full analysis — use all sections |
+| success | error | success | Full analysis — note missing infrastructure metrics |
+| **error** | success | success | **Partial report** — only infrastructure metrics + log analysis. NO performance conclusions. |
+| **error** | error | success | **Logs-only report** — state what logs show, note everything else failed. NO diagnosis. |
+| **error** | **error** | **error** | **Collection failure** — report the errors, do not analyze. |
+
+### When database_query failed — SSH key errors
+
+If the error contains `"No SSH keys found"` or `"SSH key registration required"`, handle it proactively — don't just tell the user to fix it themselves.
+
+**If error contains `"Key found but not registered"` or `"No SSH keys found"`:**
+
+Run these two commands to understand what's available:
+
+```bash
+railway ssh keys          # list keys already registered with Railway
+ls ~/.ssh/*.pub 2>/dev/null  # list local public keys
+```
+
+Then present the user with their options and ask which to use:
+
+```
+SSH introspection needs a registered key. Here's what I found:
+
+Registered with Railway: <list from `railway ssh keys`, or "none">
+Local keys available:    <list from ~/.ssh/*.pub, or "none">
+
+Options:
+  1. Register a local key — `railway ssh keys add` (uses your default key)
+  2. Import from GitHub  — `railway ssh keys github`
+  3. Generate a new key  — `ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519_railway`
+
+Which would you like to do?
+```
+
+Once the user chooses and the key is registered, re-run the full analysis.
+
+### When database_query failed — CLI outdated or missing
+
+If the error contains `"--native SSH flag is not supported"` or `"Railway CLI not found"`, the script detected an unrecoverable CLI problem. Tell the user directly:
+
+- **Outdated CLI:** "Your Railway CLI doesn't support native SSH. Update it: `npm i -g @railway/cli@latest` or `brew upgrade railway`"
+- **Missing CLI:** "Railway CLI not installed. Install it: `npm i -g @railway/cli` or `brew install railway`"
+
+Then ask if they'd like to proceed with a partial analysis (metrics + logs only) while they update, or wait until the CLI is fixed and re-run the full analysis.
+
+### When database_query failed — other SSH errors
+
+This means SSH could not reach the database or the query failed. You have NO connection stats, NO cache hit ratios, NO vacuum health, NO query performance data. All those fields will be null/empty.
+
+**You MUST:**
+1. State clearly: "Database introspection failed — SSH could not connect to the service"
+2. Show the `collection_status` errors
+3. Show only the data that DID succeed (metrics, logs)
+4. Do NOT produce recommendations based on null metrics
+5. Do NOT diagnose performance issues from logs alone
+
+**Partial report template:**
+```
+Service: <name>
+Status: Data collection partially failed
+
+## Collection Status
+| Source | Status |
+|--------|--------|
+| Database Query (SSH) | ERROR: <error from collection_status> |
+| Metrics API | <status> |
+| Logs API | <status> |
+
+## Available Data
+<Show metrics and log summary from sources that succeeded>
+
+## What We Cannot Determine
+<List what requires the database query: connection health, cache performance, vacuum health, query analysis, etc.>
+```
+
+## Output Structure: Data First, Actions Second
+
+**Always present information in this order:**
+
+### 1. Context Header
+```
+Service: <name> (<project> <environment>)
+Status: <deployment health>, <RAM>, <disk used>
+```
+
+### 2. Consolidated Data Tables
+
+Before any analysis, show the raw metrics in tables so the user sees their actual state. The DB-specific reference defines exactly which tables to show for each database type — present the relevant health sections first, then connections, then query performance.
+
+**Logs & Active Issues:**
+- Parse the `recent_logs` array (1000 lines of raw logs) - don't just check if empty
+- Summarize: "Analyzed 1000 log lines: 3 errors (connection timeouts), 0 critical issues"
+- Show specific concerning log entries if found
+- **Categorize log entries**: group by type (errors, warnings, connection events, replication, crashes/restarts)
+- **Count patterns**: note if a single type dominates the log output
+- **Quote actual log lines** for errors — don't just say "errors found", show the exact message so the user can search their codebase
+
+### 3. Analysis
+
+After showing the data, explain the chain of causation. Connect the dots between tables.
+
+### 4. Recommended Actions
+
+Group by urgency. For databases that support configuration changes without restart vs those that require one, call that out explicitly.
+
+### 5. Expected Outcomes
+
+What metrics should change after fixes.
+
+---
+
+**Why this order matters:**
+- Users can verify the data matches their understanding
+- They see the full picture before being told what to do
+- Actions have context - they know WHY each fix is recommended
+- No valuable data is hidden in prose or omitted
+
+## CRITICAL: Use the Actual Data
+
+**NEVER fabricate or assume values.** The script outputs JSON with exact numbers. Before stating any metric:
+
+1. **Read the actual JSON output** - Don't truncate or skim
+2. **Quote the exact values** - e.g., `"max": 5000` not "100"
+3. **Investigate outliers** - Dig into any field that seems unusually high or low
+
+Common errors to avoid (all database types):
+- **Not parsing `recent_logs`** - always analyze the raw log lines, don't just report "no errors"
+- **Diagnosing performance issues from logs when all metrics are null** — logs show what happened, not how the database is performing
+- **Treating startup/restart log entries as evidence of failure** — databases restart for many normal reasons (deploys, config changes, scaling)
+- **Producing recommendations when all database metrics are null** — if `collection_status.database_query` is "error", you have no basis for tuning advice
+
+See the DB-specific reference for additional errors to avoid per database type.
+
+## Running the Analysis
+
+Pass project, environment, and service IDs directly — no `railway link` needed:
+
+```bash
+# From plugins/railway/skills/use-railway directory:
+# Use the script name from the "Database Type Detection" table above
+python3 scripts/analyze-postgres.py --service <name> --json \
+  --project-id <project-id> --environment-id <env-id> --service-id <service-id>
+```
+
+All three IDs come from the URL (see "Context: URL First" above). The service name comes from the API query.
+
+**Options:**
+- `--metrics-hours <N>` — Hours of metrics history to fetch (default: 24, max: 168). Use `--metrics-hours 168` for 7-day trends, `--metrics-hours 1` for recent snapshot.
+
+**SSH retry:** The script automatically retries SSH connectivity up to 3 times with increasing timeouts (30s, 60s, 90s). Each individual SSH command (database query, slowlog, bigkeys, etc.) also retries up to 3 times on failure — covering transient errors like `exec request failed on channel 0`. Progress is logged to stderr.
+
+**Output:** Progress messages go to stderr. JSON results go to stdout. Do not redirect or pipe stderr — just run the command as-is and read the full output.
+
+### Resolving environment by name
+
+If the URL has no `environmentId` and the user specifies an environment by name (e.g., "production"), resolve it:
+
+```bash
+scripts/railway-api.sh \
+  'query getProject($id: String!) {
+    project(id: $id) {
+      environments { edges { node { id name } } }
+    }
+  }' \
+  '{"id": "<PROJECT_ID>"}'
+```
+
+Match the environment name (case-insensitive) to get the `environmentId`.
+
+### Debugging individual steps
+
+```bash
+# Use the script name from the "Database Type Detection" table above
+python3 scripts/analyze-postgres.py --service <name> \
+  --project-id <pid> --environment-id <eid> --service-id <sid> \
+  --step ssh-test    # Test SSH connectivity
+  --step query       # Run only the database query
+  --step metrics     # Fetch only API metrics
+  --step logs        # Fetch only logs
+```
+
+## Database-Specific References
+
+After running the script and checking collection status, load the reference for the specific database type:
+
+| Database | Reference | What It Covers |
+|----------|-----------|----------------|
+| PostgreSQL | [analyze-db-postgres.md](analyze-db-postgres.md) | What psql collects, log analysis checklist, tuning formulas, vacuum priority, pg_stat_statements, applying fixes |
+| MySQL | [analyze-db-mysql.md](analyze-db-mysql.md) | All 12 metric sections (overview, query throughput, InnoDB, efficiency, buffer pool, I/O, network, locks, cache, top queries, tables, active queries), patterns, tuning |
+| Redis | [analyze-db-redis.md](analyze-db-redis.md) | INFO ALL metrics, memory fragmentation, cache thrashing, persistence, command stats |
+| MongoDB | [analyze-db-mongo.md](analyze-db-mongo.md) | serverStatus, WiredTiger cache, query efficiency, connection saturation, oplog |
+
+**Always load the DB-specific reference** — it contains the metric sections, thresholds, and tuning knowledge needed for proper analysis.
+
+## Infrastructure Metrics (All Database Types)
+
+All scripts collect the same infrastructure metrics via Railway API:
+
+**Metrics History (`metrics_history`):**
+The script fetches **7 days** (168 hours) of time-series data from Railway's metrics API by default and produces **two analysis windows**:
+
+```json
+{
+  "metrics_history": {
+    "windows": {
+      "7d": { "window_hours": 168, "metrics": { "cpu": {...}, "memory": {...}, ... } },
+      "24h": { "window_hours": 24, "metrics": { "cpu": {...}, "memory": {...}, ... } }
+    }
+  }
+}
+```
+
+Each window independently computes:
+- **Summary stats**: current, min, max, avg for each metric
+- **Trend analysis**: compares first-quarter avg to last-quarter avg — reports direction (increasing/decreasing/stable) and % change
+- **Spike detection**: flags values > avg + 2*stddev with timestamps of peaks
+- **Downsampled series**: ~48 data points per window
+
+Available metrics: CPU, memory (with limits), disk, network RX/TX.
+
+**Comparing windows reveals whether a trend is new or sustained:**
+- "Memory increasing in 24h but stable over 7d" → temporary spike, likely a batch job
+- "Memory increasing in both 24h AND 7d" → sustained growth, may need investigation
+- "CPU spike in 24h, no spikes in 7d" → new issue
+- "Disk growing over 7d" → data accumulation trend
+
+Use `--metrics-hours N` to change the long window (default: 168, max: 168). The 24h window is always produced when the long window is > 24h.
+
+### Railway auto-scales vertically
+
+Railway services auto-scale CPU, RAM, and disk based on actual usage. Users do NOT pick or control resource sizes. The `cpu_limit` and `memory_limit` values from metrics are the **autoscale ceiling** (typically 32 vCPU / 32 GB), not user-provisioned allocations. Users are billed for actual usage, not the ceiling.
+
+**Rules for ALL database types:**
+- **Never say "right-size the instance"** or suggest reducing CPU/RAM — it's not a user action.
+- **Never flag low utilization % against the limit as waste** — a service showing 0.01 vCPU / 70 MB actual usage against a 32 vCPU / 32 GB ceiling is normal, not over-provisioned.
+- **Disk does NOT auto-scale** — Railway volumes have a fixed capacity. Paid users (Hobby and Pro) can expand them live without downtime, but it requires a manual resize. Flag high disk utilization as actionable. Users are billed for actual disk utilization, not the full volume size.
+- **Focus on actual usage values**, not the ratio to limits. Analyze whether 70 MB of memory is healthy for this workload — don't compare it to the 32 GB ceiling.
+- When tuning database parameters (shared_buffers, innodb_buffer_pool_size, maxmemory, etc.), base recommendations on the **current actual RAM** from `metrics_history.memory`, not the limit.

--- a/.claude/skills/use-railway/references/configure.md
+++ b/.claude/skills/use-railway/references/configure.md
@@ -1,0 +1,285 @@
+# Configure
+
+Manage environments, variables, service config, domains, and networking.
+
+## Environments
+
+### List and switch
+
+```bash
+railway environment list --json
+railway environment link <environment>           # switch active environment
+```
+
+### Create
+
+```bash
+railway environment new <name>
+railway environment new <name> --duplicate <source-environment>    # clone config from existing
+```
+
+Duplicating copies all service configurations and variables from the source environment.
+
+## Variables
+
+### Read, set, and delete
+
+```bash
+railway variable list --service <service> --environment <env> --json
+railway variable set KEY=value --service <service> --environment <env>
+railway variable delete KEY --service <service> --environment <env>
+```
+
+Variable changes trigger a redeployment by default. This is usually the desired behavior, since the service picks up the values on restart.
+
+### Template syntax
+
+Railway supports interpolation between services and shared variables:
+
+```text
+${{KEY}}                                         # same-service variable
+${{shared.API_KEY}}                              # shared variable
+${{postgres.DATABASE_URL}}                       # variable from another service
+${{api.RAILWAY_PRIVATE_DOMAIN}}                  # another service's private domain
+```
+
+Wiring example, a frontend connecting to a backend over private networking:
+
+```text
+BACKEND_URL=http://${{api.RAILWAY_PRIVATE_DOMAIN}}:${{api.PORT}}
+```
+
+### Wiring services together
+
+Each managed database creates connection variables automatically. Reference them from other services using template syntax:
+
+| Database | Variable reference |
+|---|---|
+| Postgres | `${{Postgres.DATABASE_URL}}` |
+| Redis | `${{Redis.REDIS_URL}}` |
+| MySQL | `${{MySQL.MYSQL_URL}}` |
+| MongoDB | `${{MongoDB.MONGO_URL}}` |
+
+Service names in references are case-sensitive and must match the service name exactly as it appears in the project.
+
+**Public vs private networking decision:**
+
+| Traffic path | Use |
+|---|---|
+| Browser → API | Public domain |
+| Service → Service | Private domain (`RAILWAY_PRIVATE_DOMAIN`) |
+| Service → Database | Private (automatic, uses internal DNS) |
+
+**Frontend apps cannot use private networking.** Frontends run in the user's browser, not on Railway's network. They cannot reach `RAILWAY_PRIVATE_DOMAIN` or internal database URLs. Options:
+
+1. **Backend proxy** (recommended): frontend calls a backend API on a public domain, backend connects to the database over the private network.
+2. **Public database URL**: use the public connection variable (for example, `${{Postgres.DATABASE_PUBLIC_URL}}`). This requires a TCP proxy on the database service and exposes the database to the internet — only appropriate for development or low-sensitivity data.
+
+### Railway-provided variables
+
+These are set automatically at runtime. Availability depends on resource configuration.
+
+**Networking:**
+
+| Variable | Available when |
+|---|---|
+| `RAILWAY_PUBLIC_DOMAIN` | Public domain is configured |
+| `RAILWAY_PRIVATE_DOMAIN` | Always (internal DNS for service-to-service traffic) |
+| `RAILWAY_TCP_PROXY_DOMAIN` | TCP proxy is enabled |
+| `RAILWAY_TCP_PROXY_PORT` | TCP proxy is enabled |
+
+**Context:**
+
+| Variable | Available when |
+|---|---|
+| `RAILWAY_PROJECT_ID` | Always |
+| `RAILWAY_ENVIRONMENT_ID` | Always |
+| `RAILWAY_ENVIRONMENT_NAME` | Always |
+| `RAILWAY_SERVICE_ID` | Always |
+| `RAILWAY_SERVICE_NAME` | Always |
+| `RAILWAY_DEPLOYMENT_ID` | Always |
+| `RAILWAY_REPLICA_ID` | Replicas configured |
+| `RAILWAY_REPLICA_REGION` | Multi-region configured |
+
+**Git (present when deployed from a linked repo):**
+
+| Variable | Description |
+|---|---|
+| `RAILWAY_GIT_COMMIT_SHA` | Full commit hash of the deployed revision |
+| `RAILWAY_GIT_AUTHOR` | Commit author name |
+| `RAILWAY_GIT_COMMIT_MESSAGE` | First line of the commit message |
+| `RAILWAY_GIT_BRANCH` | Branch that triggered the deploy |
+
+**Storage (present when a volume is attached):**
+
+| Variable | Description |
+|---|---|
+| `RAILWAY_VOLUME_MOUNT_PATH` | Filesystem path where the volume is mounted |
+| `RAILWAY_VOLUME_NAME` | Name of the attached volume |
+
+Sealed variables are write-only. Their values don't appear in CLI output.
+
+## Service config
+
+Service configuration controls source, build, deploy, and networking settings. There are two ways to mutate it.
+
+### Dot-path patch
+
+For single-field changes:
+
+```bash
+railway environment edit --service-config <service> deploy.startCommand "npm start"
+railway environment edit --service-config <service> build.buildCommand "npm run build"
+railway environment edit --service-config <service> source.rootDirectory "/apps/api"
+railway environment edit --service-config <service> deploy.numReplicas 2
+```
+
+### JSON patch
+
+For multi-field changes or complex structures:
+
+```bash
+railway environment edit --json <<'JSON'
+{"services":{"<service-id>":{"build":{"buildCommand":"npm run build"},"deploy":{"startCommand":"npm start"}}}}
+JSON
+```
+
+Resolve exact service IDs from `railway status --json` before constructing JSON patches. Using names in the JSON payload doesn't work.
+
+### Config schema (typed paths)
+
+Include only keys you're changing. The full shape:
+
+**Source**: `source.image` (string), `source.repo` (string), `source.branch` (string), `source.rootDirectory` (string), `source.checkSuites` (boolean), `source.commitSha` (string), `source.autoUpdates.type` (string: `disabled`, `patch`, `minor`)
+
+**Build**: `build.builder` (string: `RAILPACK`, `NIXPACKS`, `DOCKERFILE`), `build.buildCommand` (string), `build.dockerfilePath` (string), `build.watchPatterns` (string array), `build.nixpacksConfigPath` (string)
+
+**Deploy**: `deploy.startCommand` (string), `deploy.preDeployCommand` (string), `deploy.healthcheckPath` (string), `deploy.healthcheckTimeout` (integer), `deploy.numReplicas` (integer), `deploy.restartPolicyType` (string: `ON_FAILURE`, `ALWAYS`, `NEVER`), `deploy.restartPolicyMaxRetries` (integer), `deploy.sleepApplication` (boolean), `deploy.cronSchedule` (string), `deploy.multiRegionConfig` (object)
+
+**Multi-region config** structure for `deploy.multiRegionConfig`:
+
+```json
+{ "us-west2": { "numReplicas": 2 }, "europe-west4-drams3a": { "numReplicas": 1 } }
+```
+
+| Region identifier | Location |
+|---|---|
+| `us-west2` | US West (Oregon) |
+| `us-east4-eqdc4a` | US East (Virginia) |
+| `europe-west4-drams3a` | Europe (Netherlands) |
+| `asia-southeast1-eqsg3a` | Asia (Singapore) |
+
+Natural language mapping: "add replicas in Europe" → `europe-west4-drams3a`, "US East" → `us-east4-eqdc4a`. When the user doesn't specify a region, query current config first with `railway environment config --json` to see existing region assignments before modifying.
+
+**Variables**: `variables.<KEY>.value` (string), `variables.<KEY>.isOptional` (boolean), `variables.<KEY>.isSealed` (boolean). Delete a variable by setting it to `null`.
+
+**Lifecycle**: `isDeleted` (boolean) removes the service. `isCreated` (boolean) marks as new.
+
+**Storage**: `volumeMounts.<volume-id>.mountPath` (string), `volumes.<volume-id>.isDeleted` (boolean)
+
+**Buckets**: `buckets.<bucket-id>.region` (string: `sjc`, `iad`, `ams`, `sin`), `buckets.<bucket-id>.isCreated` (boolean), `buckets.<bucket-id>.isDeleted` (boolean). Buckets are created at the project level via `railway bucket create` and deployed to environments via config patches. The CLI handles this automatically — use `railway bucket` commands
+
+### Shared variables and project-level config
+
+```bash
+railway environment edit --json <<'JSON'
+{"sharedVariables":{"API_BASE":{"value":"https://example.com"}}}
+JSON
+```
+
+Shared variables are accessible from any service via `${{shared.KEY}}`.
+
+### Read config
+
+Always inspect before mutating. Config patches merge, so you need to know the state to avoid overwriting fields unintentionally:
+
+```bash
+railway environment config --json
+```
+
+Verify after mutation to confirm the change took effect:
+
+```bash
+railway environment config --json
+railway service status --all --json
+```
+
+## Domains
+
+### Railway domain
+
+One Railway-provided domain per service, generated automatically:
+
+```bash
+railway domain --service <service> --json
+```
+
+### Custom domain
+
+```bash
+railway domain example.com --service <service> --json
+```
+
+This returns the DNS records you need to configure at your DNS provider. Multiple custom domains per service are supported.
+
+### Target port
+
+If the service listens on a non-default port:
+
+```bash
+railway domain example.com --service <service> --port 8080 --json
+```
+
+### Private networking
+
+For service-to-service traffic within a project, use private domain references instead of public URLs. This avoids egress and is faster:
+
+```text
+BACKEND_URL=http://${{api.RAILWAY_PRIVATE_DOMAIN}}:${{api.PORT}}
+```
+
+### Read current domains
+
+Domain configuration lives in `config.services.<service-id>.networking` under `serviceDomains` (Railway-provided) and `customDomains`. Inspect with:
+
+```bash
+railway environment config --json
+```
+
+### Remove a domain
+
+Remove domains via JSON config patch by setting the domain ID to `null`:
+
+**Remove a custom domain:**
+
+```bash
+railway environment edit --json <<'JSON'
+{"services":{"<service-id>":{"networking":{"customDomains":{"<domain-id>":null}}}}}
+JSON
+```
+
+**Remove a Railway-provided domain:**
+
+```bash
+railway environment edit --json <<'JSON'
+{"services":{"<service-id>":{"networking":{"serviceDomains":{"<domain-id>":null}}}}}
+JSON
+```
+
+Get the domain IDs from `railway environment config --json` under the service's `networking` object.
+
+## Troubleshoot configuration
+
+- **Invalid dot-path**: check field names and types in the config schema section above
+- **Wrong service key in JSON patch**: resolve service IDs from `railway status --json`
+- **Variable change didn't take effect**: verify with `railway variable list`, changes trigger redeploy by default
+- **Domain returns errors**: verify the service has a healthy deployment and the target port is correct
+- **DNS propagation delay**: custom domains take time to propagate, this is normal
+- **Cloudflare proxy issues**: align SSL/TLS mode per Railway's domain guidance
+- **Private networking failing**: verify the service is listening on the referenced port and that the private domain variable reference is correct
+- **Multi-region patch ignored**: verify region names match the exact identifiers (`us-west2`, `us-east4-eqdc4a`, `europe-west4-drams3a`, `asia-southeast1-eqsg3a`)
+
+## Validated against
+
+- Docs: [environment.md](https://docs.railway.com/cli/environment), [variable.md](https://docs.railway.com/cli/variable), [variables.md](https://docs.railway.com/variables), [domains.md](https://docs.railway.com/networking/domains), [public-networking.md](https://docs.railway.com/networking/public-networking), [private-networking.md](https://docs.railway.com/networking/private-networking)
+- CLI source: [environment/mod.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/environment/mod.rs), [environment/edit.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/environment/edit.rs), [variable.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/variable.rs), [domain.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/domain.rs), [controllers/config/patch.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/controllers/config/patch.rs)

--- a/.claude/skills/use-railway/references/deploy.md
+++ b/.claude/skills/use-railway/references/deploy.md
@@ -1,0 +1,184 @@
+# Deploy
+
+Ship code, manage releases, and configure builds.
+
+## Deploy code
+
+### Standard deploy
+
+```bash
+railway up --detach -m "<release summary>"
+```
+
+`--detach` returns immediately instead of streaming build logs. Without it, the deploy blocks execution until the build finishes. Always include `-m` with a release summary for auditability.
+
+### Watch the build
+
+```bash
+railway up --ci -m "<release summary>"
+```
+
+`--ci` streams build logs and exits when the build completes. Use this when the user wants to see build output or when you need to triage build failures immediately.
+
+### Targeted deploy
+
+When multiple services exist, target explicitly:
+
+```bash
+railway up --service <service> --environment <environment> --detach -m "<summary>"
+```
+
+### Deploy to an unlinked project
+
+For CI or cross-project deploys where the directory isn't linked:
+
+```bash
+railway up --project <project-id> --environment <environment> --detach -m "<summary>"
+```
+
+`--project` requires `--environment`. Railway needs both to resolve context.
+
+## Manage releases
+
+### Redeploy and restart
+
+```bash
+railway redeploy --service <service> --yes       # rebuild and deploy from same source
+railway restart --service <service> --yes         # restart without rebuilding
+```
+
+Redeploy triggers a full build cycle. Restart only restarts the running container. Use restart when the code hasn't changed but the service needs a fresh process (for example, after variable changes).
+
+### Remove latest deployment
+
+```bash
+railway down --service <service> --yes
+```
+
+This removes the latest successful deployment but doesn't delete the service. To delete a service entirely, use environment config patching (see [configure.md](configure.md)).
+
+## Deployment history and logs
+
+```bash
+railway deployment list --service <service> --limit 20 --json
+railway logs --service <service> --lines 200 --json              # runtime logs
+railway logs --service <service> --build --lines 200 --json      # build logs
+railway logs --latest --lines 200 --json                         # latest deployment
+```
+
+`railway logs` streams indefinitely when no bounding flags are given. An open stream blocks execution and never returns. Always use `--lines`, `--since`, or `--until` to get a bounded fetch.
+
+## Build configuration
+
+Railway uses Railpack as the default builder. It detects language and framework from repo contents and assembles a build plan automatically.
+
+### Builder selection
+
+Three builder options, set via service config:
+
+- **RAILPACK** auto-detects language and framework, builds from source (default)
+- **NIXPACKS** is the legacy builder. DO NOT USE THIS, use RAILPACK instead.
+- **DOCKERFILE** uses a Dockerfile you provide
+
+```bash
+railway environment edit --service-config <service> build.builder RAILPACK
+railway environment edit --service-config <service> build.builder DOCKERFILE
+railway environment edit --service-config <service> build.dockerfilePath "docker/Dockerfile.prod"
+```
+
+### Build and start commands
+
+Override when auto-detection gets it wrong:
+
+```bash
+railway environment edit --service-config <service> build.buildCommand "npm run build"
+railway environment edit --service-config <service> deploy.startCommand "npm start"
+```
+
+Common reasons to override: wrong package manager detected, multiple build targets in a monorepo, framework-specific output paths.
+
+### Railpack environment variables
+
+Control Railpack behavior by setting these as service variables:
+
+| Variable | Purpose |
+|---|---|
+| `RAILPACK_NODE_VERSION` | Pin Node.js version (e.g., `20`, `22.1.0`) |
+| `RAILPACK_PYTHON_VERSION` | Pin Python version (e.g., `3.12`) |
+| `RAILPACK_GO_BIN` | Go binary name to build |
+| `RAILPACK_STATIC_FILE_ROOT` | Directory for static site output (e.g., `dist`, `build`) |
+| `RAILPACK_SPA_OUTPUT_DIR` | SPA output directory with client-side routing support |
+| `RAILPACK_PACKAGES` | Additional system packages for the build |
+| `RAILPACK_BUILD_APT_PACKAGES` | Apt packages available during build only |
+| `RAILPACK_DEPLOY_APT_PACKAGES` | Apt packages available at runtime only |
+
+For full Railpack documentation including language-specific detection, config files, and framework support: https://railpack.com/llms.txt
+
+### Static sites
+
+Railpack detects static sites from `Staticfile`, `index.html`, or `RAILPACK_STATIC_FILE_ROOT` and serves them with a built-in static file server. If the build outputs to a non-standard directory (for example, `dist/`, `build/`), set `RAILPACK_STATIC_FILE_ROOT` as a variable so Railpack knows where to find the output.
+
+## Monorepo patterns
+
+### Isolated monorepo
+
+When services don't share code, isolate each with its own root directory:
+
+```bash
+railway environment edit --service-config <service> source.rootDirectory "/packages/api"
+```
+
+Each service sees only its subdirectory. This approach is clean but breaks if services import from shared packages.
+
+### Shared monorepo
+
+When services depend on shared packages or root-level workspace config, keep the full repo context and scope via build/start commands instead:
+
+```bash
+# pnpm workspaces
+railway environment edit --service-config <service> build.buildCommand "pnpm --filter api build"
+railway environment edit --service-config <service> deploy.startCommand "pnpm --filter api start"
+
+# yarn workspaces
+railway environment edit --service-config <service> build.buildCommand "yarn workspace api build"
+railway environment edit --service-config <service> deploy.startCommand "yarn workspace api start"
+
+# bun workspaces
+railway environment edit --service-config <service> build.buildCommand "bun run --filter api build"
+railway environment edit --service-config <service> deploy.startCommand "bun run --filter api start"
+
+# turborepo (works with any package manager)
+railway environment edit --service-config <service> build.buildCommand "npx turbo run build --filter=api"
+railway environment edit --service-config <service> deploy.startCommand "npx turbo run start --filter=api"
+```
+
+Don't set a restrictive `rootDirectory` in this case. The build needs access to the workspace root.
+
+### Watch paths
+
+Prevent unrelated package changes from redeploying every service:
+
+```bash
+railway environment edit --service-config <service> build.watchPatterns '["packages/api/**","packages/shared/**"]'
+```
+
+### Common monorepo pitfalls
+
+- **Using `rootDirectory` with shared imports**: if service A imports from `packages/shared/`, setting `rootDirectory: "/packages/a"` hides the shared code. Use the shared monorepo pattern instead.
+- **Forgetting watch paths**: without watch paths, every push redeploys all services, even when only one package changed.
+- **Wrong filter target**: `pnpm --filter api` uses the `name` field in each package's `package.json`, not the directory name. Verify the package name matches.
+
+## Troubleshoot deploys
+
+- **No project/service context**: run `railway link` or pass `--project` with `--environment`
+- **Build fails before compile**: check dependency graph, lockfiles, and whether the right builder is selected
+- **Build succeeds but app crashes**: verify start command and required runtime variables
+- **Wrong files in build**: check root directory and watch patterns
+- **`railway down` treated as delete**: `down` only removes the latest deployment. For full service deletion, use `isDeleted` in config patch (see [configure.md](configure.md))
+- **Wrong Node/Python version detected**: set `RAILPACK_NODE_VERSION` or `RAILPACK_PYTHON_VERSION` as a service variable to pin the version
+- **Missing system package at runtime**: add the package to `RAILPACK_DEPLOY_APT_PACKAGES`
+
+## Validated against
+
+- Docs: [up.md](https://docs.railway.com/cli/up), [deploying.md](https://docs.railway.com/cli/deploying), [deployment.md](https://docs.railway.com/cli/deployment), [down.md](https://docs.railway.com/cli/down), [railpack.md](https://docs.railway.com/builds/railpack), [monorepo.md](https://docs.railway.com/deployments/monorepo)
+- CLI source: [up.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/up.rs), [deployment.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/deployment.rs), [down.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/down.rs), [redeploy.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/redeploy.rs), [restart.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/restart.rs)

--- a/.claude/skills/use-railway/references/operate.md
+++ b/.claude/skills/use-railway/references/operate.md
@@ -1,0 +1,175 @@
+# Operate
+
+Check health, read logs, query metrics, and troubleshoot failures.
+
+## Health snapshot
+
+Start broad, then narrow:
+
+```bash
+railway status --json                                    # linked context
+railway service status --all --json                      # all services, deployment states
+railway deployment list --limit 10 --json                # recent deployments
+```
+
+Deployment statuses: `SUCCESS`, `BUILDING`, `DEPLOYING`, `FAILED`, `CRASHED`, `REMOVED`.
+
+For projects with buckets, include bucket status:
+
+```bash
+railway bucket list --json                                       # buckets in current environment
+railway bucket info --bucket <name> --json                       # storage size, object count, region
+```
+
+If everything looks healthy, return a summary and stop. If something is degraded or failing, continue to log inspection.
+
+## Logs
+
+### Recent logs
+
+```bash
+railway logs --service <service> --lines 200 --json              # runtime logs
+railway logs --service <service> --build --lines 200 --json      # build logs
+railway logs --latest --lines 200 --json                         # latest deployment
+```
+
+`railway logs` streams indefinitely when no bounding flags are given. Always use `--lines`, `--since`, or `--until` to get a bounded fetch. Open streams block execution.
+
+### Time-bounded queries
+
+```bash
+railway logs --service <service> --since 1h --lines 400 --json
+railway logs --service <service> --since 30m --until 10m --lines 400 --json
+```
+
+### Filtered queries
+
+Use `--filter` to narrow logs without scanning everything manually:
+
+```bash
+railway logs --service <service> --lines 200 --filter "@level:error" --json
+railway logs --service <service> --lines 200 --filter "@level:warn AND timeout" --json
+railway logs --service <service> --lines 200 --filter "connection refused" --json
+```
+
+Filter syntax supports text search (`"error message"`), attribute filters (`@level:error`, `@level:warn`), and boolean operators (`AND`, `OR`, `-` for negation). Full syntax: https://docs.railway.com/guides/logs
+
+### Scoped by environment
+
+```bash
+railway logs --service <service> --environment <env> --lines 200 --json
+```
+
+## Metrics
+
+Resource usage metrics (CPU, memory, network, disk) are only available through the GraphQL API:
+
+```bash
+scripts/railway-api.sh \
+  'query metrics($environmentId: String!, $serviceId: String, $startDate: DateTime!, $groupBy: [MetricTag!], $measurements: [MetricMeasurement!]!) {
+    metrics(environmentId: $environmentId, serviceId: $serviceId, startDate: $startDate, groupBy: $groupBy, measurements: $measurements) {
+      measurement tags { serviceId deploymentId region } values { ts value }
+    }
+  }' \
+  '{"environmentId":"<env-id>","serviceId":"<service-id>","startDate":"2026-02-19T00:00:00Z","measurements":["CPU_USAGE","MEMORY_USAGE_GB"]}'
+```
+
+Available measurements: `CPU_USAGE`, `CPU_LIMIT`, `MEMORY_USAGE_GB`, `MEMORY_LIMIT_GB`, `NETWORK_RX_GB`, `NETWORK_TX_GB`, `DISK_USAGE_GB`, `EPHEMERAL_DISK_USAGE_GB`, `BACKUP_USAGE_GB`.
+
+Omit `serviceId` and add `"groupBy": ["SERVICE_ID"]` to query all services in the environment at once. Get the environment and service IDs from `railway status --json`.
+
+## Database inspection
+
+For database-level metrics and introspection, always use the analysis scripts. See [analyze-db.md](analyze-db.md) for comprehensive database analysis including:
+
+- Deep Postgres analysis (pg_stat_statements, vacuum health, index health, cache hit ratios)
+- HA cluster checks (Patroni, etcd, HAProxy)
+- Redis, MySQL, and MongoDB introspection
+- Combined analysis via `scripts/analyze-<type>.py` (postgres, mysql, redis, mongo)
+
+## Failure triage
+
+When something is broken, classify the failure first. The fix depends on the class.
+
+### Build failures
+
+The service failed to build. Look at build logs:
+
+```bash
+railway logs --latest --build --lines 400 --json
+```
+
+Common causes and fixes:
+- **Missing dependencies**: check lockfiles, verify package manager detection
+- **Wrong build command**: override with `railway environment edit --service-config <service> build.buildCommand "<command>"`
+- **Builder mismatch**: switch builders with `railway environment edit --service-config <service> build.builder RAILPACK`
+- **Wrong root directory** (monorepo): set `source.rootDirectory` to the correct package path
+
+### Runtime failures
+
+The build succeeded but the service crashes or misbehaves:
+
+```bash
+railway logs --latest --lines 400 --json
+railway logs --service <service> --since 1h --lines 400 --json
+```
+
+Common causes and fixes:
+- **Bad start command**: override with `railway environment edit --service-config <service> deploy.startCommand "<command>"`
+- **Missing runtime variable**: check `railway variable list --service <service> --json` and set missing values
+- **Port mismatch**: the service must listen on `$PORT` (Railway injects this). Verify with logs.
+- **Upstream dependency down**: check other services' status and logs
+
+### Config-driven failures
+
+Something worked before and broke after a config change:
+
+```bash
+railway environment config --json
+railway variable list --service <service> --json
+```
+
+Compare the config against expected values. Look for changes that may have introduced the regression.
+
+### Networking failures
+
+Domain returns errors, or service-to-service calls fail:
+
+```bash
+railway domain --service <service> --json
+railway logs --service <service> --lines 200 --json
+```
+
+Check: target port matches what the service listens on, domain status is healthy, private domain variable references are correct.
+
+## Recovery
+
+After identifying the cause, fix and verify:
+
+```bash
+# Fix (examples)
+railway environment edit --service-config <service> deploy.startCommand "<correct-command>"
+railway variable set MISSING_VAR=value --service <service>
+
+# Redeploy
+railway redeploy --service <service> --yes
+
+# Verify
+railway service status --service <service> --json
+railway logs --service <service> --lines 200 --json
+```
+
+Always verify after fixing. Don't assume the redeploy succeeded.
+
+## Troubleshoot common blockers
+
+- **Unlinked context**: `railway link --project <id-or-name>`
+- **Missing service scope for logs**: pass `--service` and `--environment` explicitly
+- **No deployments found**: the service exists but has never deployed, create an initial deploy first
+- **Metrics query returns empty**: verify IDs from `railway status --json` and check the time window
+- **Config patch type error**: check the typed paths in [configure.md](configure.md), for example, `numReplicas` is an integer, not a string
+
+## Validated against
+
+- Docs: [status.md](https://docs.railway.com/cli/status), [logs.md](https://docs.railway.com/cli/logs), [observability.md](https://docs.railway.com/observability), [observability/logs.md](https://docs.railway.com/observability/logs), [observability/metrics.md](https://docs.railway.com/observability/metrics)
+- CLI source: [status.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/status.rs), [logs.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/logs.rs), [deployment.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/deployment.rs), [redeploy.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/redeploy.rs)

--- a/.claude/skills/use-railway/references/request.md
+++ b/.claude/skills/use-railway/references/request.md
@@ -1,0 +1,238 @@
+# Request
+
+Official documentation and community endpoints. GraphQL operations for things the CLI doesn't expose.
+
+## Official documentation
+
+Primary sources for authoritative Railway information:
+
+- **Full LLM docs**: `https://docs.railway.com/api/llms-docs.md`
+- **LLM summary**: `https://railway.com/llms.txt`
+- **Templates**: `https://railway.com/llms-templates.md`
+- **Changelog**: `https://railway.com/llms-changelog.md`
+- **Blog**: `https://blog.railway.com/llms-blog.md`
+- **Direct doc pages**: `https://docs.railway.com/<path>` (for example, `cli/up`, `networking/domains`, `observability/logs`)
+
+Tip: append `.md` to any `docs.railway.com` page URL to get a markdown version suitable for LLM consumption.
+
+Common doc paths:
+
+| Topic | Path |
+|---|---|
+| Projects | `guides/projects` |
+| Deployments | `guides/deployments` |
+| Volumes | `guides/volumes` |
+| Variables | `guides/variables` |
+| CLI reference | `reference/cli-api` |
+| Pricing | `reference/pricing` |
+| Public networking | `networking/public-networking` |
+| Private networking | `networking/private-networking` |
+
+Fetch official docs first for product behavior questions. Use Central Station only when you need community evidence, prior incidents, or implementation anecdotes.
+
+
+## Central Station (community)
+
+Search and browse Railway's community platform for prior discussions, issue patterns, and field solutions.
+
+### Recent threads
+
+```bash
+curl -s 'https://station-server.railway.com/gql' \
+  -H 'content-type: application/json' \
+  -d '{"query":"{ threads(first: 10, sort: recent_activity) { edges { node { slug subject status upvoteCount createdAt topic { slug displayName } } } } }"}'
+```
+
+Filter by topic with the `topic` parameter (`"questions"`, `"feedback"`, `"community"`, `"billing"`):
+
+```bash
+curl -s 'https://station-server.railway.com/gql' \
+  -H 'content-type: application/json' \
+  -d '{"query":"{ threads(first: 10, sort: recent_activity, topic: \"questions\") { edges { node { slug subject status topic { displayName } upvoteCount } } } }"}'
+```
+
+Sort options: `recent_activity` (default), `newest`, `highest_votes`.
+
+### Search threads
+
+```bash
+curl -s 'https://station-server.railway.com/gql' \
+  -H 'content-type: application/json' \
+  -d '{"query":"{ threads(first: 10, search: \"<search-term>\") { edges { node { slug subject status } } } }"}'
+```
+
+### LLM data export
+
+Bulk search alternative — fetches all public threads with full content:
+
+```bash
+curl -s 'https://station-server.railway.com/api/llms-station'
+```
+
+### Read a full thread
+
+```bash
+curl -s 'https://station-server.railway.com/api/threads/<slug>?format=md'
+```
+
+Thread URLs follow the format: `https://station.railway.com/{topic_slug}/{thread_slug}`
+
+Community threads are anecdotal. Always pair with official docs when the answer informs an operational decision.
+
+
+## GraphQL helper
+
+All GraphQL operations use the API helper script, which handles authentication automatically:
+
+```bash
+scripts/railway-api.sh '<query>' '<variables-json>'
+```
+
+The script reads the API token from `~/.railway/config.json` and sends requests to `https://backboard.railway.com/graphql/v2`.
+
+For the full API schema, see: https://docs.railway.com/api/llms-docs.md
+
+## Project mutations
+
+The CLI doesn't expose project setting updates (rename, PR deploys, visibility). Use GraphQL:
+
+```bash
+scripts/railway-api.sh \
+  'mutation updateProject($id: String!, $input: ProjectUpdateInput!) {
+    projectUpdate(id: $id, input: $input) { id name isPublic prDeploys botPrEnvironments }
+  }' \
+  '{"id":"<project-id>","input":{"name":"new-name","prDeploys":true}}'
+```
+
+Common `ProjectUpdateInput` fields: `name`, `isPublic`, `prDeploys`, `botPrEnvironments`.
+
+
+## Service mutations
+
+The CLI can create services (`railway add`) but cannot rename them or change icons. Use GraphQL:
+
+```bash
+scripts/railway-api.sh \
+  'mutation updateService($id: String!, $input: ServiceUpdateInput!) {
+    serviceUpdate(id: $id, input: $input) { id name icon }
+  }' \
+  '{"id":"<service-id>","input":{"name":"new-name"}}'
+```
+
+`ServiceUpdateInput` fields: `name`, `icon` (image URL, animated GIF, or devicons URL like `https://devicons.railway.app/postgres`).
+
+Get the service ID from `railway status --json`.
+
+
+## Service creation via GraphQL
+
+Prefer `railway add` for most cases. Use GraphQL for programmatic or advanced use:
+
+```bash
+scripts/railway-api.sh \
+  'mutation createService($input: ServiceCreateInput!) {
+    serviceCreate(input: $input) { id name }
+  }' \
+  '{"input":{"projectId":"<project-id>","name":"my-service","source":{"image":"nginx:latest"}}}'
+```
+
+`ServiceCreateInput` fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `projectId` | String! | Target project (required) |
+| `name` | String | Service name (auto-generated if omitted) |
+| `source.image` | String | Docker image (for example, `nginx:latest`) |
+| `source.repo` | String | GitHub repo (for example, `user/repo`) |
+| `branch` | String | Git branch for repo source |
+| `environmentId` | String | Create only in a specific environment |
+
+After creating a service via GraphQL, configure it with a JSON config patch including `isCreated: true` (see [configure.md](configure.md)).
+
+
+## Metrics queries
+
+Resource usage metrics are only available via GraphQL:
+
+```bash
+scripts/railway-api.sh \
+  'query metrics($environmentId: String!, $serviceId: String, $startDate: DateTime!, $endDate: DateTime, $sampleRateSeconds: Int, $averagingWindowSeconds: Int, $groupBy: [MetricTag!], $measurements: [MetricMeasurement!]!) {
+    metrics(environmentId: $environmentId, serviceId: $serviceId, startDate: $startDate, endDate: $endDate, sampleRateSeconds: $sampleRateSeconds, averagingWindowSeconds: $averagingWindowSeconds, groupBy: $groupBy, measurements: $measurements) {
+      measurement tags { serviceId deploymentId region } values { ts value }
+    }
+  }' \
+  '{"environmentId":"<env-id>","serviceId":"<service-id>","startDate":"2026-02-19T00:00:00Z","measurements":["CPU_USAGE","MEMORY_USAGE_GB"]}'
+```
+
+Available `MetricMeasurement` values: `CPU_USAGE`, `CPU_LIMIT`, `MEMORY_USAGE_GB`, `MEMORY_LIMIT_GB`, `NETWORK_RX_GB`, `NETWORK_TX_GB`, `DISK_USAGE_GB`, `EPHEMERAL_DISK_USAGE_GB`, `BACKUP_USAGE_GB`.
+
+Optional parameters: `endDate` (defaults to now), `sampleRateSeconds`, `averagingWindowSeconds`. Use `groupBy: ["SERVICE_ID"]` without `serviceId` to query all services in an environment at once. Valid `MetricTag` values for `groupBy`: `SERVICE_ID`, `DEPLOYMENT_ID`, `DEPLOYMENT_INSTANCE_ID`, `REGION`.
+
+Get environment and service IDs from `railway status --json`.
+
+## Template search
+
+Search Railway's template marketplace:
+
+```bash
+scripts/railway-api.sh \
+  'query templates($query: String!, $verified: Boolean, $recommended: Boolean) {
+    templates(query: $query, verified: $verified, recommended: $recommended) {
+      edges { node { code name description category } }
+    }
+  }' \
+  '{"query":"redis","verified":true}'
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | String | Search term |
+| `verified` | Boolean | Only verified templates |
+| `recommended` | Boolean | Only recommended templates |
+| `first` | Int | Number of results (max ~100) |
+
+Common template codes: `ghost`, `strapi`, `minio`, `n8n`, `uptime-kuma`, `umami`, `postgres`, `redis`, `mysql`, `mongodb`.
+
+Deploy a found template via CLI:
+
+```bash
+railway deploy --template <template-code>
+```
+
+### GraphQL template deployment
+
+For deploying into a specific environment or tracking the workflow, use the two-step GraphQL flow:
+
+**Step 1** — Fetch the template config:
+
+```bash
+scripts/railway-api.sh \
+  'query template($code: String!) {
+    template(code: $code) { id serializedConfig }
+  }' \
+  '{"code":"postgres"}'
+```
+
+**Step 2** — Deploy with `templateDeployV2`:
+
+```bash
+scripts/railway-api.sh \
+  'mutation deploy($input: TemplateDeployV2Input!) {
+    templateDeployV2(input: $input) { projectId workflowId }
+  }' \
+  '{"input":{
+    "templateId":"<id-from-step-1>",
+    "serializedConfig":<config-object-from-step-1>,
+    "projectId":"<project-id>",
+    "environmentId":"<env-id>",
+    "workspaceId":"<workspace-id>"
+  }}'
+```
+
+`serializedConfig` is the raw JSON object from the template query, not a string. Get `workspaceId` via `scripts/railway-api.sh 'query { project(id: "<project-id>") { workspaceId } }' '{}'`.
+
+
+## Validated against
+
+- Docs: [api docs](https://docs.railway.com/api/llms-docs.md), [community.md](https://docs.railway.com/community), [cli/docs.md](https://docs.railway.com/cli/docs)
+- CLI source: [docs.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/docs.rs)

--- a/.claude/skills/use-railway/references/setup.md
+++ b/.claude/skills/use-railway/references/setup.md
@@ -1,0 +1,288 @@
+# Setup
+
+Create, link, and organize Railway projects, services, databases, and workspaces.
+
+## Projects
+
+### List and discover
+
+```bash
+railway project list --json        # projects in current workspace
+railway list --json                # all projects across workspaces with service metadata
+railway whoami --json              # current user, workspace memberships
+```
+
+### Link to an existing project
+
+Linking sets the working context for all subsequent CLI commands in this directory.
+
+```bash
+railway link --project <project-id-or-name>
+railway status --json              # confirm linked context
+```
+
+Without `--project`, `railway link` runs interactively. For scripted or CI use, always pass explicit flags.
+
+### Link to a specific service
+
+Switch the linked service within an already-linked project:
+
+```bash
+railway service link              # interactive service picker
+railway service link <name>       # link directly by name
+```
+
+### Create a new project
+
+```bash
+railway init --name <project-name>
+railway init --name <project-name> --workspace <workspace-id-or-name>
+```
+
+`railway init` both creates and links in one step. In CI or multi-workspace setups, pass `--workspace` explicitly to avoid ambiguity.
+
+### Update project settings
+
+Settings like project name, PR deploys, and visibility aren't exposed through the CLI. Use the GraphQL API helper (see [request.md](request.md)):
+
+```bash
+scripts/railway-api.sh \
+  'mutation updateProject($id: String!, $input: ProjectUpdateInput!) {
+    projectUpdate(id: $id, input: $input) { id name isPublic prDeploys }
+  }' \
+  '{"id":"<project-id>","input":{"name":"new-name","prDeploys":true}}'
+```
+
+## Services
+
+### Create a service
+
+```bash
+railway add --service <service-name>          # empty service
+railway add --database postgres               # managed database (postgres, redis, mysql, mongodb)
+railway add                                   # interactive, prompts for type
+```
+
+Before adding a database, check for existing database services to avoid duplicates. Run `railway environment config --json` and inspect `source.image` for each service:
+
+| Image pattern | Database |
+|---|---|
+| `ghcr.io/railway/postgres*` or `postgres:*` | Postgres |
+| `ghcr.io/railway/redis*` or `redis:*` | Redis |
+| `ghcr.io/railway/mysql*` or `mysql:*` | MySQL |
+| `ghcr.io/railway/mongo*` or `mongo:*` | MongoDB |
+
+If a matching database already exists, skip creation and wire the existing service's variables to the app.
+
+Empty services have no source until you configure one. This is the right pattern when you need to set source repo, branch, or build config before the first deploy.
+
+### Connect a database to a service
+
+After `railway add --database <type>`, the database creates connection variables automatically. Wire them to your app service using variable references:
+
+| Database | Connection variable |
+|---|---|
+| Postgres | `${{Postgres.DATABASE_URL}}` |
+| Redis | `${{Redis.REDIS_URL}}` |
+| MySQL | `${{MySQL.MYSQL_URL}}` |
+| MongoDB | `${{MongoDB.MONGO_URL}}` |
+
+```bash
+railway variable set DATABASE_URL='${{Postgres.DATABASE_URL}}' --service <app-service>
+```
+
+Service names in variable references are case-sensitive and must match exactly. For full wiring details including public/private networking decisions, see [configure.md](configure.md).
+
+When creating new service instances via JSON config patches, include `isCreated: true` in the service block to mark it as a new service.
+
+### Deploy from a template
+
+Templates provision pre-configured services with sensible defaults, faster than creating an empty service and configuring it manually:
+
+```bash
+railway deploy --template <template-code>
+```
+
+Common template codes: `postgres`, `redis`, `mysql`, `mongodb`, `minio`, `umami`. For the full list, search via the GraphQL API (see [request.md](request.md)).
+
+Template deployments typically create:
+
+- A service with pre-configured image or source
+- Environment variables (connection strings, secrets)
+- A volume for persistent data (databases)
+- A TCP proxy for external access (where applicable)
+
+### Bootstrap source for an empty service
+
+After creating an empty service, wire it to a repo:
+
+```bash
+railway environment edit --service-config <service> source.repo <repo-url>
+railway environment edit --service-config <service> source.branch <branch>
+```
+
+### Deploy a Docker image
+
+When you have a built image (for example, from a private registry or Docker Hub), skip source builds entirely:
+
+```bash
+railway environment edit --service-config <service> source.image <image:tag>
+```
+
+This sets the service to pull from a container registry instead of building from source.
+
+## Buckets
+
+Buckets are S3-compatible object storage. They are created at the project level and deployed to environments via config patches.
+
+### List buckets
+
+```bash
+railway bucket list --json                                # buckets in current environment
+railway bucket list --environment production --json       # buckets in a specific environment
+```
+
+### Create a bucket
+
+```bash
+railway bucket create my-bucket --region sjc              # create with name and region
+railway bucket create --region iad --json                 # auto-named, JSON output
+```
+
+Available regions:
+
+| Code | Location |
+|---|---|
+| `sjc` | US West (California) |
+| `iad` | US East (Virginia) |
+| `ams` | EU West (Amsterdam) |
+| `sin` | Asia Pacific (Singapore) |
+
+Without `--region`, the CLI prompts interactively. For scripted use, always pass `--region`.
+
+### Delete a bucket
+
+Deletion is permanent and destroys all objects in the bucket.
+
+```bash
+railway bucket delete --bucket my-bucket --yes            # non-interactive
+railway bucket delete --bucket my-bucket --yes --2fa-code 123456   # with 2FA
+```
+
+### Rename a bucket
+
+```bash
+railway bucket rename --bucket my-bucket --name new-name --json
+```
+
+### Bucket info
+
+Check storage usage and object count:
+
+```bash
+railway bucket info --bucket my-bucket --json
+```
+
+Returns storage size (bytes), object count, region, and environment.
+
+### Bucket credentials
+
+Get S3-compatible credentials for connecting your app to a bucket:
+
+```bash
+railway bucket credentials --bucket my-bucket --json
+```
+
+Returns: `endpoint`, `accessKeyId`, `secretAccessKey`, `bucketName`, `region`, `urlStyle`.
+
+Without `--json`, output uses `AWS_*=value` lines suitable for `eval $(railway bucket credentials)` or piping into `.env` files.
+
+To reset credentials (invalidates existing ones):
+
+```bash
+railway bucket credentials --bucket my-bucket --reset --yes
+railway bucket credentials --bucket my-bucket --reset --yes --2fa-code 123456  # with 2FA
+```
+
+### Connect a bucket to a service
+
+After creating a bucket, wire the S3 credentials to your app service as environment variables:
+
+```bash
+# Get credentials
+railway bucket credentials --bucket my-bucket --json
+
+# Set them on your app service
+railway variable set \
+  AWS_ENDPOINT_URL=<endpoint> \
+  AWS_ACCESS_KEY_ID=<access-key> \
+  AWS_SECRET_ACCESS_KEY=<secret-key> \
+  AWS_S3_BUCKET_NAME=<bucket-name> \
+  AWS_DEFAULT_REGION=<region> \
+  --service <app-service>
+```
+
+All subcommands support `--bucket (-b)` and `--environment (-e)` as global flags to skip interactive prompts.
+
+## Analyze codebase before setup
+
+When setting up a new service from source, detect the project type from marker files:
+
+| Marker file | Type |
+|---|---|
+| `package.json` | Node.js |
+| `requirements.txt` or `pyproject.toml` | Python |
+| `go.mod` | Go |
+| `Cargo.toml` | Rust |
+| `index.html` (no package.json) | Static site |
+
+### Monorepo detection
+
+| Marker | Monorepo type |
+|---|---|
+| `pnpm-workspace.yaml` | pnpm workspace (shared) |
+| `package.json` with `workspaces` field | npm/yarn workspace (shared) |
+| `turbo.json` | Turborepo (shared) |
+| Multiple subdirectories with separate `package.json`, no workspace config | Isolated monorepo |
+
+**Isolated monorepo** (apps don't share code): set `rootDirectory` to the app's subdirectory (for example, `/apps/api`).
+
+**Shared monorepo** (TypeScript workspaces, shared packages): do not set `rootDirectory`. Set custom build and start commands instead:
+
+- pnpm: `pnpm --filter <package> build`
+- npm: `npm run build --workspace=packages/<package>`
+- yarn: `yarn workspace <package> build`
+- Turborepo: `turbo run build --filter=<package>`
+
+### Scaffolding hints
+
+When no code exists, minimal starting points for common types:
+
+- **Static site**: create `index.html` in the root directory.
+- **Vite React**: `npm create vite@latest . -- --template react`
+- **Python FastAPI**: create `main.py` with a FastAPI app and `requirements.txt` with `fastapi` and `uvicorn`.
+- **Go**: create `main.go` with an HTTP server that reads `PORT` from the environment.
+
+## Workspaces
+
+Workspaces scope billing and team access. Most users have one personal workspace and possibly team workspaces.
+
+```bash
+railway whoami --json              # lists workspace memberships
+```
+
+When creating projects, Railway uses the default workspace unless `--workspace` is specified.
+
+## Troubleshoot setup issues
+
+- **CLI missing**: install via `brew install railway` or `curl -fsSL https://railway.com/install.sh | sh`
+- **Not authenticated**: `railway login`
+- **Project not found**: verify with `railway project list --json`, check workspace context
+- **Service not found**: `railway service status --all --json` to list all services in the project
+- **Wrong workspace**: inspect `railway whoami --json`, re-run with explicit `--workspace`
+- **Permission denied**: check workspace role, mutations require member or admin access
+
+## Validated against
+
+- Docs: [cli.md](https://docs.railway.com/cli), [init.md](https://docs.railway.com/cli/init), [add.md](https://docs.railway.com/cli/add), [link.md](https://docs.railway.com/cli/link), [project.md](https://docs.railway.com/cli/project), [list.md](https://docs.railway.com/cli/list), [whoami.md](https://docs.railway.com/cli/whoami)
+- CLI source: [init.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/init.rs), [add.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/add.rs), [project.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/project.rs), [list.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/list.rs), [bucket.rs](https://github.com/railwayapp/cli/blob/feat/bucket-command/src/commands/bucket.rs)

--- a/.claude/skills/use-railway/scripts/analyze-mongo.py
+++ b/.claude/skills/use-railway/scripts/analyze-mongo.py
@@ -1,0 +1,1549 @@
+#!/usr/bin/env python3
+"""
+MongoDB analysis for Railway deployments.
+
+Produces a comprehensive report covering:
+- Deployment status & overview
+- Connections & operations
+- Latency (opLatencies)
+- Memory & WiredTiger cache
+- Storage & collection stats
+- Replication / oplog
+- Slow queries & active operations
+- Top collections by activity
+- Recommendations
+
+Usage:
+    analyze-mongo.py --service <name>
+    analyze-mongo.py --service <name> --json
+    analyze-mongo.py --service <name> --step ssh-test
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Any, Tuple
+from dataclasses import dataclass, field, asdict
+
+import dal
+from dal import (
+    LOG_LINES_DEFAULT, ProgressTimer, RailwayContext,
+    _init_context, progress, run_railway_command, run_ssh_query,
+    get_railway_status, get_deployment_status,
+    get_all_metrics_from_api, _analyze_window, _build_metrics_history,
+    get_recent_logs,
+    _trend_indicator,
+)
+
+
+# ---------------------------------------------------------------------------
+# Result container
+# ---------------------------------------------------------------------------
+
+@dataclass
+class MongoAnalysisResult:
+    """Container for MongoDB analysis results."""
+    service: str
+    db_type: str
+    timestamp: str
+    deployment_status: str = "UNKNOWN"
+
+    # Server overview
+    version: Optional[str] = None
+    storage_engine: Optional[str] = None
+    uptime_seconds: Optional[int] = None
+
+    # Connections
+    connections: Optional[Dict[str, Any]] = None
+
+    # Operations
+    opcounters: Optional[Dict[str, Any]] = None
+    opcounters_repl: Optional[Dict[str, Any]] = None
+
+    # Latency
+    op_latencies: Optional[Dict[str, Any]] = None
+
+    # Memory
+    memory: Optional[Dict[str, Any]] = None
+    page_faults: Optional[int] = None
+
+    # Network
+    network: Optional[Dict[str, Any]] = None
+
+    # WiredTiger
+    wiredtiger_cache: Optional[Dict[str, Any]] = None
+    wiredtiger_checkpoint: Optional[Dict[str, Any]] = None
+    wiredtiger_tickets: Optional[Dict[str, Any]] = None
+
+    # Global lock
+    global_lock: Optional[Dict[str, Any]] = None
+
+    # Document metrics
+    document_metrics: Optional[Dict[str, Any]] = None
+
+    # Query efficiency
+    query_executor: Optional[Dict[str, Any]] = None
+
+    # Plan cache (7.0+)
+    plan_cache: Optional[Dict[str, Any]] = None
+
+    # Sort (7.0+)
+    sort_metrics: Optional[Dict[str, Any]] = None
+
+    # Cursors
+    cursors: Optional[Dict[str, Any]] = None
+
+    # TTL
+    ttl_metrics: Optional[Dict[str, Any]] = None
+
+    # Asserts
+    asserts: Optional[Dict[str, Any]] = None
+
+    # Replication
+    replication: Optional[Dict[str, Any]] = None
+    oplog: Optional[Dict[str, Any]] = None
+
+    # Storage (db.stats)
+    storage: Optional[Dict[str, Any]] = None
+
+    # Collection stats
+    collection_stats: List[Dict[str, Any]] = field(default_factory=list)
+
+    # Top collections
+    top_collections: Optional[List[Dict[str, Any]]] = None
+
+    # Slow queries
+    slow_queries: List[Dict[str, Any]] = field(default_factory=list)
+
+    # Active operations
+    active_ops: List[Dict[str, Any]] = field(default_factory=list)
+
+    # Logs
+    recent_logs: List[str] = field(default_factory=list)
+    recent_errors: List[str] = field(default_factory=list)
+
+    # Railway metrics (CPU, memory, disk, network trends)
+    cpu_memory: Optional[Dict[str, Any]] = None
+    disk_usage: Optional[Dict[str, Any]] = None
+    metrics_history: Optional[Dict[str, Any]] = None
+
+    # Status tracking
+    collection_status: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    errors: List[str] = field(default_factory=list)
+    recommendations: List[Dict[str, str]] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# MongoDB-specific helpers
+# ---------------------------------------------------------------------------
+
+def run_mongosh_query(service: str, js_expr: str, timeout: int = 30) -> Tuple[int, str, str]:
+    """Run a mongosh query via SSH and return (returncode, stdout, stderr).
+
+    The query is wrapped in EJSON.stringify and executed through mongosh
+    connecting to the local MongoDB instance using container env vars.
+    """
+    # Escape single quotes in the JS expression for the shell
+    escaped = js_expr.replace("'", "'\\''")
+    command = (
+        f'''bash +H -c 'mongosh "mongodb://$MONGOUSER:$MONGOPASSWORD@localhost:27017" '''
+        f'''--quiet --norc --eval "EJSON.stringify({escaped})"' '''
+    )
+    return run_ssh_query(service, command, timeout)
+
+
+
+# ---------------------------------------------------------------------------
+# MongoDB queries
+# ---------------------------------------------------------------------------
+
+QUERY_SERVER_STATUS = """(function(){ var s = db.serverStatus(); return { connections: s.connections, opcounters: s.opcounters, opcountersRepl: s.opcountersRepl || null, repl: s.repl || null, mem: s.mem, network: s.network, uptime: s.uptime, opLatencies: s.opLatencies, wiredTiger: s.wiredTiger ? { cache: s.wiredTiger.cache, concurrentTransactions: s.wiredTiger.concurrentTransactions, transaction: s.wiredTiger.transaction || null } : null, globalLock: s.globalLock, metrics: s.metrics ? { document: s.metrics.document, queryExecutor: s.metrics.queryExecutor, cursor: s.metrics.cursor, ttl: s.metrics.ttl || null, query: s.metrics.query || null } : null, extra_info: s.extra_info ? { page_faults: s.extra_info.page_faults } : null, version: s.version, storageEngine: s.storageEngine, asserts: s.asserts }; })()"""
+
+QUERY_DB_STATS = """db.stats()"""
+
+QUERY_CURRENT_OP = """db.currentOp({ active: true })"""
+
+QUERY_COLLECTION_STATS = """db.getCollectionNames().map(function(c) { var s = db.getCollection(c).stats(); return { name: c, count: s.count || 0, size: s.size || 0, storageSize: s.storageSize || 0, indexSize: s.totalIndexSize || 0, nindexes: s.nindexes || 0 }; })"""
+
+QUERY_SLOW_QUERIES = """(function(){ try { var logs = db.system.profile.find().sort({ts: -1}).limit(10).toArray(); return logs.map(function(l) { return { op: l.op, ns: l.ns, millis: l.millis, ts: l.ts, command: JSON.stringify(l.command || l.query || {}).substring(0, 200), planSummary: l.planSummary || '' }; }); } catch(e) { return []; } })()"""
+
+QUERY_REPL_INFO = """(function(){ try { var info = db.getReplicationInfo(); return { logSizeMB: info.logSizeMB, usedMB: info.usedMB, timeDiffHours: info.timeDiffHours }; } catch(e) { return null; } })()"""
+
+QUERY_TOP = """(function(){ try { var t = db.adminCommand({top:1}); var totals = t.totals; var result = []; for (var ns in totals) { if (ns.indexOf('.') > 0 && ns.indexOf('system.') === -1) { var c = totals[ns]; result.push({ ns: ns, reads: c.readLock ? c.readLock.count : 0, readTimeUs: c.readLock ? c.readLock.time : 0, writes: c.writeLock ? c.writeLock.count : 0, writeTimeUs: c.writeLock ? c.writeLock.time : 0 }); } } return result; } catch(e) { return null; } })()"""
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+def _safe_json(raw: str) -> Any:
+    """Parse JSON from mongosh EJSON output, returning None on failure."""
+    raw = raw.strip()
+    if not raw:
+        return None
+    # mongosh may emit warnings before the JSON; find the first { or [
+    for i, ch in enumerate(raw):
+        if ch in ('{', '['):
+            raw = raw[i:]
+            break
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+
+
+def _parse_server_status(data: Dict[str, Any], result: MongoAnalysisResult) -> None:
+    """Extract metrics from serverStatus into result."""
+    # Overview
+    result.version = data.get("version")
+    se = data.get("storageEngine")
+    if se:
+        result.storage_engine = se.get("name")
+    result.uptime_seconds = data.get("uptime")
+
+    # Connections
+    conn = data.get("connections")
+    if conn:
+        result.connections = {
+            "current": conn.get("current", 0),
+            "available": conn.get("available", 0),
+            "totalCreated": conn.get("totalCreated", 0),
+        }
+
+    # Opcounters
+    result.opcounters = data.get("opcounters")
+    result.opcounters_repl = data.get("opcountersRepl")
+
+    # Replication info from serverStatus
+    repl = data.get("repl")
+    if repl:
+        result.replication = {
+            "setName": repl.get("setName"),
+            "isWritablePrimary": repl.get("isWritablePrimary"),
+            "primary": repl.get("primary"),
+            "hosts": repl.get("hosts"),
+        }
+
+    # Latency
+    lat = data.get("opLatencies")
+    if lat:
+        result.op_latencies = {}
+        for key in ("reads", "writes", "commands"):
+            entry = lat.get(key, {})
+            ops = entry.get("ops", 0)
+            latency = entry.get("latency", 0)
+            result.op_latencies[key] = {
+                "latency": latency,
+                "ops": ops,
+                "avg_us": round(latency / ops, 1) if ops > 0 else 0,
+            }
+
+    # Memory
+    mem = data.get("mem")
+    if mem:
+        result.memory = {
+            "resident_mb": mem.get("resident", 0),
+            "virtual_mb": mem.get("virtual", 0),
+        }
+
+    extra = data.get("extra_info")
+    if extra:
+        result.page_faults = extra.get("page_faults", 0)
+
+    # Network
+    net = data.get("network")
+    if net:
+        result.network = {
+            "bytesIn": net.get("bytesIn", 0),
+            "bytesOut": net.get("bytesOut", 0),
+            "numRequests": net.get("numRequests", 0),
+        }
+
+    # WiredTiger
+    wt = data.get("wiredTiger")
+    if wt:
+        cache = wt.get("cache", {})
+        result.wiredtiger_cache = {
+            "bytes_in_cache": cache.get("bytes currently in the cache", 0),
+            "max_bytes": cache.get("maximum bytes configured", 0),
+            "dirty_bytes": cache.get("tracked dirty bytes in the cache", 0),
+            "pages_read": cache.get("pages read into cache", 0),
+            "pages_written": cache.get("pages written from cache", 0),
+            "app_evictions": cache.get("pages evicted by application threads", 0),
+        }
+
+        txn = wt.get("transaction", {})
+        if txn:
+            result.wiredtiger_checkpoint = {
+                "most_recent_time_ms": txn.get("transaction checkpoint most recent time (msecs)", 0),
+            }
+
+        ct = wt.get("concurrentTransactions", {})
+        if ct:
+            read_info = ct.get("read", {})
+            write_info = ct.get("write", {})
+            result.wiredtiger_tickets = {
+                "read_available": read_info.get("available", 0),
+                "read_total": read_info.get("totalTickets", 0),
+                "write_available": write_info.get("available", 0),
+                "write_total": write_info.get("totalTickets", 0),
+            }
+
+    # Global lock
+    gl = data.get("globalLock")
+    if gl:
+        cq = gl.get("currentQueue", {})
+        ac = gl.get("activeClients", {})
+        result.global_lock = {
+            "queue_readers": cq.get("readers", 0),
+            "queue_writers": cq.get("writers", 0),
+            "active_readers": ac.get("readers", 0),
+            "active_writers": ac.get("writers", 0),
+        }
+
+    # Metrics
+    metrics = data.get("metrics")
+    if metrics:
+        doc = metrics.get("document")
+        if doc:
+            result.document_metrics = {
+                "inserted": doc.get("inserted", 0),
+                "updated": doc.get("updated", 0),
+                "deleted": doc.get("deleted", 0),
+                "returned": doc.get("returned", 0),
+            }
+
+        qe = metrics.get("queryExecutor")
+        if qe:
+            result.query_executor = {
+                "scanned": qe.get("scanned", 0),
+                "scannedObjects": qe.get("scannedObjects", 0),
+            }
+
+        cursor = metrics.get("cursor")
+        if cursor:
+            open_cursors = cursor.get("open", {})
+            result.cursors = {
+                "open_total": open_cursors.get("total", 0),
+                "timed_out": cursor.get("timedOut", 0),
+            }
+
+        ttl = metrics.get("ttl")
+        if ttl:
+            result.ttl_metrics = {
+                "deletedDocuments": ttl.get("deletedDocuments", 0),
+                "passes": ttl.get("passes", 0),
+            }
+
+        query_metrics = metrics.get("query")
+        if query_metrics:
+            pc = query_metrics.get("planCache", {})
+            if pc:
+                result.plan_cache = {
+                    "hits": pc.get("hits", 0),
+                    "misses": pc.get("misses", 0),
+                }
+            sort = query_metrics.get("sort", {})
+            if sort:
+                result.sort_metrics = {
+                    "spillToDisk": sort.get("spillToDisk", 0),
+                    "totalBytesSorted": sort.get("totalBytesSorted", 0),
+                }
+
+    # Asserts
+    result.asserts = data.get("asserts")
+
+
+def _parse_db_stats(data: Dict[str, Any], result: MongoAnalysisResult) -> None:
+    """Extract metrics from db.stats()."""
+    result.storage = {
+        "dataSize": data.get("dataSize", 0),
+        "storageSize": data.get("storageSize", 0),
+        "indexSize": data.get("indexSize", 0),
+        "objects": data.get("objects", 0),
+        "collections": data.get("collections", 0),
+    }
+
+
+def _parse_current_op(data: Any, result: MongoAnalysisResult) -> None:
+    """Extract active operations from currentOp."""
+    if not data:
+        return
+    inprog = data.get("inprog", []) if isinstance(data, dict) else []
+    ops = []
+    for op in inprog:
+        ops.append({
+            "opid": op.get("opid"),
+            "type": op.get("type", op.get("op", "")),
+            "ns": op.get("ns", ""),
+            "microsecs_running": op.get("microsecs_running", 0),
+            "desc": op.get("desc", ""),
+        })
+    result.active_ops = ops
+
+
+def _parse_collection_stats(data: Any, result: MongoAnalysisResult) -> None:
+    """Parse per-collection stats."""
+    if not isinstance(data, list):
+        return
+    result.collection_stats = data
+
+
+def _parse_slow_queries(data: Any, result: MongoAnalysisResult) -> None:
+    """Parse slow queries from profiler."""
+    if not isinstance(data, list):
+        return
+    result.slow_queries = data
+
+
+def _parse_repl_info(data: Any, result: MongoAnalysisResult) -> None:
+    """Parse oplog replication info."""
+    if not data or not isinstance(data, dict):
+        return
+    result.oplog = {
+        "logSizeMB": data.get("logSizeMB", 0),
+        "usedMB": data.get("usedMB", 0),
+        "timeDiffHours": data.get("timeDiffHours", 0),
+    }
+
+
+def _parse_top(data: Any, result: MongoAnalysisResult) -> None:
+    """Parse top collection activity."""
+    if not isinstance(data, list):
+        return
+    result.top_collections = data
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+def _fmt_bytes(b: int) -> str:
+    """Format bytes as human-readable."""
+    if b >= 1024 * 1024 * 1024:
+        return f"{b / 1024 / 1024 / 1024:.1f} GB"
+    elif b >= 1024 * 1024:
+        return f"{b / 1024 / 1024:.1f} MB"
+    elif b >= 1024:
+        return f"{b / 1024:.1f} KB"
+    return f"{b} B"
+
+
+def _fmt_count(n: int) -> str:
+    """Format large numbers with K/M suffix."""
+    if n >= 1_000_000_000:
+        return f"{n / 1_000_000_000:.1f}B"
+    elif n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    elif n >= 1_000:
+        return f"{n / 1_000:.1f}K"
+    return str(n)
+
+
+def _fmt_uptime(seconds: int) -> str:
+    """Format seconds as Xd Yh."""
+    days = seconds // 86400
+    hours = (seconds % 86400) // 3600
+    if days > 0:
+        return f"{days}d {hours}h"
+    elif hours > 0:
+        return f"{hours}h {(seconds % 3600) // 60}m"
+    return f"{seconds // 60}m"
+
+
+def _fmt_us(microseconds: float) -> str:
+    """Format microseconds as human-readable latency."""
+    if microseconds >= 1_000_000:
+        return f"{microseconds / 1_000_000:.1f}s"
+    elif microseconds >= 1_000:
+        return f"{microseconds / 1_000:.1f}ms"
+    return f"{microseconds:.0f}us"
+
+
+# ---------------------------------------------------------------------------
+# Main analysis
+# ---------------------------------------------------------------------------
+
+def analyze_mongo(service: str, timeout: int = 300, quiet: bool = False,
+                  skip_logs: bool = False, metrics_hours: int = 168,
+                  project_id: Optional[str] = None,
+                  environment_id: Optional[str] = None,
+                  service_id: Optional[str] = None) -> MongoAnalysisResult:
+    """Run complete MongoDB analysis."""
+    if not quiet:
+        print(f"Analyzing MongoDB database: {service}", file=sys.stderr)
+
+    result = MongoAnalysisResult(
+        service=service,
+        db_type="mongo",
+        timestamp=datetime.now(timezone.utc).isoformat(),
+    )
+
+    # === CONTEXT ===
+    if not quiet:
+        print("  [0/5] Getting Railway context...", file=sys.stderr, flush=True)
+    dal._progress_timer.start()
+
+    if environment_id and service_id:
+        dal._ctx = RailwayContext(project_id=project_id, environment_id=environment_id, service_id=service_id)
+        if not quiet:
+            print(f"        using explicit IDs (env={environment_id[:8]}..., svc={service_id[:8]}...)", file=sys.stderr, flush=True)
+    else:
+        railway_status = get_railway_status()
+        if railway_status:
+            dal._ctx = RailwayContext(
+                project_id=railway_status.get("projectId"),
+                environment_id=railway_status.get("environmentId"),
+                service_id=railway_status.get("serviceId"),
+            )
+        environment_id = dal._ctx.environment_id
+        service_id = dal._ctx.service_id
+
+    # === DEPLOYMENT STATUS ===
+    progress(1, 5, "Fetching deployment status...", quiet)
+    result.deployment_status = get_deployment_status(service, service_id=service_id)
+
+    # === SSH PRE-CHECK ===
+    progress(2, 5, "Testing SSH connectivity...", quiet)
+    ssh_available = False
+    ssh_stderr = ""
+    ssh_attempts = [30, 60, 90]
+    for attempt, attempt_timeout in enumerate(ssh_attempts, 1):
+        ssh_code, ssh_stdout, ssh_stderr = run_ssh_query(service, "echo ok", timeout=attempt_timeout)
+        if ssh_code == 0 and "ok" in ssh_stdout:
+            ssh_available = True
+            if not quiet:
+                for line in ssh_stderr.splitlines():
+                    if line.startswith("Using SSH key:"):
+                        print(f"        {line}", file=sys.stderr, flush=True)
+                        break
+            break
+        if not quiet:
+            remaining = len(ssh_attempts) - attempt
+            if remaining > 0:
+                print(f"        SSH attempt {attempt}/{len(ssh_attempts)} failed ({ssh_stderr or 'no response'}), retrying with {ssh_attempts[attempt]}s timeout...", file=sys.stderr, flush=True)
+            else:
+                print(f"        SSH attempt {attempt}/{len(ssh_attempts)} failed ({ssh_stderr or 'no response'}), giving up", file=sys.stderr, flush=True)
+
+    # === PARALLEL DATA COLLECTION ===
+    progress(3, 5, "Running analysis (metrics, mongo queries, logs in parallel)...", quiet)
+
+    def task_metrics():
+        if environment_id and service_id:
+            return get_all_metrics_from_api(environment_id, service_id, hours=metrics_hours)
+        return None
+
+    def task_mongo_batch1():
+        """serverStatus + dbStats + collectionStats."""
+        if not ssh_available:
+            return ("error", f"SSH not available: {ssh_stderr or 'connection failed'}")
+        results = {}
+        # serverStatus
+        code, stdout, stderr = run_mongosh_query(service, QUERY_SERVER_STATUS, timeout=30)
+        if code == 0:
+            results["serverStatus"] = _safe_json(stdout)
+        else:
+            results["serverStatus_error"] = stderr or stdout or "unknown"
+        # dbStats
+        code, stdout, stderr = run_mongosh_query(service, QUERY_DB_STATS, timeout=30)
+        if code == 0:
+            results["dbStats"] = _safe_json(stdout)
+        else:
+            results["dbStats_error"] = stderr or stdout or "unknown"
+        # collectionStats
+        code, stdout, stderr = run_mongosh_query(service, QUERY_COLLECTION_STATS, timeout=30)
+        if code == 0:
+            results["collStats"] = _safe_json(stdout)
+        else:
+            results["collStats_error"] = stderr or stdout or "unknown"
+        return ("ok", results)
+
+    def task_mongo_batch2():
+        """slowQueries + currentOp + replInfo + top."""
+        if not ssh_available:
+            return ("error", f"SSH not available: {ssh_stderr or 'connection failed'}")
+        results = {}
+        # slow queries
+        code, stdout, stderr = run_mongosh_query(service, QUERY_SLOW_QUERIES, timeout=30)
+        if code == 0:
+            results["slowQueries"] = _safe_json(stdout)
+        else:
+            results["slowQueries_error"] = stderr or stdout or "unknown"
+        # currentOp
+        code, stdout, stderr = run_mongosh_query(service, QUERY_CURRENT_OP, timeout=30)
+        if code == 0:
+            results["currentOp"] = _safe_json(stdout)
+        else:
+            results["currentOp_error"] = stderr or stdout or "unknown"
+        # replication info
+        code, stdout, stderr = run_mongosh_query(service, QUERY_REPL_INFO, timeout=30)
+        if code == 0:
+            results["replInfo"] = _safe_json(stdout)
+        else:
+            results["replInfo_error"] = stderr or stdout or "unknown"
+        # top
+        code, stdout, stderr = run_mongosh_query(service, QUERY_TOP, timeout=30)
+        if code == 0:
+            results["top"] = _safe_json(stdout)
+        else:
+            results["top_error"] = stderr or stdout or "unknown"
+        return ("ok", results)
+
+    def task_logs():
+        if skip_logs:
+            return []
+        return get_recent_logs(service, lines=LOG_LINES_DEFAULT,
+                               environment_id=environment_id,
+                               service_id=service_id)
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        future_metrics = executor.submit(task_metrics)
+        future_batch1 = executor.submit(task_mongo_batch1)
+        future_batch2 = executor.submit(task_mongo_batch2)
+        future_logs = executor.submit(task_logs)
+
+        metrics_result = future_metrics.result()
+        batch1_result = future_batch1.result()
+        batch2_result = future_batch2.result()
+        logs_result = future_logs.result()
+
+    # === PROCESS METRICS ===
+    if metrics_result:
+        result.disk_usage = metrics_result.get("disk_usage")
+        result.cpu_memory = metrics_result.get("cpu_memory")
+        result.metrics_history = metrics_result.get("metrics_history")
+        result.collection_status["metrics_api"] = {"status": "success"}
+    else:
+        result.collection_status["metrics_api"] = {
+            "status": "error",
+            "error": "Metrics API returned no data"
+        }
+
+    # === PROCESS BATCH 1 (serverStatus, dbStats, collStats) ===
+    if batch1_result[0] == "ok":
+        b1 = batch1_result[1]
+        ss = b1.get("serverStatus")
+        if ss:
+            _parse_server_status(ss, result)
+            result.collection_status["server_status"] = {"status": "success"}
+        else:
+            err = b1.get("serverStatus_error", "no data")
+            result.errors.append(f"serverStatus failed: {err}")
+            result.collection_status["server_status"] = {"status": "error", "error": err}
+
+        dbs = b1.get("dbStats")
+        if dbs:
+            _parse_db_stats(dbs, result)
+            result.collection_status["db_stats"] = {"status": "success"}
+        else:
+            err = b1.get("dbStats_error", "no data")
+            result.collection_status["db_stats"] = {"status": "error", "error": err}
+
+        cs = b1.get("collStats")
+        if cs:
+            _parse_collection_stats(cs, result)
+            result.collection_status["collection_stats"] = {"status": "success"}
+        else:
+            err = b1.get("collStats_error", "no data")
+            result.collection_status["collection_stats"] = {"status": "error", "error": err}
+    else:
+        error_msg = batch1_result[1] if len(batch1_result) > 1 else "unknown"
+        result.errors.append(f"Batch 1 (serverStatus/dbStats/collStats) failed: {error_msg}")
+        for src in ("server_status", "db_stats", "collection_stats"):
+            result.collection_status[src] = {"status": "error", "error": error_msg}
+
+    # === PROCESS BATCH 2 (slowQueries, currentOp, replInfo, top) ===
+    if batch2_result[0] == "ok":
+        b2 = batch2_result[1]
+
+        sq = b2.get("slowQueries")
+        if sq is not None:
+            _parse_slow_queries(sq, result)
+            result.collection_status["slow_queries"] = {"status": "success"}
+        else:
+            err = b2.get("slowQueries_error", "no data")
+            result.collection_status["slow_queries"] = {"status": "error", "error": err}
+
+        co = b2.get("currentOp")
+        if co is not None:
+            _parse_current_op(co, result)
+            result.collection_status["current_op"] = {"status": "success"}
+        else:
+            err = b2.get("currentOp_error", "no data")
+            result.collection_status["current_op"] = {"status": "error", "error": err}
+
+        ri = b2.get("replInfo")
+        if ri is not None:
+            _parse_repl_info(ri, result)
+            result.collection_status["repl_info"] = {"status": "success"}
+        else:
+            err = b2.get("replInfo_error", "no data or not a replica set")
+            result.collection_status["repl_info"] = {"status": "skipped", "reason": err}
+
+        top = b2.get("top")
+        if top is not None:
+            _parse_top(top, result)
+            result.collection_status["top"] = {"status": "success"}
+        else:
+            err = b2.get("top_error", "no data or insufficient privileges")
+            result.collection_status["top"] = {"status": "skipped", "reason": err}
+    else:
+        error_msg = batch2_result[1] if len(batch2_result) > 1 else "unknown"
+        result.errors.append(f"Batch 2 (slowQueries/currentOp/replInfo/top) failed: {error_msg}")
+        for src in ("slow_queries", "current_op", "repl_info", "top"):
+            result.collection_status[src] = {"status": "error", "error": error_msg}
+
+    # === PROCESS LOGS ===
+    progress(4, 5, "Processing logs...", quiet)
+    if skip_logs:
+        result.collection_status["logs_api"] = {"status": "skipped", "reason": "skip_logs flag set"}
+    elif logs_result:
+        result.recent_logs = logs_result
+        result.collection_status["logs_api"] = {"status": "success", "lines": len(logs_result)}
+        result.recent_errors = [
+            line for line in result.recent_logs
+            if 'ERROR' in line.upper() or 'FATAL' in line.upper() or 'PANIC' in line.upper()
+        ][:100]
+    else:
+        result.recent_logs = []
+        result.collection_status["logs_api"] = {"status": "error", "error": "Logs API returned no data"}
+
+    # === RECOMMENDATIONS ===
+    progress(5, 5, "Generating recommendations...", quiet)
+    result.recommendations = generate_recommendations(result)
+
+    if not quiet:
+        total = dal._progress_timer.total_elapsed()
+        print(f"Done.{total}", file=sys.stderr)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Recommendations engine
+# ---------------------------------------------------------------------------
+
+def generate_recommendations(result: MongoAnalysisResult) -> List[Dict[str, str]]:
+    """Generate recommendations based on analysis results."""
+    recs: List[Dict[str, str]] = []
+
+    # Collection failures — surface critical issues when SSH/introspection failed
+    if result.collection_status:
+        failed = {k: v for k, v in result.collection_status.items()
+                  if v.get("status") in ("failed", "error")}
+        ssh_sources = {"server_status", "db_stats", "collection_stats",
+                       "slow_queries", "current_op", "repl_info", "top"}
+        ssh_failed = {k: v for k, v in failed.items() if k in ssh_sources}
+        if ssh_failed:
+            sources = ", ".join(ssh_failed.keys())
+            errors = "; ".join(v.get("error", "unknown") for v in ssh_failed.values())
+            recs.append({
+                "severity": "critical",
+                "category": "collection",
+                "message": f"SSH introspection failed — unable to collect {sources}. "
+                           f"Error: {errors}. "
+                           f"Analysis is incomplete: WiredTiger cache, connections, "
+                           f"collection stats, and replication health could not be evaluated.",
+            })
+
+    # --- WiredTiger cache usage ---
+    wt = result.wiredtiger_cache
+    if wt:
+        max_bytes = wt.get("max_bytes", 0)
+        used_bytes = wt.get("bytes_in_cache", 0)
+        dirty_bytes = wt.get("dirty_bytes", 0)
+        app_evictions = wt.get("app_evictions", 0)
+
+        if max_bytes > 0:
+            usage_pct = round(100.0 * used_bytes / max_bytes, 1)
+            if usage_pct > 80:
+                recs.append({
+                    "priority": "immediate",
+                    "issue": f"WiredTiger cache is {usage_pct}% full ({_fmt_bytes(used_bytes)} of {_fmt_bytes(max_bytes)})",
+                    "action": "Consider increasing service RAM. WiredTiger cache defaults to 50% of RAM minus 1 GB.",
+                    "explanation": "When the WiredTiger cache is nearly full, MongoDB must evict pages more aggressively, "
+                                   "increasing latency for reads and writes. Increasing RAM gives WiredTiger more room to cache data.",
+                })
+
+            if used_bytes > 0:
+                dirty_pct = round(100.0 * dirty_bytes / max_bytes, 1)
+                if dirty_pct > 20:
+                    recs.append({
+                        "priority": "short-term",
+                        "issue": f"High dirty cache ({dirty_pct}% of total cache). Checkpoint may be falling behind.",
+                        "action": "Monitor checkpoint duration and consider increasing RAM or reducing write throughput.",
+                        "explanation": "Dirty pages must be written to disk during checkpoints. A high dirty ratio means "
+                                       "checkpoints have more work, potentially causing latency spikes.",
+                    })
+
+        if app_evictions and app_evictions > 0:
+            recs.append({
+                "priority": "immediate",
+                "issue": f"Application threads performing evictions ({app_evictions:,} pages). WiredTiger cache under pressure.",
+                "action": "Increase RAM to give WiredTiger more cache space.",
+                "explanation": "Normally the WiredTiger eviction threads handle cache pressure. When application threads "
+                               "must evict pages themselves, queries stall waiting for cache space. This directly increases latency.",
+            })
+
+    # --- Connection usage ---
+    conn = result.connections
+    if conn:
+        current = conn.get("current", 0)
+        available = conn.get("available", 0)
+        total = current + available
+        if total > 0:
+            pct = round(100.0 * current / total, 1)
+            if pct > 80:
+                recs.append({
+                    "priority": "immediate" if pct > 90 else "short-term",
+                    "issue": f"Connection usage at {pct}% ({current} of {total}). Approaching connection limit.",
+                    "action": "Review application connection pooling. Consider using a connection pooler or increasing maxIncomingConnections.",
+                    "explanation": "Running out of connections will cause new client connections to be refused. "
+                                   "Most applications should use connection pooling to limit concurrent connections.",
+                })
+
+    # --- Page faults ---
+    if result.page_faults and result.page_faults > 10000:
+        recs.append({
+            "priority": "short-term",
+            "issue": f"Significant page faults ({result.page_faults:,}). Working set may exceed available RAM.",
+            "action": "Increase service RAM or optimize queries to reduce working set size.",
+            "explanation": "Page faults occur when MongoDB accesses data not in memory, requiring disk reads. "
+                           "High page faults indicate the working set is larger than available RAM.",
+        })
+
+    # --- Queued operations ---
+    gl = result.global_lock
+    if gl:
+        qr = gl.get("queue_readers", 0)
+        qw = gl.get("queue_writers", 0)
+        if qr > 0 or qw > 0:
+            recs.append({
+                "priority": "immediate" if (qr + qw) > 10 else "short-term",
+                "issue": f"Operations queuing detected (readers: {qr}, writers: {qw}). Database may be under resource pressure.",
+                "action": "Investigate slow operations and consider increasing RAM or CPU.",
+                "explanation": "Queued operations mean requests are waiting for a lock. This can be caused by slow queries, "
+                               "write-heavy workloads, or insufficient resources.",
+            })
+
+    # --- Query efficiency ---
+    qe = result.query_executor
+    dm = result.document_metrics
+    if qe and dm:
+        scanned = qe.get("scannedObjects", 0)
+        returned = dm.get("returned", 0)
+        if returned > 0 and scanned > returned * 10:
+            ratio = round(scanned / returned, 1)
+            recs.append({
+                "priority": "immediate" if ratio > 100 else "short-term",
+                "issue": f"Query efficiency concern: {_fmt_count(scanned)} objects scanned vs {_fmt_count(returned)} returned (ratio: {ratio}x).",
+                "action": "Create indexes for frequently queried fields. Review slow query log for full collection scans.",
+                "explanation": "A high scan-to-return ratio means MongoDB is examining many documents to satisfy queries. "
+                               "Adding appropriate indexes dramatically reduces the number of documents examined.",
+            })
+
+    # --- Plan cache ---
+    pc = result.plan_cache
+    if pc:
+        hits = pc.get("hits", 0)
+        misses = pc.get("misses", 0)
+        total = hits + misses
+        if total > 100 and misses > hits:
+            recs.append({
+                "priority": "short-term",
+                "issue": f"High plan cache miss ratio ({misses:,} misses vs {hits:,} hits). Queries may not be using optimal plans.",
+                "action": "Consider creating indexes for frequent query patterns to stabilize query plans.",
+                "explanation": "Plan cache misses mean MongoDB must re-evaluate query plans. Stable indexes help the planner "
+                               "pick consistent, efficient plans.",
+            })
+
+    # --- Sort spill to disk ---
+    sm = result.sort_metrics
+    if sm:
+        spill = sm.get("spillToDisk", 0)
+        if spill > 0:
+            recs.append({
+                "priority": "short-term",
+                "issue": f"Sorts spilling to disk ({spill:,} times). Queries performing in-memory sorts exceeding limit.",
+                "action": "Add indexes to support sort operations, or increase RAM.",
+                "explanation": "When a sort operation exceeds the memory limit (100 MB by default), MongoDB spills to disk. "
+                               "Creating an index that matches the sort key avoids the in-memory sort entirely.",
+            })
+
+    # --- Cursor timeouts ---
+    cur = result.cursors
+    if cur:
+        timed_out = cur.get("timed_out", 0)
+        if timed_out > 0:
+            recs.append({
+                "priority": "short-term",
+                "issue": f"Cursor timeouts detected ({timed_out:,}). Long-running queries may need optimization.",
+                "action": "Review application code for unbounded queries or missing pagination.",
+                "explanation": "Cursors time out after 10 minutes of inactivity by default. Frequent timeouts suggest "
+                               "clients are not consuming results quickly enough or queries are returning too much data.",
+            })
+
+    # --- Asserts ---
+    asserts = result.asserts
+    if asserts:
+        regular = asserts.get("regular", 0)
+        warning = asserts.get("warning", 0)
+        user = asserts.get("user", 0)
+        msg = asserts.get("msg", 0)
+        if regular > 0 or warning > 0 or user > 0:
+            recs.append({
+                "priority": "short-term",
+                "issue": f"Database asserts detected (regular: {regular}, warning: {warning}, user: {user}, msg: {msg}). Investigate error conditions.",
+                "action": "Check MongoDB logs for assert details. User asserts often indicate client errors; regular/warning asserts may signal server issues.",
+                "explanation": "Asserts are internal consistency checks. Regular and warning asserts may indicate bugs or data issues. "
+                               "User asserts are typically client-side errors (e.g., duplicate key violations).",
+            })
+
+    # --- Oplog usage ---
+    oplog = result.oplog
+    if oplog:
+        log_size = oplog.get("logSizeMB", 0)
+        used = oplog.get("usedMB", 0)
+        if log_size > 0:
+            oplog_pct = round(100.0 * used / log_size, 1)
+            if oplog_pct > 80:
+                recs.append({
+                    "priority": "short-term",
+                    "issue": f"Oplog is {oplog_pct}% full ({used:.0f} MB of {log_size:.0f} MB). May impact replication if oplog window is too small.",
+                    "action": "Consider increasing the oplog size to maintain a larger replication window.",
+                    "explanation": "The oplog stores recent write operations for replication. If it fills up and wraps around too quickly, "
+                                   "replica set members that fall behind may need a full resync instead of incremental replication.",
+                })
+
+    return recs
+
+
+# ---------------------------------------------------------------------------
+# Report formatting
+# ---------------------------------------------------------------------------
+
+def format_report(result: MongoAnalysisResult) -> str:
+    """Format analysis result as human-readable markdown report."""
+    lines: List[str] = []
+    lines.append("=" * 60)
+    lines.append(f"# MongoDB Analysis: {result.service}")
+    lines.append("=" * 60)
+    lines.append(f"Timestamp: {result.timestamp}")
+    lines.append(f"Status: {result.deployment_status}")
+    lines.append("")
+
+    # --- Data Collection Status ---
+    if result.collection_status:
+        lines.append("## Data Collection Status")
+        lines.append("")
+        lines.append("| Source | Status | Details |")
+        lines.append("|--------|--------|---------|")
+        source_labels = {
+            "server_status": "Server Status (SSH)",
+            "db_stats": "Database Stats (SSH)",
+            "collection_stats": "Collection Stats (SSH)",
+            "slow_queries": "Slow Queries (SSH)",
+            "current_op": "Current Operations (SSH)",
+            "repl_info": "Replication Info (SSH)",
+            "top": "Top Collections (SSH)",
+            "metrics_api": "Metrics API",
+            "logs_api": "Logs API",
+        }
+        for source in ["server_status", "db_stats", "collection_stats",
+                        "slow_queries", "current_op", "repl_info", "top",
+                        "metrics_api", "logs_api"]:
+            if source in result.collection_status:
+                info = result.collection_status[source]
+                status = info["status"].upper()
+                details = ""
+                if info.get("error"):
+                    details = info["error"]
+                elif info.get("reason"):
+                    details = info["reason"]
+                elif info.get("lines"):
+                    details = f"{info['lines']} lines collected"
+                elif status == "SUCCESS":
+                    details = "OK"
+                label = source_labels.get(source, source)
+                lines.append(f"| {label} | {status} | {details} |")
+        lines.append("")
+
+    # --- Overview ---
+    lines.append("## Overview")
+    lines.append("")
+    lines.append("| Metric | Value |")
+    lines.append("|--------|-------|")
+    if result.version:
+        lines.append(f"| Version | {result.version} |")
+    if result.storage_engine:
+        lines.append(f"| Storage Engine | {result.storage_engine} |")
+    if result.uptime_seconds is not None:
+        lines.append(f"| Uptime | {_fmt_uptime(result.uptime_seconds)} |")
+    status_icon = "Healthy" if result.deployment_status == "SUCCESS" else "Warning"
+    lines.append(f"| Deployment | {result.deployment_status} | {status_icon} |")
+    lines.append("")
+
+    # --- Connections ---
+    if result.connections:
+        lines.append("## Connections")
+        lines.append("")
+        lines.append("| Metric | Value | Status |")
+        lines.append("|--------|-------|--------|")
+        c = result.connections
+        current = c.get("current", 0)
+        available = c.get("available", 0)
+        total = current + available
+        pct = round(100.0 * current / total, 1) if total > 0 else 0
+        status = "Critical" if pct > 90 else "Warning" if pct > 80 else ""
+        lines.append(f"| Current | {current:,} | {status} |")
+        lines.append(f"| Available | {available:,} | |")
+        lines.append(f"| Total Created | {c.get('totalCreated', 0):,} | |")
+        lines.append("")
+
+    # --- Operations (since startup) ---
+    if result.opcounters:
+        lines.append("## Operations (since startup)")
+        lines.append("")
+        lines.append("| Operation | Count |")
+        lines.append("|-----------|-------|")
+        for op in ("insert", "query", "update", "delete", "getmore", "command"):
+            val = result.opcounters.get(op, 0)
+            lines.append(f"| {op} | {_fmt_count(val)} |")
+        lines.append("")
+
+    # --- Replication opcounters ---
+    if result.opcounters_repl:
+        any_repl = any(v > 0 for v in result.opcounters_repl.values() if isinstance(v, (int, float)))
+        if any_repl:
+            lines.append("## Replication Operations")
+            lines.append("")
+            lines.append("| Operation | Count |")
+            lines.append("|-----------|-------|")
+            for op in ("insert", "query", "update", "delete", "getmore", "command"):
+                val = result.opcounters_repl.get(op, 0)
+                lines.append(f"| {op} | {_fmt_count(val)} |")
+            lines.append("")
+
+    # --- Latency ---
+    if result.op_latencies:
+        lines.append("## Latency")
+        lines.append("")
+        lines.append("| Operation | Avg Latency | Total Ops |")
+        lines.append("|-----------|-------------|-----------|")
+        for key, label in [("reads", "Reads"), ("writes", "Writes"), ("commands", "Commands")]:
+            entry = result.op_latencies.get(key, {})
+            avg_us = entry.get("avg_us", 0)
+            ops = entry.get("ops", 0)
+            lines.append(f"| {label} | {_fmt_us(avg_us)} | {_fmt_count(ops)} |")
+        lines.append("")
+
+    # --- Memory ---
+    if result.memory:
+        lines.append("## Memory")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        lines.append(f"| Resident | {result.memory.get('resident_mb', 0):,} MB |")
+        lines.append(f"| Virtual | {result.memory.get('virtual_mb', 0):,} MB |")
+        if result.page_faults is not None:
+            lines.append(f"| Page Faults | {result.page_faults:,} |")
+        lines.append("")
+
+    # --- WiredTiger Cache ---
+    wt = result.wiredtiger_cache
+    if wt:
+        lines.append("## WiredTiger Cache")
+        lines.append("")
+        lines.append("| Metric | Value | Status |")
+        lines.append("|--------|-------|--------|")
+        used = wt.get("bytes_in_cache", 0)
+        max_b = wt.get("max_bytes", 0)
+        dirty = wt.get("dirty_bytes", 0)
+        app_evict = wt.get("app_evictions", 0)
+        lines.append(f"| Used | {_fmt_bytes(used)} | |")
+        lines.append(f"| Maximum | {_fmt_bytes(max_b)} | |")
+        if max_b > 0:
+            usage_pct = round(100.0 * used / max_b, 1)
+            cache_status = "Critical" if usage_pct > 90 else "Warning" if usage_pct > 80 else "OK"
+            lines.append(f"| Usage | {usage_pct}% | {cache_status} |")
+        lines.append(f"| Dirty | {_fmt_bytes(dirty)} | |")
+        evict_status = "Warning" if app_evict > 0 else "OK"
+        lines.append(f"| App Thread Evictions | {app_evict:,} | {evict_status} |")
+        lines.append(f"| Pages Read Into Cache | {wt.get('pages_read', 0):,} | |")
+        lines.append(f"| Pages Written From Cache | {wt.get('pages_written', 0):,} | |")
+        lines.append("")
+
+    # --- WiredTiger Checkpoint ---
+    cp = result.wiredtiger_checkpoint
+    if cp:
+        ms = cp.get("most_recent_time_ms", 0)
+        lines.append("## WiredTiger Checkpoint")
+        lines.append("")
+        lines.append(f"| Most Recent Checkpoint Time | {ms:,} ms |")
+        lines.append("")
+
+    # --- WiredTiger Tickets ---
+    tk = result.wiredtiger_tickets
+    if tk:
+        lines.append("## WiredTiger Tickets")
+        lines.append("")
+        lines.append("| Metric | Available | Total |")
+        lines.append("|--------|-----------|-------|")
+        lines.append(f"| Read | {tk.get('read_available', 0)} | {tk.get('read_total', 0)} |")
+        lines.append(f"| Write | {tk.get('write_available', 0)} | {tk.get('write_total', 0)} |")
+        lines.append("")
+
+    # --- Global Lock ---
+    gl = result.global_lock
+    if gl:
+        lines.append("## Global Lock")
+        lines.append("")
+        lines.append("| Metric | Readers | Writers |")
+        lines.append("|--------|---------|---------|")
+        lines.append(f"| Queue | {gl.get('queue_readers', 0)} | {gl.get('queue_writers', 0)} |")
+        lines.append(f"| Active | {gl.get('active_readers', 0)} | {gl.get('active_writers', 0)} |")
+        lines.append("")
+
+    # --- Network ---
+    if result.network:
+        lines.append("## Network")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        lines.append(f"| Bytes In | {_fmt_bytes(result.network.get('bytesIn', 0))} |")
+        lines.append(f"| Bytes Out | {_fmt_bytes(result.network.get('bytesOut', 0))} |")
+        lines.append(f"| Requests | {_fmt_count(result.network.get('numRequests', 0))} |")
+        lines.append("")
+
+    # --- Document Metrics ---
+    dm = result.document_metrics
+    if dm:
+        lines.append("## Documents")
+        lines.append("")
+        lines.append("| Operation | Count |")
+        lines.append("|-----------|-------|")
+        for key in ("inserted", "updated", "deleted", "returned"):
+            lines.append(f"| {key} | {_fmt_count(dm.get(key, 0))} |")
+        lines.append("")
+
+    # --- Query Efficiency ---
+    qe = result.query_executor
+    if qe:
+        lines.append("## Query Efficiency")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        lines.append(f"| Scanned Objects | {_fmt_count(qe.get('scannedObjects', 0))} |")
+        lines.append(f"| Scanned Keys | {_fmt_count(qe.get('scanned', 0))} |")
+        if dm:
+            returned = dm.get("returned", 0)
+            scanned = qe.get("scannedObjects", 0)
+            if returned > 0:
+                ratio = round(scanned / returned, 1)
+                status = "Warning" if ratio > 10 else "OK"
+                lines.append(f"| Scan-to-Return Ratio | {ratio}x | {status} |")
+        lines.append("")
+
+    # --- Plan Cache ---
+    pc = result.plan_cache
+    if pc:
+        lines.append("## Plan Cache (7.0+)")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        lines.append(f"| Hits | {_fmt_count(pc.get('hits', 0))} |")
+        lines.append(f"| Misses | {_fmt_count(pc.get('misses', 0))} |")
+        lines.append("")
+
+    # --- Sort Metrics ---
+    sm = result.sort_metrics
+    if sm:
+        lines.append("## Sort (7.0+)")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        lines.append(f"| Spill to Disk | {sm.get('spillToDisk', 0):,} |")
+        lines.append(f"| Total Bytes Sorted | {_fmt_bytes(sm.get('totalBytesSorted', 0))} |")
+        lines.append("")
+
+    # --- Cursors ---
+    cur = result.cursors
+    if cur:
+        lines.append("## Cursors")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        lines.append(f"| Open Total | {cur.get('open_total', 0):,} |")
+        timed = cur.get("timed_out", 0)
+        status = "Warning" if timed > 0 else ""
+        lines.append(f"| Timed Out | {timed:,} | {status} |")
+        lines.append("")
+
+    # --- TTL ---
+    ttl = result.ttl_metrics
+    if ttl:
+        lines.append("## TTL")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        lines.append(f"| Deleted Documents | {_fmt_count(ttl.get('deletedDocuments', 0))} |")
+        lines.append(f"| Passes | {ttl.get('passes', 0):,} |")
+        lines.append("")
+
+    # --- Asserts ---
+    asserts = result.asserts
+    if asserts:
+        any_assert = any(asserts.get(k, 0) > 0 for k in ("regular", "warning", "msg", "user"))
+        if any_assert:
+            lines.append("## Asserts")
+            lines.append("")
+            lines.append("| Type | Count |")
+            lines.append("|------|-------|")
+            for key in ("regular", "warning", "msg", "user", "rollovers"):
+                lines.append(f"| {key} | {asserts.get(key, 0):,} |")
+            lines.append("")
+
+    # --- Storage ---
+    st = result.storage
+    if st:
+        lines.append("## Storage")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        lines.append(f"| Data Size | {_fmt_bytes(st.get('dataSize', 0))} |")
+        lines.append(f"| Storage Size | {_fmt_bytes(st.get('storageSize', 0))} |")
+        lines.append(f"| Index Size | {_fmt_bytes(st.get('indexSize', 0))} |")
+        lines.append(f"| Objects | {_fmt_count(st.get('objects', 0))} |")
+        lines.append(f"| Collections | {st.get('collections', 0)} |")
+        lines.append("")
+
+    # --- Collections ---
+    if result.collection_stats:
+        lines.append("## Collections")
+        lines.append("")
+        lines.append("| Collection | Documents | Data Size | Storage | Indexes |")
+        lines.append("|------------|-----------|-----------|---------|---------|")
+        # Sort by size descending
+        sorted_colls = sorted(result.collection_stats, key=lambda c: c.get("size", 0), reverse=True)
+        for c in sorted_colls:
+            name = c.get("name", "?")
+            count = _fmt_count(c.get("count", 0))
+            size = _fmt_bytes(c.get("size", 0))
+            storage = _fmt_bytes(c.get("storageSize", 0))
+            nidx = c.get("nindexes", 0)
+            lines.append(f"| {name} | {count} | {size} | {storage} | {nidx} |")
+        lines.append("")
+
+    # --- Top Collections by Activity ---
+    if result.top_collections:
+        lines.append("## Top Collections by Activity")
+        lines.append("")
+        lines.append("| Namespace | Reads | Read Time | Writes | Write Time |")
+        lines.append("|-----------|-------|-----------|--------|------------|")
+        # Sort by total activity
+        sorted_top = sorted(result.top_collections,
+                            key=lambda t: t.get("reads", 0) + t.get("writes", 0),
+                            reverse=True)
+        for t in sorted_top[:20]:
+            ns = t.get("ns", "?")
+            reads = _fmt_count(t.get("reads", 0))
+            read_time = _fmt_us(t.get("readTimeUs", 0))
+            writes = _fmt_count(t.get("writes", 0))
+            write_time = _fmt_us(t.get("writeTimeUs", 0))
+            lines.append(f"| {ns} | {reads} | {read_time} | {writes} | {write_time} |")
+        lines.append("")
+
+    # --- Replication ---
+    if result.replication:
+        lines.append("## Replication")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        r = result.replication
+        if r.get("setName"):
+            lines.append(f"| Replica Set | {r['setName']} |")
+        lines.append(f"| Is Writable Primary | {r.get('isWritablePrimary', 'N/A')} |")
+        if r.get("primary"):
+            lines.append(f"| Primary | {r['primary']} |")
+        if r.get("hosts"):
+            lines.append(f"| Hosts | {', '.join(r['hosts'])} |")
+        lines.append("")
+
+    # --- Oplog ---
+    if result.oplog:
+        lines.append("## Oplog")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        ol = result.oplog
+        log_size = ol.get("logSizeMB", 0)
+        used = ol.get("usedMB", 0)
+        lines.append(f"| Log Size | {log_size:.0f} MB |")
+        lines.append(f"| Used | {used:.0f} MB |")
+        if log_size > 0:
+            lines.append(f"| Usage | {round(100.0 * used / log_size, 1)}% |")
+        hours = ol.get("timeDiffHours", 0)
+        lines.append(f"| Time Window | {hours:.1f} hours |")
+        lines.append("")
+
+    # --- Slow Queries ---
+    if result.slow_queries:
+        lines.append("## Slow Queries")
+        lines.append("")
+        lines.append("| Op | Namespace | Duration | Plan |")
+        lines.append("|----|-----------|----------|------|")
+        for q in result.slow_queries:
+            op = q.get("op", "?")
+            ns = q.get("ns", "?")
+            millis = q.get("millis", 0)
+            plan = q.get("planSummary", "")
+            lines.append(f"| {op} | {ns} | {millis}ms | {plan} |")
+        lines.append("")
+
+    # --- Active Operations ---
+    if result.active_ops:
+        lines.append("## Active Operations")
+        lines.append("")
+        lines.append("| OpID | Type | Namespace | Duration |")
+        lines.append("|------|------|-----------|----------|")
+        sorted_ops = sorted(result.active_ops, key=lambda o: o.get("microsecs_running", 0), reverse=True)
+        for op in sorted_ops[:20]:
+            opid = op.get("opid", "?")
+            op_type = op.get("type", "?")
+            ns = op.get("ns", "")
+            us = op.get("microsecs_running", 0)
+            lines.append(f"| {opid} | {op_type} | {ns} | {_fmt_us(us)} |")
+        lines.append("")
+
+    # --- Infrastructure Trends ---
+    if result.metrics_history and result.metrics_history.get("windows"):
+        windows = result.metrics_history.get("windows", {})
+        for window_label, window_data in windows.items():
+            mh = window_data.get("metrics", {})
+            if not mh:
+                continue
+            lines.append(f"## Infrastructure Trends ({window_label})")
+            lines.append("")
+            lines.append("| Metric | Current | Min | Max | Avg | Trend | Change |")
+            lines.append("|--------|---------|-----|-----|-----|-------|--------|")
+            display_order = [
+                ("cpu", "CPU"),
+                ("memory", "Memory"),
+                ("disk", "Disk"),
+                ("network_rx", "Network RX"),
+                ("network_tx", "Network TX"),
+            ]
+            for key, label in display_order:
+                if key in mh:
+                    m = mh[key]
+                    unit = m["unit"]
+                    trend = m.get("trend", {})
+                    direction = trend.get("direction", "?")
+                    change = trend.get("change_pct", 0)
+                    arrow = {"increasing": "^", "decreasing": "v", "stable": "~"}.get(direction, "?")
+                    spike_note = ""
+                    if m.get("spikes"):
+                        spike_note = f" ({m['spikes']['count']} spikes)"
+                    lines.append(
+                        f"| {label} | {m['current']} {unit} | {m['min']} | {m['max']} | "
+                        f"{m['avg']} | {arrow} {direction} | {change:+.1f}%{spike_note} |"
+                    )
+            lines.append("")
+
+    # --- CPU / Memory summary ---
+    if result.cpu_memory:
+        lines.append("## Resource Usage")
+        lines.append("")
+        lines.append("| Metric | Value | Status |")
+        lines.append("|--------|-------|--------|")
+        cm = result.cpu_memory
+        if "cpu_percent" in cm:
+            cpu = cm["cpu_percent"]
+            status = "Critical" if cpu > 85 else "Warning" if cpu > 70 else "Healthy"
+            trend_str = _trend_indicator(result.metrics_history, "cpu")
+            lines.append(f"| CPU Usage | {cpu} vCPU{trend_str} | {status} |")
+            if cm.get("cpu_limit"):
+                lines.append(f"| CPU Limit | {cm['cpu_limit']} vCPU | - |")
+        if "memory_gb" in cm:
+            mem_val = cm["memory_gb"]
+            trend_str = _trend_indicator(result.metrics_history, "memory")
+            utilization = ""
+            if cm.get("memory_limit_gb"):
+                pct = round((mem_val / cm["memory_limit_gb"]) * 100, 1)
+                status = "Critical" if pct > 90 else "Warning" if pct > 80 else "Healthy"
+                utilization = f" ({pct}% of {cm['memory_limit_gb']} GB)"
+            else:
+                status = "-"
+            lines.append(f"| Memory Usage | {mem_val} GB{utilization}{trend_str} | {status} |")
+        if result.disk_usage:
+            lines.append(f"| Disk Usage | {result.disk_usage.get('used', 'N/A')} | - |")
+        lines.append("")
+
+    # --- Recent Errors ---
+    if result.recent_errors:
+        lines.append("## Recent Errors")
+        lines.append("")
+        for error in result.recent_errors[:10]:
+            lines.append(f"- {error[:150]}...")
+        lines.append("")
+
+    # --- Recommendations ---
+    if result.recommendations:
+        lines.append("## Recommendations")
+        lines.append("")
+        for i, rec in enumerate(result.recommendations, 1):
+            priority = rec["priority"].upper()
+            lines.append(f"{i}. **[{priority}]** {rec['issue']}")
+            lines.append(f"   **Action:** {rec['action']}")
+            if rec.get("explanation"):
+                lines.append(f"   **Why:** {rec['explanation']}")
+            lines.append("")
+
+    # --- Errors ---
+    if result.errors:
+        lines.append("## Errors")
+        lines.append("")
+        for error in result.errors:
+            lines.append(f"- {error}")
+        lines.append("")
+
+    lines.append("=" * 60)
+    lines.append("END OF REPORT")
+    lines.append("=" * 60)
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Single-step debugging
+# ---------------------------------------------------------------------------
+
+def run_single_step(args) -> int:
+    """Run a single collection step for debugging."""
+    service = args.service
+    _init_context(args)
+    environment_id = dal._ctx.environment_id
+    service_id = dal._ctx.service_id
+
+    if args.step == "ssh-test":
+        print(f"Testing SSH to service: {service}", file=sys.stderr)
+        code, stdout, stderr = run_ssh_query(service, "echo ok", timeout=45)
+        print(f"Exit code: {code}")
+        print(f"Stdout: {stdout.strip()}")
+        if stderr:
+            print(f"Stderr: {stderr.strip()}")
+        return 0 if (code == 0 and "ok" in stdout) else 1
+
+    elif args.step == "server-status":
+        print(f"Running serverStatus on: {service}", file=sys.stderr)
+        code, stdout, stderr = run_mongosh_query(service, QUERY_SERVER_STATUS, timeout=30)
+        print(f"Exit code: {code}")
+        if code == 0 and stdout:
+            data = _safe_json(stdout)
+            if data:
+                print(json.dumps(data, indent=2))
+            else:
+                print(f"Raw output:\n{stdout}")
+        else:
+            print(f"Error: {stderr or stdout}")
+        return code
+
+    elif args.step == "db-stats":
+        print(f"Running db.stats() on: {service}", file=sys.stderr)
+        code, stdout, stderr = run_mongosh_query(service, QUERY_DB_STATS, timeout=30)
+        print(f"Exit code: {code}")
+        if code == 0 and stdout:
+            data = _safe_json(stdout)
+            if data:
+                print(json.dumps(data, indent=2))
+            else:
+                print(f"Raw output:\n{stdout}")
+        else:
+            print(f"Error: {stderr or stdout}")
+        return code
+
+    elif args.step == "logs":
+        print(f"Fetching logs for: {service}", file=sys.stderr)
+        logs = get_recent_logs(service, lines=LOG_LINES_DEFAULT,
+                               environment_id=environment_id,
+                               service_id=service_id)
+        print(f"Lines fetched: {len(logs)}")
+        for line in logs:
+            print(line)
+        return 0
+
+    elif args.step == "metrics":
+        print(f"Fetching metrics for: {service}", file=sys.stderr)
+        if environment_id and service_id:
+            metrics = get_all_metrics_from_api(environment_id, service_id)
+            if metrics:
+                print(json.dumps(metrics, indent=2))
+            else:
+                print("Metrics API returned no data")
+                return 1
+        else:
+            print("Missing environment_id or service_id from railway config")
+            return 1
+        return 0
+
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="MongoDB analysis for Railway services.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument("--service", required=True, help="Service name")
+    parser.add_argument("--json", action="store_true",
+                        help="Output as JSON")
+    parser.add_argument("--timeout", type=int, default=300,
+                        help="Timeout in seconds (default: 300)")
+    parser.add_argument("--quiet", "-q", action="store_true",
+                        help="Suppress progress messages")
+    parser.add_argument("--skip-logs", action="store_true",
+                        help="Skip log fetching for faster analysis")
+    parser.add_argument("--metrics-hours", type=int, default=168,
+                        help="Hours of metrics history to fetch (default: 168, max: 168)")
+    parser.add_argument("--step",
+                        choices=["ssh-test", "server-status", "db-stats", "logs", "metrics"],
+                        help="Run a single collection step for debugging")
+    parser.add_argument("--project-id", help="Project ID (bypasses railway link)")
+    parser.add_argument("--environment-id", help="Environment ID (bypasses railway link)")
+    parser.add_argument("--service-id", help="Service ID (bypasses railway link)")
+
+    args = parser.parse_args()
+
+    if args.step:
+        return run_single_step(args)
+
+    result = analyze_mongo(
+        args.service,
+        timeout=args.timeout,
+        quiet=args.quiet,
+        skip_logs=args.skip_logs,
+        metrics_hours=min(args.metrics_hours, 168),
+        project_id=args.project_id,
+        environment_id=args.environment_id,
+        service_id=args.service_id,
+    )
+
+    if args.json:
+        print(json.dumps(asdict(result), indent=2))
+    else:
+        print(format_report(result))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/use-railway/scripts/analyze-mysql.py
+++ b/.claude/skills/use-railway/scripts/analyze-mysql.py
@@ -1,0 +1,1195 @@
+#!/usr/bin/env python3
+"""
+MySQL analysis for Railway deployments.
+
+Produces a comprehensive report covering:
+- Deployment status & resource metrics (CPU, memory, disk)
+- Connection overview
+- Query throughput & efficiency
+- InnoDB buffer pool & row operations
+- Lock contention
+- Top queries (from performance_schema)
+- Table sizes
+- Active processes
+- Recommendations
+
+Usage:
+    analyze-mysql.py --service <name>
+    analyze-mysql.py --service <name> --json
+    analyze-mysql.py --service <name> --step ssh-test
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+import dal
+from dal import (
+    LOG_LINES_DEFAULT, ProgressTimer, RailwayContext,
+    _init_context, progress, run_railway_command, run_ssh_query,
+    get_railway_status, get_deployment_status,
+    get_all_metrics_from_api, _analyze_window, _build_metrics_history,
+    get_recent_logs,
+    _safe_int, _safe_float, _format_uptime, _trend_indicator,
+)
+
+
+# ---------------------------------------------------------------------------
+# Result container
+# ---------------------------------------------------------------------------
+
+@dataclass
+class MySQLAnalysisResult:
+    """Container for MySQL analysis results."""
+    service: str
+    db_type: str
+    timestamp: str
+    deployment_status: str = "UNKNOWN"
+
+    # Resource metrics from Railway API
+    disk_usage: Optional[Dict[str, Any]] = None
+    cpu_memory: Optional[Dict[str, Any]] = None
+    metrics_history: Optional[Dict[str, Any]] = None
+
+    # MySQL data
+    overview: Optional[Dict[str, Any]] = None
+    query_throughput: Optional[Dict[str, Any]] = None
+    innodb_row_ops: Optional[Dict[str, Any]] = None
+    query_efficiency: Optional[Dict[str, Any]] = None
+    innodb_buffer_pool: Optional[Dict[str, Any]] = None
+    innodb_io: Optional[Dict[str, Any]] = None
+    network: Optional[Dict[str, Any]] = None
+    locks: Optional[Dict[str, Any]] = None
+    table_cache: Optional[Dict[str, Any]] = None
+    top_queries: List[Dict[str, Any]] = field(default_factory=list)
+    top_queries_status: Optional[str] = None
+    tables: List[Dict[str, Any]] = field(default_factory=list)
+    active_processes: List[Dict[str, Any]] = field(default_factory=list)
+
+    # Logs
+    recent_logs: List[str] = field(default_factory=list)
+    recent_errors: List[str] = field(default_factory=list)
+
+    # Metadata
+    collection_status: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    errors: List[str] = field(default_factory=list)
+    recommendations: List[Dict[str, str]] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# MySQL-specific helpers
+# ---------------------------------------------------------------------------
+
+def run_mysql_query(service: str, query: str, timeout: int = 30) -> Tuple[int, str]:
+    """Run a MySQL query via SSH and return (returncode, output).
+
+    Uses -B (batch) mode which produces tab-separated output with headers.
+    Filters out the mysql CLI password warning.
+    """
+    import base64
+    query = " ".join(query.split())
+    # Base64-encode the query to avoid all shell quoting issues
+    # (single quotes in SQL IN clauses break bash -c '...' wrapping)
+    encoded = base64.b64encode(query.encode()).decode()
+    command = (
+        f'''bash +H -c 'echo {encoded} | base64 -d | MYSQL_PWD="$MYSQLPASSWORD" mysql -h localhost -P 3306 '''
+        f'''-u "$MYSQLUSER" -D "$MYSQLDATABASE" --default-character-set=utf8mb4 '''
+        f'''-B' '''
+    )
+    code, stdout, stderr = run_ssh_query(service, command, timeout)
+    # Filter out the password warning from stdout (mysql sometimes writes it there)
+    lines = []
+    for line in stdout.split("\n"):
+        if "Using a password on the command line" in line:
+            continue
+        lines.append(line)
+    stdout = "\n".join(lines)
+    if code != 0:
+        # Also filter warning from stderr
+        stderr_clean = "\n".join(
+            l for l in stderr.split("\n")
+            if "Using a password on the command line" not in l
+        )
+        return code, stderr_clean or stdout
+    return 0, stdout
+
+
+def parse_mysql_batch(output: str) -> List[Dict[str, str]]:
+    """Parse MySQL -B (batch/tab-separated) output into list of dicts.
+
+    First line is column headers, subsequent lines are values.
+    """
+    lines = [l for l in output.strip().split("\n") if l.strip()]
+    if len(lines) < 1:
+        return []
+    headers = lines[0].split("\t")
+    rows = []
+    for line in lines[1:]:
+        values = line.split("\t")
+        if len(values) == len(headers):
+            rows.append(dict(zip(headers, values)))
+    return rows
+
+
+def parse_mysql_kv(output: str) -> Dict[str, str]:
+    """Parse MySQL SHOW output (Variable_name / Value pairs) into a dict."""
+    rows = parse_mysql_batch(output)
+    result: Dict[str, str] = {}
+    for row in rows:
+        name = row.get("Variable_name", "")
+        value = row.get("Value", "")
+        if name:
+            result[name] = value
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Railway context / status / metrics helpers
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# MySQL queries
+# ---------------------------------------------------------------------------
+
+QUERY_GLOBAL_STATUS = """SHOW GLOBAL STATUS WHERE Variable_name IN ('Threads_connected','Threads_running','Max_used_connections','Questions','Slow_queries','Com_select','Com_insert','Com_update','Com_delete','Innodb_buffer_pool_read_requests','Innodb_buffer_pool_reads','Innodb_buffer_pool_pages_data','Innodb_buffer_pool_pages_free','Innodb_buffer_pool_pages_dirty','Innodb_row_lock_waits','Innodb_row_lock_time','Uptime','Bytes_received','Bytes_sent','Connections','Aborted_clients','Aborted_connects','Innodb_rows_read','Innodb_rows_inserted','Innodb_rows_updated','Innodb_rows_deleted','Innodb_data_reads','Innodb_data_writes','Innodb_buffer_pool_bytes_data','Innodb_buffer_pool_bytes_dirty','Created_tmp_disk_tables','Created_tmp_tables','Handler_read_rnd_next','Handler_read_first','Handler_read_key','Select_full_join','Select_range','Sort_merge_passes','Table_locks_waited','Table_locks_immediate','Open_tables','Opened_tables')"""
+
+QUERY_VARIABLES = """SHOW VARIABLES WHERE Variable_name IN ('max_connections','innodb_buffer_pool_size','long_query_time','version','table_open_cache','performance_schema')"""
+
+QUERY_TABLE_SIZES = """SELECT TABLE_NAME, TABLE_ROWS, DATA_LENGTH, INDEX_LENGTH, DATA_LENGTH + INDEX_LENGTH AS TOTAL_SIZE FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() ORDER BY TOTAL_SIZE DESC LIMIT 15"""
+
+QUERY_PROCESSLIST = """SHOW PROCESSLIST"""
+
+QUERY_TOP_QUERIES = """SELECT DIGEST, LEFT(DIGEST_TEXT, 200) AS DIGEST_TEXT, COUNT_STAR, ROUND(SUM_TIMER_WAIT/1000000000, 2) AS TOTAL_LATENCY_MS, ROUND(AVG_TIMER_WAIT/1000000000, 2) AS AVG_LATENCY_MS, SUM_ROWS_EXAMINED, SUM_ROWS_SENT, SUM_CREATED_TMP_DISK_TABLES, SUM_NO_INDEX_USED FROM performance_schema.events_statements_summary_by_digest WHERE DIGEST IS NOT NULL AND COUNT_STAR > 0 ORDER BY SUM_TIMER_WAIT DESC LIMIT 15"""
+
+
+# ---------------------------------------------------------------------------
+# MySQL data collection
+# ---------------------------------------------------------------------------
+
+def collect_mysql_data(service: str, timeout: int = 30) -> Dict[str, Any]:
+    """Collect all MySQL metrics via SSH.
+
+    Batches queries into two SSH calls for efficiency:
+      1. SHOW GLOBAL STATUS + SHOW VARIABLES
+      2. Table sizes + processlist + top queries (performance_schema)
+
+    Returns a dict with raw parsed data keyed by section.
+    """
+    data: Dict[str, Any] = {
+        "global_status": {},
+        "variables": {},
+        "tables": [],
+        "processlist": [],
+        "top_queries": [],
+        "errors": [],
+    }
+
+    # --- Batch 1: SHOW GLOBAL STATUS; SHOW VARIABLES ---
+    batch1_query = QUERY_GLOBAL_STATUS + "; " + QUERY_VARIABLES
+    code, output = run_mysql_query(service, batch1_query, timeout=timeout)
+    if code != 0:
+        data["errors"].append(f"Batch 1 (status/variables) failed: {output}")
+    else:
+        # MySQL concatenates the two result sets; split them by detecting
+        # a second header line starting with Variable_name
+        sections = _split_mysql_resultsets(output, "Variable_name")
+        if len(sections) >= 1:
+            data["global_status"] = parse_mysql_kv(sections[0])
+        if len(sections) >= 2:
+            data["variables"] = parse_mysql_kv(sections[1])
+
+    # --- Batch 2: tables + processlist + top queries ---
+    batch2_query = QUERY_TABLE_SIZES + "; " + QUERY_PROCESSLIST + "; " + QUERY_TOP_QUERIES
+    code, output = run_mysql_query(service, batch2_query, timeout=timeout)
+    if code != 0:
+        # Top queries may fail if performance_schema is off; try without
+        batch2_fallback = QUERY_TABLE_SIZES + "; " + QUERY_PROCESSLIST
+        code2, output2 = run_mysql_query(service, batch2_fallback, timeout=timeout)
+        if code2 != 0:
+            data["errors"].append(f"Batch 2 (tables/processlist) failed: {output}")
+        else:
+            sections = _split_mysql_resultsets_multi(output2, [
+                "TABLE_NAME",
+                "Id",
+            ])
+            if len(sections) >= 1:
+                data["tables"] = parse_mysql_batch(sections[0])
+            if len(sections) >= 2:
+                data["processlist"] = parse_mysql_batch(sections[1])
+    else:
+        sections = _split_mysql_resultsets_multi(output, [
+            "TABLE_NAME",
+            "Id",
+            "DIGEST",
+        ])
+        if len(sections) >= 1:
+            data["tables"] = parse_mysql_batch(sections[0])
+        if len(sections) >= 2:
+            data["processlist"] = parse_mysql_batch(sections[1])
+        if len(sections) >= 3:
+            data["top_queries"] = parse_mysql_batch(sections[2])
+
+    return data
+
+
+def _split_mysql_resultsets(output: str, header_key: str) -> List[str]:
+    """Split concatenated MySQL batch output into sections by header line."""
+    lines = output.strip().split("\n")
+    sections: List[List[str]] = []
+    current: List[str] = []
+
+    for line in lines:
+        if line.startswith(header_key + "\t") or line.strip() == header_key:
+            if current:
+                sections.append("\n".join(current))
+            current = [line]
+        else:
+            current.append(line)
+    if current:
+        sections.append("\n".join(current))
+
+    return sections
+
+
+def _split_mysql_resultsets_multi(output: str, header_keys: List[str]) -> List[str]:
+    """Split concatenated MySQL batch output into sections by multiple different header keys."""
+    lines = output.strip().split("\n")
+    sections: List[List[str]] = []
+    current: List[str] = []
+    expected_idx = 0
+
+    for line in lines:
+        # Check if this line starts a new result set
+        matched = False
+        if expected_idx < len(header_keys):
+            key = header_keys[expected_idx]
+            if line.startswith(key + "\t") or line.strip() == key:
+                if current:
+                    sections.append("\n".join(current))
+                current = [line]
+                expected_idx += 1
+                matched = True
+        # Also check remaining headers in case we skipped one
+        if not matched:
+            for idx in range(expected_idx, len(header_keys)):
+                key = header_keys[idx]
+                if line.startswith(key + "\t") or line.strip() == key:
+                    if current:
+                        sections.append("\n".join(current))
+                    current = [line]
+                    expected_idx = idx + 1
+                    matched = True
+                    break
+        if not matched:
+            current.append(line)
+
+    if current:
+        sections.append("\n".join(current))
+
+    return sections
+
+
+# ---------------------------------------------------------------------------
+# Parse collected data into result
+# ---------------------------------------------------------------------------
+
+def parse_mysql_data(data: Dict[str, Any], result: MySQLAnalysisResult) -> None:
+    """Transform raw MySQL data into structured result sections."""
+    gs = data.get("global_status", {})
+    vs = data.get("variables", {})
+
+    # --- Overview ---
+    version = vs.get("version", "unknown")
+    uptime_sec = _safe_int(gs.get("Uptime"))
+    threads_connected = _safe_int(gs.get("Threads_connected"))
+    threads_running = _safe_int(gs.get("Threads_running"))
+    max_used_connections = _safe_int(gs.get("Max_used_connections"))
+    max_connections = _safe_int(vs.get("max_connections"), 1)
+    aborted_clients = _safe_int(gs.get("Aborted_clients"))
+    aborted_connects = _safe_int(gs.get("Aborted_connects"))
+    connection_usage_pct = round(max_used_connections / max_connections * 100, 1) if max_connections > 0 else 0
+
+    result.overview = {
+        "version": version,
+        "uptime_seconds": uptime_sec,
+        "uptime_human": _format_uptime(uptime_sec),
+        "threads_connected": threads_connected,
+        "threads_running": threads_running,
+        "max_used_connections": max_used_connections,
+        "max_connections": max_connections,
+        "connection_usage_percent": connection_usage_pct,
+        "aborted_clients": aborted_clients,
+        "aborted_connects": aborted_connects,
+    }
+
+    # --- Query Throughput ---
+    questions = _safe_int(gs.get("Questions"))
+    slow_queries = _safe_int(gs.get("Slow_queries"))
+    long_query_time = vs.get("long_query_time", "10")
+    com_select = _safe_int(gs.get("Com_select"))
+    com_insert = _safe_int(gs.get("Com_insert"))
+    com_update = _safe_int(gs.get("Com_update"))
+    com_delete = _safe_int(gs.get("Com_delete"))
+
+    result.query_throughput = {
+        "questions": questions,
+        "slow_queries": slow_queries,
+        "long_query_time": long_query_time,
+        "com_select": com_select,
+        "com_insert": com_insert,
+        "com_update": com_update,
+        "com_delete": com_delete,
+    }
+
+    # --- InnoDB Row Operations ---
+    result.innodb_row_ops = {
+        "rows_read": _safe_int(gs.get("Innodb_rows_read")),
+        "rows_inserted": _safe_int(gs.get("Innodb_rows_inserted")),
+        "rows_updated": _safe_int(gs.get("Innodb_rows_updated")),
+        "rows_deleted": _safe_int(gs.get("Innodb_rows_deleted")),
+    }
+
+    # --- Query Efficiency ---
+    created_tmp_disk = _safe_int(gs.get("Created_tmp_disk_tables"))
+    created_tmp = _safe_int(gs.get("Created_tmp_tables"))
+    tmp_disk_pct = round(created_tmp_disk / created_tmp * 100, 1) if created_tmp > 0 else 0
+    handler_rnd_next = _safe_int(gs.get("Handler_read_rnd_next"))
+    handler_first = _safe_int(gs.get("Handler_read_first"))
+    handler_key = _safe_int(gs.get("Handler_read_key"))
+    scan_total = handler_rnd_next + handler_first + handler_key
+    table_scan_pct = round((handler_rnd_next + handler_first) / scan_total * 100, 1) if scan_total > 0 else 0
+    select_full_join = _safe_int(gs.get("Select_full_join"))
+    select_range = _safe_int(gs.get("Select_range"))
+    sort_merge_passes = _safe_int(gs.get("Sort_merge_passes"))
+
+    result.query_efficiency = {
+        "created_tmp_disk_tables": created_tmp_disk,
+        "created_tmp_tables": created_tmp,
+        "tmp_disk_table_percent": tmp_disk_pct,
+        "handler_read_rnd_next": handler_rnd_next,
+        "handler_read_first": handler_first,
+        "handler_read_key": handler_key,
+        "table_scan_percent": table_scan_pct,
+        "select_full_join": select_full_join,
+        "select_range": select_range,
+        "sort_merge_passes": sort_merge_passes,
+    }
+
+    # --- InnoDB Buffer Pool ---
+    read_requests = _safe_int(gs.get("Innodb_buffer_pool_read_requests"))
+    reads = _safe_int(gs.get("Innodb_buffer_pool_reads"))
+    hit_ratio = round((read_requests - reads) / read_requests * 100, 2) if read_requests > 0 else 0
+    pool_size = _safe_int(vs.get("innodb_buffer_pool_size"))
+    bytes_data = _safe_int(gs.get("Innodb_buffer_pool_bytes_data"))
+    bytes_dirty = _safe_int(gs.get("Innodb_buffer_pool_bytes_dirty"))
+    usage_pct = round(bytes_data / pool_size * 100, 1) if pool_size > 0 else 0
+    pages_free = _safe_int(gs.get("Innodb_buffer_pool_pages_free"))
+    pages_data = _safe_int(gs.get("Innodb_buffer_pool_pages_data"))
+    pages_dirty = _safe_int(gs.get("Innodb_buffer_pool_pages_dirty"))
+
+    result.innodb_buffer_pool = {
+        "hit_ratio": hit_ratio,
+        "read_requests": read_requests,
+        "reads": reads,
+        "buffer_pool_size": pool_size,
+        "bytes_data": bytes_data,
+        "bytes_dirty": bytes_dirty,
+        "usage_percent": usage_pct,
+        "pages_data": pages_data,
+        "pages_free": pages_free,
+        "pages_dirty": pages_dirty,
+    }
+
+    # --- InnoDB I/O ---
+    result.innodb_io = {
+        "data_reads": _safe_int(gs.get("Innodb_data_reads")),
+        "data_writes": _safe_int(gs.get("Innodb_data_writes")),
+    }
+
+    # --- Network ---
+    result.network = {
+        "bytes_received": _safe_int(gs.get("Bytes_received")),
+        "bytes_sent": _safe_int(gs.get("Bytes_sent")),
+    }
+
+    # --- Locks ---
+    row_lock_waits = _safe_int(gs.get("Innodb_row_lock_waits"))
+    row_lock_time = _safe_int(gs.get("Innodb_row_lock_time"))
+    table_locks_waited = _safe_int(gs.get("Table_locks_waited"))
+    table_locks_immediate = _safe_int(gs.get("Table_locks_immediate"))
+    lock_total = table_locks_waited + table_locks_immediate
+    table_lock_contention = round(table_locks_waited / lock_total * 100, 2) if lock_total > 0 else 0
+
+    result.locks = {
+        "row_lock_waits": row_lock_waits,
+        "row_lock_time": row_lock_time,
+        "table_locks_waited": table_locks_waited,
+        "table_locks_immediate": table_locks_immediate,
+        "table_lock_contention": table_lock_contention,
+    }
+
+    # --- Table Cache ---
+    open_tables = _safe_int(gs.get("Open_tables"))
+    opened_tables = _safe_int(gs.get("Opened_tables"))
+    table_open_cache = _safe_int(vs.get("table_open_cache"))
+    cache_utilization_pct = round(open_tables / table_open_cache * 100, 1) if table_open_cache > 0 else 0
+    opens_per_sec = round(opened_tables / uptime_sec, 2) if uptime_sec > 0 else 0
+
+    result.table_cache = {
+        "open_tables": open_tables,
+        "opened_tables": opened_tables,
+        "table_open_cache": table_open_cache,
+        "cache_utilization_percent": cache_utilization_pct,
+        "opens_per_second": opens_per_sec,
+    }
+
+    # --- Top Queries ---
+    for row in data.get("top_queries", []):
+        result.top_queries.append({
+            "digest": row.get("DIGEST", ""),
+            "digest_text": row.get("DIGEST_TEXT", ""),
+            "count_star": _safe_int(row.get("COUNT_STAR")),
+            "total_latency_ms": _safe_float(row.get("TOTAL_LATENCY_MS")),
+            "avg_latency_ms": _safe_float(row.get("AVG_LATENCY_MS")),
+            "rows_examined": _safe_int(row.get("SUM_ROWS_EXAMINED")),
+            "rows_sent": _safe_int(row.get("SUM_ROWS_SENT")),
+            "tmp_disk_tables": _safe_int(row.get("SUM_CREATED_TMP_DISK_TABLES")),
+            "no_index_used": _safe_int(row.get("SUM_NO_INDEX_USED")),
+        })
+
+    if result.top_queries:
+        result.top_queries_status = "ok"
+    else:
+        perf_schema = vs.get("performance_schema", "").upper()
+        if perf_schema == "OFF":
+            result.top_queries_status = "performance_schema_disabled"
+        elif perf_schema == "ON":
+            result.top_queries_status = "no_queries_recorded"
+        else:
+            result.top_queries_status = "unknown"
+
+    # --- Tables ---
+    for row in data.get("tables", []):
+        result.tables.append({
+            "name": row.get("TABLE_NAME", ""),
+            "rows": _safe_int(row.get("TABLE_ROWS")),
+            "data_length": _safe_int(row.get("DATA_LENGTH")),
+            "index_length": _safe_int(row.get("INDEX_LENGTH")),
+            "total_size": _safe_int(row.get("TOTAL_SIZE")),
+        })
+
+    # --- Active Processes ---
+    for row in data.get("processlist", []):
+        result.active_processes.append({
+            "id": row.get("Id", ""),
+            "user": row.get("User", ""),
+            "db": row.get("db", ""),
+            "command": row.get("Command", ""),
+            "time": _safe_int(row.get("Time")),
+            "state": row.get("State", ""),
+            "info": row.get("Info", ""),
+        })
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+def _format_count(n: int) -> str:
+    """Format large numbers with K/M/G suffix."""
+    if n >= 1_000_000_000:
+        return f"{n / 1_000_000_000:.1f}G"
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}K"
+    return str(n)
+
+
+def _format_bytes(b: int) -> str:
+    """Format bytes to human-readable."""
+    if b >= 1_073_741_824:
+        return f"{b / 1_073_741_824:.1f} GB"
+    if b >= 1_048_576:
+        return f"{b / 1_048_576:.1f} MB"
+    if b >= 1_024:
+        return f"{b / 1_024:.1f} KB"
+    return f"{b} B"
+
+
+def _status_ok_warn_crit(value: float, warn_threshold: float, crit_threshold: float) -> str:
+    if value >= crit_threshold:
+        return "CRITICAL"
+    if value >= warn_threshold:
+        return "WARN"
+    return "OK"
+
+
+# ---------------------------------------------------------------------------
+# Recommendations
+# ---------------------------------------------------------------------------
+
+def generate_recommendations(result: MySQLAnalysisResult) -> List[Dict[str, str]]:
+    recs: List[Dict[str, str]] = []
+
+    # Collection failures — surface critical issues when SSH/introspection failed
+    if result.collection_status:
+        failed = {k: v for k, v in result.collection_status.items()
+                  if v.get("status") in ("failed", "error")}
+        ssh_sources = {"mysql_query"}
+        ssh_failed = {k: v for k, v in failed.items() if k in ssh_sources}
+        if ssh_failed:
+            sources = ", ".join(ssh_failed.keys())
+            errors = "; ".join(v.get("error", "unknown") for v in ssh_failed.values())
+            recs.append({
+                "severity": "critical",
+                "category": "collection",
+                "message": f"SSH introspection failed — unable to collect {sources}. "
+                           f"Error: {errors}. "
+                           f"Analysis is incomplete: InnoDB buffer pool, query throughput, "
+                           f"locks, and tuning parameters could not be evaluated.",
+            })
+
+    def rec(severity: str, message: str):
+        recs.append({"severity": severity, "message": message})
+
+    ov = result.overview or {}
+    qt = result.query_throughput or {}
+    qe = result.query_efficiency or {}
+    bp = result.innodb_buffer_pool or {}
+    lk = result.locks or {}
+    tc = result.table_cache or {}
+
+    # Connection usage
+    conn_pct = ov.get("connection_usage_percent", 0)
+    max_conn = ov.get("max_connections", 0)
+    if conn_pct >= 90:
+        rec("critical", f"Connection usage critical at {conn_pct}%. Approaching max_connections ({max_conn}).")
+    elif conn_pct >= 70:
+        rec("warning", f"Connection usage at {conn_pct}%. Consider increasing max_connections.")
+
+    # Buffer pool hit ratio
+    hit_ratio = bp.get("hit_ratio", 100)
+    if hit_ratio < 95:
+        rec("critical", f"Buffer pool hit ratio at {hit_ratio}%. Increase innodb_buffer_pool_size.")
+    elif hit_ratio < 99:
+        rec("warning", f"Buffer pool hit ratio at {hit_ratio}% -- room for improvement with more RAM.")
+
+    # Buffer pool usage
+    bp_usage = bp.get("usage_percent", 0)
+    if bp_usage > 95:
+        rec("warning", f"Buffer pool {bp_usage}% full. Data pages may be evicted under load.")
+
+    # Temp tables to disk
+    tmp_pct = qe.get("tmp_disk_table_percent", 0)
+    created_disk = qe.get("created_tmp_disk_tables", 0)
+    created_total = qe.get("created_tmp_tables", 0)
+    if tmp_pct > 25:
+        rec("warning", f"{tmp_pct}% of temp tables going to disk. Increase tmp_table_size/max_heap_table_size or optimize queries.")
+    elif tmp_pct > 10:
+        rec("info", f"Temp tables to disk at {tmp_pct}%. Watch for queries creating large temporary results.")
+
+    # Table scan ratio
+    scan_pct = qe.get("table_scan_percent", 0)
+    if scan_pct > 75:
+        rec("critical", f"Table scan ratio at {scan_pct}%. Most reads are full scans -- add indexes.")
+    elif scan_pct > 50:
+        rec("warning", f"Table scan ratio at {scan_pct}%. Consider indexing frequently queried columns.")
+
+    # Full joins
+    full_joins = qe.get("select_full_join", 0)
+    if full_joins > 100:
+        rec("warning", f"{_format_count(full_joins)} full joins detected. These scan entire tables -- add indexes to join columns.")
+
+    # Sort merge passes
+    sort_passes = qe.get("sort_merge_passes", 0)
+    if sort_passes > 0:
+        rec("info", f"Sort merge passes ({_format_count(sort_passes)}). Increase sort_buffer_size or optimize queries.")
+
+    # Row lock waits
+    row_lock_waits = lk.get("row_lock_waits", 0)
+    if row_lock_waits > 1000:
+        rec("warning", f"InnoDB row lock waits ({_format_count(row_lock_waits)}). Check for lock contention in concurrent writes.")
+    elif row_lock_waits > 0:
+        rec("info", f"InnoDB row lock waits ({_format_count(row_lock_waits)}). Check for lock contention in concurrent writes.")
+
+    # Table lock contention
+    tl_contention = lk.get("table_lock_contention", 0)
+    if tl_contention > 5:
+        rec("warning", f"Table lock contention at {tl_contention}%. May indicate MyISAM tables -- convert to InnoDB.")
+
+    # Slow queries
+    slow = qt.get("slow_queries", 0)
+    threshold = qt.get("long_query_time", "10")
+    if slow > 0:
+        rec("info", f"{_format_count(slow)} slow queries (threshold: {threshold}s). Review with performance_schema or slow query log.")
+
+    # Aborted clients
+    aborted_clients = ov.get("aborted_clients", 0)
+    if aborted_clients > 0:
+        rec("info", f"{_format_count(aborted_clients)} aborted clients. Applications may not be closing connections properly.")
+
+    # Aborted connects
+    aborted_connects = ov.get("aborted_connects", 0)
+    if aborted_connects > 0:
+        rec("info", f"{_format_count(aborted_connects)} aborted connection attempts. Check authentication issues or connection limits.")
+
+    # No index used in top queries
+    if result.top_queries:
+        no_index_count = sum(1 for q in result.top_queries if q.get("no_index_used", 0) > 0)
+        if no_index_count > 0:
+            rec("warning", f"Top queries using no index ({no_index_count} of {len(result.top_queries)}). Missing indexes are likely impacting performance.")
+
+    # Table cache
+    tc = result.table_cache or {}
+    opens_per_sec = tc.get("opens_per_second", 0)
+    cache_util = tc.get("cache_utilization_percent", 0)
+    if cache_util >= 95:
+        rec("warning", f"Table cache {cache_util}% full ({tc.get('open_tables')}/{tc.get('table_open_cache')}). Increase table_open_cache.")
+    if opens_per_sec > 5:
+        rec("warning", f"Table opens at {opens_per_sec}/sec — cache may be undersized. Increase table_open_cache.")
+
+    # Top queries diagnostic
+    if not result.top_queries:
+        if result.top_queries_status == "performance_schema_disabled":
+            pass  # Off by default on Railway; overhead (~400MB+) is too high to recommend casually
+        elif result.top_queries_status == "no_queries_recorded":
+            rec("info", "performance_schema is ON but no queries recorded. Database may be idle or recently restarted.")
+
+    return recs
+
+
+# ---------------------------------------------------------------------------
+# Report formatter
+# ---------------------------------------------------------------------------
+
+def format_report(result: MySQLAnalysisResult) -> str:
+    lines: List[str] = []
+
+    def heading(title: str, level: int = 2):
+        prefix = "#" * level
+        lines.append(f"\n{prefix} {title}")
+
+    def table_row(*cells: str):
+        lines.append("| " + " | ".join(cells) + " |")
+
+    def table_sep(ncols: int):
+        lines.append("| " + " | ".join(["---"] * ncols) + " |")
+
+    # Title
+    lines.append(f"# MySQL Analysis: {result.service}")
+    lines.append(f"Timestamp: {result.timestamp}")
+    lines.append(f"Deployment: {result.deployment_status}")
+
+    # --- Resource Overview (from Railway API) ---
+    if result.cpu_memory or result.disk_usage:
+        heading("Resource Overview")
+        table_row("Metric", "Value")
+        table_sep(2)
+        if result.cpu_memory:
+            cm = result.cpu_memory
+            if "cpu_percent" in cm:
+                trend = _trend_indicator(result.metrics_history, "cpu")
+                lines.append(f"| CPU | {cm['cpu_percent']}% vCPU{trend} |")
+            if "memory_gb" in cm:
+                trend = _trend_indicator(result.metrics_history, "memory")
+                mem_str = f"{cm['memory_gb']} GB"
+                if "memory_limit_gb" in cm and cm["memory_limit_gb"] > 0:
+                    pct = round(cm["memory_gb"] / cm["memory_limit_gb"] * 100, 1)
+                    mem_str += f" / {cm['memory_limit_gb']} GB ({pct}%)"
+                lines.append(f"| Memory | {mem_str}{trend} |")
+        if result.disk_usage:
+            trend = _trend_indicator(result.metrics_history, "disk")
+            lines.append(f"| Disk | {result.disk_usage.get('used', 'N/A')}{trend} |")
+
+    # --- Overview ---
+    ov = result.overview
+    if ov:
+        heading("Overview")
+        table_row("Metric", "Value", "Status")
+        table_sep(3)
+        table_row("Version", str(ov["version"]), "")
+        table_row("Uptime", ov["uptime_human"], "")
+        conn_status = _status_ok_warn_crit(ov["connection_usage_percent"], 70, 90)
+        table_row(
+            "Connections",
+            f"{ov['connection_usage_percent']}% ({ov['max_used_connections']}/{ov['max_connections']})",
+            conn_status,
+        )
+        table_row("Threads Running", str(ov["threads_running"]), "")
+        aborted_c_status = "WARN" if ov["aborted_clients"] > 0 else "OK"
+        table_row("Aborted Clients", _format_count(ov["aborted_clients"]), aborted_c_status)
+        aborted_conn_status = "WARN" if ov["aborted_connects"] > 0 else "OK"
+        table_row("Aborted Connects", _format_count(ov["aborted_connects"]), aborted_conn_status)
+
+    # --- Query Throughput ---
+    qt = result.query_throughput
+    if qt:
+        heading("Query Throughput")
+        table_row("Metric", "Value", "Status")
+        table_sep(3)
+        table_row("Total Queries", _format_count(qt["questions"]), "")
+        slow_status = "WARN" if qt["slow_queries"] > 0 else "OK"
+        table_row("Slow Queries", f"{_format_count(qt['slow_queries'])} (> {qt['long_query_time']}s threshold)", slow_status)
+        table_row("SELECT", _format_count(qt["com_select"]), "")
+        table_row("INSERT", _format_count(qt["com_insert"]), "")
+        table_row("UPDATE", _format_count(qt["com_update"]), "")
+        table_row("DELETE", _format_count(qt["com_delete"]), "")
+
+    # --- InnoDB Row Operations ---
+    ro = result.innodb_row_ops
+    if ro:
+        heading("InnoDB Row Operations")
+        table_row("Operation", "Count")
+        table_sep(2)
+        table_row("Rows Read", _format_count(ro["rows_read"]))
+        table_row("Rows Inserted", _format_count(ro["rows_inserted"]))
+        table_row("Rows Updated", _format_count(ro["rows_updated"]))
+        table_row("Rows Deleted", _format_count(ro["rows_deleted"]))
+
+    # --- Query Efficiency ---
+    qe = result.query_efficiency
+    if qe:
+        heading("Query Efficiency")
+        table_row("Metric", "Value", "Status")
+        table_sep(3)
+        tmp_status = _status_ok_warn_crit(qe["tmp_disk_table_percent"], 10, 25)
+        table_row(
+            "Temp Tables to Disk",
+            f"{qe['tmp_disk_table_percent']}% ({_format_count(qe['created_tmp_disk_tables'])}/{_format_count(qe['created_tmp_tables'])})",
+            tmp_status,
+        )
+        scan_status = _status_ok_warn_crit(qe["table_scan_percent"], 50, 75)
+        table_row("Table Scan Ratio", f"{qe['table_scan_percent']}%", scan_status)
+        fj_status = "WARN" if qe["select_full_join"] > 100 else "OK"
+        table_row("Full Joins", _format_count(qe["select_full_join"]), fj_status)
+        table_row("Sort Merge Passes", _format_count(qe["sort_merge_passes"]), "")
+
+    # --- InnoDB Buffer Pool ---
+    bp = result.innodb_buffer_pool
+    if bp:
+        heading("InnoDB Buffer Pool")
+        table_row("Metric", "Value", "Status")
+        table_sep(3)
+        hr_status = _status_ok_warn_crit(100 - bp["hit_ratio"], 1, 5)  # inverted: lower hit = worse
+        table_row("Cache Hit Ratio", f"{bp['hit_ratio']}%", hr_status)
+        usage_status = _status_ok_warn_crit(bp["usage_percent"], 90, 95)
+        table_row(
+            "Pool Usage",
+            f"{bp['usage_percent']}% ({_format_bytes(bp['bytes_data'])}/{_format_bytes(bp['buffer_pool_size'])})",
+            usage_status,
+        )
+        table_row("Dirty Pages", _format_bytes(bp["bytes_dirty"]), "")
+        table_row("Free Pages", _format_count(bp["pages_free"]), "")
+
+    # --- Network ---
+    nw = result.network
+    if nw:
+        heading("Network")
+        table_row("Metric", "Value")
+        table_sep(2)
+        table_row("Bytes Received", _format_bytes(nw["bytes_received"]))
+        table_row("Bytes Sent", _format_bytes(nw["bytes_sent"]))
+
+    # --- Locks ---
+    lk = result.locks
+    if lk:
+        heading("Locks")
+        table_row("Metric", "Value", "Status")
+        table_sep(3)
+        table_row("Row Lock Waits", _format_count(lk["row_lock_waits"]), "")
+        table_row("Row Lock Time (ms)", _format_count(lk["row_lock_time"]), "")
+        tl_status = _status_ok_warn_crit(lk["table_lock_contention"], 1, 5)
+        table_row("Table Lock Contention", f"{lk['table_lock_contention']}%", tl_status)
+
+    # --- Table Cache ---
+    tc = result.table_cache
+    if tc:
+        heading("Table Cache")
+        table_row("Metric", "Value")
+        table_sep(2)
+        table_row("Open Tables", f"{_format_count(tc['open_tables'])} / {_format_count(tc.get('table_open_cache', 0))}")
+        table_row("Cache Utilization", f"{tc.get('cache_utilization_percent', 0)}%")
+        table_row("Table Opens/sec", f"{tc.get('opens_per_second', 0)}")
+
+    # --- Top Queries ---
+    if result.top_queries:
+        heading("Top Queries (by total latency)")
+        table_row("Query", "Calls", "Avg Latency", "Total Latency", "Rows Examined", "Rows Sent")
+        table_sep(6)
+        for q in result.top_queries[:15]:
+            digest = q["digest_text"][:60] + "..." if len(q["digest_text"]) > 60 else q["digest_text"]
+            # Escape pipe chars in query text
+            digest = digest.replace("|", "\\|")
+            table_row(
+                digest,
+                _format_count(q["count_star"]),
+                f"{q['avg_latency_ms']:.1f}ms",
+                f"{q['total_latency_ms']:.1f}ms",
+                _format_count(q["rows_examined"]),
+                _format_count(q["rows_sent"]),
+            )
+    else:
+        heading("Top Queries (by total latency)")
+        if result.top_queries_status == "performance_schema_disabled":
+            lines.append("performance_schema is disabled — no query-level data available.")
+            lines.append("Note: enabling it requires ~400MB+ additional memory; only advisable on larger instances.")
+        elif result.top_queries_status == "no_queries_recorded":
+            lines.append("No queries recorded. Database may be idle or recently restarted.")
+        else:
+            lines.append("No query data available.")
+        lines.append("")
+
+    # --- Tables ---
+    if result.tables:
+        heading("Tables (by size)")
+        table_row("Table", "Rows", "Data", "Indexes", "Total")
+        table_sep(5)
+        for t in result.tables[:15]:
+            table_row(
+                t["name"],
+                _format_count(t["rows"]),
+                _format_bytes(t["data_length"]),
+                _format_bytes(t["index_length"]),
+                _format_bytes(t["total_size"]),
+            )
+
+    # --- Active Queries ---
+    if result.active_processes:
+        heading("Active Queries")
+        # Filter out system processes
+        user_procs = [p for p in result.active_processes if p["command"] != "Daemon"]
+        if user_procs:
+            table_row("User", "Database", "Command", "Time (s)", "Query")
+            table_sep(5)
+            for p in user_procs[:20]:
+                info = (p["info"] or "")[:80]
+                info = info.replace("|", "\\|")
+                table_row(
+                    p["user"],
+                    p["db"] or "",
+                    p["command"],
+                    str(p["time"]),
+                    info,
+                )
+        else:
+            lines.append("\nNo active user queries.")
+
+    # --- Infrastructure Metrics ---
+    if result.metrics_history:
+        windows = result.metrics_history.get("windows", {})
+        for window_label, window_data in windows.items():
+            mh = window_data.get("metrics", {})
+            if not mh:
+                continue
+            lines.append(f"## Infrastructure Metrics ({window_label})")
+            lines.append("| Metric | Current | Min | Max | Avg | Trend |")
+            lines.append("|--------|---------|-----|-----|-----|-------|")
+            for key in ["cpu", "memory", "disk", "network_rx", "network_tx"]:
+                if key in mh:
+                    entry = mh[key]
+                    trend = entry.get("trend", {})
+                    trend_str = trend.get("direction", "N/A")
+                    change = trend.get("change_pct", 0)
+                    if change != 0:
+                        trend_str += f" ({change:+.1f}%)"
+                    lines.append(
+                        f"| {key.replace('_', ' ').title()} "
+                        f"| {entry['current']}{entry['unit']} "
+                        f"| {entry['min']}{entry['unit']} "
+                        f"| {entry['max']}{entry['unit']} "
+                        f"| {entry['avg']}{entry['unit']} "
+                        f"| {trend_str} |"
+                    )
+            lines.append("")
+
+    # --- Collection Errors ---
+    if result.errors:
+        heading("Collection Errors")
+        for err in result.errors:
+            lines.append(f"- {err}")
+
+    # --- Recommendations ---
+    heading("Recommendations")
+    if result.recommendations:
+        for r in result.recommendations:
+            severity = r["severity"].upper()
+            lines.append(f"- **[{severity}]** {r['message']}")
+    else:
+        lines.append("No issues detected.")
+
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Main analysis function
+# ---------------------------------------------------------------------------
+
+def analyze_mysql(service: str, timeout: int = 60, quiet: bool = False,
+                  skip_logs: bool = False, metrics_hours: int = 168,
+                  project_id: Optional[str] = None,
+                  environment_id: Optional[str] = None,
+                  service_id: Optional[str] = None) -> MySQLAnalysisResult:
+    """Run complete MySQL analysis."""
+    if not quiet:
+        print(f"Analyzing mysql database: {service}", file=sys.stderr)
+
+    result = MySQLAnalysisResult(
+        service=service,
+        db_type="mysql",
+        timestamp=datetime.now(timezone.utc).isoformat(),
+    )
+
+    # === CONTEXT ===
+    if not quiet:
+        print("  [0/5] Getting Railway context...", file=sys.stderr, flush=True)
+    dal._progress_timer.start()
+
+    if environment_id and service_id:
+        dal._ctx = RailwayContext(project_id=project_id, environment_id=environment_id, service_id=service_id)
+        if not quiet:
+            print(f"        using explicit IDs (env={environment_id[:8]}..., svc={service_id[:8]}...)", file=sys.stderr, flush=True)
+    else:
+        railway_status = get_railway_status()
+        if railway_status:
+            dal._ctx = RailwayContext(
+                project_id=railway_status.get("projectId"),
+                environment_id=railway_status.get("environmentId"),
+                service_id=railway_status.get("serviceId"),
+            )
+        environment_id = dal._ctx.environment_id
+        service_id = dal._ctx.service_id
+
+    # === DEPLOYMENT STATUS ===
+    progress(1, 5, "Fetching deployment status...", quiet)
+    result.deployment_status = get_deployment_status(service, service_id=service_id)
+
+    # === SSH PRE-CHECK ===
+    progress(2, 5, "Testing SSH connectivity...", quiet)
+    ssh_available = False
+    ssh_stderr = ""
+    ssh_attempts = [30, 60, 90]
+    for attempt, attempt_timeout in enumerate(ssh_attempts, 1):
+        ssh_code, ssh_stdout, ssh_stderr = run_ssh_query(service, "echo ok", timeout=attempt_timeout)
+        if ssh_code == 0 and "ok" in ssh_stdout:
+            ssh_available = True
+            if not quiet:
+                for line in ssh_stderr.splitlines():
+                    if line.startswith("Using SSH key:"):
+                        print(f"        {line}", file=sys.stderr, flush=True)
+                        break
+            break
+        if not quiet:
+            remaining = len(ssh_attempts) - attempt
+            if remaining > 0:
+                print(f"        SSH attempt {attempt}/{len(ssh_attempts)} failed ({ssh_stderr or 'no response'}), retrying with {ssh_attempts[attempt]}s timeout...", file=sys.stderr, flush=True)
+            else:
+                print(f"        SSH attempt {attempt}/{len(ssh_attempts)} failed ({ssh_stderr or 'no response'}), giving up", file=sys.stderr, flush=True)
+
+    # === PARALLEL EXECUTION ===
+    progress(3, 5, "Running analysis (metrics, queries, logs in parallel)...", quiet)
+
+    def task_metrics():
+        if environment_id and service_id:
+            return get_all_metrics_from_api(environment_id, service_id, hours=metrics_hours)
+        return None
+
+    def task_mysql_queries():
+        if not ssh_available:
+            return {"errors": [f"SSH not available: {ssh_stderr or 'connection failed'}"]}
+        data = collect_mysql_data(service, timeout=timeout)
+        if data.get("errors") and not data.get("global_status"):
+            # Retry once
+            data = collect_mysql_data(service, timeout=timeout)
+        return data
+
+    def task_logs():
+        if skip_logs:
+            return []
+        return get_recent_logs(service, lines=LOG_LINES_DEFAULT,
+                               environment_id=environment_id,
+                               service_id=service_id)
+
+    with ThreadPoolExecutor(max_workers=3) as executor:
+        future_metrics = executor.submit(task_metrics)
+        future_mysql = executor.submit(task_mysql_queries)
+        future_logs = executor.submit(task_logs)
+
+        metrics_result = future_metrics.result()
+        mysql_data = future_mysql.result()
+        logs_result = future_logs.result()
+
+    # Process metrics
+    if metrics_result:
+        result.disk_usage = metrics_result.get("disk_usage")
+        result.cpu_memory = metrics_result.get("cpu_memory")
+        result.metrics_history = metrics_result.get("metrics_history")
+        result.collection_status["metrics_api"] = {"status": "success"}
+    else:
+        result.collection_status["metrics_api"] = {
+            "status": "error",
+            "error": "Metrics API returned no data",
+        }
+
+    # Process MySQL data
+    progress(4, 5, "Processing results...", quiet)
+    mysql_errors = mysql_data.get("errors", [])
+    if mysql_data.get("global_status"):
+        parse_mysql_data(mysql_data, result)
+        result.collection_status["mysql_query"] = {"status": "success"}
+        if mysql_errors:
+            result.collection_status["mysql_query"]["warnings"] = mysql_errors
+    else:
+        error_msg = "; ".join(mysql_errors) if mysql_errors else "No data returned"
+        if not ssh_available:
+            error_msg = f"SSH failed after {len(ssh_attempts)} attempts: {ssh_stderr or 'connection failed'}"
+        result.errors.append(f"MySQL data collection failed: {error_msg}")
+        result.collection_status["mysql_query"] = {
+            "status": "error",
+            "error": error_msg,
+        }
+
+    # Process logs
+    if skip_logs:
+        result.collection_status["logs_api"] = {"status": "skipped", "reason": "skip_logs flag set"}
+    elif logs_result:
+        result.recent_logs = logs_result
+        result.collection_status["logs_api"] = {"status": "success", "lines": len(logs_result)}
+        result.recent_errors = [
+            line for line in result.recent_logs
+            if "ERROR" in line.upper() or "FATAL" in line.upper()
+        ][:100]
+    else:
+        result.recent_logs = []
+        result.collection_status["logs_api"] = {
+            "status": "error",
+            "error": "Logs API returned no data",
+        }
+
+    # === RECOMMENDATIONS ===
+    progress(5, 5, "Generating recommendations...", quiet)
+    result.recommendations = generate_recommendations(result)
+
+    if not quiet:
+        total = dal._progress_timer.total_elapsed()
+        print(f"Done.{total}", file=sys.stderr)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Single-step debugging
+# ---------------------------------------------------------------------------
+
+def run_single_step(args) -> int:
+    """Run a single collection step for debugging."""
+    service = args.service
+    _init_context(args)
+    environment_id = dal._ctx.environment_id
+    service_id = dal._ctx.service_id
+
+    if args.step == "ssh-test":
+        print(f"Testing SSH to service: {service}", file=sys.stderr)
+        code, stdout, stderr = run_ssh_query(service, "echo ok", timeout=45)
+        print(f"Exit code: {code}")
+        print(f"Stdout: {stdout.strip()}")
+        if stderr:
+            print(f"Stderr: {stderr.strip()}")
+        return 0 if (code == 0 and "ok" in stdout) else 1
+
+    elif args.step == "query":
+        print(f"Running MySQL queries on: {service}", file=sys.stderr)
+        data = collect_mysql_data(service, timeout=args.timeout)
+        print(json.dumps(data, indent=2, default=str))
+        return 0 if data.get("global_status") else 1
+
+    elif args.step == "logs":
+        print(f"Fetching logs for: {service}", file=sys.stderr)
+        logs = get_recent_logs(service, lines=LOG_LINES_DEFAULT,
+                               environment_id=environment_id,
+                               service_id=service_id)
+        print(f"Lines fetched: {len(logs)}")
+        for line in logs:
+            print(line)
+        return 0
+
+    elif args.step == "metrics":
+        print(f"Fetching metrics for: {service}", file=sys.stderr)
+        if environment_id and service_id:
+            metrics = get_all_metrics_from_api(environment_id, service_id)
+            if metrics:
+                print(json.dumps(metrics, indent=2))
+            else:
+                print("Metrics API returned no data")
+                return 1
+        else:
+            print("Missing environment_id or service_id from railway config")
+            return 1
+        return 0
+
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="MySQL analysis for Railway services.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument("--service", required=True, help="Service name")
+    parser.add_argument("--json", action="store_true",
+                        help="Output as JSON")
+    parser.add_argument("--timeout", type=int, default=60,
+                        help="Timeout in seconds for SSH queries (default: 60)")
+    parser.add_argument("--quiet", "-q", action="store_true",
+                        help="Suppress progress messages")
+    parser.add_argument("--skip-logs", action="store_true",
+                        help="Skip log fetching for faster analysis")
+    parser.add_argument("--metrics-hours", type=int, default=168,
+                        help="Hours of metrics history to fetch (default: 168, max: 168)")
+    parser.add_argument("--step", choices=["ssh-test", "query", "logs", "metrics"],
+                        help="Run a single collection step for debugging")
+    parser.add_argument("--project-id", help="Project ID (bypasses railway link)")
+    parser.add_argument("--environment-id", help="Environment ID (bypasses railway link)")
+    parser.add_argument("--service-id", help="Service ID (bypasses railway link)")
+
+    args = parser.parse_args()
+
+    # Single-step debugging mode
+    if args.step:
+        return run_single_step(args)
+
+    # Run analysis
+    result = analyze_mysql(
+        args.service,
+        timeout=args.timeout,
+        quiet=args.quiet,
+        skip_logs=args.skip_logs,
+        metrics_hours=min(args.metrics_hours, 168),
+        project_id=args.project_id,
+        environment_id=args.environment_id,
+        service_id=args.service_id,
+    )
+
+    # Output
+    if args.json:
+        print(json.dumps(asdict(result), indent=2))
+    else:
+        print(format_report(result))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/use-railway/scripts/analyze-postgres.py
+++ b/.claude/skills/use-railway/scripts/analyze-postgres.py
@@ -1,0 +1,3058 @@
+#!/usr/bin/env python3
+"""
+Complete database analysis for Railway deployments.
+
+Produces a comprehensive report covering:
+- Deployment status
+- Resource overview (disk, connections)
+- Memory configuration
+- Cache efficiency (overall and per-table)
+- Vacuum health
+- Query performance (with --deep)
+- Index health
+- Recommendations
+
+Usage:
+    analyze-postgres.py --service <name>
+    analyze-postgres.py --service <name> --deep
+    analyze-postgres.py --service <name> --json
+"""
+
+import argparse
+import base64
+import json
+import os
+import subprocess
+import sys
+import re
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Any, Tuple
+from dataclasses import dataclass, field, asdict
+
+import dal
+from dal import (
+    LOG_LINES_DEFAULT, ProgressTimer, RailwayContext,
+    _init_context, progress, run_railway_command, run_ssh_query, run_psql_query,
+    get_railway_status, get_deployment_status,
+    get_all_metrics_from_api, _analyze_window, _build_metrics_history,
+    get_recent_logs,
+    _trend_indicator,
+)
+
+
+@dataclass
+class AnalysisResult:
+    """Container for analysis results."""
+    service: str
+    db_type: str
+    timestamp: str
+    deployment_status: str = "UNKNOWN"
+    disk_usage: Optional[Dict[str, Any]] = None
+    cpu_memory: Optional[Dict[str, Any]] = None
+    connections: Optional[Dict[str, Any]] = None
+    connection_states: List[Dict[str, Any]] = field(default_factory=list)
+    connections_by_app: List[Dict[str, Any]] = field(default_factory=list)
+    connections_by_age: List[Dict[str, Any]] = field(default_factory=list)
+    oldest_connection_sec: Optional[int] = None
+    oldest_connections: List[Dict[str, Any]] = field(default_factory=list)
+    memory_config: Optional[Dict[str, Any]] = None
+    cache_hit: Optional[Dict[str, Any]] = None
+    cache_per_table: List[Dict[str, Any]] = field(default_factory=list)
+    table_sizes: List[Dict[str, Any]] = field(default_factory=list)
+    database_stats: Optional[Dict[str, Any]] = None
+    size_breakdown: Optional[Dict[str, Any]] = None
+    vacuum_health: List[Dict[str, Any]] = field(default_factory=list)
+    xid_age: Optional[Dict[str, Any]] = None
+    pg_stat_statements_installed: bool = False
+    top_queries: List[Dict[str, Any]] = field(default_factory=list)
+    long_running_queries: List[Dict[str, Any]] = field(default_factory=list)
+    idle_in_transaction: List[Dict[str, Any]] = field(default_factory=list)
+    blocked_queries: List[Dict[str, Any]] = field(default_factory=list)
+    locks: List[Dict[str, Any]] = field(default_factory=list)
+    unused_indexes: List[Dict[str, Any]] = field(default_factory=list)
+    invalid_indexes: List[Dict[str, Any]] = field(default_factory=list)
+    seq_scan_tables: List[Dict[str, Any]] = field(default_factory=list)
+    replication: List[Dict[str, Any]] = field(default_factory=list)
+    bgwriter: Optional[Dict[str, Any]] = None
+    archiver: Optional[Dict[str, Any]] = None
+    progress_vacuum: List[Dict[str, Any]] = field(default_factory=list)
+    ssl_stats: Optional[Dict[str, Any]] = None
+    ha_cluster: Optional[Dict[str, Any]] = None
+    cluster_logs: List[Dict[str, Any]] = field(default_factory=list)
+    recent_logs: List[str] = field(default_factory=list)  # Raw unfiltered logs for LLM analysis
+    recent_errors: List[str] = field(default_factory=list)  # Legacy: filtered error logs
+    metrics_history: Optional[Dict[str, Any]] = None  # Multi-window time series + trend analysis for CPU, memory, disk, network
+    collection_status: Dict[str, Dict[str, Any]] = field(default_factory=dict)  # Status of each data source
+    errors: List[str] = field(default_factory=list)
+    recommendations: List[Dict[str, str]] = field(default_factory=list)
+
+
+
+def run_psql_query_safe(service: str, query: str, timeout: int = 60) -> Tuple[int, str, str]:
+    """Run a psql query using base64 encoding to avoid shell quoting issues."""
+    encoded = base64.b64encode(query.encode()).decode()
+    # 2>/dev/null suppresses psql warnings (e.g., collation version mismatch) that pollute stdout
+    command = f"echo '{encoded}' | base64 -d | psql $DATABASE_URL -P pager=off -t -A 2>/dev/null"
+    return run_ssh_query(service, command, timeout)
+
+
+def build_analysis_query() -> str:
+    """Build a single SQL query that returns all analysis data as JSON."""
+    return """
+SELECT json_build_object(
+    'connections', (
+        SELECT json_build_object(
+            'current', (SELECT count(*) FROM pg_stat_activity WHERE datname = current_database()),
+            'max', (SELECT setting::int FROM pg_settings WHERE name = 'max_connections'),
+            'reserved', (SELECT setting::int FROM pg_settings WHERE name = 'superuser_reserved_connections'),
+            'active', (SELECT count(*) FROM pg_stat_activity WHERE datname = current_database() AND state = 'active'),
+            'idle', (SELECT count(*) FROM pg_stat_activity WHERE datname = current_database() AND state = 'idle'),
+            'idle_in_transaction', (SELECT count(*) FROM pg_stat_activity WHERE datname = current_database() AND state = 'idle in transaction')
+        )
+    ),
+    'memory_config', (
+        SELECT json_agg(json_build_object(
+            'name', name,
+            'setting', setting,
+            'unit', unit
+        ))
+        FROM pg_settings
+        WHERE name IN (
+            'shared_buffers', 'effective_cache_size', 'work_mem', 'maintenance_work_mem',
+            'wal_buffers', 'checkpoint_completion_target', 'min_wal_size', 'max_wal_size',
+            'max_parallel_workers', 'max_parallel_workers_per_gather', 'random_page_cost',
+            'default_statistics_target', 'synchronous_commit', 'max_connections',
+            'autovacuum', 'autovacuum_vacuum_scale_factor', 'autovacuum_analyze_scale_factor',
+            'track_activity_query_size', 'log_min_duration_statement',
+            'idle_in_transaction_session_timeout', 'statement_timeout',
+            'track_io_timing'
+        )
+    ),
+    'cache_hit', (
+        SELECT json_build_object(
+            'table_hit_pct', ROUND(100.0 * sum(heap_blks_hit) / NULLIF(sum(heap_blks_hit) + sum(heap_blks_read), 0), 2),
+            'index_hit_pct', ROUND(100.0 * sum(idx_blks_hit) / NULLIF(sum(idx_blks_hit) + sum(idx_blks_read), 0), 2)
+        )
+        FROM pg_statio_user_tables
+    ),
+    'database_stats', (
+        SELECT json_build_object(
+            'deadlocks', deadlocks,
+            'temp_files', temp_files,
+            'temp_bytes', temp_bytes,
+            'stats_reset', COALESCE(stats_reset::text, 'never'),
+            'blks_read', blks_read,
+            'blks_hit', blks_hit,
+            'tup_returned', tup_returned,
+            'tup_fetched', tup_fetched,
+            'tup_inserted', tup_inserted,
+            'tup_updated', tup_updated,
+            'tup_deleted', tup_deleted,
+            'conflicts', conflicts,
+            'checksum_failures', COALESCE(checksum_failures, 0)
+        )
+        FROM pg_stat_database
+        WHERE datname = current_database()
+    ),
+    'cache_per_table', (
+        SELECT COALESCE(json_agg(t ORDER BY t.disk_reads DESC), '[]'::json)
+        FROM (
+            SELECT
+                relname as table_name,
+                heap_blks_read as disk_reads,
+                heap_blks_hit as cache_hits,
+                ROUND(100.0 * heap_blks_hit / NULLIF(heap_blks_hit + heap_blks_read, 0), 2) as hit_pct
+            FROM pg_statio_user_tables
+            WHERE heap_blks_read > 10000
+            ORDER BY heap_blks_read DESC LIMIT 1000
+        ) t
+    ),
+    'table_sizes', (
+        SELECT COALESCE(json_agg(t ORDER BY t.total_bytes DESC), '[]'::json)
+        FROM (
+            SELECT
+                schemaname as schema,
+                relname as table_name,
+                pg_size_pretty(pg_total_relation_size(relid)) as size,
+                pg_total_relation_size(relid) as total_bytes,
+                pg_table_size(relid) as data_bytes,
+                pg_indexes_size(relid) as index_bytes,
+                n_live_tup as row_count
+            FROM pg_stat_user_tables
+            ORDER BY pg_total_relation_size(relid) DESC LIMIT 1000
+        ) t
+    ),
+    'size_breakdown', (
+        SELECT json_build_object(
+            'database_bytes', pg_database_size(current_database()),
+            'wal_bytes', COALESCE((SELECT sum(size) FROM pg_ls_waldir()), 0),
+            'user_tables_bytes', COALESCE((SELECT sum(pg_table_size(relid)) FROM pg_stat_user_tables), 0),
+            'user_indexes_bytes', COALESCE((SELECT sum(pg_indexes_size(relid)) FROM pg_stat_user_tables), 0),
+            'system_bytes', COALESCE((
+                SELECT sum(pg_total_relation_size(c.oid))
+                FROM pg_class c
+                JOIN pg_namespace n ON n.oid = c.relnamespace
+                WHERE n.nspname IN ('pg_catalog', 'information_schema') AND NOT c.relisshared
+            ), 0)
+        )
+    ),
+    'vacuum_health', (
+        SELECT COALESCE(json_agg(t ORDER BY t.dead_rows DESC), '[]'::json)
+        FROM (
+            SELECT
+                s.schemaname as schema,
+                s.relname as table_name,
+                n_live_tup as live_rows,
+                n_dead_tup as dead_rows,
+                CASE WHEN n_live_tup > 0 THEN ROUND(100.0 * n_dead_tup / n_live_tup, 2) ELSE 0 END as dead_pct,
+                vacuum_count,
+                autovacuum_count,
+                COALESCE(last_vacuum::text, 'never') as last_vacuum,
+                COALESCE(last_autovacuum::text, 'never') as last_autovacuum,
+                COALESCE(last_analyze::text, 'never') as last_analyze,
+                age(c.relfrozenxid) as xid_age,
+                CASE WHEN n_dead_tup > 1000 AND (n_live_tup = 0 OR n_dead_tup::float / NULLIF(n_live_tup, 0) > 0.1) THEN true ELSE false END as needs_vacuum,
+                CASE WHEN age(c.relfrozenxid) > 150000000 THEN true ELSE false END as needs_freeze
+            FROM pg_stat_user_tables s
+            JOIN pg_class c ON c.oid = s.relid
+            WHERE n_dead_tup > 100
+            ORDER BY n_dead_tup DESC LIMIT 1000
+        ) t
+    ),
+    'xid_age', (
+        SELECT json_build_object(
+            'value', age(datfrozenxid)
+        )
+        FROM pg_database WHERE datname = current_database()
+    ),
+    'unused_indexes', (
+        SELECT COALESCE(json_agg(t ORDER BY t.size_bytes DESC), '[]'::json)
+        FROM (
+            SELECT
+                s.schemaname as schema,
+                s.relname as table_name,
+                s.indexrelname as index_name,
+                pg_size_pretty(pg_relation_size(s.indexrelid)) as size,
+                pg_relation_size(s.indexrelid) as size_bytes,
+                s.idx_scan as scans,
+                t.seq_scan as table_seq_scans,
+                t.idx_scan as table_idx_scans,
+                t.n_live_tup as table_rows,
+                i.indisprimary as is_primary,
+                i.indisunique as is_unique,
+                CASE WHEN t.seq_scan > 0 AND s.idx_scan = 0 AND t.n_live_tup > 1000
+                    THEN t.seq_scan ELSE 0 END as missing_index_score
+            FROM pg_stat_user_indexes s
+            JOIN pg_stat_user_tables t ON s.relid = t.relid
+            JOIN pg_index i ON s.indexrelid = i.indexrelid
+            WHERE s.idx_scan = 0 AND pg_relation_size(s.indexrelid) > 8192
+            ORDER BY pg_relation_size(s.indexrelid) DESC LIMIT 1000
+        ) t
+    ),
+    'connection_states', (
+        SELECT COALESCE(json_agg(t ORDER BY t.count DESC), '[]'::json)
+        FROM (
+            SELECT state, count(*) as count
+            FROM pg_stat_activity
+            WHERE datname = current_database()
+            GROUP BY state
+            ORDER BY count DESC
+        ) t
+    ),
+    'connections_by_app', (
+        SELECT COALESCE(json_agg(t ORDER BY t.count DESC), '[]'::json)
+        FROM (
+            SELECT COALESCE(application_name, '') as app, COUNT(*) as count
+            FROM pg_stat_activity
+            WHERE datname = current_database()
+            GROUP BY application_name
+            ORDER BY count DESC LIMIT 100
+        ) t
+    ),
+    'connections_by_age', (
+        SELECT COALESCE(json_agg(t), '[]'::json)
+        FROM (
+            SELECT
+                CASE
+                    WHEN age_seconds < 60 THEN '< 1 min'
+                    WHEN age_seconds < 300 THEN '1-5 min'
+                    WHEN age_seconds < 3600 THEN '5-60 min'
+                    WHEN age_seconds < 86400 THEN '1-24 hr'
+                    ELSE '> 24 hr'
+                END as range,
+                count(*) as count
+            FROM (
+                SELECT EXTRACT(EPOCH FROM (now() - backend_start)) as age_seconds
+                FROM pg_stat_activity WHERE datname = current_database()
+            ) sub
+            GROUP BY 1
+            ORDER BY MIN(age_seconds)
+        ) t
+    ),
+    'oldest_connection_sec', (
+        SELECT COALESCE(MAX(EXTRACT(EPOCH FROM (now() - backend_start)))::int, 0)
+        FROM pg_stat_activity
+        WHERE datname = current_database()
+    ),
+    'oldest_connections', (
+        SELECT COALESCE(json_agg(t), '[]'::json)
+        FROM (
+            SELECT
+                COALESCE(application_name, '') as application_name,
+                state,
+                LEFT(query, 100) as query_preview,
+                ROUND(EXTRACT(EPOCH FROM (now() - backend_start)) / 3600)::int as age_hours,
+                ROUND(EXTRACT(EPOCH FROM (now() - backend_start)) / 86400, 1) as age_days,
+                client_addr::text,
+                wait_event_type,
+                wait_event
+            FROM pg_stat_activity
+            WHERE datname = current_database()
+              AND EXTRACT(EPOCH FROM (now() - backend_start)) > 86400
+            ORDER BY backend_start ASC
+            LIMIT 5
+        ) t
+    ),
+    'seq_scan_tables', (
+        SELECT COALESCE(json_agg(t ORDER BY t.seq_scans DESC), '[]'::json)
+        FROM (
+            SELECT
+                relname as table_name,
+                seq_scan as seq_scans,
+                idx_scan as idx_scans,
+                n_live_tup as rows
+            FROM pg_stat_user_tables
+            WHERE seq_scan > 100 AND n_live_tup > 1000
+            ORDER BY seq_scan DESC LIMIT 100
+        ) t
+    ),
+    'pg_stat_statements_installed', (
+        SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements')
+    ),
+    'top_queries', (
+        SELECT COALESCE(json_agg(t), '[]'::json)
+        FROM (
+            SELECT
+                query,
+                calls,
+                ROUND(total_exec_time::numeric/1000/60, 1) as total_min,
+                ROUND(mean_exec_time::numeric, 1) as mean_ms,
+                ROUND(min_exec_time::numeric, 1) as min_ms,
+                ROUND(max_exec_time::numeric, 1) as max_ms,
+                ROUND(stddev_exec_time::numeric, 1) as stddev_ms,
+                rows,
+                CASE WHEN calls > 0 THEN ROUND(rows::numeric / calls, 2) ELSE 0 END as rows_per_call,
+                total_exec_time,
+                ROUND(total_plan_time::numeric, 1) as total_plan_ms,
+                ROUND(mean_plan_time::numeric, 1) as mean_plan_ms,
+                shared_blks_hit,
+                shared_blks_read,
+                shared_blks_dirtied,
+                shared_blks_written,
+                ROUND(100.0 * shared_blks_hit / NULLIF(shared_blks_hit + shared_blks_read, 0), 2) as cache_hit_pct,
+                local_blks_hit,
+                local_blks_read,
+                temp_blks_read,
+                temp_blks_written,
+                ROUND(blk_read_time::numeric, 1) as blk_read_time_ms,
+                ROUND(blk_write_time::numeric, 1) as blk_write_time_ms,
+                wal_records,
+                wal_bytes
+            FROM pg_stat_statements s
+            JOIN pg_database d ON s.dbid = d.oid
+            WHERE d.datname = current_database()
+            ORDER BY total_exec_time DESC LIMIT 100
+        ) t
+    ),
+    'long_running_queries', (
+        SELECT COALESCE(json_agg(t ORDER BY t.duration_sec DESC), '[]'::json)
+        FROM (
+            SELECT
+                pid,
+                EXTRACT(EPOCH FROM (now() - query_start))::int as duration_sec,
+                query
+            FROM pg_stat_activity
+            WHERE state = 'active'
+                AND now() - query_start > interval '5 seconds'
+            ORDER BY query_start LIMIT 100
+        ) t
+    ),
+    'idle_in_transaction', (
+        SELECT COALESCE(json_agg(t ORDER BY t.idle_sec DESC), '[]'::json)
+        FROM (
+            SELECT
+                pid,
+                EXTRACT(EPOCH FROM (now() - state_change))::int as idle_sec,
+                COALESCE(usename, '') as username,
+                COALESCE(application_name, '') as app,
+                query as last_query
+            FROM pg_stat_activity
+            WHERE state = 'idle in transaction'
+                AND now() - state_change > interval '30 seconds'
+            ORDER BY state_change LIMIT 100
+        ) t
+    ),
+    'blocked_queries', (
+        SELECT COALESCE(json_agg(t ORDER BY t.wait_sec DESC), '[]'::json)
+        FROM (
+            SELECT
+                blocked.pid,
+                EXTRACT(EPOCH FROM (now() - blocked.query_start))::int as wait_sec,
+                COALESCE(blocked.usename, '') as username,
+                COALESCE(blocking.pid::text, '') as blocking_pid,
+                left(blocked.query, 60) as query
+            FROM pg_stat_activity blocked
+            JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid
+            JOIN pg_locks blocking_locks ON blocked_locks.locktype = blocking_locks.locktype
+                AND blocked_locks.database IS NOT DISTINCT FROM blocking_locks.database
+                AND blocked_locks.relation IS NOT DISTINCT FROM blocking_locks.relation
+                AND blocked_locks.page IS NOT DISTINCT FROM blocking_locks.page
+                AND blocked_locks.tuple IS NOT DISTINCT FROM blocking_locks.tuple
+                AND blocked_locks.virtualxid IS NOT DISTINCT FROM blocking_locks.virtualxid
+                AND blocked_locks.transactionid IS NOT DISTINCT FROM blocking_locks.transactionid
+                AND blocked_locks.classid IS NOT DISTINCT FROM blocking_locks.classid
+                AND blocked_locks.objid IS NOT DISTINCT FROM blocking_locks.objid
+                AND blocked_locks.objsubid IS NOT DISTINCT FROM blocking_locks.objsubid
+                AND blocked_locks.pid != blocking_locks.pid
+            JOIN pg_stat_activity blocking ON blocking_locks.pid = blocking.pid
+            WHERE NOT blocked_locks.granted
+            ORDER BY blocked.query_start LIMIT 100
+        ) t
+    ),
+    'locks', (
+        SELECT COALESCE(json_agg(t), '[]'::json)
+        FROM (
+            SELECT
+                l.locktype,
+                l.mode,
+                COALESCE(a.usename, '') as username,
+                COALESCE(a.application_name, '') as app,
+                left(COALESCE(a.query, ''), 50) as query
+            FROM pg_locks l
+            JOIN pg_stat_activity a ON l.pid = a.pid
+            WHERE a.datname = current_database() AND NOT l.granted
+            LIMIT 100
+        ) t
+    ),
+    'replication', (
+        SELECT COALESCE(json_agg(t), '[]'::json)
+        FROM (
+            SELECT
+                COALESCE(client_addr::text, 'local') as client,
+                state,
+                sent_lsn::text as sent_lsn,
+                replay_lsn::text as replay_lsn
+            FROM pg_stat_replication
+        ) t
+    ),
+    'bgwriter', (
+        SELECT json_build_object(
+            'checkpoints_timed', checkpoints_timed,
+            'checkpoints_req', checkpoints_req,
+            'buffers_checkpoint', buffers_checkpoint,
+            'buffers_clean', buffers_clean,
+            'buffers_backend', buffers_backend,
+            'buffers_backend_fsync', buffers_backend_fsync,
+            'maxwritten_clean', maxwritten_clean,
+            'stats_reset', COALESCE(stats_reset::text, 'never')
+        )
+        FROM pg_stat_bgwriter
+    ),
+    'invalid_indexes', (
+        SELECT COALESCE(json_agg(json_build_object(
+            'schema', n.nspname,
+            'table', c.relname,
+            'index', i.relname
+        )), '[]'::json)
+        FROM pg_index x
+        JOIN pg_class c ON c.oid = x.indrelid
+        JOIN pg_class i ON i.oid = x.indexrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE NOT x.indisvalid
+    ),
+    'archiver', (
+        SELECT json_build_object(
+            'archived_count', archived_count,
+            'failed_count', failed_count,
+            'last_archived_wal', last_archived_wal,
+            'last_archived_time', COALESCE(last_archived_time::text, 'never'),
+            'last_failed_wal', last_failed_wal,
+            'last_failed_time', COALESCE(last_failed_time::text, 'never'),
+            'stats_reset', COALESCE(stats_reset::text, 'never')
+        )
+        FROM pg_stat_archiver
+    ),
+    'progress_vacuum', (
+        SELECT COALESCE(json_agg(json_build_object(
+            'pid', p.pid,
+            'datname', d.datname,
+            'relname', c.relname,
+            'phase', p.phase,
+            'heap_blks_total', p.heap_blks_total,
+            'heap_blks_scanned', p.heap_blks_scanned,
+            'heap_blks_vacuumed', p.heap_blks_vacuumed,
+            'index_vacuum_count', p.index_vacuum_count,
+            'max_dead_tuples', p.max_dead_tuples,
+            'num_dead_tuples', p.num_dead_tuples
+        )), '[]'::json)
+        FROM pg_stat_progress_vacuum p
+        JOIN pg_database d ON p.datid = d.oid
+        LEFT JOIN pg_class c ON p.relid = c.oid
+    ),
+    'ssl_stats', (
+        SELECT json_build_object(
+            'ssl_connections', (SELECT count(*) FROM pg_stat_ssl WHERE ssl = true),
+            'non_ssl_connections', (SELECT count(*) FROM pg_stat_ssl WHERE ssl = false),
+            'ssl_versions', (
+                SELECT COALESCE(json_agg(json_build_object('version', version, 'count', cnt)), '[]'::json)
+                FROM (SELECT version, count(*) as cnt FROM pg_stat_ssl WHERE ssl = true GROUP BY version) v
+            )
+        )
+    )
+)::text;
+"""
+
+
+def parse_batched_analysis(data: Dict[str, Any], result: AnalysisResult) -> None:
+    """Parse the batched JSON analysis data into the result object."""
+
+    # Connections
+    conn = data.get("connections")
+    if conn:
+        current = conn.get("current", 0)
+        max_conn = conn.get("max", 1)
+        reserved = conn.get("reserved", 3)
+        result.connections = {
+            "current": current,
+            "max": max_conn,
+            "reserved": reserved,
+            "available": max_conn - current - reserved,
+            "percent": round(current / max_conn * 100, 1) if max_conn > 0 else 0,
+            "active": conn.get("active", 0),
+            "idle": conn.get("idle", 0),
+            "idle_in_transaction": conn.get("idle_in_transaction", 0),
+        }
+
+    # Memory config (expanded for tuning analysis)
+    mem_config = data.get("memory_config")
+    if mem_config:
+        result.memory_config = {}
+        for row in mem_config:
+            name = row["name"]
+            setting = row["setting"]
+            unit = row["unit"]
+
+            # Handle different value types
+            if unit == "8kB":
+                # Convert 8kB pages to MB
+                mb = int(setting) * 8 / 1024 if str(setting).isdigit() else 0
+                result.memory_config[name] = {"value": int(setting) if str(setting).isdigit() else 0, "unit": unit, "mb": round(mb, 1)}
+            elif unit == "kB":
+                mb = int(setting) / 1024 if str(setting).isdigit() else 0
+                result.memory_config[name] = {"value": int(setting) if str(setting).isdigit() else 0, "unit": unit, "mb": round(mb, 1)}
+            elif unit == "MB":
+                result.memory_config[name] = {"value": int(setting) if str(setting).isdigit() else 0, "unit": unit, "mb": int(setting) if str(setting).isdigit() else 0}
+            elif unit in ("ms", "s", "min"):
+                # Time-based settings
+                result.memory_config[name] = {"value": setting, "unit": unit}
+            elif name in ("random_page_cost", "checkpoint_completion_target", "autovacuum_vacuum_scale_factor", "autovacuum_analyze_scale_factor"):
+                # Float settings
+                result.memory_config[name] = {"value": float(setting) if setting else 0}
+            elif name in ("synchronous_commit", "autovacuum", "track_io_timing"):
+                # On/off settings
+                result.memory_config[name] = {"value": setting}
+            else:
+                # Integer settings (max_connections, max_parallel_workers, etc.)
+                result.memory_config[name] = {"value": int(setting) if str(setting).isdigit() else setting}
+
+    # Cache hit
+    cache = data.get("cache_hit")
+    if cache:
+        result.cache_hit = {
+            "table_hit_pct": cache.get("table_hit_pct"),
+            "index_hit_pct": cache.get("index_hit_pct"),
+        }
+
+    # Database stats
+    db_stats = data.get("database_stats")
+    if db_stats:
+        result.database_stats = {
+            "deadlocks": db_stats.get("deadlocks", 0),
+            "temp_files": db_stats.get("temp_files", 0),
+            "temp_bytes": db_stats.get("temp_bytes", 0),
+            "stats_reset": db_stats.get("stats_reset", "unknown"),
+            "blks_read": db_stats.get("blks_read", 0),
+            "blks_hit": db_stats.get("blks_hit", 0),
+            "tup_returned": db_stats.get("tup_returned", 0),
+            "tup_fetched": db_stats.get("tup_fetched", 0),
+            "tup_inserted": db_stats.get("tup_inserted", 0),
+            "tup_updated": db_stats.get("tup_updated", 0),
+            "tup_deleted": db_stats.get("tup_deleted", 0),
+            "conflicts": db_stats.get("conflicts", 0),
+            "checksum_failures": db_stats.get("checksum_failures", 0),
+        }
+
+    # Cache per table
+    cache_per_table = data.get("cache_per_table", [])
+    result.cache_per_table = [
+        {
+            "table": t.get("table_name"),
+            "disk_reads": str(t.get("disk_reads", 0)),
+            "cache_hits": str(t.get("cache_hits", 0)),
+            "hit_pct": str(t.get("hit_pct", 0)),
+        }
+        for t in cache_per_table
+    ]
+
+    # Table sizes
+    table_sizes = data.get("table_sizes", [])
+    result.table_sizes = [
+        {
+            "schema": t.get("schema"),
+            "table": t.get("table_name"),
+            "size": t.get("size"),
+            "total_bytes": str(t.get("total_bytes", 0)),
+            "data_bytes": str(t.get("data_bytes", 0)),
+            "index_bytes": str(t.get("index_bytes", 0)),
+            "row_count": str(t.get("row_count", 0)),
+        }
+        for t in table_sizes
+    ]
+
+    # Size breakdown
+    size = data.get("size_breakdown")
+    if size:
+        result.size_breakdown = {
+            "database_bytes": size.get("database_bytes", 0),
+            "wal_bytes": size.get("wal_bytes", 0),
+            "user_tables_bytes": size.get("user_tables_bytes", 0),
+            "user_indexes_bytes": size.get("user_indexes_bytes", 0),
+            "system_bytes": size.get("system_bytes", 0),
+        }
+
+    # Vacuum health
+    vacuum = data.get("vacuum_health", [])
+    result.vacuum_health = [
+        {
+            "schema": t.get("schema"),
+            "table": t.get("table_name"),
+            "live_rows": str(t.get("live_rows", 0)),
+            "dead_rows": str(t.get("dead_rows", 0)),
+            "dead_pct": str(t.get("dead_pct", 0)),
+            "vacuum_count": str(t.get("vacuum_count", 0)),
+            "autovacuum_count": str(t.get("autovacuum_count", 0)),
+            "last_vacuum": t.get("last_vacuum", "never"),
+            "last_autovacuum": t.get("last_autovacuum", "never"),
+            "last_analyze": t.get("last_analyze", "never"),
+            "xid_age": str(t.get("xid_age", 0)),
+            "needs_vacuum": "true" if t.get("needs_vacuum") else "false",
+            "needs_freeze": "true" if t.get("needs_freeze") else "false",
+        }
+        for t in vacuum
+    ]
+
+    # XID age
+    xid = data.get("xid_age")
+    if xid and xid.get("value") is not None:
+        xid_val = xid["value"]
+        result.xid_age = {
+            "value": xid_val,
+            "millions": round(xid_val / 1_000_000, 1),
+            "pct_to_wraparound": round(xid_val / 2_147_483_647 * 100, 2)
+        }
+
+    # Unused indexes
+    unused = data.get("unused_indexes", [])
+    result.unused_indexes = [
+        {
+            "schema": t.get("schema"),
+            "table": t.get("table_name"),
+            "index": t.get("index_name"),
+            "size": t.get("size"),
+            "size_bytes": str(t.get("size_bytes", 0)),
+            "scans": str(t.get("scans", 0)),
+            "table_seq_scans": str(t.get("table_seq_scans", 0)),
+            "table_idx_scans": str(t.get("table_idx_scans", 0)),
+            "table_rows": str(t.get("table_rows", 0)),
+            "is_primary": t.get("is_primary", False),
+            "is_unique": t.get("is_unique", False),
+            "missing_index_score": str(t.get("missing_index_score", 0)),
+        }
+        for t in unused
+    ]
+
+    # Connection states
+    conn_states = data.get("connection_states", [])
+    result.connection_states = [
+        {"state": t.get("state"), "count": str(t.get("count", 0))}
+        for t in conn_states
+    ]
+
+    # Connections by app
+    conn_app = data.get("connections_by_app", [])
+    result.connections_by_app = [
+        {"app": t.get("app", ""), "count": str(t.get("count", 0))}
+        for t in conn_app
+    ]
+
+    # Connections by age
+    conn_age = data.get("connections_by_age", [])
+    result.connections_by_age = [
+        {"range": t.get("range"), "count": str(t.get("count", 0))}
+        for t in conn_age
+    ]
+
+    # Oldest connection
+    oldest = data.get("oldest_connection_sec")
+    if oldest is not None:
+        result.oldest_connection_sec = oldest
+
+    # Details of old connections (>24 hours)
+    oldest_conns = data.get("oldest_connections", [])
+    result.oldest_connections = [
+        {
+            "application_name": c.get("application_name", ""),
+            "state": c.get("state"),
+            "query_preview": c.get("query_preview"),
+            "age_hours": c.get("age_hours"),
+            "age_days": c.get("age_days"),
+            "client_addr": c.get("client_addr"),
+            "wait_event_type": c.get("wait_event_type"),
+            "wait_event": c.get("wait_event"),
+        }
+        for c in oldest_conns
+    ]
+
+    # Seq scan tables
+    seq_tables = data.get("seq_scan_tables", [])
+    result.seq_scan_tables = [
+        {
+            "table": t.get("table_name"),
+            "seq_scans": str(t.get("seq_scans", 0)),
+            "idx_scans": str(t.get("idx_scans", 0)),
+            "rows": str(t.get("rows", 0)),
+        }
+        for t in seq_tables
+    ]
+
+    # Top queries
+    top_q = data.get("top_queries", [])
+    result.top_queries = [
+        {
+            "query": t.get("query"),
+            "calls": str(t.get("calls", 0)),
+            "total_min": str(t.get("total_min", 0)),
+            "mean_ms": str(t.get("mean_ms", 0)),
+            "min_ms": str(t.get("min_ms", 0)),
+            "max_ms": str(t.get("max_ms", 0)),
+            "stddev_ms": str(t.get("stddev_ms", 0)),
+            "rows": str(t.get("rows", 0)),
+            "rows_per_call": str(t.get("rows_per_call", 0)),
+            "total_plan_ms": str(t.get("total_plan_ms", 0)),
+            "mean_plan_ms": str(t.get("mean_plan_ms", 0)),
+            "shared_blks_hit": t.get("shared_blks_hit", 0),
+            "shared_blks_read": t.get("shared_blks_read", 0),
+            "shared_blks_dirtied": t.get("shared_blks_dirtied", 0),
+            "shared_blks_written": t.get("shared_blks_written", 0),
+            "cache_hit_pct": t.get("cache_hit_pct"),
+            "local_blks_hit": t.get("local_blks_hit", 0),
+            "local_blks_read": t.get("local_blks_read", 0),
+            "temp_blks_read": t.get("temp_blks_read", 0),
+            "temp_blks_written": t.get("temp_blks_written", 0),
+            "blk_read_time_ms": str(t.get("blk_read_time_ms", 0)),
+            "blk_write_time_ms": str(t.get("blk_write_time_ms", 0)),
+            "wal_records": t.get("wal_records", 0),
+            "wal_bytes": t.get("wal_bytes", 0),
+        }
+        for t in top_q
+    ]
+
+    # Long running queries
+    long_q = data.get("long_running_queries", [])
+    result.long_running_queries = [
+        {
+            "pid": str(t.get("pid")),
+            "duration_sec": str(t.get("duration_sec", 0)),
+            "query": t.get("query"),
+        }
+        for t in long_q
+    ]
+
+    # Idle in transaction
+    idle_txn = data.get("idle_in_transaction", [])
+    result.idle_in_transaction = [
+        {
+            "pid": str(t.get("pid")),
+            "idle_sec": str(t.get("idle_sec", 0)),
+            "user": t.get("username", ""),
+            "app": t.get("app", ""),
+            "last_query": t.get("last_query"),
+        }
+        for t in idle_txn
+    ]
+
+    # Blocked queries
+    blocked = data.get("blocked_queries", [])
+    result.blocked_queries = [
+        {
+            "pid": str(t.get("pid")),
+            "wait_sec": str(t.get("wait_sec", 0)),
+            "user": t.get("username", ""),
+            "blocking_pid": t.get("blocking_pid", ""),
+            "query": t.get("query"),
+        }
+        for t in blocked
+    ]
+
+    # Locks
+    locks = data.get("locks", [])
+    result.locks = [
+        {
+            "locktype": t.get("locktype"),
+            "mode": t.get("mode"),
+            "user": t.get("username", ""),
+            "app": t.get("app", ""),
+            "query": t.get("query"),
+        }
+        for t in locks
+    ]
+
+    # Replication
+    repl = data.get("replication", [])
+    result.replication = [
+        {
+            "client": t.get("client"),
+            "state": t.get("state"),
+            "sent_lsn": t.get("sent_lsn"),
+            "replay_lsn": t.get("replay_lsn"),
+        }
+        for t in repl
+    ]
+
+    # pg_stat_statements installed flag
+    result.pg_stat_statements_installed = data.get("pg_stat_statements_installed", False)
+
+    # Background writer stats
+    bgwriter = data.get("bgwriter")
+    if bgwriter:
+        result.bgwriter = {
+            "checkpoints_timed": bgwriter.get("checkpoints_timed", 0),
+            "checkpoints_req": bgwriter.get("checkpoints_req", 0),
+            "buffers_checkpoint": bgwriter.get("buffers_checkpoint", 0),
+            "buffers_clean": bgwriter.get("buffers_clean", 0),
+            "buffers_backend": bgwriter.get("buffers_backend", 0),
+            "buffers_backend_fsync": bgwriter.get("buffers_backend_fsync", 0),
+            "maxwritten_clean": bgwriter.get("maxwritten_clean", 0),
+            "stats_reset": bgwriter.get("stats_reset", "never"),
+        }
+
+    # Invalid indexes
+    invalid_idx = data.get("invalid_indexes", [])
+    result.invalid_indexes = [
+        {
+            "schema": t.get("schema"),
+            "table": t.get("table"),
+            "index": t.get("index"),
+        }
+        for t in invalid_idx
+    ]
+
+    # WAL archiver stats
+    archiver = data.get("archiver")
+    if archiver:
+        result.archiver = {
+            "archived_count": archiver.get("archived_count", 0),
+            "failed_count": archiver.get("failed_count", 0),
+            "last_archived_wal": archiver.get("last_archived_wal"),
+            "last_archived_time": archiver.get("last_archived_time", "never"),
+            "last_failed_wal": archiver.get("last_failed_wal"),
+            "last_failed_time": archiver.get("last_failed_time", "never"),
+            "stats_reset": archiver.get("stats_reset", "never"),
+        }
+
+    # Vacuum progress
+    progress_vac = data.get("progress_vacuum", [])
+    result.progress_vacuum = [
+        {
+            "pid": t.get("pid"),
+            "datname": t.get("datname"),
+            "relname": t.get("relname"),
+            "phase": t.get("phase"),
+            "heap_blks_total": t.get("heap_blks_total", 0),
+            "heap_blks_scanned": t.get("heap_blks_scanned", 0),
+            "heap_blks_vacuumed": t.get("heap_blks_vacuumed", 0),
+            "index_vacuum_count": t.get("index_vacuum_count", 0),
+            "max_dead_tuples": t.get("max_dead_tuples", 0),
+            "num_dead_tuples": t.get("num_dead_tuples", 0),
+        }
+        for t in progress_vac
+    ]
+
+    # SSL connection stats
+    ssl = data.get("ssl_stats")
+    if ssl:
+        result.ssl_stats = {
+            "ssl_connections": ssl.get("ssl_connections", 0),
+            "non_ssl_connections": ssl.get("non_ssl_connections", 0),
+            "ssl_versions": ssl.get("ssl_versions", []),
+        }
+
+
+def parse_psql_output(output: str, columns: List[str]) -> List[Dict[str, str]]:
+    """Parse psql -t -A output (pipe-separated) into list of dicts."""
+    rows = []
+    for line in output.strip().split("\n"):
+        if not line or line.startswith("("):
+            continue
+        values = line.split("|")
+        if len(values) == len(columns):
+            rows.append(dict(zip(columns, [v.strip() for v in values])))
+    return rows
+
+
+def get_disk_usage_from_api(environment_id: str, service_id: str) -> Optional[Dict[str, Any]]:
+    """Get disk usage from Railway metrics API."""
+    from datetime import timedelta
+
+    # Build the API query
+    start_date = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+
+    # Use railway-api.sh script
+    import os
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    api_script = os.path.join(script_dir, "railway-api.sh")
+
+    if not os.path.exists(api_script):
+        return None
+
+    query = '''query metrics($environmentId: String!, $serviceId: String, $startDate: DateTime!, $measurements: [MetricMeasurement!]!) {
+        metrics(environmentId: $environmentId, serviceId: $serviceId, startDate: $startDate, measurements: $measurements) {
+            measurement values { ts value }
+        }
+    }'''
+
+    variables = json.dumps({
+        "environmentId": environment_id,
+        "serviceId": service_id,
+        "startDate": start_date,
+        "measurements": ["DISK_USAGE_GB"]
+    })
+
+    try:
+        result = subprocess.run(
+            [api_script, query, variables],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+        if result.returncode != 0:
+            return None
+
+        data = json.loads(result.stdout)
+        metrics = data.get("data", {}).get("metrics", [])
+
+        for metric in metrics:
+            if metric.get("measurement") == "DISK_USAGE_GB":
+                values = metric.get("values", [])
+                if values:
+                    # Get latest value
+                    latest = values[-1].get("value", 0)
+                    return {
+                        "used_gb": round(latest, 2),
+                        "used": f"{latest:.1f} GB",
+                    }
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
+        pass
+
+    return None
+
+
+def get_disk_usage(service: str, environment_id: Optional[str] = None, service_id: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    """Get disk usage - try API first, fall back to SSH."""
+    # Try Railway API first
+    if environment_id and service_id:
+        api_result = get_disk_usage_from_api(environment_id, service_id)
+        if api_result:
+            return api_result
+
+    # Fall back to SSH
+    command = "df -h /var/lib/postgresql/data 2>/dev/null || df -h / | tail -1"
+    code, stdout, stderr = run_ssh_query(service, command)
+    if code != 0 or not stdout:
+        return None
+
+    # Parse df output: Filesystem Size Used Avail Use% Mounted
+    lines = stdout.strip().split("\n")
+    for line in lines:
+        if line and not line.startswith("Filesystem"):
+            parts = line.split()
+            if len(parts) >= 5:
+                return {
+                    "total": parts[1],
+                    "used": parts[2],
+                    "available": parts[3],
+                    "use_percent": parts[4].rstrip("%"),
+                }
+    return None
+
+
+def get_cpu_memory_from_api(environment_id: str, service_id: str) -> Optional[Dict[str, Any]]:
+    """Get CPU and memory usage from Railway metrics API.
+
+    DEPRECATED: Use get_all_metrics_from_api() instead for combined disk/cpu/memory.
+    """
+    result = get_all_metrics_from_api(environment_id, service_id)
+    if result:
+        return result.get("cpu_memory")
+    return None
+
+
+def get_recent_errors(service: str, limit: int = 10) -> List[str]:
+    """Get recent error logs (legacy - kept for backwards compat)."""
+    code, stdout, stderr = run_railway_command(
+        ["logs", "--service", service, "--lines", "100", "--filter", "@level:error"],
+        timeout=30
+    )
+    if code != 0:
+        return []
+
+    errors = []
+    for line in stdout.strip().split("\n")[:limit]:
+        if line.strip():
+            errors.append(line.strip())
+    return errors
+
+
+def get_cluster_logs(
+    ha_cluster: Optional[Dict[str, Any]],
+    environment_id: Optional[str],
+    limit: int = 100
+) -> List[Dict[str, Any]]:
+    """Get logs from all HA cluster members via Railway API.
+
+    For HA clusters, each member may be a separate deployment.
+    This function fetches recent logs from each cluster member.
+    """
+    if not ha_cluster or not environment_id:
+        return []
+
+    members = ha_cluster.get("members", [])
+    if not members:
+        return []
+
+    import os
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    api_script = os.path.join(script_dir, "railway-api.sh")
+
+    if not os.path.exists(api_script):
+        return []
+
+    cluster_logs = []
+
+    # Query to get deployments for the environment
+    deployment_query = '''query deployments($environmentId: String!) {
+        deployments(input: { environmentId: $environmentId }) {
+            edges { node { id status staticUrl service { id name } } }
+        }
+    }'''
+
+    try:
+        result = subprocess.run(
+            [api_script, deployment_query, json.dumps({"environmentId": environment_id})],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+        if result.returncode != 0:
+            return []
+
+        data = json.loads(result.stdout)
+        deployments = data.get("data", {}).get("deployments", {}).get("edges", [])
+
+        # Find deployments that match cluster member names
+        member_names = {m.get("name", "").lower() for m in members}
+
+        for edge in deployments:
+            deployment = edge.get("node", {})
+            deployment_id = deployment.get("id")
+            service_name = deployment.get("service", {}).get("name", "").lower()
+            status = deployment.get("status")
+
+            # Check if this deployment corresponds to a cluster member
+            is_member = any(
+                member_name in service_name or service_name in member_name
+                for member_name in member_names
+            )
+
+            if not is_member and status != "SUCCESS":
+                continue
+
+            if not deployment_id:
+                continue
+
+            # Fetch logs for this deployment
+            log_query = '''query deploymentLogs($deploymentId: String!, $limit: Int) {
+                deploymentLogs(deploymentId: $deploymentId, limit: $limit) {
+                    timestamp message severity
+                }
+            }'''
+
+            log_result = subprocess.run(
+                [api_script, log_query, json.dumps({
+                    "deploymentId": deployment_id,
+                    "limit": limit
+                })],
+                capture_output=True,
+                text=True,
+                timeout=30
+            )
+
+            if log_result.returncode == 0:
+                log_data = json.loads(log_result.stdout)
+                logs = log_data.get("data", {}).get("deploymentLogs", [])
+                if logs:
+                    cluster_logs.append({
+                        "member": service_name,
+                        "deployment_id": deployment_id,
+                        "status": status,
+                        "logs": logs[-limit:],  # Last N logs
+                    })
+
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
+        pass
+
+    return cluster_logs
+
+
+def is_postgres_ha_service(service_id: Optional[str]) -> bool:
+    """Check if service is from postgres-ha template.
+
+    Returns True if the service source repo contains 'postgres-ha',
+    indicating this is part of an HA cluster that uses Patroni.
+    """
+    if not service_id:
+        return False
+
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    api_script = os.path.join(script_dir, "railway-api.sh")
+
+    if not os.path.exists(api_script):
+        return False
+
+    query = '''query service($id: String!) {
+        service(id: $id) {
+            source { repo }
+        }
+    }'''
+
+    try:
+        result = subprocess.run(
+            [api_script, query, json.dumps({"id": service_id})],
+            capture_output=True,
+            text=True,
+            timeout=10
+        )
+        if result.returncode != 0:
+            return False
+
+        data = json.loads(result.stdout)
+        repo = data.get("data", {}).get("service", {}).get("source", {}).get("repo", "")
+        return "postgres-ha" in repo.lower() if repo else False
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
+        return False
+
+
+def analyze_postgres(service: str, timeout: int = 300, quiet: bool = False,
+                     skip_logs: bool = False,
+                     metrics_hours: int = 168,
+                     project_id: Optional[str] = None,
+                     environment_id: Optional[str] = None,
+                     service_id: Optional[str] = None) -> AnalysisResult:
+    """Run complete Postgres analysis with maximum data collection.
+
+    Uses a single batched SQL query to collect all database metrics,
+    minimizing SSH connections (~3 total instead of ~22).
+
+    Args:
+        skip_logs: Skip log fetching for faster analysis (~60s saved)
+        metrics_hours: Hours of metrics history to fetch (default: 168, max: 168)
+        project_id: Project ID (bypasses railway link config)
+        environment_id: Environment ID (bypasses railway link config)
+        service_id: Service ID (bypasses railway link config)
+    """
+    if not quiet:
+        print(f"Analyzing postgres database: {service}", file=sys.stderr)
+
+    result = AnalysisResult(
+        service=service,
+        db_type="postgres",
+        timestamp=datetime.now(timezone.utc).isoformat(),
+    )
+
+    # === FAST CONTEXT LOADING ===
+    # Use explicit IDs if provided, otherwise read from config file (instant)
+    if not quiet:
+        print("  [0/5] Getting Railway context...", file=sys.stderr, flush=True)
+    dal._progress_timer.start()
+
+    if environment_id and service_id:
+        # IDs passed directly — no need to read config or link
+        dal._ctx = RailwayContext(project_id=project_id, environment_id=environment_id, service_id=service_id)
+        if not quiet:
+            print(f"        using explicit IDs (env={environment_id[:8]}..., svc={service_id[:8]}...)", file=sys.stderr, flush=True)
+    else:
+        # Fall back to reading railway context from local config (instant, no API call)
+        railway_status = get_railway_status()
+        if railway_status:
+            dal._ctx = RailwayContext(
+                project_id=railway_status.get("projectId"),
+                environment_id=railway_status.get("environmentId"),
+                service_id=railway_status.get("serviceId"),
+            )
+        environment_id = dal._ctx.environment_id
+        service_id = dal._ctx.service_id
+
+    # Check if this is an HA service - only call API if name suggests HA
+    is_ha_service = False
+    if any(hint in service.lower() for hint in ["postgres-ha", "patroni", "-ha"]):
+        is_ha_service = is_postgres_ha_service(service_id)
+
+    # Get deployment status via API (~1s) instead of CLI (~15s)
+    progress(1, 5, "Fetching deployment status...", quiet)
+    result.deployment_status = get_deployment_status(service, service_id=service_id)
+
+    # === SSH PRE-CHECK WITH RETRY ===
+    # SSH can be flaky — retry with increasing timeouts before giving up
+    progress(2, 4, "Testing SSH connectivity...", quiet)
+    ssh_available = False
+    ssh_stderr = ""
+    ssh_attempts = [30, 60, 90]
+    for attempt, attempt_timeout in enumerate(ssh_attempts, 1):
+        ssh_code, ssh_stdout, ssh_stderr = run_ssh_query(service, "echo ok", timeout=attempt_timeout)
+        if ssh_code == 0 and "ok" in ssh_stdout:
+            ssh_available = True
+            if not quiet:
+                for line in ssh_stderr.splitlines():
+                    if line.startswith("Using SSH key:"):
+                        print(f"        {line}", file=sys.stderr, flush=True)
+                        break
+            break
+        if not quiet:
+            remaining = len(ssh_attempts) - attempt
+            if remaining > 0:
+                print(f"        SSH attempt {attempt}/{len(ssh_attempts)} failed ({ssh_stderr or 'no response'}), retrying with {ssh_attempts[attempt]}s timeout...", file=sys.stderr, flush=True)
+            else:
+                print(f"        SSH attempt {attempt}/{len(ssh_attempts)} failed ({ssh_stderr or 'no response'}), giving up", file=sys.stderr, flush=True)
+
+    # === PARALLEL EXECUTION OF SLOW OPERATIONS ===
+    # Run metrics API, database query, and logs in parallel (~17-27s down to ~max of the three)
+    progress(3, 4, "Running analysis (metrics, query, logs in parallel)...", quiet)
+
+    analysis_query = build_analysis_query()
+
+    # Define parallel tasks
+    def task_metrics():
+        """Fetch all metrics (disk, CPU, memory) in one API call."""
+        if environment_id and service_id:
+            return get_all_metrics_from_api(environment_id, service_id, hours=metrics_hours)
+        return None
+
+    def task_database_query():
+        """Run the batched database analysis query with retry."""
+        if not ssh_available:
+            return (1, "", f"SSH not available: {ssh_stderr or 'connection failed'}")
+        code, stdout, stderr = run_psql_query_safe(service, analysis_query, timeout=timeout)
+        if code != 0:
+            # Retry once — SSH sessions can drop mid-query
+            if not quiet:
+                print(f"        Database query failed ({stderr or 'unknown'}), retrying...", file=sys.stderr, flush=True)
+            code, stdout, stderr = run_psql_query_safe(service, analysis_query, timeout=timeout)
+        return (code, stdout, stderr)
+
+    def task_logs():
+        """Fetch recent logs via API (~3s)."""
+        if skip_logs:
+            return []
+        return get_recent_logs(service, lines=LOG_LINES_DEFAULT,
+                               environment_id=environment_id,
+                               service_id=service_id)
+
+    def task_ha_cluster():
+        """Check HA cluster status (Patroni)."""
+        if not is_ha_service:
+            return "skipped_not_ha"
+        if not ssh_available:
+            return "skipped_no_ssh"
+        code, stdout, stderr = run_ssh_query(service, "curl -s localhost:8008/cluster 2>/dev/null || echo '{}'")
+        if code == 0 and stdout and stdout.strip() != "{}":
+            try:
+                patroni_data = json.loads(stdout)
+                members = patroni_data.get("members", [])
+                if members:
+                    return {
+                        "members": [
+                            {
+                                "name": m.get("name"),
+                                "role": m.get("role"),
+                                "state": m.get("state"),
+                                "timeline": m.get("timeline"),
+                                "lag": m.get("lag"),
+                            }
+                            for m in members
+                        ]
+                    }
+            except json.JSONDecodeError:
+                pass
+        return None
+
+    # Run all tasks in parallel
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        future_metrics = executor.submit(task_metrics)
+        future_db = executor.submit(task_database_query)
+        future_logs = executor.submit(task_logs)
+        future_ha = executor.submit(task_ha_cluster)
+
+        # Collect results
+        metrics_result = future_metrics.result()
+        db_result = future_db.result()
+        logs_result = future_logs.result()
+        ha_result = future_ha.result()
+
+    # Process metrics result (combined disk + cpu/memory + 24h history)
+    if metrics_result:
+        result.disk_usage = metrics_result.get("disk_usage")
+        result.cpu_memory = metrics_result.get("cpu_memory")
+        result.metrics_history = metrics_result.get("metrics_history")
+        result.collection_status["metrics_api"] = {"status": "success"}
+    else:
+        result.collection_status["metrics_api"] = {
+            "status": "error",
+            "error": "Metrics API returned no data"
+        }
+
+    # Process database query result
+    code, stdout, stderr = db_result
+    if code == 0 and stdout:
+        try:
+            data = json.loads(stdout.strip())
+            parse_batched_analysis(data, result)
+            result.collection_status["database_query"] = {"status": "success"}
+        except json.JSONDecodeError as e:
+            result.errors.append(f"Failed to parse batched analysis JSON: {e}")
+            result.collection_status["database_query"] = {
+                "status": "error",
+                "error": f"JSON parse error: {e}"
+            }
+    else:
+        error_msg = stderr or stdout or "Unknown error"
+        if not ssh_available:
+            error_msg = f"SSH failed after {len(ssh_attempts)} attempts: {ssh_stderr or 'connection failed'}"
+        result.errors.append(f"Batched analysis query failed: {error_msg}")
+        result.collection_status["database_query"] = {
+            "status": "error",
+            "error": error_msg
+        }
+
+    # Process HA cluster result
+    if ha_result == "skipped_not_ha":
+        result.ha_cluster = None
+        result.collection_status["ha_cluster"] = {"status": "skipped", "reason": "not an HA service"}
+    elif ha_result == "skipped_no_ssh":
+        result.ha_cluster = None
+        result.collection_status["ha_cluster"] = {"status": "skipped", "reason": "SSH not available"}
+    elif ha_result is not None:
+        result.ha_cluster = ha_result
+        result.collection_status["ha_cluster"] = {"status": "success"}
+    else:
+        result.ha_cluster = None
+        result.collection_status["ha_cluster"] = {
+            "status": "error" if is_ha_service else "skipped",
+            "error": "Failed to retrieve Patroni cluster data" if is_ha_service else "not an HA service"
+        }
+
+    # Process logs result
+    if skip_logs:
+        result.collection_status["logs_api"] = {"status": "skipped", "reason": "skip_logs flag set"}
+    elif logs_result:
+        result.recent_logs = logs_result
+        result.collection_status["logs_api"] = {
+            "status": "success",
+            "lines": len(logs_result)
+        }
+
+        # Extract error logs locally
+        result.recent_errors = [
+            line for line in result.recent_logs
+            if 'ERROR' in line.upper() or 'FATAL' in line.upper() or 'PANIC' in line.upper()
+        ][:100]
+
+        # HA cluster logs (API call) - done after parallel since it depends on ha_cluster
+        if result.ha_cluster and environment_id:
+            progress(4, 5, "Fetching HA cluster logs...", quiet)
+            result.cluster_logs = get_cluster_logs(result.ha_cluster, environment_id, limit=5000)
+    else:
+        result.recent_logs = []
+        result.collection_status["logs_api"] = {
+            "status": "error",
+            "error": "Logs API returned no data"
+        }
+
+    # Generate recommendations
+    progress(5, 5, "Generating recommendations...", quiet)
+    result.recommendations = generate_recommendations(result)
+
+    if not quiet:
+        total = dal._progress_timer.total_elapsed()
+        print(f"Done.{total}", file=sys.stderr)
+
+    return result
+
+
+def generate_recommendations(result: AnalysisResult) -> List[Dict[str, str]]:
+    """Generate recommendations based on analysis results."""
+    recommendations = []
+
+    # Collection failures — surface critical issues when SSH/introspection failed
+    if result.collection_status:
+        failed = {k: v for k, v in result.collection_status.items()
+                  if v.get("status") in ("failed", "error")}
+        ssh_sources = {"database_query", "ha_cluster"}
+        ssh_failed = {k: v for k, v in failed.items() if k in ssh_sources}
+        if ssh_failed:
+            sources = ", ".join(ssh_failed.keys())
+            errors = "; ".join(v.get("error", "unknown") for v in ssh_failed.values())
+            recommendations.append({
+                "severity": "critical",
+                "category": "collection",
+                "message": f"SSH introspection failed — unable to collect {sources}. "
+                           f"Error: {errors}. "
+                           f"Analysis is incomplete: connection stats, query performance, "
+                           f"table bloat, and tuning parameters could not be evaluated.",
+            })
+
+    # === POSTGRESQL TUNING RECOMMENDATIONS ===
+    # Based on best practices from PostgreSQL wiki and community
+    if result.memory_config:
+        mem = result.memory_config
+
+        # Get system memory from CPU/memory metrics if available
+        system_memory_gb = None
+        if result.cpu_memory and "memory_limit_gb" in result.cpu_memory:
+            # Use actual memory limit from Railway API
+            system_memory_gb = result.cpu_memory["memory_limit_gb"]
+        elif result.cpu_memory and "memory_gb" in result.cpu_memory:
+            # Fallback: estimate total as ~2x current usage
+            system_memory_gb = result.cpu_memory["memory_gb"] * 2  # rough estimate
+
+        # shared_buffers check (should be ~25% of RAM, max ~40%)
+        shared_buffers = mem.get("shared_buffers", {})
+        if shared_buffers and shared_buffers.get("mb"):
+            sb_mb = shared_buffers["mb"]
+            # Flag if shared_buffers is very low (< 128MB) - likely default
+            if sb_mb < 128:
+                # Calculate recommended value based on system memory or default to 1GB
+                rec_sb = "1GB"
+                if system_memory_gb:
+                    rec_sb_mb = int(system_memory_gb * 1024 * 0.25)
+                    rec_sb = f"{rec_sb_mb}MB" if rec_sb_mb < 1024 else f"{round(rec_sb_mb/1024, 1)}GB"
+                recommendations.append({
+                    "priority": "immediate",
+                    "issue": f"shared_buffers is only {sb_mb}MB (likely default)",
+                    "action": f"Increase shared_buffers to {rec_sb} (25% of RAM)",
+                    "explanation": "shared_buffers is PostgreSQL's main data cache - pages read from disk are stored here. "
+                                   f"At {sb_mb}MB, your entire working set cannot fit in memory, forcing repeated disk reads. "
+                                   "The rule of thumb is 25% of total RAM, up to 40% for read-heavy workloads.",
+                    "commands": [
+                        f"ALTER SYSTEM SET shared_buffers = '{rec_sb}';",
+                        "-- Requires database restart to take effect"
+                    ],
+                    "restart_required": True,
+                })
+            elif sb_mb < 256:
+                rec_sb = "512MB"
+                if system_memory_gb:
+                    rec_sb_mb = int(system_memory_gb * 1024 * 0.25)
+                    rec_sb = f"{rec_sb_mb}MB" if rec_sb_mb < 1024 else f"{round(rec_sb_mb/1024, 1)}GB"
+                recommendations.append({
+                    "priority": "short-term",
+                    "issue": f"shared_buffers is {sb_mb}MB - may be undersized",
+                    "action": f"Consider increasing shared_buffers to {rec_sb} (25% of RAM)",
+                    "explanation": "shared_buffers holds cached data pages. A larger buffer pool means more data stays in memory, "
+                                   "reducing disk I/O. Current size may be limiting cache hit ratio.",
+                    "commands": [
+                        f"ALTER SYSTEM SET shared_buffers = '{rec_sb}';",
+                        "-- Requires database restart to take effect"
+                    ],
+                    "restart_required": True,
+                })
+
+        # effective_cache_size check (should be 50-75% of RAM)
+        effective_cache = mem.get("effective_cache_size", {})
+        if effective_cache and effective_cache.get("mb"):
+            ec_mb = effective_cache["mb"]
+            # Flag if effective_cache_size seems low
+            if ec_mb < 512:
+                rec_ec = "3GB"
+                if system_memory_gb:
+                    rec_ec_mb = int(system_memory_gb * 1024 * 0.75)
+                    rec_ec = f"{rec_ec_mb}MB" if rec_ec_mb < 1024 else f"{round(rec_ec_mb/1024, 1)}GB"
+                recommendations.append({
+                    "priority": "short-term",
+                    "issue": f"effective_cache_size is {ec_mb}MB - may cause poor query plans",
+                    "action": f"Set effective_cache_size to {rec_ec} (75% of RAM)",
+                    "explanation": "effective_cache_size is a hint to the query planner about how much memory is available for caching "
+                                   "(shared_buffers + OS cache). It does NOT allocate memory - it just helps PostgreSQL estimate "
+                                   "whether data is likely to be cached. A low value makes the planner pessimistic, avoiding efficient "
+                                   "index scans in favor of sequential scans.",
+                    "commands": [
+                        f"ALTER SYSTEM SET effective_cache_size = '{rec_ec}';",
+                        "SELECT pg_reload_conf();  -- Takes effect immediately"
+                    ],
+                    "restart_required": False,
+                })
+
+        # work_mem check (per-operation memory for sorts/hashes)
+        work_mem = mem.get("work_mem", {})
+        if work_mem and work_mem.get("mb"):
+            wm_mb = work_mem["mb"]
+            # Calculate recommended work_mem based on connections and RAM
+            max_conns = result.connections.get("max", 100) if result.connections else 100
+            rec_wm = "32MB"
+            if system_memory_gb:
+                # Formula: (RAM / max_connections) / 4
+                rec_wm_mb = int((system_memory_gb * 1024 / max_conns) / 4)
+                rec_wm_mb = max(16, min(rec_wm_mb, 128))  # Clamp between 16-128MB
+                rec_wm = f"{rec_wm_mb}MB"
+
+            # Flag if work_mem is at default (4MB) with high temp file usage
+            if result.database_stats:
+                temp_files = result.database_stats.get("temp_files", 0)
+                temp_bytes = result.database_stats.get("temp_bytes", 0)
+                temp_gb = round(temp_bytes / 1024 / 1024 / 1024, 1) if temp_bytes > 0 else 0
+                if wm_mb <= 4 and temp_files > 1000:
+                    recommendations.append({
+                        "priority": "immediate",
+                        "issue": f"work_mem is only {wm_mb}MB with {temp_files:,} temp files ({temp_gb} GB) spilled to disk",
+                        "action": f"Increase work_mem to {rec_wm}",
+                        "explanation": f"work_mem controls how much memory each sort, hash, or join operation can use BEFORE "
+                                       f"spilling to disk (temp files). At {wm_mb}MB, your queries are constantly spilling. "
+                                       f"The {temp_files:,} temp files mean disk I/O instead of fast memory operations. "
+                                       f"CAUTION: A query can use multiple work_mem allocations (one per sort node), "
+                                       f"so don't set this too high. Formula: (RAM / max_connections) / 4.",
+                        "commands": [
+                            f"ALTER SYSTEM SET work_mem = '{rec_wm}';",
+                            "SELECT pg_reload_conf();  -- Takes effect for new connections"
+                        ],
+                        "restart_required": False,
+                    })
+                elif wm_mb <= 4:
+                    recommendations.append({
+                        "priority": "long-term",
+                        "issue": f"work_mem is at default ({wm_mb}MB)",
+                        "action": f"Consider increasing work_mem to {rec_wm} for complex queries",
+                        "explanation": "work_mem is memory per sort/hash operation. The default 4MB is conservative. "
+                                       "Increasing it can speed up complex queries but uses more memory per operation.",
+                        "commands": [
+                            f"ALTER SYSTEM SET work_mem = '{rec_wm}';",
+                            "SELECT pg_reload_conf();  -- Takes effect for new connections"
+                        ],
+                        "restart_required": False,
+                    })
+
+        # maintenance_work_mem check
+        maint_mem = mem.get("maintenance_work_mem", {})
+        if maint_mem and maint_mem.get("mb"):
+            mm_mb = maint_mem["mb"]
+            if mm_mb < 64:
+                rec_mm = "256MB"
+                if system_memory_gb and system_memory_gb >= 8:
+                    rec_mm = "512MB"
+                recommendations.append({
+                    "priority": "short-term",
+                    "issue": f"maintenance_work_mem is {mm_mb}MB - VACUUM and CREATE INDEX will be slow",
+                    "action": f"Increase maintenance_work_mem to {rec_mm}",
+                    "explanation": "maintenance_work_mem is used by VACUUM, CREATE INDEX, and ALTER TABLE operations. "
+                                   f"At {mm_mb}MB, these maintenance operations process data in small batches, making them slow. "
+                                   "Unlike work_mem, only one maintenance operation runs per session, so this can safely be higher.",
+                    "commands": [
+                        f"ALTER SYSTEM SET maintenance_work_mem = '{rec_mm}';",
+                        "SELECT pg_reload_conf();  -- Takes effect immediately"
+                    ],
+                    "restart_required": False,
+                })
+
+        # random_page_cost check (default 4.0, should be 1.1-2.0 for SSD)
+        rpc = mem.get("random_page_cost", {})
+        if rpc and rpc.get("value"):
+            rpc_val = float(rpc["value"])
+            if rpc_val >= 4.0:
+                recommendations.append({
+                    "priority": "short-term",
+                    "issue": f"random_page_cost is {rpc_val} (HDD default) - Railway uses SSDs",
+                    "action": "Set random_page_cost to 1.5 for SSD storage",
+                    "explanation": "random_page_cost tells the query planner how expensive random disk access is compared to "
+                                   "sequential access. The default 4.0 assumes slow HDDs where random reads are 4x more expensive. "
+                                   "Railway uses fast SSDs where random reads are almost as fast as sequential. At 4.0, "
+                                   "the planner avoids index scans (random access) in favor of slower sequential scans.",
+                    "commands": [
+                        "ALTER SYSTEM SET random_page_cost = 1.5;",
+                        "SELECT pg_reload_conf();  -- Takes effect immediately"
+                    ],
+                    "restart_required": False,
+                })
+
+        # checkpoint_completion_target check (should be 0.9)
+        cct = mem.get("checkpoint_completion_target", {})
+        if cct and cct.get("value"):
+            cct_val = float(cct["value"])
+            if cct_val < 0.9:
+                recommendations.append({
+                    "priority": "long-term",
+                    "issue": f"checkpoint_completion_target is {cct_val} - I/O may be spiky",
+                    "action": "Set checkpoint_completion_target to 0.9",
+                    "explanation": f"PostgreSQL periodically writes dirty buffers to disk (checkpoints). At {cct_val}, "
+                                   f"it tries to complete this in {int(cct_val*100)}% of the checkpoint interval, causing I/O spikes. "
+                                   "At 0.9, writes spread over 90% of the interval, smoothing disk I/O. "
+                                   "WHY: Spiky I/O can cause query latency spikes during checkpoints. "
+                                   "SIDE EFFECT: Slightly more consistent (but spread out) disk writes. No downside in practice.",
+                    "commands": [
+                        "ALTER SYSTEM SET checkpoint_completion_target = 0.9;",
+                        "SELECT pg_reload_conf();  -- Takes effect immediately"
+                    ],
+                    "restart_required": False,
+                })
+
+        # max_parallel_workers check
+        mpw = mem.get("max_parallel_workers", {})
+        mpwpg = mem.get("max_parallel_workers_per_gather", {})
+        if mpw and mpw.get("value") == 0:
+            recommendations.append({
+                "priority": "short-term",
+                "issue": "max_parallel_workers is 0 - parallel queries disabled",
+                "action": "Set max_parallel_workers to number of CPU cores",
+                "explanation": "PostgreSQL can use multiple CPU cores for large sequential scans, aggregates, and joins. "
+                               "With max_parallel_workers=0, all queries run single-threaded regardless of table size. "
+                               "WHY: Large analytical queries (COUNT, SUM, scans of big tables) could run 2-8x faster with parallelism. "
+                               "SIDE EFFECT: Parallel queries use more CPU and memory simultaneously. For OLTP workloads with many "
+                               "small queries, this rarely triggers. For analytical queries, it's a significant speedup. "
+                               "IF NOT CHANGED: Large table scans will always be slow, even with idle CPU cores.",
+                "commands": [
+                    "ALTER SYSTEM SET max_parallel_workers = 4;  -- Adjust to your CPU count",
+                    "ALTER SYSTEM SET max_parallel_workers_per_gather = 2;",
+                    "SELECT pg_reload_conf();"
+                ],
+                "restart_required": False,
+            })
+        elif mpwpg and mpwpg.get("value") == 0:
+            recommendations.append({
+                "priority": "long-term",
+                "issue": "max_parallel_workers_per_gather is 0 - parallel queries won't use workers",
+                "action": "Set max_parallel_workers_per_gather to 2-4",
+                "explanation": "Even though max_parallel_workers allows parallel execution, max_parallel_workers_per_gather=0 "
+                               "means each query can use 0 parallel workers (i.e., none). "
+                               "WHY: This effectively disables parallelism for all queries. "
+                               "SIDE EFFECT: Each parallel query can use up to this many additional workers. "
+                               "Setting to 2 means a query could use 3 total processes (1 leader + 2 workers). "
+                               "IF NOT CHANGED: You have parallel infrastructure configured but no queries will use it.",
+                "commands": [
+                    "ALTER SYSTEM SET max_parallel_workers_per_gather = 2;",
+                    "SELECT pg_reload_conf();"
+                ],
+                "restart_required": False,
+            })
+
+        # autovacuum check
+        autovac = mem.get("autovacuum", {})
+        if autovac and autovac.get("value") == "off":
+            recommendations.append({
+                "priority": "immediate",
+                "issue": "autovacuum is DISABLED - database will bloat and eventually fail",
+                "action": "Enable autovacuum immediately",
+                "explanation": "Autovacuum is PostgreSQL's background process that reclaims space from deleted/updated rows "
+                               "and prevents transaction ID wraparound. With autovacuum OFF: "
+                               "1) Tables bloat indefinitely - deleted rows waste space and slow queries. "
+                               "2) Transaction IDs (XIDs) are never frozen - the database WILL shut down when XIDs wrap (~2 billion transactions). "
+                               "3) Table statistics become stale - query planner makes bad decisions. "
+                               "WHY IT WAS DISABLED: Sometimes disabled for bulk loads, but must be re-enabled after. "
+                               "IF NOT CHANGED: Database will eventually refuse all writes to prevent corruption. This is not recoverable without maintenance.",
+                "commands": [
+                    "ALTER SYSTEM SET autovacuum = on;",
+                    "SELECT pg_reload_conf();"
+                ],
+                "restart_required": False,
+            })
+
+        # synchronous_commit info (not a warning, just info)
+        sync = mem.get("synchronous_commit", {})
+        if sync and sync.get("value") == "off":
+            recommendations.append({
+                "priority": "long-term",
+                "issue": "synchronous_commit is off - faster writes but risk of data loss on crash",
+                "action": "Evaluate if this is acceptable for your data",
+                "explanation": "With synchronous_commit=off, PostgreSQL returns 'success' to clients BEFORE data is flushed to disk. "
+                               "BENEFIT: Write transactions are 2-10x faster because they don't wait for disk. "
+                               "RISK: If the server crashes, the last ~100-800ms of committed transactions may be lost. "
+                               "The database will NOT be corrupted - it will be consistent, just missing recent commits. "
+                               "ACCEPTABLE FOR: Session data, analytics, caches, logs - anything you can afford to lose. "
+                               "NOT ACCEPTABLE FOR: Financial transactions, user data, anything where 'committed' must mean 'durable'. "
+                               "IF NOT CHANGED: You keep the performance benefit but accept the crash-loss risk.",
+            })
+
+    # pg_stat_statements not available
+    if not result.top_queries:
+        recommendations.append({
+            "priority": "short-term",
+            "issue": "pg_stat_statements extension not available - cannot analyze query performance",
+            "action": "Enable pg_stat_statements extension",
+            "explanation": "pg_stat_statements tracks execution statistics for all SQL queries: call count, total time, "
+                           "rows returned, cache hits, temp file usage. Without it, you cannot identify slow queries or optimization targets. "
+                           "WHY: This analysis found memory/vacuum issues but cannot pinpoint which QUERIES cause problems. "
+                           "SIDE EFFECT: Minor overhead (~1-5%) for tracking. Stores stats in shared memory. "
+                           "IF NOT ENABLED: You're flying blind - you can see symptoms (high I/O, temp files) but not the queries causing them. "
+                           "To enable, run: python3 scripts/enable-pg-stats.py --service <name> (may require brief restart).",
+        })
+
+    # Cache hit ratio
+    if result.cache_hit:
+        table_hit = result.cache_hit.get("table_hit_pct")
+        if table_hit is not None and table_hit < 95:
+            priority = "immediate" if table_hit < 90 else "short-term"
+            # Find the worst offending tables for context
+            worst_tables = []
+            for t in result.cache_per_table[:3]:
+                if float(t.get("hit_pct") or 100) < 90:
+                    worst_tables.append(f"{t['table']} ({t['hit_pct']}%)")
+            context = f" Worst tables: {', '.join(worst_tables)}." if worst_tables else ""
+            recommendations.append({
+                "priority": priority,
+                "issue": f"Table cache hit ratio is {table_hit}% (should be >95%)",
+                "action": "Increase shared_buffers - data is being read from disk instead of memory cache",
+                "explanation": f"Cache hit ratio measures how often PostgreSQL finds requested data in memory (shared_buffers) "
+                               f"vs reading from disk. At {table_hit}%, roughly {100-table_hit}% of data requests hit disk.{context}",
+            })
+
+    # Per-table cache - check for low hit rates with high disk reads
+    for table in result.cache_per_table:
+        try:
+            hit_pct = float(table.get("hit_pct") or 100)
+            disk_reads = int(table.get("disk_reads") or 0)
+            table_size = table.get("size", "unknown")
+        except (ValueError, TypeError):
+            continue
+
+        if hit_pct < 50 and disk_reads > 1_000_000:
+            recommendations.append({
+                "priority": "immediate",
+                "issue": f"Table '{table['table']}' has {hit_pct}% cache hit with {disk_reads:,} disk reads",
+                "action": "Increase shared_buffers to fit this table in memory",
+                "explanation": f"The '{table['table']}' table ({table_size}) is almost never found in cache. "
+                               f"With {disk_reads:,} disk reads, every query touching this table causes disk I/O. "
+                               f"This is likely because the table is larger than shared_buffers.",
+            })
+        elif hit_pct < 80 and disk_reads > 10_000_000:
+            recommendations.append({
+                "priority": "short-term",
+                "issue": f"Table '{table['table']}' has {hit_pct}% cache hit with {disk_reads:,} disk reads",
+                "action": "Consider increasing shared_buffers for better caching",
+                "explanation": f"The '{table['table']}' table has a low cache hit rate, causing frequent disk reads. "
+                               f"Increasing shared_buffers would allow more of this table to stay in memory.",
+            })
+
+    # Memory config
+    if result.memory_config and result.table_sizes:
+        shared_buffers_mb = result.memory_config.get("shared_buffers", {}).get("mb", 0)
+        total_table_bytes = sum(int(t.get("bytes", 0)) for t in result.table_sizes)
+        total_table_mb = total_table_bytes / 1024 / 1024
+
+        if shared_buffers_mb > 0 and total_table_mb > shared_buffers_mb * 4:
+            largest_table = result.table_sizes[0] if result.table_sizes else None
+            context = ""
+            if largest_table:
+                lt_mb = int(largest_table.get("bytes", 0)) / 1024 / 1024
+                context = f" Your largest table ({largest_table['table']}) is {round(lt_mb)}MB alone."
+            recommendations.append({
+                "priority": "immediate",
+                "issue": f"shared_buffers ({shared_buffers_mb}MB) is much smaller than working set (~{round(total_table_mb)}MB)",
+                "action": f"Increase shared_buffers to at least {round(total_table_mb / 4)}MB",
+                "explanation": f"Your database has ~{round(total_table_mb)}MB of table data but only {shared_buffers_mb}MB of buffer cache.{context} "
+                               f"PostgreSQL cannot keep frequently-accessed data in memory, causing constant disk I/O.",
+            })
+
+    # Vacuum health (using enhanced flags)
+    for table in result.vacuum_health:
+        dead_pct = float(table.get("dead_pct", 0))
+        dead_rows = int(table.get("dead_rows", 0))
+        needs_vacuum = table.get("needs_vacuum") == "true"
+        needs_freeze = table.get("needs_freeze") == "true"
+        last_vacuum = table.get("last_vacuum", "never")
+        last_analyze = table.get("last_analyze", "never")
+
+        # Check needs_freeze flag first (more urgent)
+        if needs_freeze:
+            recommendations.append({
+                "priority": "immediate",
+                "issue": f"Table '{table['table']}' needs FREEZE (XID age > 150M)",
+                "action": f"Run: VACUUM FREEZE \"{table['table']}\";",
+                "explanation": "PostgreSQL uses transaction IDs (XIDs) that can wrap around after ~2 billion transactions. "
+                               "VACUUM FREEZE marks old rows as 'frozen' so they don't need XID checking. "
+                               "If XIDs wrap around without freezing, the database will shut down to prevent data corruption.",
+                "commands": [f"VACUUM FREEZE \"{table['table']}\";"],
+            })
+        elif needs_vacuum:
+            recommendations.append({
+                "priority": "immediate",
+                "issue": f"Table '{table['table']}' needs VACUUM ({dead_pct}% dead rows, {dead_rows:,} rows)",
+                "action": f"Run: VACUUM ANALYZE \"{table['table']}\";",
+                "explanation": f"This table has {dead_rows:,} dead rows ({dead_pct}% of table) from UPDATE/DELETE operations. "
+                               "Dead rows waste disk space and slow down queries by making them scan more pages. "
+                               f"Last vacuum: {last_vacuum}. Last analyze: {last_analyze}. "
+                               "ANALYZE also updates statistics for better query plans.",
+                "commands": [f"VACUUM ANALYZE \"{table['table']}\";"],
+            })
+        elif dead_pct > 20:
+            recommendations.append({
+                "priority": "immediate",
+                "issue": f"Table '{table['table']}' has {dead_pct}% dead rows ({dead_rows:,} rows)",
+                "action": f"Run: VACUUM ANALYZE \"{table['table']}\";",
+                "explanation": f"Over 20% of this table is dead rows from UPDATEs and DELETEs. "
+                               f"This bloat forces queries to scan many useless rows. Last vacuum: {last_vacuum}.",
+                "commands": [f"VACUUM ANALYZE \"{table['table']}\";"],
+            })
+        elif dead_pct > 10:
+            recommendations.append({
+                "priority": "short-term",
+                "issue": f"Table '{table['table']}' has {dead_pct}% dead rows ({dead_rows:,} rows)",
+                "action": f"Run: VACUUM ANALYZE \"{table['table']}\";",
+                "explanation": f"This table has accumulated {dead_rows:,} dead rows. While autovacuum should handle this, "
+                               f"it may be falling behind. Last vacuum: {last_vacuum}.",
+                "commands": [f"VACUUM ANALYZE \"{table['table']}\";"],
+            })
+
+    # XID age
+    if result.xid_age:
+        xid_millions = result.xid_age.get("millions", 0)
+        if xid_millions > 150:
+            recommendations.append({
+                "priority": "immediate",
+                "issue": f"XID age is {xid_millions}M (wraparound risk at 2147M)",
+                "action": "Run VACUUM FREEZE on all high-XID tables",
+                "explanation": "PostgreSQL's transaction ID counter wraps around at ~2.1 billion. At 150M+, you're using ~7% of "
+                               "the available space. If this reaches 2 billion without VACUUM FREEZE, PostgreSQL will "
+                               "shut down to prevent data corruption. This is a critical issue requiring immediate action.",
+                "commands": ["VACUUM FREEZE;  -- Run on affected tables"],
+            })
+        elif xid_millions > 100:
+            recommendations.append({
+                "priority": "short-term",
+                "issue": f"XID age is {xid_millions}M (approaching wraparound risk)",
+                "action": "Monitor autovacuum and consider manual VACUUM FREEZE",
+                "explanation": "XID age is elevated. Autovacuum should handle this, but verify it's running. "
+                               "If tables are being vacuumed but XID age stays high, long-running transactions may be blocking freezing.",
+            })
+
+    # Database stats (deadlocks, temp files)
+    if result.database_stats:
+        deadlocks = result.database_stats.get("deadlocks", 0)
+        if deadlocks > 0:
+            recommendations.append({
+                "priority": "short-term",
+                "issue": f"{deadlocks} deadlock(s) detected since last stats reset",
+                "action": "Review application transaction logic and lock ordering",
+                "explanation": f"A deadlock occurs when two transactions each hold a lock the other needs, creating a cycle. "
+                               f"PostgreSQL detects this and kills one transaction (the 'victim') so the other can proceed. "
+                               f"WHY THIS MATTERS: {deadlocks} deadlocks means {deadlocks} transactions were aborted and had to retry. "
+                               f"COMMON CAUSES: 1) Transactions locking rows in different orders. 2) Long transactions holding locks. "
+                               f"3) Hot rows updated by many concurrent transactions. "
+                               f"FIX: Ensure all code paths lock tables/rows in the same order. Keep transactions short. "
+                               f"IF NOT FIXED: Deadlocks will continue, causing random transaction failures and retries.",
+            })
+
+        # Temp files - flag with description based on daily rate
+        temp_files = result.database_stats.get("temp_files", 0)
+        temp_bytes = result.database_stats.get("temp_bytes", 0)
+        temp_gb = round(temp_bytes / 1024 / 1024 / 1024, 1) if temp_bytes > 0 else 0
+        stats_reset = result.database_stats.get("stats_reset", "unknown")
+        # Calculate days since reset for rate-based thresholds
+        days_since_reset = None
+        if stats_reset and stats_reset not in ("unknown", "never"):
+            try:
+                reset_date = datetime.fromisoformat(stats_reset.replace('Z', '+00:00'))
+                days_since_reset = (datetime.now(timezone.utc) - reset_date).days
+                days_since_reset = max(days_since_reset, 1)  # Avoid division by zero
+            except (ValueError, TypeError):
+                pass
+        # Use rate-based threshold if we have time period data
+        if days_since_reset and days_since_reset > 0:
+            gb_per_day = temp_gb / days_since_reset
+            files_per_day = round(temp_files / days_since_reset)
+            if gb_per_day > 5:  # More than 5GB/day is concerning
+                # Get current work_mem for context
+                wm_mb = result.memory_config.get("work_mem", {}).get("mb", 4) if result.memory_config else 4
+                recommendations.append({
+                    "priority": "short-term",
+                    "issue": f"High temp file usage: ~{files_per_day:,} files/day ({round(gb_per_day, 1)} GB/day)",
+                    "action": "Increase work_mem from {wm_mb}MB to 32-64MB",
+                    "explanation": f"When a query needs to sort or hash more data than work_mem allows ({wm_mb}MB), "
+                                   f"PostgreSQL spills to temp files on disk. Your queries are creating ~{files_per_day:,} temp files daily, "
+                                   f"writing {round(gb_per_day, 1)}GB to disk. This is slower than in-memory operations.",
+                    "commands": [
+                        "ALTER SYSTEM SET work_mem = '32MB';",
+                        "SELECT pg_reload_conf();  -- Takes effect for new connections"
+                    ],
+                    "restart_required": False,
+                })
+        elif temp_files > 10000 or temp_gb > 10:  # Fallback if no date
+            wm_mb = result.memory_config.get("work_mem", {}).get("mb", 4) if result.memory_config else 4
+            recommendations.append({
+                "priority": "short-term",
+                "issue": f"High temp file usage: {temp_files:,} files, {temp_gb} GB written since stats reset",
+                "action": f"Increase work_mem from {wm_mb}MB to 32-64MB",
+                "explanation": f"Queries are spilling to disk because work_mem ({wm_mb}MB) is too small for sort/hash operations. "
+                               f"Each temp file represents a query that couldn't fit its working data in memory.",
+                "commands": [
+                    "ALTER SYSTEM SET work_mem = '32MB';",
+                    "SELECT pg_reload_conf();  -- Takes effect for new connections"
+                ],
+                "restart_required": False,
+            })
+
+    # Connection usage
+    if result.connections:
+        pct = result.connections.get("percent", 0)
+        current = result.connections.get("current", 0)
+        max_conn = result.connections.get("max", 100)
+        available = result.connections.get("available", max_conn - current)
+        if pct > 90:
+            recommendations.append({
+                "priority": "immediate",
+                "issue": f"Connection usage is {pct}% ({current}/{max_conn}, only {available} available)",
+                "action": "Use connection pooling (PgBouncer) or increase max_connections",
+                "explanation": f"You're using {current} of {max_conn} connections. Each PostgreSQL connection uses memory "
+                               f"(~10MB each). Rather than increasing max_connections, use connection pooling (PgBouncer) "
+                               f"to multiplex many app connections over fewer database connections.",
+            })
+        elif pct > 70:
+            recommendations.append({
+                "priority": "short-term",
+                "issue": f"Connection usage is {pct}% ({current}/{max_conn})",
+                "action": "Consider connection pooling for scalability",
+                "explanation": "Connection usage is elevated. Connection pooling (PgBouncer) helps applications share "
+                               "database connections efficiently, especially during traffic spikes.",
+            })
+
+    # Old connections
+    if result.oldest_connection_sec is not None:
+        age_hours = result.oldest_connection_sec / 3600
+        age_days = round(age_hours / 24, 1)
+        if age_hours > 48:
+            # Include details about what the old connections are
+            conn_details = ""
+            if result.oldest_connections:
+                details_list = []
+                for c in result.oldest_connections[:3]:
+                    app = c.get("application_name") or "(unnamed)"
+                    state = c.get("state", "unknown")
+                    days = c.get("age_days", "?")
+                    details_list.append(f"{app} ({state}, {days} days)")
+                conn_details = f" Old connections: {'; '.join(details_list)}."
+
+            recommendations.append({
+                "priority": "short-term",
+                "issue": f"Oldest connection is ~{age_days} days old ({round(age_hours)} hours)",
+                "action": "Review connection pooling settings and application connection management",
+                "explanation": f"Long-lived connections can indicate connection pool misconfiguration or connection leaks. "
+                               f"They can also hold locks or prevent autovacuum from cleaning up. "
+                               f"If using connection pooling, ensure idle connections are recycled.{conn_details}",
+            })
+
+    # Disk usage
+    if result.disk_usage:
+        use_pct = int(result.disk_usage.get("use_percent", 0))
+        used = result.disk_usage.get("used", "unknown")
+        total = result.disk_usage.get("total", "unknown")
+        if use_pct > 85:
+            recommendations.append({
+                "priority": "immediate",
+                "issue": f"Disk usage is {use_pct}% ({used} / {total})",
+                "action": "Increase volume size or clean up data",
+                "explanation": "PostgreSQL needs free disk space for WAL files, temp files, and VACUUM operations. "
+                               "Running out of disk space can cause database crashes. Consider: "
+                               "1) Increasing volume size, 2) Dropping unused indexes, 3) VACUUM FULL on bloated tables, "
+                               "4) Archiving old data.",
+            })
+        elif use_pct > 70:
+            recommendations.append({
+                "priority": "short-term",
+                "issue": f"Disk usage is {use_pct}% ({used} / {total})",
+                "action": "Plan for volume expansion",
+                "explanation": f"Disk is at {use_pct}%, approaching the danger zone. PostgreSQL needs free space for: "
+                               f"1) WAL files - write-ahead logs that ensure durability. "
+                               f"2) Temp files - sorts and hashes spill here when work_mem is exceeded. "
+                               f"3) VACUUM operations - need space to rewrite tables during VACUUM FULL. "
+                               f"IF NOT ADDRESSED: At 85%+ you risk write failures. At 100%, database crashes and may not restart. "
+                               f"ACTIONS: Increase volume size in Railway, or identify large unused tables/indexes to drop.",
+            })
+
+    # Unused indexes - only flag non-PK, non-unique indexes >100MB
+    droppable_indexes = [
+        idx for idx in result.unused_indexes
+        if not idx.get("is_primary") and not idx.get("is_unique")
+        and int(idx.get("size_bytes", 0)) > 100 * 1024 * 1024
+    ]
+    if droppable_indexes:
+        total_size = sum_index_sizes(droppable_indexes)
+        index_names = [idx['index'] for idx in droppable_indexes[:3]]
+        recommendations.append({
+            "priority": "long-term",
+            "issue": f"{len(droppable_indexes)} unused non-constraint indexes >100MB ({total_size})",
+            "action": "Review and drop unused indexes to save space and improve write performance",
+            "explanation": f"These indexes have 0 scans since stats reset, meaning no queries are using them. "
+                           f"Each index costs disk space AND slows down writes (INSERT/UPDATE/DELETE must update all indexes). "
+                           f"Examples: {', '.join(index_names)}{'...' if len(droppable_indexes) > 3 else ''}",
+            "commands": [f"DROP INDEX IF EXISTS \"{idx['index']}\";  -- saves {idx['size']}" for idx in droppable_indexes[:3]],
+        })
+
+    # Tables with high missing index score (lots of seq scans, no index usage)
+    for idx in result.unused_indexes:
+        try:
+            missing_score = int(idx.get("missing_index_score", 0))
+            if missing_score > 1000:
+                table_rows = idx.get("table_rows", "unknown")
+                recommendations.append({
+                    "priority": "short-term",
+                    "issue": f"Table '{idx['table']}' has {missing_score:,} sequential scans with no index usage",
+                    "action": f"Consider adding an index on commonly filtered columns of '{idx['table']}'",
+                    "explanation": f"Sequential scans read the entire table ({table_rows} rows) for each query. "
+                                   f"With {missing_score:,} sequential scans, queries are repeatedly scanning all rows. "
+                                   f"An index on commonly filtered columns (WHERE clauses) would dramatically speed this up.",
+                })
+        except (ValueError, TypeError):
+            pass
+
+    # Long-running queries
+    if result.long_running_queries:
+        for q in result.long_running_queries[:3]:
+            try:
+                duration = int(q.get("duration_sec", 0))
+                query_preview = q.get("query", "")[:80]
+                if duration > 60:
+                    recommendations.append({
+                        "priority": "immediate",
+                        "issue": f"Query running for {duration}s (PID {q.get('pid')})",
+                        "action": "Investigate and potentially cancel",
+                        "explanation": f"This query has been running for {duration} seconds. "
+                                       f"QUERY: {query_preview}... "
+                                       f"WHY THIS MATTERS: Long queries hold locks, consume memory, and may indicate missing indexes or inefficient queries. "
+                                       f"TO CANCEL (graceful): SELECT pg_cancel_backend({q.get('pid')}); "
+                                       f"TO TERMINATE (force): SELECT pg_terminate_backend({q.get('pid')}); "
+                                       f"SIDE EFFECT OF CANCEL: The query's transaction will be rolled back. The application will receive an error.",
+                        "commands": [f"SELECT pg_cancel_backend({q.get('pid')});  -- Graceful cancel"],
+                    })
+            except (ValueError, TypeError):
+                pass
+
+    # Idle in transaction (stuck transactions)
+    if result.idle_in_transaction:
+        for txn in result.idle_in_transaction[:3]:
+            try:
+                idle_sec = int(txn.get("idle_sec", 0))
+                app_name = txn.get("application_name", "unknown app")
+                if idle_sec > 300:  # 5 minutes
+                    recommendations.append({
+                        "priority": "immediate",
+                        "issue": f"Transaction idle for {idle_sec}s (PID {txn.get('pid')}, user: {txn.get('user', 'unknown')}, app: {app_name})",
+                        "action": "Terminate the stuck transaction",
+                        "explanation": f"This connection started a transaction (BEGIN) but hasn't done anything for {idle_sec}s. "
+                                       f"WHY THIS IS BAD: 1) Holds row-level locks that block other queries. "
+                                       f"2) Prevents VACUUM from cleaning dead rows in any table it touched. "
+                                       f"3) Holds a transaction ID slot, contributing to XID bloat. "
+                                       f"COMMON CAUSES: Application bug, network timeout without cleanup, abandoned connection. "
+                                       f"TO FIX: SELECT pg_terminate_backend({txn.get('pid')}); (terminates connection). "
+                                       f"PREVENTION: Set idle_in_transaction_session_timeout to auto-kill stuck transactions.",
+                        "commands": [
+                            f"SELECT pg_terminate_backend({txn.get('pid')});  -- Kill this connection",
+                            "ALTER SYSTEM SET idle_in_transaction_session_timeout = '5min';  -- Auto-kill in future",
+                        ],
+                    })
+                elif idle_sec > 60:
+                    recommendations.append({
+                        "priority": "short-term",
+                        "issue": f"Transaction idle for {idle_sec}s (PID {txn.get('pid')}, app: {app_name})",
+                        "action": "Review application transaction handling",
+                        "explanation": f"This transaction has been idle for {idle_sec}s. While not critical yet, "
+                                       f"transactions should be short-lived. Long idle transactions hold locks and block VACUUM. "
+                                       f"COMMON CAUSES: Missing COMMIT/ROLLBACK, waiting for user input inside transaction, connection pool issues. "
+                                       f"PREVENTION: Use idle_in_transaction_session_timeout to auto-terminate stuck transactions.",
+                    })
+            except (ValueError, TypeError):
+                pass
+
+    # Blocked queries
+    if result.blocked_queries:
+        for q in result.blocked_queries[:3]:
+            try:
+                wait_sec = int(q.get("wait_sec", 0))
+                if wait_sec > 30:
+                    recommendations.append({
+                        "priority": "immediate",
+                        "issue": f"Query waiting {wait_sec}s for lock (PID {q.get('pid')} blocked by {q.get('blocking_pid')})",
+                        "action": "Investigate the blocking query and terminate if appropriate",
+                        "explanation": f"PID {q.get('pid')} has been waiting {wait_sec}s for a lock held by PID {q.get('blocking_pid')}. "
+                                       f"WHY: The blocking query/transaction is holding a lock (row, table, or advisory) that this query needs. "
+                                       f"COMMON CAUSES: Long-running transaction, idle-in-transaction, DDL operations (ALTER TABLE). "
+                                       f"TO INVESTIGATE: SELECT query FROM pg_stat_activity WHERE pid = {q.get('blocking_pid')}; "
+                                       f"TO UNBLOCK: Cancel or terminate the blocking PID if it's stuck. "
+                                       f"SIDE EFFECT: Terminating the blocker will rollback its transaction, but unblock waiting queries.",
+                        "commands": [
+                            f"-- See what {q.get('blocking_pid')} is doing:",
+                            f"SELECT pid, state, query FROM pg_stat_activity WHERE pid = {q.get('blocking_pid')};",
+                            f"-- To terminate (if stuck): SELECT pg_terminate_backend({q.get('blocking_pid')});",
+                        ],
+                    })
+            except (ValueError, TypeError):
+                pass
+
+    # Lock contention
+    if result.locks:
+        lock_types = set(lock.get("locktype", "unknown") for lock in result.locks)
+        recommendations.append({
+            "priority": "immediate",
+            "issue": f"{len(result.locks)} blocked lock(s) detected ({', '.join(lock_types)})",
+            "action": "Investigate lock contention - may indicate long transactions or deadlocks",
+            "explanation": "Queries are waiting for locks held by other transactions. Common causes: "
+                           "1) Long-running transactions holding locks, 2) Deadlocks (PostgreSQL will resolve these automatically), "
+                           "3) DDL operations (ALTER TABLE) blocking normal queries. "
+                           "Check blocked_queries and idle_in_transaction sections for details.",
+        })
+
+    # Sequential scans on large tables
+    for table in result.seq_scan_tables:
+        try:
+            seq_scans = int(table.get("seq_scans", 0))
+            idx_scans = int(table.get("idx_scans", 0))
+            rows = int(table.get("rows", 0))
+            if seq_scans > 1000 and idx_scans == 0 and rows > 10000:
+                recommendations.append({
+                    "priority": "short-term",
+                    "issue": f"Table '{table['table']}' has {seq_scans:,} sequential scans with 0 index scans ({rows:,} rows)",
+                    "action": "Add indexes on columns used in WHERE, JOIN, and ORDER BY clauses",
+                    "explanation": f"Every query on '{table['table']}' scans all {rows:,} rows instead of using an index. "
+                                   f"With {seq_scans:,} sequential scans, this table is a performance hotspot. "
+                                   f"To find which columns to index, run: EXPLAIN ANALYZE on slow queries touching this table, "
+                                   f"or check pg_stat_statements for common query patterns.",
+                })
+        except (ValueError, TypeError):
+            pass
+
+    # HA cluster issues
+    if result.ha_cluster:
+        members = result.ha_cluster.get("members", [])
+        for m in members:
+            state = m.get("state", "")
+            if state == "start failed":
+                recommendations.append({
+                    "priority": "immediate",
+                    "issue": f"HA replica '{m.get('name')}' is in 'start failed' state",
+                    "action": "Resync the replica",
+                    "explanation": f"The replica '{m.get('name')}' failed to start, typically due to timeline divergence. "
+                                   f"This happens when the replica's WAL history diverges from the primary (e.g., after failover). "
+                                   f"WHY THIS MATTERS: This replica cannot be used for failover or read scaling until fixed. "
+                                   f"FIX: The replica needs a fresh base backup (pg_basebackup) from the primary. "
+                                   f"IF NOT FIXED: You're running without redundancy - if the primary fails, no automatic failover is possible.",
+                })
+            elif state not in ("running", "streaming"):
+                recommendations.append({
+                    "priority": "short-term",
+                    "issue": f"HA replica '{m.get('name')}' is in '{state}' state",
+                    "action": "Investigate replica health",
+                    "explanation": f"Expected state is 'running' or 'streaming', but replica is '{state}'. "
+                                   f"POSSIBLE STATES: 'creating' (initializing), 'stopped' (manually stopped), 'start failed' (broken). "
+                                   f"WHY THIS MATTERS: Non-streaming replicas may have stale data and can't be used for failover. "
+                                   f"CHECK: Replica logs for specific errors. Network connectivity to primary. WAL lag.",
+                })
+
+    # Recent errors
+    if result.recent_errors and len(result.recent_errors) > 5:
+        # Summarize error types (recent_errors is a list of strings)
+        error_samples = [e[:60] if isinstance(e, str) else str(e)[:60] for e in result.recent_errors[:3]]
+        recommendations.append({
+            "priority": "short-term",
+            "issue": f"{len(result.recent_errors)} recent errors in logs",
+            "action": "Review error logs for patterns",
+            "explanation": f"Multiple errors detected in recent logs. Sample messages: {'; '.join(error_samples)}... "
+                           f"WHY THIS MATTERS: Frequent errors may indicate application bugs, configuration issues, or resource constraints. "
+                           f"CHECK: Look for patterns - are errors from one app? One query? Specific time periods? "
+                           f"COMMON TYPES: Connection errors (app/network issue), query errors (syntax/permissions), "
+                           f"out-of-memory errors (need more RAM or lower work_mem).",
+        })
+
+    # Invalid indexes
+    if result.invalid_indexes:
+        for idx in result.invalid_indexes:
+            recommendations.append({
+                "priority": "immediate",
+                "issue": f"Invalid index '{idx.get('index')}' on {idx.get('schema')}.{idx.get('table')}",
+                "action": "Drop and recreate the index",
+                "explanation": f"This index is marked as invalid - PostgreSQL will NOT use it for queries. "
+                               f"CAUSE: Usually a CREATE INDEX CONCURRENTLY that failed partway through (e.g., due to constraint violation, "
+                               f"out of disk space, or duplicate key). "
+                               f"WHY THIS MATTERS: The index takes up disk space and slows writes, but provides zero query benefit. "
+                               f"FIX: Drop it and recreate. Use CONCURRENTLY to avoid locking the table.",
+                "commands": [
+                    f"DROP INDEX CONCURRENTLY IF EXISTS \"{idx.get('index')}\";",
+                    f"-- Then recreate with: CREATE INDEX CONCURRENTLY ...",
+                ],
+            })
+
+    # WAL archiver failures
+    if result.archiver and result.archiver.get("failed_count", 0) > 0:
+        last_failed_wal = result.archiver.get("last_failed_wal", "unknown")
+        last_failed_time = result.archiver.get("last_failed_time", "unknown")
+        recommendations.append({
+            "priority": "immediate",
+            "issue": f"WAL archiver has {result.archiver['failed_count']} failed archival(s)",
+            "action": "Check archive_command configuration and destination storage",
+            "explanation": f"WAL (Write-Ahead Log) archiving is failing. Last failed WAL: {last_failed_wal} at {last_failed_time}. "
+                           f"This affects point-in-time recovery capability. Common causes: "
+                           f"1) Archive destination full or unreachable, 2) Permissions issues, 3) archive_command misconfiguration.",
+        })
+
+    # Background writer issues
+    if result.bgwriter:
+        bg = result.bgwriter
+        # High backend fsync indicates shared_buffers pressure
+        if bg.get("buffers_backend_fsync", 0) > 0:
+            recommendations.append({
+                "priority": "short-term",
+                "issue": f"Backend processes forced {bg['buffers_backend_fsync']:,} fsync operations",
+                "action": "Increase shared_buffers to reduce dirty buffer pressure",
+                "explanation": "Normally, the background writer or checkpointer flushes dirty buffers to disk. "
+                               f"When shared_buffers is too small, backends must flush dirty buffers themselves "
+                               f"(buffers_backend_fsync > 0). This forces query processes to do I/O, causing latency spikes.",
+            })
+
+        # Check if most checkpoints are requested (not timed)
+        timed = bg.get("checkpoints_timed", 0)
+        req = bg.get("checkpoints_req", 0)
+        total = timed + req
+        if total > 10 and req > timed:
+            req_pct = round(100.0 * req / total, 1)
+            recommendations.append({
+                "priority": "short-term",
+                "issue": f"{req_pct}% of checkpoints are requested (not timed) - WAL is filling up",
+                "action": "Increase max_wal_size to 2-4GB",
+                "explanation": f"Checkpoints should happen on a timer (checkpoint_timeout), not because WAL fills up. "
+                               f"With {req_pct}% requested checkpoints, WAL segments are filling faster than expected. "
+                               f"This causes I/O spikes. Increasing max_wal_size gives more headroom before forced checkpoints.",
+                "commands": [
+                    "ALTER SYSTEM SET max_wal_size = '2GB';",
+                    "SELECT pg_reload_conf();  -- Takes effect immediately"
+                ],
+                "restart_required": False,
+            })
+
+        # High maxwritten_clean indicates bgwriter can't keep up
+        if bg.get("maxwritten_clean", 0) > 100:
+            recommendations.append({
+                "priority": "long-term",
+                "issue": f"Background writer hit max write limit {bg['maxwritten_clean']:,} times",
+                "action": "Increase bgwriter_lru_maxpages to let bgwriter flush more buffers per round",
+                "explanation": "The background writer proactively flushes dirty buffers before they're needed. "
+                               f"It hit the per-round limit {bg['maxwritten_clean']:,} times, meaning it couldn't "
+                               f"keep up with the write rate. Increasing bgwriter_lru_maxpages allows more buffer "
+                               f"flushes per round.",
+            })
+
+    return recommendations
+
+
+def sum_index_sizes(indexes: List[Dict[str, Any]]) -> str:
+    """Sum up index sizes and return human-readable string."""
+    total_bytes = 0
+    for idx in indexes:
+        size_str = idx.get("size", "0")
+        # Parse sizes like "23 MB", "8448 kB", etc.
+        match = re.match(r"(\d+)\s*(MB|kB|GB|bytes?)?", size_str, re.IGNORECASE)
+        if match:
+            value = int(match.group(1))
+            unit = (match.group(2) or "bytes").upper()
+            if unit in ("KB", "KB"):
+                total_bytes += value * 1024
+            elif unit == "MB":
+                total_bytes += value * 1024 * 1024
+            elif unit == "GB":
+                total_bytes += value * 1024 * 1024 * 1024
+            else:
+                total_bytes += value
+
+    if total_bytes >= 1024 * 1024 * 1024:
+        return f"{total_bytes / 1024 / 1024 / 1024:.1f} GB"
+    elif total_bytes >= 1024 * 1024:
+        return f"{total_bytes / 1024 / 1024:.1f} MB"
+    elif total_bytes >= 1024:
+        return f"{total_bytes / 1024:.1f} KB"
+    return f"{total_bytes} bytes"
+
+
+def format_report(result: AnalysisResult) -> str:
+    """Format analysis result as human-readable report."""
+    lines = []
+    lines.append("=" * 60)
+    lines.append(f"Database Analysis: {result.service}")
+    lines.append("=" * 60)
+    lines.append(f"Type: {result.db_type}")
+    lines.append(f"Generated: {result.timestamp}")
+    lines.append(f"Status: {result.deployment_status}")
+    lines.append("")
+
+    # Collection status table
+    if result.collection_status:
+        lines.append("## Data Collection Status")
+        lines.append("")
+        lines.append("| Source | Status | Details |")
+        lines.append("|--------|--------|---------|")
+        source_labels = {
+            "database_query": "Database Query (SSH)",
+            "metrics_api": "Metrics API",
+            "logs_api": "Logs API",
+            "ha_cluster": "HA Cluster (Patroni)",
+        }
+        for source in ["database_query", "metrics_api", "logs_api", "ha_cluster"]:
+            if source in result.collection_status:
+                info = result.collection_status[source]
+                status = info["status"].upper()
+                details = ""
+                if info.get("error"):
+                    details = info["error"]
+                elif info.get("reason"):
+                    details = info["reason"]
+                elif info.get("lines"):
+                    details = f"{info['lines']} lines collected"
+                elif status == "SUCCESS":
+                    details = "OK"
+                label = source_labels.get(source, source)
+                lines.append(f"| {label} | {status} | {details} |")
+        lines.append("")
+
+    # Summary table
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| Metric | Value | Status |")
+    lines.append("|--------|-------|--------|")
+
+    # Deployment
+    status_icon = "Healthy" if result.deployment_status == "SUCCESS" else "Warning"
+    lines.append(f"| Deployment | {result.deployment_status} | {status_icon} |")
+
+    # Connections
+    if result.connections:
+        pct = result.connections["percent"]
+        current = result.connections["current"]
+        max_conn = result.connections["max"]
+        reserved = result.connections.get("reserved", 3)
+        available = result.connections.get("available", max_conn - current)
+        active = result.connections.get("active", 0)
+        idle = result.connections.get("idle", 0)
+        idle_in_txn = result.connections.get("idle_in_transaction", 0)
+        status = "Critical" if pct > 90 else "Warning" if pct > 70 else "Healthy"
+        lines.append(f"| Connections | {current} / {max_conn} ({pct}%) | {status} |")
+        lines.append(f"| - Active/Idle/IdleTxn | {active} / {idle} / {idle_in_txn} | {'Warning' if idle_in_txn > 5 else '-'} |")
+        lines.append(f"| - Available | {available} (reserved: {reserved}) | - |")
+
+    # Database size
+    if result.size_breakdown and result.size_breakdown.get("database_bytes"):
+        db_bytes = result.size_breakdown["database_bytes"]
+        db_gb = round(db_bytes / 1024 / 1024 / 1024, 2)
+        lines.append(f"| Database Size | {db_gb} GB | - |")
+
+    # Disk
+    if result.disk_usage:
+        pct = int(result.disk_usage["use_percent"])
+        status = "Critical" if pct > 85 else "Warning" if pct > 70 else "Healthy"
+        lines.append(f"| Disk | {result.disk_usage['used']} / {result.disk_usage['total']} ({pct}%) | {status} |")
+
+    # Cache hit
+    if result.cache_hit:
+        table_hit = result.cache_hit.get("table_hit_pct")
+        if table_hit is not None:
+            status = "Healthy" if table_hit >= 99 else "OK" if table_hit >= 95 else "Warning" if table_hit >= 90 else "Critical"
+            lines.append(f"| Table Cache Hit | {table_hit}% | {status} |")
+
+        index_hit = result.cache_hit.get("index_hit_pct")
+        if index_hit is not None:
+            status = "Healthy" if index_hit >= 99 else "OK" if index_hit >= 95 else "Warning"
+            lines.append(f"| Index Cache Hit | {index_hit}% | {status} |")
+
+    # Memory config summary
+    if result.memory_config:
+        if "shared_buffers" in result.memory_config:
+            sb = result.memory_config["shared_buffers"]
+            mb = sb.get("mb", 0)
+            status = "Warning" if mb < 128 else "OK" if mb < 256 else "Healthy"
+            lines.append(f"| shared_buffers | {mb} MB | {status} |")
+        if "work_mem" in result.memory_config:
+            wm = result.memory_config["work_mem"]
+            mb = wm.get("mb", 0)
+            status = "Default" if mb <= 4 else "OK"
+            lines.append(f"| work_mem | {mb} MB | {status} |")
+
+    # XID age
+    if result.xid_age:
+        millions = result.xid_age["millions"]
+        status = "Critical" if millions > 150 else "Warning" if millions > 100 else "Healthy"
+        lines.append(f"| XID Age | {millions}M | {status} |")
+
+    # CPU/Memory (with trend indicators from 24h history)
+    if result.cpu_memory:
+        if "cpu_percent" in result.cpu_memory:
+            cpu = result.cpu_memory["cpu_percent"]
+            status = "Critical" if cpu > 85 else "Warning" if cpu > 70 else "Healthy"
+            trend_str = _trend_indicator(result.metrics_history, "cpu")
+            lines.append(f"| CPU Usage | {cpu} vCPU{trend_str} | {status} |")
+            if result.cpu_memory.get("cpu_limit"):
+                lines.append(f"| CPU Limit | {result.cpu_memory['cpu_limit']} vCPU | - |")
+        if "memory_gb" in result.cpu_memory:
+            mem = result.cpu_memory["memory_gb"]
+            trend_str = _trend_indicator(result.metrics_history, "memory")
+            utilization = ""
+            if result.cpu_memory.get("memory_limit_gb"):
+                pct = round((mem / result.cpu_memory["memory_limit_gb"]) * 100, 1)
+                status = "Critical" if pct > 90 else "Warning" if pct > 80 else "Healthy"
+                utilization = f" ({pct}% of {result.cpu_memory['memory_limit_gb']} GB)"
+            else:
+                status = "-"
+            lines.append(f"| Memory Usage | {mem} GB{utilization}{trend_str} | {status} |")
+
+    # Database stats
+    if result.database_stats:
+        stats_reset = result.database_stats.get("stats_reset", "unknown")
+        # Calculate days since stats reset for rate calculations
+        days_since_reset = None
+        if stats_reset and stats_reset not in ("unknown", "never"):
+            try:
+                reset_date = datetime.fromisoformat(stats_reset.replace('Z', '+00:00'))
+                days_since_reset = (datetime.now(timezone.utc) - reset_date).days
+                days_since_reset = max(days_since_reset, 1)  # Avoid division by zero
+            except (ValueError, TypeError):
+                pass
+        # Shorten timestamp to just date if it's a full timestamp
+        stats_reset_display = stats_reset
+        if stats_reset and stats_reset != "unknown" and stats_reset != "never" and len(stats_reset) > 10:
+            stats_reset_display = stats_reset[:10]
+        lines.append(f"| Stats Reset | {stats_reset_display} | - |")
+        deadlocks = result.database_stats.get("deadlocks", 0)
+        temp_files = result.database_stats.get("temp_files", 0)
+        temp_bytes = result.database_stats.get("temp_bytes", 0)
+        temp_gb = round(temp_bytes / 1024 / 1024 / 1024, 2) if temp_bytes > 0 else 0
+        status = "Warning" if deadlocks > 0 else "Healthy"
+        lines.append(f"| Deadlocks | {deadlocks} (since reset) | {status} |")
+        # Show temp files with daily rate if we have time period data
+        if days_since_reset:
+            files_per_day = round(temp_files / days_since_reset)
+            gb_per_day = round(temp_gb / days_since_reset, 2)
+            # Status based on daily rate, not totals
+            if gb_per_day > 5:
+                temp_status = "High"
+            elif gb_per_day > 1:
+                temp_status = "Moderate"
+            else:
+                temp_status = "OK"
+            lines.append(f"| Temp Files | {temp_files:,} ({temp_gb} GB) over {days_since_reset}d (~{files_per_day}/day, {gb_per_day} GB/day) | {temp_status} |")
+        else:
+            lines.append(f"| Temp Files | {temp_files:,} ({temp_gb} GB since reset) | - |")
+
+    # Size breakdown
+    if result.size_breakdown:
+        wal_bytes = result.size_breakdown.get("wal_bytes", 0)
+        wal_mb = round(wal_bytes / 1024 / 1024, 1)
+        lines.append(f"| WAL Size | {wal_mb} MB | - |")
+
+    # Oldest connection
+    if result.oldest_connection_sec is not None:
+        age_hrs = round(result.oldest_connection_sec / 3600, 1)
+        status = "Warning" if age_hrs > 24 else "Healthy"
+        lines.append(f"| Oldest Connection | {age_hrs} hrs | {status} |")
+
+    # pg_stat_statements extension
+    pss_status = "Installed" if result.pg_stat_statements_installed else "Not installed"
+    pss_icon = "OK" if result.pg_stat_statements_installed else "Info"
+    lines.append(f"| pg_stat_statements | {pss_status} | {pss_icon} |")
+
+    lines.append("")
+
+    # Infrastructure Trends (multi-window)
+    if result.metrics_history and result.metrics_history.get("windows"):
+        windows = result.metrics_history.get("windows", {})
+        for window_label, window_data in windows.items():
+            mh = window_data.get("metrics", {})
+            if not mh:
+                continue
+            lines.append(f"## Infrastructure Trends ({window_label})")
+            lines.append("")
+            lines.append("| Metric | Current | Min | Max | Avg | Trend | Change |")
+            lines.append("|--------|---------|-----|-----|-----|-------|--------|")
+            display_order = [
+                ("cpu", "CPU"),
+                ("memory", "Memory"),
+                ("disk", "Disk"),
+                ("network_rx", "Network RX"),
+                ("network_tx", "Network TX"),
+            ]
+            for key, label in display_order:
+                if key in mh:
+                    m = mh[key]
+                    unit = m["unit"]
+                    trend = m.get("trend", {})
+                    direction = trend.get("direction", "?")
+                    change = trend.get("change_pct", 0)
+                    arrow = {"increasing": "^", "decreasing": "v", "stable": "~"}.get(direction, "?")
+                    spike_note = ""
+                    if m.get("spikes"):
+                        spike_note = f" ({m['spikes']['count']} spikes)"
+                    lines.append(
+                        f"| {label} | {m['current']} {unit} | {m['min']} | {m['max']} | {m['avg']} | "
+                        f"{arrow} {direction} | {change:+.1f}%{spike_note} |"
+                    )
+            lines.append("")
+
+    # PostgreSQL Configuration (tuning parameters)
+    if result.memory_config:
+        lines.append("## PostgreSQL Configuration")
+        lines.append("")
+        lines.append("| Parameter | Value | Recommended | Status |")
+        lines.append("|-----------|-------|-------------|--------|")
+
+        mem = result.memory_config
+
+        # Memory settings
+        if "shared_buffers" in mem:
+            sb = mem["shared_buffers"]
+            mb = sb.get("mb", 0)
+            status = "Low" if mb < 128 else "Default" if mb < 256 else "OK"
+            lines.append(f"| shared_buffers | {mb} MB | 25% of RAM | {status} |")
+
+        if "effective_cache_size" in mem:
+            ec = mem["effective_cache_size"]
+            mb = ec.get("mb", 0)
+            status = "Low" if mb < 512 else "OK"
+            lines.append(f"| effective_cache_size | {mb} MB | 50-75% of RAM | {status} |")
+
+        if "work_mem" in mem:
+            wm = mem["work_mem"]
+            mb = wm.get("mb", 0)
+            status = "Default" if mb <= 4 else "OK"
+            lines.append(f"| work_mem | {mb} MB | 16-64 MB | {status} |")
+
+        if "maintenance_work_mem" in mem:
+            mm = mem["maintenance_work_mem"]
+            mb = mm.get("mb", 0)
+            status = "Low" if mb < 64 else "OK"
+            lines.append(f"| maintenance_work_mem | {mb} MB | 256-1024 MB | {status} |")
+
+        # WAL settings
+        if "wal_buffers" in mem:
+            wb = mem["wal_buffers"]
+            mb = wb.get("mb", 0)
+            lines.append(f"| wal_buffers | {mb} MB | 16 MB | OK |")
+
+        if "checkpoint_completion_target" in mem:
+            cct = mem["checkpoint_completion_target"]
+            val = cct.get("value", 0)
+            status = "Low" if float(val) < 0.9 else "OK"
+            lines.append(f"| checkpoint_completion_target | {val} | 0.9 | {status} |")
+
+        # Parallelism
+        if "max_parallel_workers" in mem:
+            mpw = mem["max_parallel_workers"]
+            val = mpw.get("value", 0)
+            status = "Disabled" if val == 0 else "OK"
+            lines.append(f"| max_parallel_workers | {val} | CPU cores | {status} |")
+
+        if "max_parallel_workers_per_gather" in mem:
+            mpwpg = mem["max_parallel_workers_per_gather"]
+            val = mpwpg.get("value", 0)
+            status = "Disabled" if val == 0 else "OK"
+            lines.append(f"| max_parallel_workers_per_gather | {val} | 2-4 | {status} |")
+
+        # Planner
+        if "random_page_cost" in mem:
+            rpc = mem["random_page_cost"]
+            val = rpc.get("value", 4.0)
+            status = "HDD default" if float(val) >= 4.0 else "SSD optimized" if float(val) <= 2.0 else "OK"
+            lines.append(f"| random_page_cost | {val} | 1.1-2.0 (SSD) | {status} |")
+
+        if "default_statistics_target" in mem:
+            dst = mem["default_statistics_target"]
+            val = dst.get("value", 100)
+            lines.append(f"| default_statistics_target | {val} | 100-500 | OK |")
+
+        # Autovacuum
+        if "autovacuum" in mem:
+            av = mem["autovacuum"]
+            val = av.get("value", "on")
+            status = "CRITICAL" if val == "off" else "OK"
+            lines.append(f"| autovacuum | {val} | on | {status} |")
+
+        # Durability
+        if "synchronous_commit" in mem:
+            sc = mem["synchronous_commit"]
+            val = sc.get("value", "on")
+            status = "Faster (risk)" if val == "off" else "Safe"
+            lines.append(f"| synchronous_commit | {val} | on (safe) | {status} |")
+
+        lines.append("")
+
+    # Connection states
+    if result.connection_states:
+        lines.append("## Connection States")
+        lines.append("")
+        lines.append("| State | Count |")
+        lines.append("|-------|-------|")
+        for s in result.connection_states:
+            lines.append(f"| {s.get('state', 'unknown')} | {s.get('count', 0)} |")
+        lines.append("")
+
+    # Connections by application
+    if result.connections_by_app:
+        lines.append("## Connections by Application")
+        lines.append("")
+        lines.append("| Application | Count |")
+        lines.append("|-------------|-------|")
+        for c in result.connections_by_app[:10]:
+            app = c.get('app', '') or '(empty)'
+            lines.append(f"| {app} | {c.get('count', 0)} |")
+        lines.append("")
+
+    # Connections by age
+    if result.connections_by_age:
+        lines.append("## Connections by Age")
+        lines.append("")
+        lines.append("| Age Range | Count |")
+        lines.append("|-----------|-------|")
+        for c in result.connections_by_age:
+            lines.append(f"| {c.get('range', '')} | {c.get('count', 0)} |")
+        lines.append("")
+
+    # Per-table cache
+    if result.cache_per_table:
+        lines.append("## Per-Table Cache Hit Rates")
+        lines.append("")
+        lines.append("| Table | Hit % | Disk Reads | Status |")
+        lines.append("|-------|-------|------------|--------|")
+        for t in result.cache_per_table[:10]:
+            hit_pct = float(t.get("hit_pct", 0))
+            status = "OK" if hit_pct >= 95 else "Warning" if hit_pct >= 80 else "Critical"
+            lines.append(f"| {t['table']} | {t['hit_pct']}% | {int(t['disk_reads']):,} | {status} |")
+        lines.append("")
+
+    # Table sizes
+    if result.table_sizes:
+        lines.append("## Table Sizes")
+        lines.append("")
+        lines.append("| Schema.Table | Total | Data | Indexes | Rows |")
+        lines.append("|--------------|-------|------|---------|------|")
+        for t in result.table_sizes[:10]:
+            schema = t.get('schema', 'public')
+            table = t.get('table', '')
+            full_name = f"{schema}.{table}" if schema != 'public' else table
+            data_bytes = int(t.get('data_bytes', 0))
+            index_bytes = int(t.get('index_bytes', 0))
+            data_mb = round(data_bytes / 1024 / 1024, 1)
+            index_mb = round(index_bytes / 1024 / 1024, 1)
+            row_count = t.get('row_count', '0')
+            lines.append(f"| {full_name} | {t['size']} | {data_mb}MB | {index_mb}MB | {row_count} |")
+        lines.append("")
+
+    # Vacuum health
+    if result.vacuum_health:
+        lines.append("## Vacuum Health")
+        lines.append("")
+        lines.append("| Schema.Table | Dead Rows | Dead % | V/AV Count | Last Analyze | XID Age | Flags |")
+        lines.append("|--------------|-----------|--------|------------|--------------|---------|-------|")
+        for t in result.vacuum_health[:10]:
+            schema = t.get('schema', 'public')
+            table = t.get('table', '')
+            vacuum_count = t.get('vacuum_count', '0')
+            autovacuum_count = t.get('autovacuum_count', '0')
+            last_analyze = t.get('last_analyze', 'never')
+            # Shorten timestamp to just date
+            if last_analyze and last_analyze != 'never' and len(last_analyze) > 10:
+                last_analyze = last_analyze[:10]
+            xid_age = t.get('xid_age', '0')
+            xid_millions = round(int(xid_age) / 1_000_000, 1) if xid_age.isdigit() else 0
+            flags = []
+            if t.get('needs_vacuum') == 'true':
+                flags.append('VACUUM')
+            if t.get('needs_freeze') == 'true':
+                flags.append('FREEZE')
+            flags_str = ', '.join(flags) if flags else '-'
+            full_name = f"{schema}.{table}" if schema != 'public' else table
+            lines.append(f"| {full_name} | {int(t['dead_rows']):,} | {t['dead_pct']}% | {vacuum_count}/{autovacuum_count} | {last_analyze} | {xid_millions}M | {flags_str} |")
+        lines.append("")
+
+    # Unused indexes
+    if result.unused_indexes:
+        lines.append("## Unused Indexes (0 scans since stats reset)")
+        lines.append("")
+        lines.append("| Schema.Table | Index | Size | Type | Table Idx Scans |")
+        lines.append("|--------------|-------|------|------|-----------------|")
+        for t in result.unused_indexes[:20]:
+            schema = t.get('schema', 'public')
+            table = t.get('table', '')
+            full_name = f"{schema}.{table}" if schema != 'public' else table
+            table_idx_scans = t.get('table_idx_scans', '0')
+            # Show index type
+            idx_type = "PK" if t.get('is_primary') else "UNIQUE" if t.get('is_unique') else "idx"
+            lines.append(f"| {full_name} | {t['index']} | {t['size']} | {idx_type} | {table_idx_scans} |")
+        lines.append("")
+
+    # Invalid indexes (failed concurrent index builds)
+    if result.invalid_indexes:
+        lines.append("## Invalid Indexes (require rebuild)")
+        lines.append("")
+        lines.append("| Schema | Table | Index |")
+        lines.append("|--------|-------|-------|")
+        for t in result.invalid_indexes:
+            lines.append(f"| {t.get('schema', '')} | {t.get('table', '')} | {t.get('index', '')} |")
+        lines.append("")
+
+    # Top queries
+    if result.top_queries:
+        lines.append("## Top Queries by Execution Time")
+        lines.append("")
+        lines.append("| Query | Calls | Total (min) | Mean (ms) | Min/Max (ms) | Stddev | Rows/Call | Cache Hit % | Temp R/W | Plan (ms) | I/O Time (ms) |")
+        lines.append("|-------|-------|-------------|-----------|--------------|--------|-----------|-------------|----------|-----------|---------------|")
+        for t in result.top_queries[:15]:
+            query = t.get('query', '')[:50]
+            cache_pct = t.get('cache_hit_pct')
+            cache_str = f"{cache_pct}%" if cache_pct is not None else "-"
+            temp_r = t.get('temp_blks_read', 0)
+            temp_w = t.get('temp_blks_written', 0)
+            temp_str = f"{temp_r:,}/{temp_w:,}" if (temp_r or temp_w) else "-"
+            min_max = f"{t.get('min_ms', '-')}/{t.get('max_ms', '-')}"
+            stddev = t.get('stddev_ms', '-')
+            rows_per_call = t.get('rows_per_call', '-')
+            plan_ms = t.get('mean_plan_ms', '-')
+            blk_read = float(t.get('blk_read_time_ms', 0) or 0)
+            blk_write = float(t.get('blk_write_time_ms', 0) or 0)
+            io_time = f"{blk_read + blk_write:.0f}" if (blk_read + blk_write) > 0 else "-"
+            lines.append(f"| {query}... | {t.get('calls', '')} | {t.get('total_min', '')} | {t.get('mean_ms', '')} | {min_max} | {stddev} | {rows_per_call} | {cache_str} | {temp_str} | {plan_ms} | {io_time} |")
+        lines.append("")
+
+    # Long-running queries
+    if result.long_running_queries:
+        lines.append("## Long-Running Queries (>5s)")
+        lines.append("")
+        lines.append("| PID | Duration (s) | Query |")
+        lines.append("|-----|--------------|-------|")
+        for q in result.long_running_queries:
+            lines.append(f"| {q.get('pid', '')} | {q.get('duration_sec', '')} | {q.get('query', '')[:40]}... |")
+        lines.append("")
+
+    # Idle in transaction (stuck transactions)
+    if result.idle_in_transaction:
+        lines.append("## Idle In Transaction (>30s)")
+        lines.append("")
+        lines.append("| PID | Idle (s) | User | App | Last Query |")
+        lines.append("|-----|----------|------|-----|------------|")
+        for txn in result.idle_in_transaction:
+            lines.append(f"| {txn.get('pid', '')} | {txn.get('idle_sec', '')} | {txn.get('user', '')} | {txn.get('app', '')[:15]} | {txn.get('last_query', '')[:30]}... |")
+        lines.append("")
+
+    # Blocked queries
+    if result.blocked_queries:
+        lines.append("## Blocked Queries (waiting on locks)")
+        lines.append("")
+        lines.append("| PID | Wait (s) | User | Blocked By | Query |")
+        lines.append("|-----|----------|------|------------|-------|")
+        for q in result.blocked_queries:
+            lines.append(f"| {q.get('pid', '')} | {q.get('wait_sec', '')} | {q.get('user', '')} | PID {q.get('blocking_pid', '')} | {q.get('query', '')[:30]}... |")
+        lines.append("")
+
+    # Lock contention
+    if result.locks:
+        lines.append("## Lock Contention")
+        lines.append("")
+        lines.append("| Lock Type | Mode | User | App | Query |")
+        lines.append("|-----------|------|------|-----|-------|")
+        for lock in result.locks:
+            lines.append(f"| {lock.get('locktype', '')} | {lock.get('mode', '')} | {lock.get('user', '')} | {lock.get('app', '')[:15]} | {lock.get('query', '')[:25]}... |")
+        lines.append("")
+
+    # Sequential scan patterns
+    if result.seq_scan_tables:
+        lines.append("## Tables with High Sequential Scans")
+        lines.append("")
+        lines.append("| Table | Seq Scans | Index Scans | Rows |")
+        lines.append("|-------|-----------|-------------|------|")
+        for t in result.seq_scan_tables[:10]:
+            lines.append(f"| {t.get('table', '')} | {t.get('seq_scans', '')} | {t.get('idx_scans', '')} | {t.get('rows', '')} |")
+        lines.append("")
+
+    # Replication
+    if result.replication:
+        lines.append("## Replication Status")
+        lines.append("")
+        lines.append("| Client | State | Sent LSN | Replay LSN |")
+        lines.append("|--------|-------|----------|------------|")
+        for r in result.replication:
+            lines.append(f"| {r.get('client', '')} | {r.get('state', '')} | {r.get('sent_lsn', '')} | {r.get('replay_lsn', '')} |")
+        lines.append("")
+
+    # HA Cluster
+    if result.ha_cluster:
+        lines.append("## HA Cluster (Patroni)")
+        lines.append("")
+        members = result.ha_cluster.get("members", [])
+        if members:
+            lines.append("| Name | Role | State | Timeline | Lag |")
+            lines.append("|------|------|-------|----------|-----|")
+            for m in members:
+                lag = m.get('lag', 0) or 0
+                lines.append(f"| {m.get('name', '')} | {m.get('role', '')} | {m.get('state', '')} | {m.get('timeline', '')} | {lag} |")
+        lines.append("")
+
+    # Cluster logs (for HA clusters) - raw output for LLM analysis
+    if result.cluster_logs:
+        lines.append("## Cluster Member Logs")
+        lines.append("")
+        lines.append("(Use --json for full log data. LLM will analyze patterns.)")
+        lines.append("")
+        for member_log in result.cluster_logs:
+            member = member_log.get('member', 'unknown')
+            status = member_log.get('status', 'unknown')
+            logs = member_log.get('logs', [])
+            lines.append(f"### {member} ({status}) - {len(logs)} log entries collected")
+            lines.append("")
+
+    # Background writer stats
+    if result.bgwriter:
+        lines.append("## Background Writer Stats")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        bg = result.bgwriter
+        total_checkpoints = bg.get('checkpoints_timed', 0) + bg.get('checkpoints_req', 0)
+        timed_pct = round(100.0 * bg.get('checkpoints_timed', 0) / total_checkpoints, 1) if total_checkpoints > 0 else 0
+        lines.append(f"| Checkpoints (timed/requested) | {bg.get('checkpoints_timed', 0):,} / {bg.get('checkpoints_req', 0):,} ({timed_pct}% timed) |")
+        lines.append(f"| Buffers: checkpoint | {bg.get('buffers_checkpoint', 0):,} |")
+        lines.append(f"| Buffers: bgwriter clean | {bg.get('buffers_clean', 0):,} |")
+        lines.append(f"| Buffers: backend direct | {bg.get('buffers_backend', 0):,} |")
+        lines.append(f"| Buffers: backend fsync | {bg.get('buffers_backend_fsync', 0):,} |")
+        lines.append(f"| Max written clean | {bg.get('maxwritten_clean', 0):,} |")
+        stats_reset = bg.get('stats_reset', 'never')
+        if stats_reset and stats_reset != 'never' and len(stats_reset) > 10:
+            stats_reset = stats_reset[:10]
+        lines.append(f"| Stats reset | {stats_reset} |")
+        lines.append("")
+
+    # WAL archiver stats
+    if result.archiver:
+        arch = result.archiver
+        lines.append("## WAL Archiver Status")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        lines.append(f"| Archived WAL count | {arch.get('archived_count', 0):,} |")
+        lines.append(f"| Failed archival count | {arch.get('failed_count', 0):,} |")
+        last_wal = arch.get('last_archived_wal') or 'none'
+        last_time = arch.get('last_archived_time', 'never')
+        if last_time and last_time != 'never' and len(last_time) > 19:
+            last_time = last_time[:19]
+        lines.append(f"| Last archived WAL | {last_wal} |")
+        lines.append(f"| Last archived time | {last_time} |")
+        if arch.get('failed_count', 0) > 0:
+            failed_wal = arch.get('last_failed_wal') or 'none'
+            failed_time = arch.get('last_failed_time', 'never')
+            if failed_time and failed_time != 'never' and len(failed_time) > 19:
+                failed_time = failed_time[:19]
+            lines.append(f"| Last failed WAL | {failed_wal} |")
+            lines.append(f"| Last failed time | {failed_time} |")
+        lines.append("")
+
+    # Vacuum progress (ongoing vacuums)
+    if result.progress_vacuum:
+        lines.append("## Ongoing Vacuum Operations")
+        lines.append("")
+        lines.append("| PID | Table | Phase | Progress |")
+        lines.append("|-----|-------|-------|----------|")
+        for vac in result.progress_vacuum:
+            total = vac.get('heap_blks_total', 0)
+            scanned = vac.get('heap_blks_scanned', 0)
+            pct = round(100.0 * scanned / total, 1) if total > 0 else 0
+            lines.append(f"| {vac.get('pid', '')} | {vac.get('relname', '')} | {vac.get('phase', '')} | {pct}% ({scanned:,}/{total:,} blks) |")
+        lines.append("")
+
+    # SSL connection stats
+    if result.ssl_stats:
+        ssl = result.ssl_stats
+        lines.append("## SSL Connection Stats")
+        lines.append("")
+        total = ssl.get('ssl_connections', 0) + ssl.get('non_ssl_connections', 0)
+        ssl_pct = round(100.0 * ssl.get('ssl_connections', 0) / total, 1) if total > 0 else 0
+        lines.append(f"- SSL connections: {ssl.get('ssl_connections', 0)} ({ssl_pct}%)")
+        lines.append(f"- Non-SSL connections: {ssl.get('non_ssl_connections', 0)}")
+        versions = ssl.get('ssl_versions', [])
+        if versions:
+            lines.append("- SSL versions in use:")
+            for v in versions:
+                lines.append(f"  - {v.get('version', 'unknown')}: {v.get('count', 0)} connections")
+        lines.append("")
+
+    # Recent errors
+    if result.recent_errors:
+        lines.append("## Recent Errors")
+        lines.append("")
+        for error in result.recent_errors[:5]:
+            lines.append(f"- {error[:100]}...")
+        lines.append("")
+
+    # Recommendations
+    if result.recommendations:
+        lines.append("## Recommendations")
+        lines.append("")
+        for i, rec in enumerate(result.recommendations, 1):
+            priority = rec["priority"].upper()
+            lines.append(f"{i}. **[{priority}]** {rec['issue']}")
+            lines.append(f"   **Action:** {rec['action']}")
+
+            # Show explanation if available
+            if rec.get("explanation"):
+                lines.append(f"   **Why:** {rec['explanation']}")
+
+            # Show commands if available
+            if rec.get("commands"):
+                lines.append("   **Commands:**")
+                for cmd in rec["commands"]:
+                    lines.append(f"   ```sql")
+                    lines.append(f"   {cmd}")
+                    lines.append(f"   ```")
+
+            # Note if restart is required
+            if rec.get("restart_required"):
+                lines.append("   ⚠️ *Requires database restart*")
+
+            lines.append("")
+
+    # Errors
+    if result.errors:
+        lines.append("## Errors")
+        lines.append("")
+        for error in result.errors:
+            lines.append(f"- {error}")
+        lines.append("")
+
+    lines.append("=" * 60)
+    lines.append("END OF REPORT")
+    lines.append("=" * 60)
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Complete database analysis for Railway services.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument("--service", required=True, help="Service name")
+    parser.add_argument("--json", action="store_true",
+                       help="Output as JSON")
+    parser.add_argument("--timeout", type=int, default=300,
+                       help="Timeout in seconds for analysis query (default: 300)")
+    parser.add_argument("--quiet", "-q", action="store_true",
+                       help="Suppress progress messages")
+    parser.add_argument("--skip-logs", action="store_true",
+                       help="Skip log fetching for faster analysis")
+    parser.add_argument("--metrics-hours", type=int, default=168,
+                       help="Hours of metrics history to fetch (default: 168, max: 168)")
+    parser.add_argument("--step", choices=["ssh-test", "query", "logs", "metrics"],
+                       help="Run a single collection step for debugging")
+    parser.add_argument("--project-id", help="Project ID (bypasses railway link)")
+    parser.add_argument("--environment-id", help="Environment ID (bypasses railway link)")
+    parser.add_argument("--service-id", help="Service ID (bypasses railway link)")
+
+    args = parser.parse_args()
+
+    # Single-step debugging mode
+    if args.step:
+        return run_single_step(args)
+
+    # Run analysis
+    result = analyze_postgres(args.service, timeout=args.timeout, quiet=args.quiet,
+                              skip_logs=args.skip_logs,
+                              metrics_hours=min(args.metrics_hours, 168),
+                              project_id=args.project_id,
+                              environment_id=args.environment_id,
+                              service_id=args.service_id)
+
+    # Output
+    if args.json:
+        print(json.dumps(asdict(result), indent=2))
+    else:
+        print(format_report(result))
+
+    return 0
+
+
+def run_single_step(args) -> int:
+    """Run a single collection step for debugging."""
+    service = args.service
+    _init_context(args)
+    environment_id = dal._ctx.environment_id
+    service_id = dal._ctx.service_id
+
+    if args.step == "ssh-test":
+        print(f"Testing SSH to service: {service}", file=sys.stderr)
+        code, stdout, stderr = run_ssh_query(service, "echo ok", timeout=45)
+        print(f"Exit code: {code}")
+        print(f"Stdout: {stdout.strip()}")
+        if stderr:
+            print(f"Stderr: {stderr.strip()}")
+        return 0 if (code == 0 and "ok" in stdout) else 1
+
+    elif args.step == "query":
+        print(f"Running analysis query on: {service}", file=sys.stderr)
+        query = build_analysis_query()
+        code, stdout, stderr = run_psql_query_safe(service, query, timeout=args.timeout)
+        print(f"Exit code: {code}")
+        if code == 0 and stdout:
+            try:
+                data = json.loads(stdout.strip())
+                print(json.dumps(data, indent=2))
+            except json.JSONDecodeError:
+                print(f"Raw output:\n{stdout}")
+        else:
+            print(f"Error: {stderr or stdout}")
+        return code
+
+    elif args.step == "logs":
+        print(f"Fetching logs for: {service}", file=sys.stderr)
+        logs = get_recent_logs(service, lines=LOG_LINES_DEFAULT,
+                               environment_id=environment_id,
+                               service_id=service_id)
+        print(f"Lines fetched: {len(logs)}")
+        for line in logs:
+            print(line)
+        return 0
+
+    elif args.step == "metrics":
+        print(f"Fetching metrics for: {service}", file=sys.stderr)
+        if environment_id and service_id:
+            metrics = get_all_metrics_from_api(environment_id, service_id)
+            if metrics:
+                print(json.dumps(metrics, indent=2))
+            else:
+                print("Metrics API returned no data")
+                return 1
+        else:
+            print("Missing environment_id or service_id from railway config")
+            return 1
+        return 0
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/use-railway/scripts/analyze-redis.py
+++ b/.claude/skills/use-railway/scripts/analyze-redis.py
@@ -1,0 +1,1090 @@
+#!/usr/bin/env python3
+"""
+Redis analysis for Railway deployments.
+
+Produces a comprehensive report covering:
+- Server overview (version, uptime, clients)
+- Memory usage and fragmentation
+- Throughput and command stats
+- Cache performance (hit/miss ratio)
+- Persistence status
+- Keyspace summary
+- Railway infrastructure metrics (CPU, memory, disk, network)
+- Recent logs
+- Recommendations
+
+Usage:
+    analyze-redis.py --service <name>
+    analyze-redis.py --service <name> --json
+    analyze-redis.py --service <name> --step ssh-test
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import re
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Any, Tuple
+from dataclasses import dataclass, field, asdict
+
+import dal
+from dal import (
+    LOG_LINES_DEFAULT, ProgressTimer, RailwayContext,
+    _init_context, progress, run_railway_command, run_ssh_query,
+    get_railway_status, get_deployment_status,
+    get_all_metrics_from_api, _analyze_window, _build_metrics_history,
+    get_recent_logs,
+    _safe_int, _safe_float, _format_uptime,
+)
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RedisAnalysisResult:
+    """Container for Redis analysis results."""
+    service: str
+    db_type: str
+    timestamp: str
+    deployment_status: str = "UNKNOWN"
+
+    # Redis INFO sections
+    overview: Optional[Dict[str, Any]] = None
+    memory: Optional[Dict[str, Any]] = None
+    throughput: Optional[Dict[str, Any]] = None
+    cache: Optional[Dict[str, Any]] = None
+    persistence: Optional[Dict[str, Any]] = None
+    keyspace: List[Dict[str, Any]] = field(default_factory=list)
+    total_keys: int = 0
+    command_stats: List[Dict[str, Any]] = field(default_factory=list)
+    slowlog_len: Optional[int] = None
+    slowlog_entries: List[Dict[str, Any]] = field(default_factory=list)
+    big_keys: List[Dict[str, Any]] = field(default_factory=list)
+
+    # Railway infrastructure
+    metrics_history: Optional[Dict[str, Any]] = None
+    recent_logs: List[str] = field(default_factory=list)
+
+    # Status tracking
+    collection_status: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    errors: List[str] = field(default_factory=list)
+    recommendations: List[Dict[str, str]] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Redis data collection
+# ---------------------------------------------------------------------------
+
+def parse_redis_info(raw: str) -> Dict[str, str]:
+    """Parse Redis INFO output into a flat key:value dict.
+
+    Lines starting with # are section headers and are skipped.
+    """
+    info: Dict[str, str] = {}
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if ":" in line:
+            key, _, value = line.partition(":")
+            info[key.strip()] = value.strip()
+    return info
+
+
+def extract_overview(info: Dict[str, str]) -> Dict[str, Any]:
+    """Extract overview metrics from INFO dict."""
+    return {
+        "redis_version": info.get("redis_version", "unknown"),
+        "uptime_in_seconds": _safe_int(info.get("uptime_in_seconds")),
+        "connected_clients": _safe_int(info.get("connected_clients")),
+        "blocked_clients": _safe_int(info.get("blocked_clients")),
+        "rejected_connections": _safe_int(info.get("rejected_connections")),
+    }
+
+
+def extract_memory(info: Dict[str, str]) -> Dict[str, Any]:
+    """Extract memory metrics from INFO dict."""
+    return {
+        "used_memory_human": info.get("used_memory_human", "N/A"),
+        "used_memory_rss_human": info.get("used_memory_rss_human", "N/A"),
+        "used_memory_peak_human": info.get("used_memory_peak_human", "N/A"),
+        "mem_fragmentation_ratio": _safe_float(info.get("mem_fragmentation_ratio")),
+        "maxmemory": _safe_int(info.get("maxmemory")),
+        "maxmemory_human": info.get("maxmemory_human", "N/A"),
+        "maxmemory_policy": info.get("maxmemory_policy", "unknown"),
+    }
+
+
+def extract_throughput(info: Dict[str, str]) -> Dict[str, Any]:
+    """Extract throughput metrics from INFO dict."""
+    return {
+        "instantaneous_ops_per_sec": _safe_int(info.get("instantaneous_ops_per_sec")),
+        "total_commands_processed": _safe_int(info.get("total_commands_processed")),
+        "total_connections_received": _safe_int(info.get("total_connections_received")),
+    }
+
+
+def extract_cache(info: Dict[str, str]) -> Dict[str, Any]:
+    """Extract cache performance metrics from INFO dict."""
+    hits = _safe_int(info.get("keyspace_hits"))
+    misses = _safe_int(info.get("keyspace_misses"))
+    total = hits + misses
+    hit_rate = round(hits / total * 100, 2) if total > 0 else 0.0
+    return {
+        "keyspace_hits": hits,
+        "keyspace_misses": misses,
+        "hit_rate": hit_rate,
+        "expired_keys": _safe_int(info.get("expired_keys")),
+        "evicted_keys": _safe_int(info.get("evicted_keys")),
+    }
+
+
+def extract_persistence(info: Dict[str, str]) -> Dict[str, Any]:
+    """Extract persistence metrics from INFO dict."""
+    return {
+        "rdb_last_save_time": _safe_int(info.get("rdb_last_save_time")),
+        "rdb_last_bgsave_status": info.get("rdb_last_bgsave_status", "unknown"),
+        "rdb_current_bgsave_time_sec": _safe_int(info.get("rdb_current_bgsave_time_sec")),
+        "aof_enabled": info.get("aof_enabled", "0") == "1",
+        "aof_last_rewrite_status": info.get("aof_last_rewrite_status", "unknown"),
+    }
+
+
+def extract_keyspace(info: Dict[str, str]) -> Tuple[List[Dict[str, Any]], int]:
+    """Extract keyspace metrics from INFO dict.
+
+    Keyspace entries look like: db0:keys=1234,expires=567,avg_ttl=12345
+    Returns (list of db dicts, total_keys).
+    """
+    databases: List[Dict[str, Any]] = []
+    total_keys = 0
+    for key, value in info.items():
+        if not re.match(r'^db\d+$', key):
+            continue
+        # Parse keys=X,expires=Y,avg_ttl=Z
+        parts = {}
+        for item in value.split(","):
+            k, _, v = item.partition("=")
+            parts[k] = v
+        keys = _safe_int(parts.get("keys"))
+        total_keys += keys
+        databases.append({
+            "db": key,
+            "keys": keys,
+            "expires": _safe_int(parts.get("expires")),
+            "avg_ttl": _safe_int(parts.get("avg_ttl")),
+        })
+    return databases, total_keys
+
+
+def extract_command_stats(info: Dict[str, str]) -> List[Dict[str, Any]]:
+    """Extract command statistics from INFO dict.
+
+    Command stat entries look like: cmdstat_GET:calls=123,usec=456,usec_per_call=3.71
+    Returns list sorted by calls descending.
+    """
+    stats: List[Dict[str, Any]] = []
+    for key, value in info.items():
+        if not key.startswith("cmdstat_"):
+            continue
+        cmd_name = key[len("cmdstat_"):]
+        parts = {}
+        for item in value.split(","):
+            k, _, v = item.partition("=")
+            parts[k] = v
+        stats.append({
+            "command": cmd_name,
+            "calls": _safe_int(parts.get("calls")),
+            "usec": _safe_int(parts.get("usec")),
+            "usec_per_call": _safe_float(parts.get("usec_per_call")),
+        })
+    stats.sort(key=lambda x: x["calls"], reverse=True)
+    return stats
+
+
+_CLIENT_IP_RE = re.compile(r'^(\[.+\]|(?:\d{1,3}\.){3}\d{1,3}):\d+$')
+
+
+def parse_slowlog_get(raw: str) -> List[Dict[str, Any]]:
+    """Parse SLOWLOG GET output into structured entries.
+
+    redis-cli --raw SLOWLOG GET format (Redis 4.0+):
+      <id>
+      <timestamp_unix>
+      <duration_us>
+      <cmd>
+      <arg1>
+      ...
+      <argN>
+      <client_ip:port>
+      [<client_name>]   (optional, may be absent)
+
+    There is no num_args field in the raw output. The client IP line
+    (IPv4 or IPv6 with port) marks the end of each entry's arguments.
+    """
+    entries: List[Dict[str, Any]] = []
+    lines = [l.strip() for l in raw.strip().splitlines() if l.strip()]
+    if not lines:
+        return entries
+
+    i = 0
+    while i < len(lines):
+        try:
+            entry_id = int(lines[i])
+        except (ValueError, IndexError):
+            i += 1
+            continue
+
+        if i + 3 >= len(lines):
+            break
+
+        try:
+            timestamp = int(lines[i + 1])
+            duration_us = int(lines[i + 2])
+        except (ValueError, IndexError):
+            i += 1
+            continue
+
+        # lines[i+3] is the command name; scan forward for client IP
+        cmd_start = i + 3
+        client_ip_pos = None
+        for k in range(cmd_start, min(cmd_start + 30, len(lines))):
+            if _CLIENT_IP_RE.match(lines[k]):
+                client_ip_pos = k
+                break
+
+        if client_ip_pos is not None:
+            cmd_parts = lines[cmd_start:client_ip_pos]
+            # Advance past client IP and optional client name
+            next_i = client_ip_pos + 1
+            if next_i < len(lines):
+                try:
+                    int(lines[next_i])
+                except ValueError:
+                    next_i += 1  # skip client name
+        else:
+            # No client IP found — take command + first arg only and advance
+            cmd_parts = lines[cmd_start:cmd_start + 2]
+            next_i = cmd_start + 2
+
+        command = " ".join(cmd_parts) if cmd_parts else "unknown"
+        if len(command) > 120:
+            command = command[:117] + "..."
+
+        entries.append({
+            "id": entry_id,
+            "timestamp_unix": timestamp,
+            "duration_us": duration_us,
+            "command": command,
+        })
+
+        i = next_i
+
+    return entries
+
+
+def parse_bigkeys(raw: str) -> List[Dict[str, Any]]:
+    """Parse redis-cli --bigkeys output into structured entries.
+
+    Looks for lines like:
+      Biggest string found "cache:render:page/dashboard" has 2145832 bytes
+      Biggest hash found "user:sessions" has 14291 fields
+      Biggest list found "queue:notifications" has 8402 items
+      Biggest set found "tags:all" has 291 members
+      Biggest zset found "leaderboard:global" has 10042 members
+      Biggest stream found "events:main" has 5012 entries
+    """
+    entries: List[Dict[str, Any]] = []
+    # Match: Biggest <type> found "<key>" has <count> <unit>
+    # Redis 8+ uses double quotes; older versions used single quotes
+    pattern = re.compile(
+        r'Biggest\s+(\w+)\s+found\s+["\']([^"\']+)["\']\s+has\s+([\d,]+)\s+(\w+)',
+        re.IGNORECASE,
+    )
+    for line in raw.splitlines():
+        m = pattern.search(line)
+        if m:
+            key_type = m.group(1).lower()
+            key_name = m.group(2)
+            size_str = m.group(3).replace(",", "")
+            unit = m.group(4).lower()
+            size = _safe_int(size_str)
+
+            # Format size for display
+            if unit == "bytes":
+                detail = _format_bytes_human(size)
+            else:
+                detail = f"{size:,} {unit}"
+
+            entries.append({
+                "type": key_type,
+                "key": key_name,
+                "size_or_count": size,
+                "detail": detail,
+            })
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+def _format_number(n: int) -> str:
+    """Format a large number with K/M/B suffixes."""
+    if n >= 1_000_000_000:
+        return f"{n / 1_000_000_000:.1f}B"
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}K"
+    return f"{n:,}"
+
+
+def _format_duration(seconds: int) -> str:
+    """Format a duration in seconds to a human-readable relative string."""
+    if seconds <= 0:
+        return "N/A"
+    if seconds < 60:
+        return f"{seconds}s ago"
+    if seconds < 3600:
+        return f"{seconds // 60}m ago"
+    if seconds < 86400:
+        return f"{seconds // 3600}h ago"
+    return f"{seconds // 86400}d ago"
+
+
+def _format_ttl(ms: int) -> str:
+    """Format average TTL in milliseconds to a human-readable string."""
+    if ms <= 0:
+        return "none"
+    seconds = ms // 1000
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    if seconds < 86400:
+        return f"{seconds // 3600}h"
+    return f"{seconds // 86400}d"
+
+
+def _format_usec(usec: float) -> str:
+    """Format microseconds to a human-readable string."""
+    if usec < 1000:
+        return f"{usec:.1f}us"
+    if usec < 1_000_000:
+        return f"{usec / 1000:.1f}ms"
+    return f"{usec / 1_000_000:.2f}s"
+
+
+def _format_total_time(usec: int) -> str:
+    """Format total microseconds to a readable time string."""
+    seconds = usec / 1_000_000
+    if seconds < 1:
+        return f"{usec / 1000:.1f}ms"
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    if seconds < 3600:
+        return f"{seconds / 60:.1f}m"
+    return f"{seconds / 3600:.1f}h"
+
+
+def _format_bytes_human(nbytes: int) -> str:
+    """Format bytes into human-readable string."""
+    if nbytes <= 0:
+        return "0"
+    for unit in ["B", "K", "M", "G", "T"]:
+        if nbytes < 1024:
+            return f"{nbytes:.1f}{unit}" if nbytes != int(nbytes) else f"{int(nbytes)}{unit}"
+        nbytes /= 1024
+    return f"{nbytes:.1f}P"
+
+
+# ---------------------------------------------------------------------------
+# Recommendations engine
+# ---------------------------------------------------------------------------
+
+def generate_recommendations(result: RedisAnalysisResult) -> List[Dict[str, str]]:
+    """Generate recommendations based on collected metrics."""
+    recs: List[Dict[str, str]] = []
+
+    # Collection failures — surface critical issues when SSH/introspection failed
+    if result.collection_status:
+        failed = {k: v for k, v in result.collection_status.items() if v.get("status") == "failed"}
+        ssh_sources = {"redis_info", "slowlog", "slowlog_entries", "big_keys"}
+        ssh_failed = {k: v for k, v in failed.items() if k in ssh_sources}
+        if ssh_failed:
+            sources = ", ".join(ssh_failed.keys())
+            errors = "; ".join(v.get("error", "unknown") for v in ssh_failed.values())
+            recs.append({
+                "severity": "critical",
+                "category": "collection",
+                "message": f"SSH introspection failed — unable to collect {sources}. "
+                           f"Error: {errors}. "
+                           f"Analysis is incomplete: memory fragmentation, cache hit rate, "
+                           f"keyspace stats, and persistence health could not be evaluated.",
+            })
+
+    # Memory fragmentation
+    if result.memory:
+        frag = result.memory.get("mem_fragmentation_ratio", 0)
+        if frag > 1.5:
+            recs.append({
+                "severity": "warning",
+                "category": "memory",
+                "message": f"High memory fragmentation ({frag:.2f}). Consider restarting Redis to defragment, or enable activedefrag.",
+            })
+
+    # Cache hit rate
+    if result.cache:
+        hit_rate = result.cache.get("hit_rate", 0)
+        if hit_rate < 80 and (result.cache.get("keyspace_hits", 0) + result.cache.get("keyspace_misses", 0)) > 0:
+            recs.append({
+                "severity": "warning",
+                "category": "cache",
+                "message": f"Low cache hit rate ({hit_rate:.1f}%). Review key access patterns - many keys may be expired or evicted before use.",
+            })
+        elif hit_rate < 95 and hit_rate >= 80:
+            recs.append({
+                "severity": "info",
+                "category": "cache",
+                "message": f"Cache hit rate at {hit_rate:.1f}% — could be improved. Check if working set fits in memory.",
+            })
+
+    # Evicted keys
+    if result.cache:
+        evicted = result.cache.get("evicted_keys", 0)
+        if evicted > 0:
+            recs.append({
+                "severity": "warning",
+                "category": "memory",
+                "message": f"Redis is evicting keys ({_format_number(evicted)} evicted). Increase maxmemory or reduce dataset size.",
+            })
+
+    # Rejected connections
+    if result.overview:
+        rejected = result.overview.get("rejected_connections", 0)
+        if rejected > 0:
+            recs.append({
+                "severity": "warning",
+                "category": "connections",
+                "message": f"Connections being rejected ({_format_number(rejected)}). Check maxclients setting.",
+            })
+
+    # Blocked clients
+    if result.overview:
+        blocked = result.overview.get("blocked_clients", 0)
+        if blocked > 0:
+            recs.append({
+                "severity": "info",
+                "category": "connections",
+                "message": f"Blocked clients detected ({blocked}). Check for blocking operations (BLPOP, BRPOP, etc.).",
+            })
+
+    # maxmemory not set — on Railway this is expected; autoscaling handles growth
+
+    # RDB save failure
+    if result.persistence:
+        rdb_status = result.persistence.get("rdb_last_bgsave_status", "")
+        if rdb_status and rdb_status != "ok":
+            recs.append({
+                "severity": "critical",
+                "category": "persistence",
+                "message": "Last RDB save failed. Check disk space and permissions.",
+            })
+
+    # Slow log — data-driven when entries are available
+    if result.slowlog_entries:
+        # Analyze the actual slow commands
+        total_entries = len(result.slowlog_entries)
+        cmd_counts: Dict[str, int] = {}
+        total_duration = 0
+        for entry in result.slowlog_entries:
+            cmd = entry["command"].split()[0] if entry["command"] else "unknown"
+            cmd_counts[cmd] = cmd_counts.get(cmd, 0) + 1
+            total_duration += entry["duration_us"]
+        top_cmd = max(cmd_counts, key=cmd_counts.get) if cmd_counts else "unknown"
+        top_count = cmd_counts.get(top_cmd, 0)
+        avg_duration = total_duration / total_entries if total_entries > 0 else 0
+
+        msg = (f"Slow log contains {result.slowlog_len or total_entries} entries. "
+               f"Of the {total_entries} most recent: {top_count} are {top_cmd} commands "
+               f"averaging {_format_usec(avg_duration)}.")
+        if result.big_keys:
+            big_key_types = ", ".join(f"{bk['type']} ({bk['detail']})" for bk in result.big_keys[:3])
+            msg += f" Largest keys: {big_key_types} — check if these correlate with slow commands."
+        severity = "warning" if (result.slowlog_len or 0) > 100 else "info"
+        recs.append({"severity": severity, "category": "performance", "message": msg})
+    elif result.slowlog_len is not None and result.slowlog_len > 100:
+        recs.append({
+            "severity": "warning",
+            "category": "performance",
+            "message": f"High number of slow log entries ({result.slowlog_len}). Slow log details could not be collected.",
+        })
+
+    # Big keys — standalone recommendation when no slowlog correlation
+    if result.big_keys and not result.slowlog_entries:
+        big_key_summary = "; ".join(f"{bk['key']} ({bk['type']}: {bk['detail']})" for bk in result.big_keys[:5])
+        recs.append({
+            "severity": "info",
+            "category": "performance",
+            "message": f"Largest keys by type: {big_key_summary}. Large keys can cause latency spikes on read/delete operations.",
+        })
+
+    return recs
+
+
+# ---------------------------------------------------------------------------
+# Report formatting
+# ---------------------------------------------------------------------------
+
+def format_report(result: RedisAnalysisResult) -> str:
+    """Format the analysis result as a markdown report."""
+    lines: List[str] = []
+
+    lines.append(f"# Redis Analysis: {result.service}")
+    lines.append(f"Timestamp: {result.timestamp}")
+    lines.append(f"Deployment Status: {result.deployment_status}")
+    lines.append("")
+
+    # --- Overview ---
+    if result.overview:
+        o = result.overview
+        lines.append("## Overview")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        lines.append(f"| Version | {o.get('redis_version', 'N/A')} |")
+        lines.append(f"| Uptime | {_format_uptime(o.get('uptime_in_seconds', 0))} |")
+        lines.append(f"| Connected Clients | {o.get('connected_clients', 0):,} |")
+        lines.append(f"| Blocked Clients | {o.get('blocked_clients', 0):,} |")
+        lines.append(f"| Rejected Connections | {o.get('rejected_connections', 0):,} |")
+        lines.append(f"| Total Keys | {result.total_keys:,} |")
+        lines.append("")
+
+    # --- Memory ---
+    if result.memory:
+        m = result.memory
+        lines.append("## Memory")
+        lines.append("| Metric | Value | Status |")
+        lines.append("|--------|-------|--------|")
+
+        frag = m.get("mem_fragmentation_ratio", 0)
+        frag_status = "OK" if 1.0 <= frag <= 1.5 else ("HIGH" if frag > 1.5 else "LOW")
+
+        lines.append(f"| Used Memory | {m.get('used_memory_human', 'N/A')} | |")
+        lines.append(f"| RSS Memory | {m.get('used_memory_rss_human', 'N/A')} | |")
+        lines.append(f"| Peak Memory | {m.get('used_memory_peak_human', 'N/A')} | |")
+        lines.append(f"| Fragmentation Ratio | {frag:.2f} | {frag_status} |")
+
+        maxmem = m.get("maxmemory", 0)
+        if maxmem > 0:
+            lines.append(f"| Max Memory | {m.get('maxmemory_human', _format_bytes_human(maxmem))} | |")
+        else:
+            lines.append("| Max Memory | Unlimited | |")
+
+        lines.append(f"| Eviction Policy | {m.get('maxmemory_policy', 'N/A')} | |")
+        lines.append("")
+
+    # --- Throughput ---
+    if result.throughput:
+        t = result.throughput
+        lines.append("## Throughput")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        lines.append(f"| Ops/sec | {t.get('instantaneous_ops_per_sec', 0):,} |")
+        lines.append(f"| Total Commands | {_format_number(t.get('total_commands_processed', 0))} |")
+        lines.append(f"| Total Connections | {_format_number(t.get('total_connections_received', 0))} |")
+        if result.slowlog_len is not None:
+            lines.append(f"| Slow Log Entries | {result.slowlog_len:,} |")
+        lines.append("")
+
+    # --- Cache Performance ---
+    if result.cache:
+        c = result.cache
+        hit_rate = c.get("hit_rate", 0)
+        hit_status = "OK" if hit_rate >= 95 else ("WARN" if hit_rate >= 80 else "LOW")
+        evicted = c.get("evicted_keys", 0)
+        evict_status = "OK" if evicted == 0 else "WARN"
+
+        lines.append("## Cache Performance")
+        lines.append("| Metric | Value | Status |")
+        lines.append("|--------|-------|--------|")
+        lines.append(f"| Hit Rate | {hit_rate:.1f}% | {hit_status} |")
+        lines.append(f"| Hits | {_format_number(c.get('keyspace_hits', 0))} | |")
+        lines.append(f"| Misses | {_format_number(c.get('keyspace_misses', 0))} | |")
+        lines.append(f"| Expired Keys | {_format_number(c.get('expired_keys', 0))} | |")
+        lines.append(f"| Evicted Keys | {_format_number(evicted)} | {evict_status} |")
+        lines.append("")
+
+    # --- Persistence ---
+    if result.persistence:
+        p = result.persistence
+        rdb_status = p.get("rdb_last_bgsave_status", "unknown")
+        rdb_status_display = "OK" if rdb_status == "ok" else "FAIL"
+
+        lines.append("## Persistence")
+        lines.append("| Metric | Value | Status |")
+        lines.append("|--------|-------|--------|")
+
+        rdb_last_save = p.get("rdb_last_save_time", 0)
+        if rdb_last_save > 0:
+            now_epoch = int(datetime.now(timezone.utc).timestamp())
+            save_ago = now_epoch - rdb_last_save
+            lines.append(f"| RDB Last Save | {_format_duration(save_ago)} | |")
+        else:
+            lines.append("| RDB Last Save | never | |")
+
+        lines.append(f"| RDB Status | {rdb_status} | {rdb_status_display} |")
+        lines.append(f"| AOF Enabled | {'Yes' if p.get('aof_enabled') else 'No'} | |")
+
+        if p.get("aof_enabled"):
+            aof_status = p.get("aof_last_rewrite_status", "unknown")
+            aof_display = "OK" if aof_status == "ok" else aof_status
+            lines.append(f"| AOF Rewrite Status | {aof_status} | {aof_display} |")
+
+        lines.append("")
+
+    # --- Command Stats ---
+    if result.command_stats:
+        top_n = result.command_stats[:20]
+        lines.append("## Command Stats (top 20)")
+        lines.append("| Command | Calls | Avg Latency | Total Time |")
+        lines.append("|---------|-------|-------------|------------|")
+        for cs in top_n:
+            lines.append(
+                f"| {cs['command']} "
+                f"| {_format_number(cs['calls'])} "
+                f"| {_format_usec(cs['usec_per_call'])} "
+                f"| {_format_total_time(cs['usec'])} |"
+            )
+        lines.append("")
+
+    # --- Slow Log Entries ---
+    if result.slowlog_entries:
+        lines.append("## Slow Log Entries (recent)")
+        lines.append("| # | Timestamp | Duration | Command |")
+        lines.append("|---|-----------|----------|---------|")
+        now_epoch = int(datetime.now(timezone.utc).timestamp())
+        for entry in result.slowlog_entries:
+            age = now_epoch - entry["timestamp_unix"]
+            lines.append(
+                f"| {entry['id']} "
+                f"| {_format_duration(age)} "
+                f"| {_format_usec(entry['duration_us'])} "
+                f"| {entry['command']} |"
+            )
+        lines.append("")
+
+    # --- Biggest Keys ---
+    if result.big_keys:
+        lines.append("## Biggest Keys")
+        lines.append("| Type | Key | Size/Count |")
+        lines.append("|------|-----|------------|")
+        for bk in result.big_keys:
+            lines.append(
+                f"| {bk['type']} "
+                f"| {bk['key']} "
+                f"| {bk['detail']} |"
+            )
+        lines.append("")
+
+    # --- Keyspace ---
+    if result.keyspace:
+        lines.append("## Keyspace")
+        lines.append("| Database | Keys | Expires | Avg TTL |")
+        lines.append("|----------|------|---------|---------|")
+        for db in result.keyspace:
+            lines.append(
+                f"| {db['db']} "
+                f"| {db['keys']:,} "
+                f"| {db['expires']:,} "
+                f"| {_format_ttl(db['avg_ttl'])} |"
+            )
+        lines.append("")
+
+    # --- Infrastructure Metrics ---
+    if result.metrics_history:
+        windows = result.metrics_history.get("windows", {})
+        for window_label, window_data in windows.items():
+            mh = window_data.get("metrics", {})
+            if not mh:
+                continue
+            lines.append(f"## Infrastructure Metrics ({window_label})")
+            lines.append("| Metric | Current | Min | Max | Avg | Trend |")
+            lines.append("|--------|---------|-----|-----|-----|-------|")
+            for key in ["cpu", "memory", "disk", "network_rx", "network_tx"]:
+                if key in mh:
+                    entry = mh[key]
+                    trend = entry.get("trend", {})
+                    trend_str = trend.get("direction", "N/A")
+                    change = trend.get("change_pct", 0)
+                    if change != 0:
+                        trend_str += f" ({change:+.1f}%)"
+                    lines.append(
+                        f"| {key.replace('_', ' ').title()} "
+                        f"| {entry['current']}{entry['unit']} "
+                        f"| {entry['min']}{entry['unit']} "
+                        f"| {entry['max']}{entry['unit']} "
+                        f"| {entry['avg']}{entry['unit']} "
+                        f"| {trend_str} |"
+                    )
+            lines.append("")
+
+    # --- Collection Status ---
+    if result.collection_status:
+        failed = {k: v for k, v in result.collection_status.items() if v.get("status") == "failed"}
+        if failed:
+            lines.append("## Collection Issues")
+            for source, status in failed.items():
+                lines.append(f"- **{source}**: {status.get('error', 'unknown error')}")
+            lines.append("")
+
+    # --- Recommendations ---
+    if result.recommendations:
+        lines.append("## Recommendations")
+        for rec in result.recommendations:
+            severity = rec.get("severity", "info").upper()
+            lines.append(f"- [{severity}] {rec['message']}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Main analysis function
+# ---------------------------------------------------------------------------
+
+def analyze_redis(service: str, timeout: int = 300, quiet: bool = False,
+                  skip_logs: bool = False,
+                  metrics_hours: int = 168,
+                  project_id: Optional[str] = None,
+                  environment_id: Optional[str] = None,
+                  service_id: Optional[str] = None) -> RedisAnalysisResult:
+    """Run complete Redis analysis with maximum data collection.
+
+    Collects Redis INFO ALL, SLOWLOG LEN, SLOWLOG GET 20, --bigkeys,
+    Railway metrics, and logs in parallel where possible.
+
+    Args:
+        skip_logs: Skip log fetching for faster analysis
+        metrics_hours: Hours of metrics history to fetch (default: 168, max: 168)
+        project_id: Project ID (bypasses railway link config)
+        environment_id: Environment ID (bypasses railway link config)
+        service_id: Service ID (bypasses railway link config)
+    """
+    if not quiet:
+        print(f"Analyzing redis database: {service}", file=sys.stderr)
+
+    result = RedisAnalysisResult(
+        service=service,
+        db_type="redis",
+        timestamp=datetime.now(timezone.utc).isoformat(),
+    )
+
+    # === FAST CONTEXT LOADING ===
+    if not quiet:
+        print("  [0/5] Getting Railway context...", file=sys.stderr, flush=True)
+    dal._progress_timer.start()
+
+    if environment_id and service_id:
+        dal._ctx = RailwayContext(project_id=project_id, environment_id=environment_id, service_id=service_id)
+        if not quiet:
+            print(f"        using explicit IDs (env={environment_id[:8]}..., svc={service_id[:8]}...)", file=sys.stderr, flush=True)
+    else:
+        railway_status = get_railway_status()
+        if railway_status:
+            dal._ctx = RailwayContext(
+                project_id=railway_status.get("projectId"),
+                environment_id=railway_status.get("environmentId"),
+                service_id=railway_status.get("serviceId"),
+            )
+        environment_id = dal._ctx.environment_id
+        service_id = dal._ctx.service_id
+
+    # Get deployment status via API (~1s)
+    progress(1, 5, "Fetching deployment status...", quiet)
+    result.deployment_status = get_deployment_status(service, service_id=service_id)
+
+    # === SSH PRE-CHECK WITH RETRY ===
+    progress(2, 5, "Testing SSH connectivity...", quiet)
+    ssh_available = False
+    ssh_stderr = ""
+    ssh_attempts = [30, 60, 90]
+    for attempt, attempt_timeout in enumerate(ssh_attempts, 1):
+        ssh_code, ssh_stdout, ssh_stderr = run_ssh_query(service, "echo ok", timeout=attempt_timeout)
+        if ssh_code == 0 and "ok" in ssh_stdout:
+            ssh_available = True
+            if not quiet:
+                for line in ssh_stderr.splitlines():
+                    if line.startswith("Using SSH key:"):
+                        print(f"        {line}", file=sys.stderr, flush=True)
+                        break
+            break
+        if not quiet:
+            remaining = len(ssh_attempts) - attempt
+            if remaining > 0:
+                print(f"        SSH attempt {attempt}/{len(ssh_attempts)} failed ({ssh_stderr or 'no response'}), retrying with {ssh_attempts[attempt]}s timeout...", file=sys.stderr, flush=True)
+            else:
+                print(f"        SSH attempt {attempt}/{len(ssh_attempts)} failed ({ssh_stderr or 'no response'}), giving up", file=sys.stderr, flush=True)
+
+    # === PARALLEL EXECUTION ===
+    progress(3, 5, "Running analysis (Redis INFO, slowlog, bigkeys, metrics, logs in parallel)...", quiet)
+
+    def task_redis_info():
+        """Fetch Redis INFO ALL via SSH."""
+        if not ssh_available:
+            return ("failed", f"SSH not available: {ssh_stderr or 'connection failed'}", "")
+        command = 'timeout 30s redis-cli -h localhost -p 6379 -a "$REDISPASSWORD" --no-auth-warning --raw INFO ALL'
+        code, stdout, stderr = run_ssh_query(service, command, timeout=45)
+        if code == 0 and stdout.strip():
+            return ("ok", "", stdout)
+        return ("failed", stderr or "empty response", stdout)
+
+    def task_slowlog():
+        """Fetch Redis SLOWLOG LEN via SSH."""
+        if not ssh_available:
+            return ("failed", f"SSH not available: {ssh_stderr or 'connection failed'}", "")
+        command = 'timeout 30s redis-cli -h localhost -p 6379 -a "$REDISPASSWORD" --no-auth-warning --raw SLOWLOG LEN'
+        code, stdout, stderr = run_ssh_query(service, command, timeout=45)
+        if code == 0 and stdout.strip():
+            return ("ok", "", stdout.strip())
+        return ("failed", stderr or "empty response", "")
+
+    def task_slowlog_get():
+        """Fetch Redis SLOWLOG GET 20 via SSH for actual slow query details."""
+        if not ssh_available:
+            return ("failed", f"SSH not available: {ssh_stderr or 'connection failed'}", "")
+        command = 'timeout 30s redis-cli -h localhost -p 6379 -a "$REDISPASSWORD" --no-auth-warning --raw SLOWLOG GET 20'
+        code, stdout, stderr = run_ssh_query(service, command, timeout=45)
+        if code == 0 and stdout.strip():
+            return ("ok", "", stdout.strip())
+        return ("failed", stderr or "empty response", "")
+
+    def task_bigkeys():
+        """Fetch redis-cli --bigkeys via SSH (SCAN-based, may take longer)."""
+        if not ssh_available:
+            return ("failed", f"SSH not available: {ssh_stderr or 'connection failed'}", "")
+        command = 'timeout 60s redis-cli -h localhost -p 6379 -a "$REDISPASSWORD" --no-auth-warning --bigkeys'
+        code, stdout, stderr = run_ssh_query(service, command, timeout=75)
+        if code == 0 and stdout.strip():
+            return ("ok", "", stdout.strip())
+        return ("failed", stderr or "empty response", "")
+
+    def task_metrics():
+        """Fetch all metrics (disk, CPU, memory) in one API call."""
+        if environment_id and service_id:
+            return get_all_metrics_from_api(environment_id, service_id, hours=metrics_hours)
+        return None
+
+    def task_logs():
+        """Fetch recent logs via API (~3s)."""
+        if skip_logs:
+            return []
+        return get_recent_logs(service, lines=LOG_LINES_DEFAULT,
+                               environment_id=environment_id,
+                               service_id=service_id)
+
+    with ThreadPoolExecutor(max_workers=6) as executor:
+        future_info = executor.submit(task_redis_info)
+        future_slowlog = executor.submit(task_slowlog)
+        future_slowlog_get = executor.submit(task_slowlog_get)
+        future_bigkeys = executor.submit(task_bigkeys)
+        future_metrics = executor.submit(task_metrics)
+        future_logs = executor.submit(task_logs)
+
+        # Collect results
+        info_result = future_info.result()
+        slowlog_result = future_slowlog.result()
+        slowlog_get_result = future_slowlog_get.result()
+        bigkeys_result = future_bigkeys.result()
+        metrics_result = future_metrics.result()
+        logs_result = future_logs.result()
+
+    # === PROCESS RESULTS ===
+    progress(4, 5, "Processing results...", quiet)
+
+    # Redis INFO ALL
+    info_status, info_error, info_raw = info_result
+    if info_status == "ok" and info_raw:
+        result.collection_status["redis_info"] = {"status": "ok"}
+        info = parse_redis_info(info_raw)
+
+        result.overview = extract_overview(info)
+        result.memory = extract_memory(info)
+        result.throughput = extract_throughput(info)
+        result.cache = extract_cache(info)
+        result.persistence = extract_persistence(info)
+        result.keyspace, result.total_keys = extract_keyspace(info)
+        result.command_stats = extract_command_stats(info)
+    else:
+        result.collection_status["redis_info"] = {"status": "failed", "error": info_error}
+        result.errors.append(f"Redis INFO failed: {info_error}")
+
+    # SLOWLOG LEN
+    sl_status, sl_error, sl_raw = slowlog_result
+    if sl_status == "ok" and sl_raw:
+        result.collection_status["slowlog"] = {"status": "ok"}
+        result.slowlog_len = _safe_int(sl_raw)
+    else:
+        result.collection_status["slowlog"] = {"status": "failed", "error": sl_error}
+
+    # SLOWLOG GET 20
+    slg_status, slg_error, slg_raw = slowlog_get_result
+    if slg_status == "ok" and slg_raw:
+        result.collection_status["slowlog_entries"] = {"status": "ok"}
+        result.slowlog_entries = parse_slowlog_get(slg_raw)
+    else:
+        result.collection_status["slowlog_entries"] = {"status": "failed", "error": slg_error}
+
+    # Big keys
+    bk_status, bk_error, bk_raw = bigkeys_result
+    if bk_status == "ok" and bk_raw:
+        result.collection_status["big_keys"] = {"status": "ok"}
+        result.big_keys = parse_bigkeys(bk_raw)
+    else:
+        result.collection_status["big_keys"] = {"status": "failed", "error": bk_error}
+
+    # Metrics
+    if metrics_result:
+        result.collection_status["metrics"] = {"status": "ok"}
+        result.metrics_history = metrics_result.get("metrics_history")
+    else:
+        result.collection_status["metrics"] = {"status": "failed", "error": "no metrics returned"}
+
+    # Logs
+    if logs_result:
+        result.collection_status["logs"] = {"status": "ok", "lines": len(logs_result)}
+        result.recent_logs = logs_result
+    else:
+        result.collection_status["logs"] = {"status": "failed", "error": "no logs returned"}
+
+    # === RECOMMENDATIONS ===
+    progress(5, 5, "Generating recommendations...", quiet)
+    result.recommendations = generate_recommendations(result)
+
+    if not quiet:
+        elapsed = dal._progress_timer.step_elapsed()
+        if elapsed:
+            print(f"        done{elapsed}", file=sys.stderr, flush=True)
+        print(f"  Analysis complete{dal._progress_timer.total_elapsed()}", file=sys.stderr, flush=True)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Single-step debugging
+# ---------------------------------------------------------------------------
+
+def run_single_step(args) -> int:
+    """Run a single collection step for debugging."""
+    service = args.service
+    _init_context(args)
+    environment_id = dal._ctx.environment_id
+    service_id = dal._ctx.service_id
+
+    if args.step == "ssh-test":
+        print(f"Testing SSH to service: {service}", file=sys.stderr)
+        code, stdout, stderr = run_ssh_query(service, "echo ok", timeout=45)
+        print(f"Exit code: {code}")
+        print(f"Stdout: {stdout.strip()}")
+        if stderr:
+            print(f"Stderr: {stderr.strip()}")
+        return 0 if (code == 0 and "ok" in stdout) else 1
+
+    elif args.step == "query":
+        print(f"Running Redis INFO ALL on: {service}", file=sys.stderr)
+        command = 'timeout 30s redis-cli -h localhost -p 6379 -a "$REDISPASSWORD" --no-auth-warning --raw INFO ALL'
+        code, stdout, stderr = run_ssh_query(service, command, timeout=45)
+        print(f"Exit code: {code}")
+        if code == 0 and stdout:
+            info = parse_redis_info(stdout)
+            print(json.dumps(info, indent=2))
+        else:
+            print(f"Error: {stderr or stdout}")
+        return code
+
+    elif args.step == "logs":
+        print(f"Fetching logs for: {service}", file=sys.stderr)
+        logs = get_recent_logs(service, lines=LOG_LINES_DEFAULT,
+                               environment_id=environment_id,
+                               service_id=service_id)
+        print(f"Lines fetched: {len(logs)}")
+        for line in logs:
+            print(line)
+        return 0
+
+    elif args.step == "metrics":
+        print(f"Fetching metrics for: {service}", file=sys.stderr)
+        if environment_id and service_id:
+            metrics = get_all_metrics_from_api(environment_id, service_id)
+            if metrics:
+                print(json.dumps(metrics, indent=2))
+            else:
+                print("No metrics returned", file=sys.stderr)
+                return 1
+        else:
+            print("No environment_id or service_id available", file=sys.stderr)
+            return 1
+        return 0
+
+    else:
+        print(f"Unknown step: {args.step}", file=sys.stderr)
+        return 1
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Redis analysis for Railway services.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument("--service", required=True, help="Service name")
+    parser.add_argument("--json", action="store_true",
+                       help="Output as JSON")
+    parser.add_argument("--timeout", type=int, default=300,
+                       help="Timeout in seconds for analysis (default: 300)")
+    parser.add_argument("--quiet", "-q", action="store_true",
+                       help="Suppress progress messages")
+    parser.add_argument("--skip-logs", action="store_true",
+                       help="Skip log fetching for faster analysis")
+    parser.add_argument("--metrics-hours", type=int, default=168,
+                       help="Hours of metrics history to fetch (default: 168, max: 168)")
+    parser.add_argument("--step", choices=["ssh-test", "query", "logs", "metrics"],
+                       help="Run a single collection step for debugging")
+    parser.add_argument("--project-id", help="Project ID (bypasses railway link)")
+    parser.add_argument("--environment-id", help="Environment ID (bypasses railway link)")
+    parser.add_argument("--service-id", help="Service ID (bypasses railway link)")
+
+    args = parser.parse_args()
+
+    # Single-step debugging mode
+    if args.step:
+        return run_single_step(args)
+
+    # Run analysis
+    result = analyze_redis(args.service, timeout=args.timeout, quiet=args.quiet,
+                           skip_logs=args.skip_logs,
+                           metrics_hours=min(args.metrics_hours, 168),
+                           project_id=args.project_id,
+                           environment_id=args.environment_id,
+                           service_id=args.service_id)
+
+    # Output
+    if args.json:
+        print(json.dumps(asdict(result), indent=2))
+    else:
+        print(format_report(result))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/use-railway/scripts/dal.py
+++ b/.claude/skills/use-railway/scripts/dal.py
@@ -1,0 +1,671 @@
+#!/usr/bin/env python3
+"""Shared Railway infrastructure helpers for database analysis scripts."""
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+from dataclasses import dataclass
+
+LOG_LINES_DEFAULT = 1000  # Number of log lines to fetch via API
+
+
+class ProgressTimer:
+    """Track elapsed time for progress messages."""
+    def __init__(self):
+        self.start_time = None
+        self.step_start_time = None
+
+    def start(self):
+        """Start the overall timer."""
+        self.start_time = datetime.now()
+        self.step_start_time = self.start_time
+
+    def step_elapsed(self) -> str:
+        """Get elapsed time since last step, then reset step timer."""
+        if self.step_start_time is None:
+            return ""
+        now = datetime.now()
+        elapsed = (now - self.step_start_time).total_seconds()
+        self.step_start_time = now
+        if elapsed < 0.1:
+            return ""
+        return f" ({elapsed:.1f}s)"
+
+    def total_elapsed(self) -> str:
+        """Get total elapsed time."""
+        if self.start_time is None:
+            return ""
+        elapsed = (datetime.now() - self.start_time).total_seconds()
+        return f" (total: {elapsed:.1f}s)"
+
+
+# Global timer instance
+_progress_timer = ProgressTimer()
+
+
+@dataclass
+class RailwayContext:
+    """Explicit Railway IDs that bypass railway link."""
+    project_id: Optional[str] = None
+    environment_id: Optional[str] = None
+    service_id: Optional[str] = None
+
+    def ssh_flags(self) -> List[str]:
+        """Return CLI flags for railway ssh."""
+        flags = ["--native"]
+        if self.project_id:
+            flags.extend(["--project", self.project_id])
+        if self.environment_id:
+            flags.extend(["--environment", self.environment_id])
+        if self.service_id:
+            flags.extend(["--service", self.service_id])
+        return flags
+
+    def logs_flags(self) -> List[str]:
+        """Return CLI flags for railway logs."""
+        flags = []
+        if self.environment_id:
+            flags.extend(["--environment", self.environment_id])
+        return flags
+
+
+# Global context — set once at startup, used by all CLI calls
+_ctx = RailwayContext()
+
+
+def _init_context(args) -> None:
+    """Initialize global context from CLI args or railway config."""
+    global _ctx
+    if args.environment_id and args.service_id:
+        _ctx = RailwayContext(
+            project_id=getattr(args, 'project_id', None),
+            environment_id=args.environment_id,
+            service_id=args.service_id,
+        )
+    else:
+        railway_status = get_railway_status()
+        if railway_status:
+            _ctx = RailwayContext(
+                project_id=railway_status.get("projectId"),
+                environment_id=railway_status.get("environmentId"),
+                service_id=railway_status.get("serviceId"),
+            )
+
+
+def progress(step: int, total: int, message: str, quiet: bool = False):
+    """Print progress message to stderr with elapsed time."""
+    if not quiet:
+        # Show elapsed time from previous step (before current step message)
+        elapsed = _progress_timer.step_elapsed()
+        if elapsed:
+            print(f"        done{elapsed}", file=sys.stderr, flush=True)
+        print(f"  [{step}/{total}] {message}", file=sys.stderr, flush=True)
+
+
+def run_railway_command(args: List[str], timeout: int = 30) -> Tuple[int, str, str]:
+    """Run a railway CLI command and return (returncode, stdout, stderr)."""
+    try:
+        result = subprocess.run(
+            ["railway"] + args,
+            capture_output=True,
+            text=True,
+            timeout=timeout
+        )
+        return result.returncode, result.stdout, result.stderr
+    except subprocess.TimeoutExpired:
+        return 124, "", "Command timed out"
+    except FileNotFoundError:
+        return 127, "", "railway CLI not found"
+
+
+def _cli_fatal_error(returncode: int, stderr: str) -> Optional[str]:
+    """Return a friendly error string if the CLI itself is broken, else None.
+
+    These errors are unrecoverable — retrying won't help.
+    """
+    if returncode == 127 or "railway CLI not found" in stderr:
+        return (
+            "Railway CLI not found. "
+            "Install it with: npm i -g @railway/cli  "
+            "or  brew install railway"
+        )
+    lower = stderr.lower()
+    if "unknown flag" in lower or "flag provided but not defined" in lower:
+        return (
+            "Railway CLI is outdated — the --native SSH flag is not supported. "
+            "Update it with: npm i -g @railway/cli@latest  "
+            "or  brew upgrade railway"
+        )
+    return None
+
+
+def run_ssh_query(service: str, command: str, timeout: int = 60,
+                  max_attempts: int = 3) -> Tuple[int, str, str]:
+    """Run a command via railway ssh, retrying up to max_attempts times.
+
+    Passes the command as a single argument after '--'. Railway ssh
+    interprets it through a shell on the remote end, so pipes, env vars,
+    and redirects all work without an explicit sh -c wrapper.
+
+    Retries on non-zero exit code or empty stdout (covers transient errors
+    like 'exec request failed on channel 0').  Never retries when the CLI
+    itself is missing or outdated — those errors are unrecoverable.
+    """
+    flags = _ctx.ssh_flags()
+    # Only pass --service <name> if context didn't already provide --service <id>
+    if not _ctx.service_id:
+        flags += ["--service", service]
+    args = ["ssh"] + flags + ["--", command]
+    last_code, last_stdout, last_stderr = 1, "", ""
+    for attempt in range(1, max_attempts + 1):
+        last_code, last_stdout, last_stderr = run_railway_command(args, timeout)
+        if last_code == 0 and last_stdout.strip():
+            return last_code, last_stdout, last_stderr
+        fatal = _cli_fatal_error(last_code, last_stderr)
+        if fatal:
+            return last_code, last_stdout, fatal
+        if attempt < max_attempts:
+            print(
+                f"        SSH attempt {attempt}/{max_attempts} failed "
+                f"({last_stderr.strip() or 'empty response'}), retrying...",
+                file=sys.stderr, flush=True,
+            )
+    return last_code, last_stdout, last_stderr
+
+
+def run_psql_query(service: str, query: str, timeout: int = 60) -> Tuple[int, str]:
+    """Run a psql query via railway ssh and return (returncode, output).
+
+    Normalizes query whitespace and suppresses psql warnings (e.g. collation
+    version mismatch) that would otherwise pollute stdout.
+    """
+    query = " ".join(query.split())
+    command = f'''PAGER='' psql $DATABASE_URL -P pager=off -t -A -c "{query}" 2>/dev/null'''
+    code, stdout, stderr = run_ssh_query(service, command, timeout)
+    if code != 0:
+        return code, stderr or stdout
+    return 0, stdout
+
+
+def get_railway_status() -> Optional[Dict[str, Any]]:
+    """Get environment and service IDs from Railway config file.
+
+    Reads directly from ~/.railway/config.json instead of calling CLI (~15s saved).
+    """
+    config_path = os.path.expanduser("~/.railway/config.json")
+    if not os.path.exists(config_path):
+        return None
+
+    try:
+        with open(config_path, "r") as f:
+            config = json.load(f)
+
+        # Get linked project for current directory
+        cwd = os.getcwd()
+        projects = config.get("projects", {})
+
+        # Find project config for current directory or parent
+        project_config = None
+        check_path = cwd
+        while check_path != "/":
+            if check_path in projects:
+                project_config = projects[check_path]
+                break
+            check_path = os.path.dirname(check_path)
+
+        if not project_config:
+            return None
+
+        return {
+            "projectId": project_config.get("project"),
+            "environmentId": project_config.get("environment"),
+            "serviceId": project_config.get("service"),
+            "serviceName": project_config.get("name", ""),
+        }
+    except (json.JSONDecodeError, IOError):
+        return None
+
+
+def get_deployment_status(service: str, service_id: Optional[str] = None) -> str:
+    """Get deployment status for service.
+
+    Uses direct API call if service_id provided (~1s), falls back to CLI (~15s).
+    """
+    # Fast path: use API directly if we have service_id
+    if service_id:
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        api_script = os.path.join(script_dir, "railway-api.sh")
+
+        if os.path.exists(api_script):
+            query = '''query svc($id: String!) {
+                service(id: $id) {
+                    deployments(first: 1) {
+                        edges { node { status } }
+                    }
+                }
+            }'''
+            try:
+                result = subprocess.run(
+                    [api_script, query, json.dumps({"id": service_id})],
+                    capture_output=True,
+                    text=True,
+                    timeout=10
+                )
+                if result.returncode == 0:
+                    data = json.loads(result.stdout)
+                    edges = data.get("data", {}).get("service", {}).get("deployments", {}).get("edges", [])
+                    if edges:
+                        return edges[0].get("node", {}).get("status", "UNKNOWN")
+            except (subprocess.TimeoutExpired, json.JSONDecodeError):
+                pass
+
+    # Fallback: use CLI (slow, ~15s)
+    code, stdout, stderr = run_railway_command(
+        ["service", "status", "--service", service, "--json"]
+    )
+    if code != 0:
+        return "UNKNOWN"
+    try:
+        data = json.loads(stdout)
+        status = data.get("status", "UNKNOWN")
+        if data.get("stopped"):
+            return f"{status} (stopped)"
+        return status
+    except json.JSONDecodeError:
+        return "UNKNOWN"
+
+
+def get_all_metrics_from_api(environment_id: str, service_id: str, hours: int = 24) -> Optional[Dict[str, Any]]:
+    """Get disk, CPU, memory, and network usage from Railway metrics API.
+
+    Fetches time-series data and computes trend analysis including
+    min/max/avg, spike detection, and directional trends.
+
+    Args:
+        hours: Hours of history to fetch (default: 24, max: 168)
+    """
+    from datetime import timedelta
+
+    start_date = (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat()
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    api_script = os.path.join(script_dir, "railway-api.sh")
+
+    if not os.path.exists(api_script):
+        return None
+
+    query = '''query metrics($environmentId: String!, $serviceId: String, $startDate: DateTime!, $measurements: [MetricMeasurement!]!) {
+        metrics(environmentId: $environmentId, serviceId: $serviceId, startDate: $startDate, measurements: $measurements) {
+            measurement values { ts value }
+        }
+    }'''
+
+    variables = json.dumps({
+        "environmentId": environment_id,
+        "serviceId": service_id,
+        "startDate": start_date,
+        "measurements": [
+            "DISK_USAGE_GB", "CPU_USAGE", "MEMORY_USAGE_GB",
+            "MEMORY_LIMIT_GB", "CPU_LIMIT",
+            "NETWORK_RX_GB", "NETWORK_TX_GB",
+        ]
+    })
+
+    try:
+        result = subprocess.run(
+            [api_script, query, variables],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+        if result.returncode != 0:
+            return None
+
+        data = json.loads(result.stdout)
+        metrics = data.get("data", {}).get("metrics", [])
+
+        combined = {"disk_usage": None, "cpu_memory": {}, "metrics_history": None}
+
+        # Raw time series keyed by measurement name
+        raw_series: Dict[str, List[Dict[str, Any]]] = {}
+
+        for metric in metrics:
+            measurement = metric.get("measurement")
+            values = metric.get("values", [])
+            if values:
+                raw_series[measurement] = values
+                latest = values[-1].get("value", 0)
+                if measurement == "DISK_USAGE_GB":
+                    combined["disk_usage"] = {
+                        "used_gb": round(latest, 2),
+                        "used": f"{round(latest, 1)} GB"
+                    }
+                elif measurement == "CPU_USAGE":
+                    combined["cpu_memory"]["cpu_percent"] = round(latest, 1)
+                elif measurement == "MEMORY_USAGE_GB":
+                    combined["cpu_memory"]["memory_gb"] = round(latest, 2)
+                elif measurement == "MEMORY_LIMIT_GB":
+                    combined["cpu_memory"]["memory_limit_gb"] = round(latest, 2)
+                elif measurement == "CPU_LIMIT":
+                    combined["cpu_memory"]["cpu_limit"] = round(latest, 1)
+
+        if not combined["cpu_memory"]:
+            combined["cpu_memory"] = None
+
+        # Build time-series history with trend analysis
+        if raw_series:
+            combined["metrics_history"] = _build_metrics_history(raw_series, hours=hours)
+
+        return combined
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
+        pass
+
+    return None
+
+
+def _analyze_window(values: List[Dict[str, Any]], nums: List[float], d: int,
+                    unit: str) -> Dict[str, Any]:
+    """Analyze a single time window of metric data.
+
+    Returns summary stats, trend, spike detection, and downsampled series.
+    """
+    if not nums:
+        return {}
+
+    avg_val = sum(nums) / len(nums)
+    min_val = min(nums)
+    max_val = max(nums)
+
+    entry: Dict[str, Any] = {
+        "unit": unit,
+        "current": round(nums[-1], d),
+        "min": round(min_val, d),
+        "max": round(max_val, d),
+        "avg": round(avg_val, d),
+        "samples": len(nums),
+    }
+
+    # Trend: compare first quarter avg to last quarter avg
+    q_size = max(len(nums) // 4, 1)
+    first_q = nums[:q_size]
+    last_q = nums[-q_size:]
+    first_avg = sum(first_q) / len(first_q)
+    last_avg = sum(last_q) / len(last_q)
+
+    if first_avg > 0:
+        change_pct = round(((last_avg - first_avg) / first_avg) * 100, 1)
+    elif last_avg > 0:
+        change_pct = 100.0
+    else:
+        change_pct = 0.0
+
+    if change_pct > 10:
+        trend_dir = "increasing"
+    elif change_pct < -10:
+        trend_dir = "decreasing"
+    else:
+        trend_dir = "stable"
+
+    entry["trend"] = {
+        "direction": trend_dir,
+        "change_pct": change_pct,
+        "first_quarter_avg": round(first_avg, d),
+        "last_quarter_avg": round(last_avg, d),
+    }
+
+    # Spike detection
+    if len(nums) >= 10:
+        variance = sum((x - avg_val) ** 2 for x in nums) / len(nums)
+        stddev = variance ** 0.5
+        threshold = avg_val + 2 * stddev
+        if stddev > 0 and threshold > 0:
+            spikes = []
+            for v in values:
+                val = v.get("value")
+                if val is not None and val > threshold:
+                    spikes.append({"ts": v["ts"], "value": round(val, d)})
+            if spikes:
+                entry["spikes"] = {
+                    "count": len(spikes),
+                    "threshold": round(threshold, d),
+                    "peaks": spikes[:10],
+                }
+
+    # Compact time series: downsample to ~48 points
+    series_points = []
+    for v in values:
+        ts = v.get("ts")
+        val = v.get("value")
+        if ts is not None and val is not None:
+            series_points.append({"ts": ts, "value": round(val, d)})
+
+    if len(series_points) > 48:
+        step = len(series_points) / 48
+        downsampled = []
+        for i in range(48):
+            idx = int(i * step)
+            downsampled.append(series_points[idx])
+        downsampled.append(series_points[-1])
+        entry["series"] = downsampled
+    else:
+        entry["series"] = series_points
+
+    return entry
+
+
+def _build_metrics_history(raw_series: Dict[str, List[Dict[str, Any]]], hours: int = 168) -> Dict[str, Any]:
+    """Build multi-window time-series history with trend analysis.
+
+    Always produces a full-window analysis. If the window is > 24h, also
+    produces a 24h short-window analysis from the tail of the data so the
+    LLM can compare long-term vs short-term trends.
+    """
+    from datetime import timedelta
+
+    metric_info = {
+        "CPU_USAGE": {"name": "cpu", "unit": "vCPU", "decimals": 2},
+        "MEMORY_USAGE_GB": {"name": "memory", "unit": "GB", "decimals": 2},
+        "MEMORY_LIMIT_GB": {"name": "memory_limit", "unit": "GB", "decimals": 2},
+        "CPU_LIMIT": {"name": "cpu_limit", "unit": "vCPU", "decimals": 2},
+        "DISK_USAGE_GB": {"name": "disk", "unit": "GB", "decimals": 2},
+        "NETWORK_RX_GB": {"name": "network_rx", "unit": "GB", "decimals": 3},
+        "NETWORK_TX_GB": {"name": "network_tx", "unit": "GB", "decimals": 3},
+    }
+
+    # Determine the 24h cutoff timestamp
+    now_ts = int(datetime.now(timezone.utc).timestamp())
+    cutoff_24h = now_ts - (24 * 3600)
+
+    produce_short_window = hours > 24
+
+    full_window: Dict[str, Any] = {}
+    short_window: Dict[str, Any] = {}
+
+    for measurement, values in raw_series.items():
+        info = metric_info.get(measurement)
+        if not info or len(values) < 2:
+            continue
+
+        nums = [v["value"] for v in values if v.get("value") is not None]
+        if not nums:
+            continue
+
+        d = info["decimals"]
+        name = info["name"]
+
+        # Full window analysis
+        full_window[name] = _analyze_window(values, nums, d, info["unit"])
+
+        # Short window (last 24h) analysis
+        if produce_short_window:
+            recent_values = [v for v in values if v.get("ts", 0) >= cutoff_24h]
+            recent_nums = [v["value"] for v in recent_values if v.get("value") is not None]
+            if len(recent_nums) >= 2:
+                short_window[name] = _analyze_window(recent_values, recent_nums, d, info["unit"])
+
+    # Build the result with named windows
+    windows: Dict[str, Any] = {}
+
+    # Label the full window
+    if hours >= 168:
+        full_label = "7d"
+    elif hours >= 72:
+        full_label = f"{hours // 24}d"
+    else:
+        full_label = f"{hours}h"
+
+    windows[full_label] = {
+        "window_hours": hours,
+        "metrics": full_window,
+    }
+
+    if produce_short_window and short_window:
+        windows["24h"] = {
+            "window_hours": 24,
+            "metrics": short_window,
+        }
+
+    return {"windows": windows}
+
+
+def info(msg: str) -> None:
+    """Print an [INFO] message to stdout."""
+    print(f"[INFO] {msg}")
+
+
+def error(msg: str) -> None:
+    """Print an [ERROR] message to stderr and exit."""
+    print(f"[ERROR] {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def confirm_with_user(prompt: str) -> bool:
+    """Get confirmation directly from the terminal.
+
+    Reads from /dev/tty to ensure it's an actual user at a terminal,
+    not piped input. This prevents automated scripts from bypassing confirmation.
+    """
+    try:
+        with open('/dev/tty', 'r') as tty:
+            print(prompt, end=' ', flush=True)
+            response = tty.readline().strip().lower()
+            return response in ('y', 'yes')
+    except (OSError, IOError):
+        print("\n[ERROR] This command requires interactive terminal confirmation.")
+        print("It cannot be run with piped input or in non-interactive mode.")
+        print("Please run this command directly in a terminal.")
+        return False
+
+
+def _safe_int(val: Any, default: int = 0) -> int:
+    """Safely convert a value to int, returning default on failure."""
+    try:
+        return int(val)
+    except (ValueError, TypeError):
+        return default
+
+
+def _safe_float(val: Any, default: float = 0.0) -> float:
+    """Safely convert a value to float, returning default on failure."""
+    try:
+        return float(val)
+    except (ValueError, TypeError):
+        return default
+
+
+def _format_uptime(seconds: int) -> str:
+    """Format uptime seconds into a human-readable string."""
+    if seconds <= 0:
+        return "N/A"
+    days = seconds // 86400
+    hours = (seconds % 86400) // 3600
+    minutes = (seconds % 3600) // 60
+    parts = []
+    if days > 0:
+        parts.append(f"{days}d")
+    if hours > 0:
+        parts.append(f"{hours}h")
+    if minutes > 0 and days == 0:
+        parts.append(f"{minutes}m")
+    return " ".join(parts) if parts else "< 1m"
+
+
+def _trend_indicator(metrics_history: Optional[Dict[str, Any]], metric_name: str) -> str:
+    """Return a compact trend string like ' (^ +15.2% 24h)' for use in summary rows."""
+    if not metrics_history:
+        return ""
+    windows = metrics_history.get("windows", {})
+    window_data = windows.get("24h") or next(iter(windows.values()), None) if windows else None
+    if not window_data or not window_data.get("metrics"):
+        return ""
+    m = window_data["metrics"].get(metric_name)
+    if not m or "trend" not in m:
+        return ""
+    t = m["trend"]
+    direction = t.get("direction", "stable")
+    change = t.get("change_pct", 0)
+    window_label = "24h" if "24h" in windows else next(iter(windows), "")
+    arrow = {"increasing": "^", "decreasing": "v", "stable": "~"}.get(direction, "")
+    if direction == "stable":
+        return f" ({arrow} stable {window_label})"
+    return f" ({arrow} {change:+.1f}% {window_label})"
+
+
+def get_recent_logs(service: str, lines: int = LOG_LINES_DEFAULT,
+                    environment_id: Optional[str] = None,
+                    service_id: Optional[str] = None) -> List[str]:
+    """Get recent logs for LLM analysis.
+
+    Uses API if environment_id and service_id provided (~3s),
+    retries once with longer timeout on failure,
+    falls back to CLI (~27s for 100 lines).
+    """
+    # Fast path: use API directly
+    if environment_id and service_id:
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        api_script = os.path.join(script_dir, "railway-api.sh")
+
+        if os.path.exists(api_script):
+            # Use environmentLogs API with service filter
+            query = f'''query {{
+                environmentLogs(
+                    environmentId: "{environment_id}",
+                    beforeLimit: {lines},
+                    filter: "@service:{service_id}"
+                ) {{
+                    timestamp
+                    message
+                }}
+            }}'''
+            # Try API twice: first with 15s timeout, retry with 30s
+            for attempt_timeout in [15, 30]:
+                try:
+                    result = subprocess.run(
+                        [api_script, query],
+                        capture_output=True,
+                        text=True,
+                        timeout=attempt_timeout
+                    )
+                    if result.returncode == 0:
+                        data = json.loads(result.stdout)
+                        logs_data = data.get("data", {}).get("environmentLogs", [])
+                        if logs_data:
+                            return [f"{log['timestamp']} {log['message']}" for log in logs_data]
+                except (subprocess.TimeoutExpired, json.JSONDecodeError):
+                    pass
+
+    # Fallback: use CLI (slow, ~27s)
+    code, stdout, stderr = run_railway_command(
+        ["logs"] + _ctx.logs_flags() + ["--service", service, "--lines", str(lines)],
+        timeout=30
+    )
+    if code != 0:
+        return []
+
+    logs = []
+    for line in stdout.strip().split("\n"):
+        if line.strip():
+            logs.append(line.strip())
+    return logs

--- a/.claude/skills/use-railway/scripts/enable-pg-stats.py
+++ b/.claude/skills/use-railway/scripts/enable-pg-stats.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""
+Enable pg_stat_statements for query statistics tracking.
+
+This script replicates the frontend's Metrics.tsx enable logic:
+1. Check if pg_stat_statements is already in shared_preload_libraries
+2. If yes, just install the extension
+3. If no, install extension + ALTER SYSTEM + restart
+
+Usage:
+    enable-pg-stats.py --service <name>
+
+Requires: railway CLI linked to the correct project/environment
+
+IMPORTANT: This script requires interactive terminal confirmation.
+It cannot be run with piped input - the user must confirm directly.
+"""
+
+import argparse
+import sys
+import re
+from typing import List
+
+from dal import run_psql_query, info, error, confirm_with_user
+
+
+def parse_preload_libraries(value: str) -> List[str]:
+    """Parse shared_preload_libraries value into clean library names."""
+    if not value or not value.strip():
+        return []
+
+    # Split by comma and clean up quotes
+    libs = []
+    for lib in value.split(","):
+        clean = lib.strip().replace('"', '').replace("'", '')
+        # Validate as PostgreSQL identifier
+        if clean and re.match(r'^[a-zA-Z_][a-zA-Z0-9_]*$', clean):
+            libs.append(clean)
+    return libs
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Enable pg_stat_statements for query performance tracking.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+What this does:
+  1. Checks if pg_stat_statements is already in shared_preload_libraries
+  2. Installs the extension: CREATE EXTENSION IF NOT EXISTS pg_stat_statements
+  3. If library wasn't preloaded: configures shared_preload_libraries and restarts
+
+Note: If restart is needed, the database will have brief downtime.
+
+IMPORTANT: This script requires interactive terminal confirmation and cannot
+be automated. The user must confirm the action directly.
+        """
+    )
+
+    parser.add_argument("--service", required=True, help="Service name (requires linked project)")
+
+    args = parser.parse_args()
+    service = args.service
+
+    # Step 1: Check current shared_preload_libraries
+    info("Checking current shared_preload_libraries...")
+    code, output = run_psql_query(service, "SHOW shared_preload_libraries")
+    if code != 0:
+        error(f"Failed to query shared_preload_libraries: {output}")
+
+    current_libs = output
+    info(f"Current shared_preload_libraries: {current_libs or '<empty>'}")
+
+    # Check if pg_stat_statements is already loaded
+    existing_libs = parse_preload_libraries(current_libs)
+    library_already_loaded = "pg_stat_statements" in existing_libs
+
+    if library_already_loaded:
+        info("pg_stat_statements is already in shared_preload_libraries")
+        needs_restart = False
+    else:
+        info("pg_stat_statements is NOT in shared_preload_libraries (will need restart)")
+        needs_restart = True
+
+    # Step 2: Check if extension is already installed
+    info("Checking if pg_stat_statements extension is installed...")
+    code, output = run_psql_query(service, "SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements'")
+
+    extension_exists = code == 0 and output.strip() == "1"
+
+    if extension_exists:
+        info("pg_stat_statements extension is already installed")
+        needs_install = False
+    else:
+        info("pg_stat_statements extension needs to be installed")
+        needs_install = True
+
+    # If everything is already configured, exit early
+    if not needs_restart and not needs_install:
+        info("pg_stat_statements is fully configured and ready!")
+        print("")
+        print("Query statistics are available. Run:")
+        print("  SELECT * FROM pg_stat_statements LIMIT 10;")
+        return 0
+
+    # Confirm before making changes - REQUIRES interactive terminal
+    print("")
+    print(f"About to make the following changes to '{service}':")
+    if needs_install:
+        print("  - Install pg_stat_statements extension")
+    if needs_restart:
+        print("  - Configure shared_preload_libraries")
+        print("  - Restart the database (brief downtime)")
+    print("")
+
+    if not confirm_with_user("Continue? [y/N]"):
+        print("Cancelled.")
+        return 1
+
+    # Step 3: Install extension
+    if needs_install:
+        info("Installing pg_stat_statements extension...")
+        code, output = run_psql_query(service, "CREATE EXTENSION IF NOT EXISTS pg_stat_statements")
+        if code != 0:
+            error(f"Failed to install extension: {output}")
+        info("Extension installed")
+
+    # Step 4: Configure shared_preload_libraries and restart if needed
+    if needs_restart:
+        info("Configuring shared_preload_libraries...")
+
+        # Add pg_stat_statements to existing libraries
+        if "pg_stat_statements" not in existing_libs:
+            existing_libs.append("pg_stat_statements")
+
+        # Build ALTER SYSTEM with individual quoted values
+        # PostgreSQL syntax: ALTER SYSTEM SET shared_preload_libraries TO 'lib1', 'lib2'
+        quoted_libs = ", ".join(f"'{lib}'" for lib in existing_libs)
+        alter_query = f"ALTER SYSTEM SET shared_preload_libraries TO {quoted_libs}"
+
+        info(f"Setting shared_preload_libraries to: {', '.join(existing_libs)}")
+
+        code, output = run_psql_query(service, alter_query)
+        if code != 0:
+            error(f"Failed to configure shared_preload_libraries: {output}")
+        info("shared_preload_libraries configured")
+
+        # Step 5: Restart the service
+        info("Restarting database service...")
+        code, stdout, stderr = run_railway_command(["restart", "--service", service, "--yes"])
+        if code != 0:
+            error(f"Failed to restart service: {stderr or stdout}")
+
+        print("")
+        info("Database is restarting. Query statistics will be available shortly.")
+        print("")
+        print("After restart completes, verify with:")
+        print("  SHOW shared_preload_libraries;")
+        print("  SELECT * FROM pg_stat_statements LIMIT 5;")
+    else:
+        print("")
+        info("pg_stat_statements is now ready!")
+        print("")
+        print("Query statistics are available. Run:")
+        print("  SELECT * FROM pg_stat_statements LIMIT 10;")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/use-railway/scripts/pg-extensions.py
+++ b/.claude/skills/use-railway/scripts/pg-extensions.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""
+Manage PostgreSQL extensions for Railway database services.
+
+This script replicates the frontend's Extensions.tsx logic:
+- List available and installed extensions
+- Install extensions with automatic dependency handling
+- Uninstall extensions with dependency checking
+
+Usage:
+    pg-extensions.py --service <name> list
+    pg-extensions.py --service <name> install <extension> [--version <ver>]
+    pg-extensions.py --service <name> uninstall <extension>
+    pg-extensions.py --service <name> info <extension>
+
+Requires: railway CLI linked to the correct project/environment
+
+IMPORTANT: Install and uninstall require interactive terminal confirmation.
+They cannot be run with piped input - the user must confirm directly.
+"""
+
+import argparse
+import sys
+import json
+from typing import Tuple, List, Optional, Dict, Any
+from dataclasses import dataclass
+
+from dal import run_psql_query, info, error, confirm_with_user
+
+
+@dataclass
+class Extension:
+    """PostgreSQL extension info."""
+    name: str
+    default_version: str
+    installed_version: Optional[str]
+    comment: str
+
+
+def list_extensions(service: str, json_output: bool = False) -> List[Extension]:
+    """List all available and installed extensions."""
+    # Query available extensions
+    available_query = "SELECT name, default_version, comment FROM pg_available_extensions ORDER BY name"
+    code, output = run_psql_query(service, available_query)
+    if code != 0:
+        error(f"Failed to query available extensions: {output}")
+
+    # Parse available extensions
+    available = {}
+    for line in output.strip().split("\n"):
+        if not line:
+            continue
+        parts = line.split("|")
+        if len(parts) >= 2:
+            name = parts[0].strip()
+            version = parts[1].strip()
+            comment = parts[2].strip() if len(parts) > 2 else ""
+            available[name] = {"version": version, "comment": comment}
+
+    # Query installed extensions
+    installed_query = "SELECT extname, extversion FROM pg_extension"
+    code, output = run_psql_query(service, installed_query)
+    if code != 0:
+        error(f"Failed to query installed extensions: {output}")
+
+    # Parse installed extensions
+    installed = {}
+    for line in output.strip().split("\n"):
+        if not line:
+            continue
+        parts = line.split("|")
+        if len(parts) >= 2:
+            name = parts[0].strip()
+            version = parts[1].strip()
+            installed[name] = version
+
+    # Build extension list
+    extensions = []
+    for name, info in available.items():
+        ext = Extension(
+            name=name,
+            default_version=info["version"],
+            installed_version=installed.get(name),
+            comment=info["comment"]
+        )
+        extensions.append(ext)
+
+    if json_output:
+        print(json.dumps([{
+            "name": e.name,
+            "defaultVersion": e.default_version,
+            "installedVersion": e.installed_version,
+            "comment": e.comment
+        } for e in extensions], indent=2))
+    else:
+        # Print formatted output
+        installed_exts = [e for e in extensions if e.installed_version]
+        available_exts = [e for e in extensions if not e.installed_version]
+
+        print(f"\n{len(installed_exts)} Extension(s) installed:")
+        print("-" * 60)
+        if installed_exts:
+            for e in sorted(installed_exts, key=lambda x: x.name):
+                print(f"  {e.name} (v{e.installed_version})")
+        else:
+            print("  (none)")
+
+        print(f"\n{len(available_exts)} Extension(s) available:")
+        print("-" * 60)
+        for e in sorted(available_exts, key=lambda x: x.name)[:30]:
+            desc = f" - {e.comment[:50]}..." if e.comment and len(e.comment) > 50 else f" - {e.comment}" if e.comment else ""
+            print(f"  {e.name} (v{e.default_version}){desc}")
+        if len(available_exts) > 30:
+            print(f"  ... and {len(available_exts) - 30} more")
+
+    return extensions
+
+
+def get_extension_dependencies(service: str, extension: str) -> List[str]:
+    """Get dependencies for an extension."""
+    query = f"""
+        SELECT DISTINCT unnest(pev.requires) as dependency
+        FROM pg_available_extension_versions pev
+        WHERE pev.name = '{extension}' AND pev.requires IS NOT NULL
+        ORDER BY dependency
+    """
+    code, output = run_psql_query(service, query)
+    if code != 0:
+        return []
+
+    deps = []
+    for line in output.strip().split("\n"):
+        if line.strip():
+            deps.append(line.strip())
+    return deps
+
+
+def get_extension_dependents(service: str, extension: str) -> List[str]:
+    """Get extensions that depend on this extension."""
+    query = f"""
+        SELECT e.extname AS dependent_extension
+        FROM pg_depend d
+        JOIN pg_extension e ON d.objid = e.oid
+        JOIN pg_extension ref_e ON d.refobjid = ref_e.oid
+        WHERE d.classid = 'pg_extension'::regclass
+            AND d.refclassid = 'pg_extension'::regclass
+            AND ref_e.extname = '{extension}'
+        ORDER BY dependent_extension
+    """
+    code, output = run_psql_query(service, query)
+    if code != 0:
+        return []
+
+    dependents = []
+    for line in output.strip().split("\n"):
+        if line.strip():
+            dependents.append(line.strip())
+    return dependents
+
+
+def is_extension_installed(service: str, extension: str) -> Tuple[bool, Optional[str]]:
+    """Check if extension is installed, return (installed, version)."""
+    query = f"SELECT extversion FROM pg_extension WHERE extname = '{extension}'"
+    code, output = run_psql_query(service, query)
+    if code == 0 and output.strip():
+        return True, output.strip()
+    return False, None
+
+
+def is_extension_available(service: str, extension: str) -> bool:
+    """Check if extension is available in the image."""
+    query = f"SELECT 1 FROM pg_available_extensions WHERE name = '{extension}'"
+    code, output = run_psql_query(service, query)
+    return code == 0 and output.strip() == "1"
+
+
+def install_extension(service: str, extension: str, version: Optional[str] = None) -> bool:
+    """Install an extension with CASCADE (auto-install dependencies)."""
+    # Check if available
+    if not is_extension_available(service, extension):
+        error(f"Extension '{extension}' is not available in this database image")
+
+    # Check if already installed
+    installed, curr_ver = is_extension_installed(service, extension)
+    if installed:
+        info(f"Extension '{extension}' is already installed (v{curr_ver})")
+        return True
+
+    # Check dependencies and confirm - REQUIRES interactive terminal
+    deps = get_extension_dependencies(service, extension)
+    if deps:
+        print(f"\nInstalling '{extension}' will also install these dependencies: {', '.join(deps)}")
+    else:
+        print(f"\nAbout to install extension '{extension}'")
+
+    if not confirm_with_user("Continue? [y/N]"):
+        print("Cancelled.")
+        return False
+
+    # Build install query
+    query = f'CREATE EXTENSION IF NOT EXISTS "{extension}"'
+    if version:
+        query += f" VERSION '{version}'"
+    query += " CASCADE"  # Auto-install dependencies
+
+    info(f"Installing extension '{extension}'...")
+    code, output = run_psql_query(service, query)
+    if code != 0:
+        error(f"Failed to install extension: {output}")
+
+    # Verify installation
+    installed, ver = is_extension_installed(service, extension)
+    if installed:
+        info(f"Successfully installed '{extension}' (v{ver})")
+        if deps:
+            info(f"Dependencies installed: {', '.join(deps)}")
+        return True
+    else:
+        error("Extension installation failed - not found after CREATE EXTENSION")
+    return False
+
+
+def uninstall_extension(service: str, extension: str) -> bool:
+    """Uninstall an extension."""
+    # Check if installed
+    installed, ver = is_extension_installed(service, extension)
+    if not installed:
+        info(f"Extension '{extension}' is not installed")
+        return True
+
+    # Check for dependents
+    dependents = get_extension_dependents(service, extension)
+    if dependents:
+        error(f"Cannot uninstall '{extension}' - these extensions depend on it: {', '.join(dependents)}")
+
+    # Confirm - REQUIRES interactive terminal
+    print(f"\nAbout to uninstall '{extension}' (v{ver})")
+    if not confirm_with_user("Continue? [y/N]"):
+        print("Cancelled.")
+        return False
+
+    # Uninstall
+    query = f'DROP EXTENSION IF EXISTS "{extension}"'
+    info(f"Uninstalling extension '{extension}'...")
+    code, output = run_psql_query(service, query)
+    if code != 0:
+        error(f"Failed to uninstall extension: {output}")
+
+    # Verify
+    installed, _ = is_extension_installed(service, extension)
+    if not installed:
+        info(f"Successfully uninstalled '{extension}'")
+        return True
+    else:
+        error("Extension uninstall failed - still found after DROP EXTENSION")
+    return False
+
+
+def extension_info(service: str, extension: str, json_output: bool = False):
+    """Show detailed info about an extension."""
+    # Check availability
+    available = is_extension_available(service, extension)
+    if not available:
+        error(f"Extension '{extension}' is not available in this database image")
+
+    # Get info
+    query = f"SELECT name, default_version, comment FROM pg_available_extensions WHERE name = '{extension}'"
+    code, output = run_psql_query(service, query)
+    if code != 0:
+        error(f"Failed to get extension info: {output}")
+
+    parts = output.strip().split("|")
+    name = parts[0].strip() if parts else extension
+    default_version = parts[1].strip() if len(parts) > 1 else "unknown"
+    comment = parts[2].strip() if len(parts) > 2 else ""
+
+    installed, installed_version = is_extension_installed(service, extension)
+    deps = get_extension_dependencies(service, extension)
+    dependents = get_extension_dependents(service, extension) if installed else []
+
+    if json_output:
+        print(json.dumps({
+            "name": name,
+            "defaultVersion": default_version,
+            "installedVersion": installed_version,
+            "comment": comment,
+            "dependencies": deps,
+            "dependents": dependents
+        }, indent=2))
+    else:
+        print(f"\nExtension: {name}")
+        print("-" * 40)
+        print(f"  Default Version: {default_version}")
+        print(f"  Installed: {'Yes (v' + installed_version + ')' if installed else 'No'}")
+        if comment:
+            print(f"  Description: {comment}")
+        if deps:
+            print(f"  Dependencies: {', '.join(deps)}")
+        if dependents:
+            print(f"  Required by: {', '.join(dependents)}")
+        print()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Manage PostgreSQL extensions for Railway services.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  List all extensions (safe, no confirmation needed):
+    pg-extensions.py --service my-postgres list
+
+  Install an extension (requires interactive confirmation):
+    pg-extensions.py --service my-postgres install postgis
+    pg-extensions.py --service my-postgres install pgvector --version 0.5.0
+
+  Uninstall an extension (requires interactive confirmation):
+    pg-extensions.py --service my-postgres uninstall postgis
+
+  Get extension info (safe, no confirmation needed):
+    pg-extensions.py --service my-postgres info pg_stat_statements
+
+IMPORTANT: Install and uninstall require interactive terminal confirmation.
+They cannot be automated or run with piped input.
+        """
+    )
+
+    parser.add_argument("--service", required=True, help="Service name (requires linked project)")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+
+    subparsers = parser.add_subparsers(dest="command", help="Command to run")
+
+    # list command (safe - no confirmation)
+    list_parser = subparsers.add_parser("list", help="List available and installed extensions")
+
+    # install command (requires interactive confirmation)
+    install_parser = subparsers.add_parser("install", help="Install an extension (requires confirmation)")
+    install_parser.add_argument("extension", help="Extension name")
+    install_parser.add_argument("--version", "-v", help="Specific version to install")
+
+    # uninstall command (requires interactive confirmation)
+    uninstall_parser = subparsers.add_parser("uninstall", help="Uninstall an extension (requires confirmation)")
+    uninstall_parser.add_argument("extension", help="Extension name")
+
+    # info command
+    info_parser = subparsers.add_parser("info", help="Show extension info")
+    info_parser.add_argument("extension", help="Extension name")
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        return 1
+
+    service = args.service
+
+    if args.command == "list":
+        list_extensions(service, json_output=args.json)
+    elif args.command == "install":
+        install_extension(service, args.extension, version=args.version)
+    elif args.command == "uninstall":
+        uninstall_extension(service, args.extension)
+    elif args.command == "info":
+        extension_info(service, args.extension, json_output=args.json)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/use-railway/scripts/railway-api.sh
+++ b/.claude/skills/use-railway/scripts/railway-api.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Railway GraphQL API helper
+# Usage: railway-api.sh '<graphql-query>' ['<variables-json>']
+
+set -e
+
+SKILL_ID="use-railway"
+SKILL_VERSION="${RAILWAY_SKILL_VERSION:-1.2.0}"
+
+export RAILWAY_CALLER="${RAILWAY_CALLER:-skill:${SKILL_ID}@${SKILL_VERSION}}"
+export RAILWAY_AGENT_SESSION="${RAILWAY_AGENT_SESSION:-railway-skill-$(date +%s)-$$}"
+
+if ! command -v jq &>/dev/null; then
+  echo '{"error": "jq not installed. Install with: brew install jq"}'
+  exit 1
+fi
+
+CONFIG_FILE="$HOME/.railway/config.json"
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo '{"error": "Railway config not found. Run: railway login"}'
+  exit 1
+fi
+
+TOKEN=$(jq -r '.user.token' "$CONFIG_FILE")
+
+if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
+  echo '{"error": "No Railway token found. Run: railway login"}'
+  exit 1
+fi
+
+if [[ -z "$1" ]]; then
+  echo '{"error": "No query provided"}'
+  exit 1
+fi
+
+# Build payload with query and optional variables
+if [[ -n "$2" ]]; then
+  PAYLOAD=$(jq -n --arg q "$1" --argjson v "$2" '{query: $q, variables: $v}')
+else
+  PAYLOAD=$(jq -n --arg q "$1" '{query: $q}')
+fi
+
+HEADERS=(
+  -H "Authorization: Bearer $TOKEN"
+  -H "Content-Type: application/json"
+  -H "X-Railway-Skill-Id: $SKILL_ID"
+  -H "X-Railway-Skill-Version: $SKILL_VERSION"
+  -H "X-Railway-Agent-Session: $RAILWAY_AGENT_SESSION"
+)
+
+curl -s https://backboard.railway.com/graphql/v2 "${HEADERS[@]}" -d "$PAYLOAD"

--- a/.claude/skills/webjs-file-issue/SKILL.md
+++ b/.claude/skills/webjs-file-issue/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: webjs-file-issue
+description: Use this skill when the user asks to file a new task, create an issue, or track new work on the webjsdev/webjs project. Trigger phrases include "file a task for X", "create an issue for Y", "track this as a todo", "add this to the todo list", "open an issue about Z", "make this an issue", "file a bug for ...", "add a new task", or any natural-language ask to create new tracked work in the webjs project at https://github.com/orgs/webjsdev/projects/1. The skill creates the GitHub issue with an appropriate body, adds it to the project board, and reports the new issue number.
+when_to_use: |
+  Examples that should trigger this skill:
+    "file a task for adding dark mode"
+    "create an issue for the streaming bug"
+    "track this as a todo: refactor the rate limiter"
+    "open an issue about the broken sitemap"
+    "add a new task to investigate the SSR race"
+    "make this an issue"
+  Do NOT trigger for: starting work on an existing issue (webjs-start-work), listing what's open (webjs-list-todos), or asks that are clearly about closing/editing an existing issue.
+---
+
+# File a new issue on the webjs project board
+
+The webjsdev/webjs project tracks new work through GitHub issues added to the project board at https://github.com/orgs/webjsdev/projects/1. This skill captures a fresh task as an issue, files it, and adds it to the board so it appears in the Todo column.
+
+## Inputs
+
+The user describes the task in natural language. Extract:
+- A short, imperative-mood **title** (under 70 chars; the same shape as a good commit subject).
+- A **`dogfood:` title prefix** when the task came from dogfooding, meaning it surfaced while actually building a real app with webjs and hitting a framework gap, an idiomatic-code divergence, or a rough edge (the way #353 and #356 were found). Prefix the title `dogfood:` so the board shows at a glance which issues came from real app-building versus planned framework work. A task that did not come from building an app (a planned feature, a refactor, an internal bug) takes no such prefix. If it is unclear whether the task is dogfood-originated, ask, or look at whether the user was driving a generated/example app when the issue came up.
+- A **body** that follows the issue-body convention used in #112 / #113 / #114: short problem statement, design rationale or context, acceptance-criteria checklist, AND an implementation-notes section (see "Issue body convention" below for why this is mandatory).
+- A **label** if the type is clear from the description: `enhancement` for new features and improvements, `bug` for something broken, `documentation` for docs work. If unclear, default to `enhancement` (the most common case on this project).
+
+If the user's description is very thin (e.g. "track adding dark mode as a todo"), ask one clarifying question before filing: "Want me to scope this out a bit, or file the placeholder with just the title and you'll fill in details on the issue later?" Either answer is fine; just confirm before creating.
+
+## Steps
+
+1. **Create the issue AND assign it to vivek7405.** Every webjs issue is assigned to the owner (vivek7405) at creation so the project board shows ownership at a glance.
+
+   ```sh
+   gh issue create --repo webjsdev/webjs \
+     --title "<title>" \
+     --body "<body>" \
+     --label <label> \
+     --assignee vivek7405
+   ```
+
+   Capture the returned issue URL and number.
+
+2. **Add it to the project board.**
+
+   ```sh
+   gh project item-add 1 --owner webjsdev --url <issue-url>
+   ```
+
+   The card lands in Todo by default. No need to set Status explicitly.
+
+3. **Report back briefly.** One short message: issue number + title + a link, and confirm it's on the board in Todo. Do not invent next steps; just confirm the artefact exists.
+
+## Issue body convention
+
+**Standing assumption: every issue here is implemented by an AI agent working COLD.** The agent that picks the issue up has ZERO access to the conversation that produced it. So the body is the entire brief, and it MUST carry enough for that agent to implement correctly without re-discovering everything: not just WHAT and WHY, but WHERE (the concrete files / functions / dirs to edit), the LANDMINES (known gotchas, prior incidents, non-obvious constraints), and the INVARIANTS to respect. An issue that reads well to a human who was in the room but leaves an agent guessing the file paths is under-specified. The user should not have to ask for this each time; it is the default.
+
+Before filing a scoped issue, do LIGHT codebase grounding so the body cites real landmarks, not vague pointers: grep for the relevant files / functions, name them with their paths (and approximate line or symbol when helpful), and capture any gotcha you hit or know about. A few `grep` / `Read` calls now save the implementing agent a cold-start investigation later.
+
+Match the shape of issues #112 / #113 / #114 (all visible on the board):
+
+```markdown
+## Problem
+
+<one or two paragraphs describing what's wrong or what needs adding>
+
+## Design / approach
+
+<the proposed direction, alternatives considered if any, references to prior art>
+
+## Implementation notes (for the implementing agent)
+
+<the WHERE and the LANDMINES, grounded in the actual codebase:>
+- Where to edit: the concrete file(s) / function(s) / dir(s), with paths (e.g. `packages/cli/lib/create.js` `scaffoldApp()` around L275). Name the entry points, not just the area.
+- Landmines / gotchas: known traps, a prior incident this touches (link the issue/PR), runtime or build constraints, anything non-obvious that will bite an agent who does not know it.
+- Invariants to respect: project rules the change must not break (link AGENTS.md items where relevant).
+- Tests + docs surfaces the change must touch (which test layer, which markdown / docs-site pages).
+
+## Acceptance criteria
+
+- [ ] <observable result 1>
+- [ ] <observable result 2>
+- [ ] A counterfactual proves the test actually fires (where applicable)
+- [ ] Tests cover the new behaviour, at every layer it touches
+- [ ] Docs / AGENTS.md updated if the public surface changed
+```
+
+The **Implementation notes** section is mandatory for any scoped issue, precisely because the implementer is an agent with no conversational context. If you cannot fill it in without investigating, do the light grounding first (above), then file.
+
+For a thin placeholder (user just wants the line item tracked, explicitly deferring the detail), skip the Design / Implementation-notes / Acceptance sections; leave a single short paragraph in Problem and mark the issue "needs scoping". Use this ONLY when the user opts into a bare placeholder; the default for a real task is the fully-grounded body above.
+
+## What this skill does NOT do
+
+- Does not start a branch or open a PR. Those happen via `webjs-start-work` once the user is ready to work the item.
+- Does not move the card out of Todo. Status changes happen via `webjs-start-work` (Todo to In progress) and the `Closes #N` automation (In progress to Done on merge).
+- Does not consult or update internal task trackers or memory.
+
+## Failure handling
+
+- If `gh issue create` fails (auth, label missing, network): surface the error and offer to retry with adjusted args.
+- If `gh project item-add` fails after the issue was created: report the partial state ("issue #N created but not on board yet") and offer to add it manually.
+- If the user's description seems to duplicate an existing open issue: search the board first with `gh project item-list 1 --owner webjsdev --format json` and ask whether to file anyway or use the existing one.

--- a/.claude/skills/webjs-list-todos/SKILL.md
+++ b/.claude/skills/webjs-list-todos/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: webjs-list-todos
+description: Use this skill when the user asks what work is open or pending on the webjsdev/webjs project board. Trigger phrases include "what are the current todo items", "what's pending", "list todos", "what's open", "what should I work on", "show me the open issues", "any open work for webjs", "what's in progress", "what's on the board", or any natural-language query about open items on the webjs project at https://github.com/orgs/webjsdev/projects/1. The skill calls `gh project item-list` and returns a bucketed view (Todo / In progress / Done) so the user sees the current state straight from the source of truth.
+when_to_use: |
+  Examples that should trigger this skill:
+    "what are the current todo items"
+    "what's pending"
+    "list webjs todos"
+    "what should I work on next"
+    "show me the open issues"
+    "any open work on the webjs board"
+    "what's in progress right now"
+  Do NOT trigger for: starting work on a specific issue (webjs-start-work handles that), filing a new task (webjs-file-issue handles that), or asking about closed/done items only (those are queryable but not the primary intent of this skill).
+---
+
+# List open work on the webjs project board
+
+The webjsdev/webjs project tracks work on the GitHub Project at https://github.com/orgs/webjsdev/projects/1. This skill returns a current snapshot bucketed by Status, queried straight from GitHub. Do NOT consult internal task trackers or memory for this question.
+
+## Steps
+
+1. **Fetch the board state.**
+
+   ```sh
+   gh project item-list 1 --owner webjsdev --format json
+   ```
+
+2. **Bucket by Status** (Todo, In progress, Done) and pretty-print each bucket with issue numbers and titles. If the user explicitly asked for only one bucket (e.g. "what's in progress"), filter accordingly.
+
+3. **Default presentation.** Show Todo and In progress always. Show Done only if the user asks for it, or if both Todo and In progress are empty.
+
+4. **For each item, show:** `#<number>  <title>`. Wrap in markdown so the user can click through.
+
+## Example output shape
+
+```
+Todo:
+  #112  Elide browser download of display-only component modules
+  #113  Ship pre-built dist/ alongside src/ for @webjsdev/core
+  #114  Rate-limit defaultKey trusts unverified X-Forwarded-For
+
+In progress:
+  (none)
+```
+
+If everything is in Done or the board is empty, say so explicitly.
+
+## What this skill does NOT do
+
+- Does not move cards, file new issues, or open PRs. Those are sibling skills (`webjs-start-work`, `webjs-file-issue`).
+- Does not show closed issues outside the project board.
+- Does not consult `~/.claude/projects/.../memory/` or any internal task tracker.
+
+## Failure handling
+
+- If `gh` returns an auth error: surface it directly to the user and suggest `gh auth refresh -s project`.
+- If the project list is empty: report "Project board is empty" instead of fabricating items.

--- a/.claude/skills/webjs-start-work/SKILL.md
+++ b/.claude/skills/webjs-start-work/SKILL.md
@@ -1,0 +1,414 @@
+---
+name: webjs-start-work
+description: Use this skill when the user asks to start work on a tracked GitHub issue in the webjsdev/webjs project. Trigger phrases include "work on #112", "start work on issue 113", "tackle #114", "begin issue N", "let's work on the dist issue", "pick up #N", or any natural-language reference to starting an open issue on the webjs project board. The skill creates a feature branch off main, moves the project card to "In progress", and sets up the workspace so subsequent commits and the PR have the right shape.
+when_to_use: |
+  Examples that should trigger this skill:
+    "work on #112"
+    "start work on issue 113"
+    "tackle the dist issue (#113)"
+    "pick up #114"
+    "let's start work on the rate-limit issue"
+    "begin work on the next webjs todo"
+  Do NOT trigger for: opening a PR for already-in-progress work, merging, asking what issues are open, or any non-webjs project.
+---
+
+# Start work on a webjs GitHub issue
+
+The webjsdev/webjs project tracks work on the GitHub Project board at https://github.com/orgs/webjsdev/projects/1. This skill runs the start-of-work lifecycle whenever the user wants to begin a tracked issue.
+
+## Inputs
+
+The user's request typically names an issue by number (e.g. `#112`) or by description (e.g. "the dist issue"). Resolve the number first:
+
+- If the user said `#N` explicitly, use N.
+- If they described the issue by topic, run `gh project item-list 1 --owner webjsdev --format json` and match against item titles. If multiple match, ask the user to disambiguate.
+
+## Steps
+
+1. **Verify the issue exists and is open. Assign it to vivek7405 if not already.**
+
+   ```sh
+   gh issue view <N> --repo webjsdev/webjs --json title,number,state,labels,assignees
+   ```
+
+   If `state` is CLOSED, ask the user whether to reopen it or pick a different one. Otherwise note the title for the branch slug. If `assignees` is empty (an issue filed by drive-by contributor), assign to vivek7405:
+
+   ```sh
+   gh issue edit <N> --repo webjsdev/webjs --add-assignee vivek7405
+   ```
+
+2. **Confirm the issue is on the project board.**
+
+   ```sh
+   gh project item-list 1 --owner webjsdev --format json --jq ".items[] | select(.content.number == <N>)"
+   ```
+
+   If not present, add it: `gh project item-add 1 --owner webjsdev --url https://github.com/webjsdev/webjs/issues/<N>`.
+
+3. **Verify we're on `main` with a clean tree and pull latest.** If the working tree is dirty or already on a feature branch, STOP and ask the user how to proceed. Do not silently abandon their work.
+
+   ```sh
+   git status --porcelain    # must be empty
+   git branch --show-current # must be main
+   git pull origin main
+   ```
+
+4. **Create the feature branch AND push it to origin immediately.** Pick the prefix from the issue labels: `enhancement` to `feat/`, `bug` to `fix/`, `documentation` to `docs/`, otherwise `chore/`. Build the slug from the issue title (lowercase, kebab-case, max 30 chars, drop conjunctions). The empty branch goes to GitHub right away so the work survives any local-machine failure even before the first commit.
+
+   ```sh
+   git checkout -b <prefix>/<slug>
+   git push -u origin <prefix>/<slug>
+   ```
+
+   After this step, ALSO push after every subsequent commit (`git push` is cheap and is the safety net against losing work). Do not batch multiple commits before pushing.
+
+5. **Move the project card from Todo to In progress.** Resolve the four IDs and call `item-edit`:
+
+   ```sh
+   N=<issue-number>
+   PROJECT_ID=$(gh project view 1 --owner webjsdev --format json --jq '.id')
+   ITEM_ID=$(gh project item-list 1 --owner webjsdev --format json --jq ".items[] | select(.content.number == $N) | .id")
+   STATUS_FIELD_ID=$(gh project field-list 1 --owner webjsdev --format json --jq '.fields[] | select(.name == "Status") | .id')
+   IN_PROGRESS_OPT_ID=$(gh project field-list 1 --owner webjsdev --format json --jq '.fields[] | select(.name == "Status") | .options[] | select(.name == "In progress") | .id')
+   gh project item-edit --project-id "$PROJECT_ID" --id "$ITEM_ID" --field-id "$STATUS_FIELD_ID" --single-select-option-id "$IN_PROGRESS_OPT_ID"
+   ```
+
+6. **Open a DRAFT PR immediately, BEFORE writing any code.** This is the single most important ordering rule and it is NOT optional: the PR is opened at the START of the work, not the end. The whole point of the PR is to be the durable, append-only record of the change AS IT HAPPENS: every per-logical-unit commit lands on it, every design-rationale / decision / follow-up context comment is posted to it the moment that discussion happens, and every self-review round is posted to it. NONE of that is possible if the PR does not exist yet, which is exactly the failure a late `gh pr create` causes. So open it now, empty branch and all (the branch was already pushed in step 4).
+
+   Push one trivial initial commit if the branch has no commits yet (GitHub refuses a PR with no diff between head and base); the cleanest is to defer this step to immediately after the FIRST real commit, but never later than that. Open it as a DRAFT so it is clearly not yet ready to merge:
+
+   ```sh
+   gh pr create --repo webjsdev/webjs --base main --head <prefix>/<slug> --draft \
+     --assignee vivek7405 \
+     --title "<conventional-prefix>: <imperative summary>" \
+     --body "Closes #<N>
+
+   <one-line summary of the intended change; this is a living body, refined as the work lands>"
+   ```
+
+   The title MUST carry a conventional-commit prefix from the first moment (feat/fix/perf/breaking appear in the changelog; chore/docs/test/refactor do not), because a single-commit PR squashes on the COMMIT subject and a multi-commit PR on the TITLE. Refine the title/body as the change takes shape; the draft is a living document. Capture the issue URL/number for `Closes #<N>` (already in the body).
+
+   From here on, the PR exists, so: commit per logical unit and push after each (the commits stream onto the PR); post design-rationale / decision / follow-up context comments to the PR as those discussions happen (do not hoard them for the end); and run every self-review round ON the PR. The PR is marked **ready for review** (`gh pr ready <N>`) only at the very end, AFTER the Definition of done is satisfied and the self-review loop has converged to a clean round. Opening late and dumping everything at the end is the anti-pattern this step exists to kill.
+
+7. **Report back briefly.** One short message to the user: issue title + number, new branch name, draft PR URL, "project card moved to In progress". Then continue with the actual work the user asked for.
+
+## Definition of done (MUST be satisfied BEFORE marking the draft PR ready for review)
+
+The PR is already open as a draft (step 6). "Done" here means the gate to flip it from draft to **ready for review** (`gh pr ready <N>`), NOT the gate to create it. Everything below must be addressed, and the self-review loop must have converged, before that flip.
+
+Doc drift is the #1 way a framework rots. Documentation MUST stay in sync with code on the same PR that changes the code. Do NOT defer doc work to a follow-up issue, do NOT let the user have to ask. Before marking the draft PR ready for review, walk through every surface below and either update it OR write "N/A because <reason>" in the PR body so the omission is visible.
+
+### Surfaces to consider on EVERY PR
+
+1. **Tests, ALL applicable layers (not just unit).** This is generative, not "write a unit test and move on". The repo has several test layers; for the changed surface, add or update coverage in EVERY layer the change can affect, then RUN that layer. Walk them explicitly:
+   - **Unit** (`packages/*/test/**`, `test/**`): pure logic, analysers, helpers. Include counterfactuals (the negative case that proves the check actually fires).
+
+     **Running a counterfactual safely (commit FIRST, revert through git, never sed-toggle source).** A counterfactual proves a test fails when the fix is removed. The safe order is: COMMIT the fix and its test first, THEN temporarily revert ONLY the source guard, run the test (expect red), and restore. Two traps that have bitten this exact flow, both avoidable:
+       - **Do NOT `git checkout <file>` to "undo" a counterfactual while the fix is still uncommitted.** `git checkout` restores the file to HEAD, which (pre-commit) has NO fix, so it silently throws the whole fix away, not just the temporary neutering. Commit first; then `git checkout <file>` restores the COMMITTED fix, which is what you want.
+       - **Do NOT neuter a guard by `sed`-rewriting the source to a sentinel like `''`.** Shell-quoted escapes land as a literal control byte (a NUL/0x01) inside the file, which renders like a space in an editor but breaks the comparison and makes `grep` treat the file as binary (silent empty matches). Verify any byte-level edit with `od -c` on the changed line and `tr -d '\000' | wc -c` for stray NULs. Prefer the Edit tool (toggle the guard, run, toggle back) or `git stash`/`git stash pop` of the committed source over `sed` for this.
+     The clean loop: commit fix+test, run test green, `git stash push -- <source-file>` (or Edit out the guard), run test red, `git stash pop` (or Edit the guard back), run test green again. The test having gone red in the middle is the proof.
+   - **Integration** (server-level through `createRequestHandler`, SSR pipeline, scaffolds): behaviour across modules without a browser.
+   - **Browser** (`*/test/**/browser/*.test.js`, run via `npm run test:browser` / `wtr`): anything touching hydration, client render, DOM, slots, the client router, custom-element upgrade.
+   - **E2E** (`test/e2e/e2e.test.mjs`, run via `WEBJS_E2E=1`): full-stack behaviour observable only in a real browser against the running blog example, including **network probes** (was a module fetched or not), navigation, and streaming.
+   - **Smoke** (`test/examples/*/smoke/*`): the example apps still boot and serve their key routes.
+   - **Cross-runtime (Bun)** (`node scripts/run-bun-tests.js`, needs `bun` on PATH; the `test/bun/*.mjs` scripts run under both runtimes): webjs runs on **Node 24+ OR Bun** (#508), so a change to runtime-sensitive code MUST be proven on Bun, not just Node. "Runtime-sensitive" = the serializer (Blob/File/FormData/typed arrays), the server request/listener path (the node:http vs `Bun.serve` shells, SSE, WebSocket upgrade, compression, timeouts), streams + `node:fs` (anything using `Readable.fromWeb` / `pipeline` / `createWriteStream`), `node:crypto`, the TS stripper, `AsyncLocalStorage`, or ANY `node:*` API whose behaviour Bun may implement differently. The Bun matrix (`scripts/run-bun-tests.js`) re-runs the `node:test` suite under `bun test` and FAILS on a genuine divergence; a divergence is a REAL bug to fix in the framework (this session found 5: a FormData fresh-identity serializer crash, a `Readable.fromWeb` `put()` hang, the amaro vs Node TS-strip error code, a JSC vs V8 error-message format, a link-unsafe `node:module` named import), not something to skip. Add a `test/bun/<feature>.mjs` cross-runtime assert script (wired into the CI `bun` job) for any new surface that touches the listener / serializer / streaming path. A test that is legitimately Node-only (asserts a node:http internal, the built-in stripper, `module.registerHooks` seeding, the node `ws`-library subsystem) goes on the runner's documented `DENYLIST` with a reason and a note of where the Bun behaviour IS covered; if a file MIXES runtime-agnostic and Node-only tests, SPLIT the Node-only ones into their own file so the rest still runs on Bun. See `agent-docs/testing.md`.
+
+   The trap: **`npm test` does NOT run the browser, e2e, or Bun layers** (browser needs `wtr`; e2e is gated behind `WEBJS_E2E=1`; the Bun matrix is a separate `node scripts/run-bun-tests.js` and runs only the Node path otherwise). A green `npm test` is necessary but NOT sufficient. If the change can affect client behaviour or the served wire, you MUST run `npm run test:browser` and/or `WEBJS_E2E=1 node --test test/e2e/e2e.test.mjs`; if it touches runtime-sensitive code (above), you MUST run `node scripts/run-bun-tests.js` (with `bun` installed) and the `test/bun/*.mjs` scripts under Bun, then report the result. Reasoning "the unit tests pass" while shipping a change that alters what the browser downloads, OR that diverges on Bun, is the exact failure this rule exists to prevent.
+
+   Acceptance criteria phrased in browser terms ("network probe", "renders without JS", "hydrates", "no console errors") are a hard signal that an e2e or browser test is REQUIRED, not optional. For each layer, either add/update coverage and run it, or write "N/A because <reason>" in the PR body. If a pre-existing test in a layer you ran is already red on `main`, say so explicitly (with proof) rather than letting it look like your regression.
+2. **Every markdown file in the repo** that describes the changed surface. The rule is generative, not enumerative. Run `git ls-files '*.md'` and for each path ask: does this file describe behaviour, surface, or invariants this PR changed? If yes, update it on this PR. Common surfaces (non-exhaustive, this list is NOT a substitute for the git query):
+   - `AGENTS.md` (framework root + every nested one under `packages/*/`, `docs/`, `website/`, `examples/*/`, `packages/ui/packages/*/`).
+   - `agent-docs/*.md` (advanced, components, deployment, recipes, testing, typescript, lit-muscle-memory-gotchas, framework-dev, metadata, styling, built-ins).
+   - `packages/*/README.md` (npm-visible for every published package). Update when the public surface, install layout, or expected usage changed.
+   - `CHANGELOG.md` (per-package, under `changelog/<pkg>/<version>.md`). Generated automatically by the pre-commit hook on version-bump commits; review and add migration notes for breaking changes. Without a version bump, no changelog entry.
+   - `CLAUDE.md` (only if a Claude Code rule is specifically added; framework conventions go in AGENTS.md).
+   - `.github/*.md` (issue templates, PR templates, contributing) when a workflow rule shifts.
+3. **User-facing docs site** under `docs/app/docs/<topic>/page.ts` (these are `.ts` files, not markdown, so they're excluded by the markdown query but they're the canonical user-facing reference). If the change is visible to a user reading the docs site, update the matching topic page. Add a new page if the surface is new and there's no obvious home.
+4. **Scaffold templates** under `packages/cli/templates/`. Update if the change affects what `webjs create` generates (default code, agent config files, `.hooks` content, scaffolded `package.json` shape).
+5. **The MCP server** (the standalone `@webjsdev/mcp` package, `packages/mcp/src/{mcp,mcp-docs,mcp-source}.js`, extracted from the CLI in #415; `webjs mcp` and `npx @webjsdev/mcp` both run it). The MCP is how AI agents learn and introspect webjs, so it must stay in lockstep with the surfaces it exposes. Update it whenever the change touches what it serves:
+   - **Introspection tools** (`list_routes` / `list_actions` / `list_components` / `check`): if you change the route table shape, the action/RPC-hash scheme, component registration, or a `webjs check` rule, update the matching tool projection so the MCP reports reality.
+   - **Knowledge layer** (resources + `init` + `docs` + prompts): the resources are the `agent-docs/*.md` corpus + `AGENTS.md`, so a docs change is picked up automatically (it is bundled at `prepack`). But if you add or rename an `agent-docs` file, ADD A NEW INVARIANT, change the execution model, or add an authoring concept an agent should know, also: (a) confirm the `init` primer still pulls the right `AGENTS.md` sections (it sources the Execution-model + Invariants headings, so a heading rename breaks it), and (b) add a guided-workflow PROMPT for any new common recipe (a new page/route/action/component-shaped task). New recipes without a prompt are a silent gap.
+   - **Heuristic:** if your change would make an agent reading only the old MCP output write WRONG webjs code, the MCP is part of your change. Update it on this PR, with a test in `packages/mcp/test/*.test.mjs`, or write "N/A because <reason>" in the PR body.
+6. **The editor plugins** (epic #381, now under `packages/editors/` after the #402 reorg; the suite overview that maps all three + the full dev/publish flow is `packages/editors/AGENTS.md`): the all-in-one `webjs` VS Code extension (`packages/editors/vscode`), `webjs.nvim` (`packages/editors/nvim`), and the shared language service `@webjsdev/intellisense` (`packages/editors/intellisense`, renamed from `@webjsdev/ts-plugin` in #416/#420) that BOTH editor plugins bundle. Note `webjs.nvim` is developed here but installed by users from a SEPARATE repo `webjsdev/webjs.nvim` (a git-subtree split of `packages/editors/nvim`), so nvim changes are not live until that split is re-pushed on release (`packages/editors/nvim/PUBLISHING.md`). They are how a developer's editor understands webjs, so they must stay in lockstep with the surfaces they expose. Update them whenever the change touches what they project. Do this automatically when the task demands it; never make the user ask:
+   - **The shared language service** (`packages/editors/intellisense/src`): any change to its behaviour (the template parser, tag/attr resolution, completions, diagnostics, hover) flows to EVERY consumer. **This is the single most-missed step, and it reds CI:** both editor plugins **bundle** a copy. The VS Code extension esbuilds it at vsix package time (`packages/editors/vscode/scripts/build.mjs`, picked up automatically), but webjs.nvim ships a COMMITTED verbatim copy that a drift test enforces. So after ANY edit under `packages/editors/intellisense/src/` (even one line) you MUST, before pushing, run `node packages/editors/nvim/scripts/vendor-intellisense.mjs` then `git add -f packages/editors/nvim/vendor` (the copy is under a gitignored `node_modules/`), or the `packages/editors/nvim/test/vendor-sync.test.mjs` drift guard FAILS the "Unit + integration" CI job ("vendored intellisense src is byte-identical ..."). Confirm with `node --test packages/editors/nvim/test/vendor-sync.test.mjs`. The coupling is bidirectional: the nvim copy under `packages/editors/nvim/vendor/node_modules/@webjsdev/intellisense/` is GENERATED, so NEVER hand-edit it when working in the nvim package (edit `intellisense/src` + re-vendor instead); the same drift guard reds CI either way. The scaffold ALSO pins `@webjsdev/intellisense` in app node_modules + tsconfig (intelligence with no editor plugin; tsserver dedupes when both load), so an intellisense version bump is a real publish. (Full flow also in `packages/editors/intellisense/AGENTS.md`.)
+   - **Template grammars / injection queries** (`packages/editors/vscode/syntaxes/webjs-{html,css,svg}.json` AND `packages/editors/nvim/queries/{typescript,javascript}/injections.scm`): if you add, rename, or change the recognised tags (`html`/`css`/`svg`) or how `${...}` holes are scoped, update BOTH the VS Code TextMate grammars and the Neovim treesitter queries, plus their tests (`packages/editors/vscode/test/extension.test.mjs` begin-patterns, `packages/editors/nvim/test/selftest.lua` injection assertions).
+   - **Snippets + commands** (`packages/editors/vscode/snippets/webjs.json`, `src/extension.js`; webjs.nvim `lua/webjs/` commands): if you add or rename a common recipe or a surfaced command, add/adjust the matching snippet/command (the vscode test cross-checks contributed commands against `registerCommand`).
+   - **Publishing on a release.** The VS Code extension publishes to the VS Marketplace + Open VSX (`packages/editors/vscode/PUBLISHING.md`); webjs.nvim is a git subtree split mirrored to `webjsdev/webjs.nvim` (re-run the split + force-push after a change; `packages/editors/nvim/PUBLISHING.md`). Bump `packages/editors/vscode/package.json` `version` when its bundle changes.
+   - **Heuristic:** if your change would make an editor highlight wrong, resolve the wrong definition, offer a stale snippet/command, or ship a drifted bundle, the editor plugins are part of your change. Update them on the same PR (with the matching test), re-vendor the nvim copy, or write "N/A because <reason>" in the PR body.
+7. **Marketing copy** at `website/app/page.ts`. Update if the change touches positioning or any landing-page claim ("no-build", "AI-first", "web components first", etc.).
+8. **Dogfood apps must still build and boot. MANDATORY GATE, run it automatically, never wait to be asked.** The framework ships four in-repo apps that consume it: `examples/blog` (the demo), `website`, `docs`, and `packages/ui/packages/website`. A framework change that compiles is NOT done until all four still serve. This is a recurring miss: running only the blog e2e and stopping is the exact failure this gate exists to prevent. For ANY change to `packages/core`, `packages/server`, `packages/cli`, the dist build, the importmap, or anything that alters what the browser fetches, you MUST run the full four-app check below before marking the draft PR ready for review and report its result in the PR body. The user should never have to ask "did you check the apps?".
+
+   **The check (copy-paste, runs in seconds):**
+   - `examples/blog`: covered by the e2e suite. Run `WEBJS_E2E=1 node --test test/e2e/e2e.test.mjs` (it exercises the blog in a real browser; if `dist/` is built it runs in dist mode, so it covers the production wire too).
+   - `website` / `docs` / `packages/ui/packages/website`: boot each through `createRequestHandler` in PROD mode and GET a real route, asserting status < 400. Write this harness to a file INSIDE the repo (bare `@webjsdev/*` specifiers only resolve from the repo's `node_modules`, NOT from `/tmp`), run it, delete it:
+
+     ```js
+     // ./.boot-check.mjs  (write at repo root, run `node ./.boot-check.mjs`, then rm)
+     import { createRequestHandler } from '@webjsdev/server';
+     import { resolve } from 'node:path';
+     const apps = [
+       { name: 'website',    dir: 'website',                      routes: ['/'] },
+       { name: 'docs',       dir: 'docs',                         routes: ['/', '/docs/<a-page-you-touched>'] },
+       { name: 'ui-website', dir: 'packages/ui/packages/website', routes: ['/'] },
+     ];
+     let fail = false;
+     for (const app of apps) {
+       try {
+         const h = await createRequestHandler({ appDir: resolve(app.dir), dev: false });
+         if (h.warmup) await h.warmup();
+         for (const r of app.routes) {
+           const resp = await h.handle(new Request('http://localhost' + r));
+           const html = resp.status < 400 ? await resp.text() : '';
+           // Every modulepreload hint must resolve: a preload pointing at a
+           // 404 is a real bug (the preload set must be a subset of the
+           // servable set). Probe each same-origin href through the SAME
+           // in-process handler (method-agnostic, so no GET-vs-HEAD trap).
+           const preloads = [...html.matchAll(/<link[^>]+rel=["']modulepreload["'][^>]*href=["']([^"']+)["']/g)].map((m) => m[1]).filter((h) => h.startsWith('/'));
+           const broken = [];
+           for (const p of preloads) { const pr = await h.handle(new Request('http://localhost' + p)); if (pr.status >= 400) broken.push(`${p}->${pr.status}`); }
+           const ok = resp.status < 400 && broken.length === 0;
+           console.log(`${ok ? 'OK  ' : 'FAIL'} ${app.name} ${r} -> ${resp.status}, preloads=${preloads.length}, broken=[${broken.join(', ')}]`);
+           if (!ok) fail = true;
+         }
+       } catch (e) { console.log(`FAIL ${app.name} boot threw: ${String(e.message).split('\n')[0]}`); fail = true; }
+     }
+     process.exit(fail ? 1 : 0);
+     ```
+
+     Add `GET` routes for any page you edited (a 307/308 redirect is a pass; it has no body to inspect). If a change is browser-wire-affecting (dist build, importmap, core exports), also assert the served `<script type="importmap">` reflects the change (e.g. grep the response HTML for the expected URLs), since a 200 alone does not prove the right modules were wired. The harness above also asserts no `modulepreload` hint 404s, which is how the #158 / #159 class of bug (a preload pointing at a server-only or phantom file the auth gate refuses to serve) gets caught automatically. **Auditing a LIVE deployed app instead of an in-process handler? Probe each preload URL with GET, never HEAD: the dev/prod server only serves source files on GET, so a HEAD probe 404s every source URL and makes a healthy app look completely broken.**
+   - The scaffold: `webjs create` generates an app whose `package.json` pins `@webjsdev/*: 'latest'` (see `packages/cli/lib/create.js`). If the change alters generated code, agent-config files, or expected scaffold behaviour, update `packages/cli/templates/` AND the generators in `packages/cli/lib/`, then confirm a freshly scaffolded app passes `webjs check` and `webjs test` (the `test/scaffolds/` suite covers this; run it). Even when you believe no scaffold change is needed, grep `packages/cli/templates/` for anything the change renamed or removed (e.g. a dropped dist filename, a changed import path) so a stale template reference does not ship into every new app.
+
+   Report the four-app result in the PR body (e.g. "Dogfood: blog e2e 50/50; website / docs / ui-website boot 200 in dist mode; scaffold N/A"). "All four apps verified" with no evidence is not acceptable.
+9. **Version bumps must keep the workspace consistent.** When you bump a `packages/<pkg>/package.json` `version` (which the pre-commit hook turns into a changelog):
+   - Every in-repo dependent that pins that package (grep `"@webjsdev/<pkg>"` across all `package.json` files) must have its range updated so the new version still satisfies it. A minor bump (`0.7.x` -> `0.8.0`) falls outside a `^0.7.0` range, so npm stops linking the local workspace and pulls the published copy instead.
+   - Regenerate `package-lock.json` (`npm install --package-lock-only`) and commit it. `npm ci` (which CI runs) fails on any lockfile desync, so an unsynced lock is a guaranteed red CI.
+   - Prefer a patch bump for a feature/fix when the repo keeps a package in a single minor line (check whether dependents pin `^0.x.0`); reach for a minor bump only when you are also ready to bump every dependent range.
+10. **PR body** itself documents the change for reviewers. Include `Closes #<N>`, a short summary, and a test plan checklist.
+
+### How to use the checklist
+
+For each item above, explicitly answer one of:
+- **Updated**, with the file path in the commit/PR body.
+- **N/A because**, with a one-sentence reason.
+
+The "every markdown file" rule is generative because new markdown files appear over a project's lifetime. A closed enumeration silently excludes them; the git query is the source of truth.
+
+If you find yourself writing "N/A" for every item except tests, that is a smell. Most user-visible code changes touch at least one markdown file and the relevant `docs/app/docs/<topic>/page.ts` page.
+
+### Concrete examples from recent PRs
+
+- PR #110 (`fs.watch` + Web Crypto): updated `AGENTS.md` (no-build claim wording), `packages/server/AGENTS.md` (file watcher mention), `docs/app/docs/{configuration,deployment,no-build}/page.ts` (chokidar → fs.watch). Tests covered the watcher, the boundary, and the migration.
+- PR #111 (module-graph asset gate): updated `AGENTS.md` (new invariant about the gate), `packages/server/AGENTS.md` (gate + guardrail invariants), `docs/app/docs/no-build/page.ts` (new "authorisation gate" subsection). Tests covered the gate end-to-end.
+- PR #117 (core dist bundles): updated `docs/app/docs/no-build/page.ts` (the @webjsdev/core exception note), `packages/core/README.md` (tarball layout), `packages/core/AGENTS.md` (invariant 1 rewording), `packages/server/AGENTS.md` (importmap.js module-map entry).
+
+If a PR ships without ANY of those touches and the change is user-visible, the PR is incomplete; do not mark it ready for review (leave it draft until the surfaces are addressed).
+
+## Anatomy of a complete PR: four things, always
+
+A finished PR is not just a diff. It carries four artifacts, and the PR is considered incomplete until all four exist. Treat this as the standing definition of a complete PR, applied automatically on every one:
+
+1. **A meaningful, conventional-commit-prefixed title.** The title MUST start with a conventional-commit type so the changelog is generated automatically: `feat:` for a new user-facing capability, `fix:` for a bug fix, `perf:` for a performance improvement, `breaking:` (or a `!` like `feat!:`) for a breaking change, and `chore:` / `docs:` / `test:` / `refactor:` for changes that should NOT appear in the changelog. After the prefix, be imperative, specific, what-and-why, under ~72 chars total. Example: `fix: shared rich values round-trip through the RPC serializer`, not `Fix serializer` or the issue number alone.
+   **Why this matters (do not skip it):** PRs are squash-merged, so the PR TITLE becomes the squash commit subject on `main`, and `scripts/backfill-changelog.js` (run by the pre-commit hook on a version bump) extracts changelog entries by matching that subject against `^(feat|fix|breaking|perf)(scope)?!?:` and reads the commit BODY (the PR description) for the entry text. A non-prefixed title (e.g. `De-flake the prefetch e2e...`) produces ZERO changelog entries, which forces a hand-written changelog at release time, which is wrong. NEVER hand-write `changelog/<pkg>/<version>.md`: fix the PR title/body instead so the automation produces it. If you ever find yourself about to hand-write a changelog, stop and correct the merged PR titles (or the release's source commits) so they are conventional-commit prefixed.
+2. **A meaningful body.** `Closes #<N>` near the top, a summary, what changed and why, the deliberately-excluded decisions, a test plan, and the docs surfaces touched (per the Definition of done above). This is the architectural narrative of the change. Because the squash commit body IS this PR description, write the first paragraph so it reads as the changelog entry text (the generator uses it), then continue with the rest.
+3. **Context comments.** The reasoning from the working conversation that the diff and body do not capture, posted on the PR as the discussion happens (see "Capture significant design discussion as PR comments" below). The PR is the durable memory; the chat transcript is not.
+4. **Review comments: a summary AND per-code-line comments.** Every review (each self-review round and any manual review) posts a summary review plus an inline comment on each finding's `file:line` (see "Every PR review is posted ON the PR" below).
+
+All four are written in the owner's voice (first person, plain, no AI/agent framing, no machinery tells) and free of AGENTS.md invariant 11 banned glyphs. The sections below specify the mechanics for items 3 and 4.
+
+**Header every standalone comment with a short, meaningful bold heading** so a future reader (human or AI) knows what the comment is and what it is about before reading it. Put the heading on its own first line as bold markdown, blank line, then the body. Write the heading to fit THIS comment, do not pick from a fixed list. A good heading names the kind of comment and its topic, e.g. `**Design rationale: why analysis moved off boot, and what it costs**`, `**Review: lazy-boot model holds, one real bug**`, `**Decision: kept the derived gate over a declared allowlist**`, `**Follow-up: aliased-expose 404 filed as #N**`. A bare category word like `Context` or `Review` is the floor, not the goal; prefer a heading that also says the subject, so a reader scanning the PR's comment list can tell the boot-rationale note from the elision-review note without opening either. **Per-line inline review comments do NOT need a heading** because their `file:line` anchor already classifies them as review; keep those terse. The heading rule is for standalone, top-level comments (the PR body in item 2 is exempt, since it has its own `## Summary` structure).
+
+## Pre-merge self-review loop (MUST run before reporting "ready for merge")
+
+Saying "ready for merge" before the review loop completes is the single biggest source of low-quality PRs. The recurring pattern to AVOID: claim ready-for-merge, the user requests a review, find issues, fix them, claim ready-for-merge again, repeat 4-5 cycles before a review comes back clean. The cure is to run that loop internally BEFORE the first "ready" signal. The user should only hear "ready to merge" after the loop has converged.
+
+### Every PR review is posted ON the PR (summary + per-line comments)
+
+This applies to EVERY review of a PR: each round of the self-review loop below, AND any time the user asks you to "review the PR" manually. A review that lives only in your chat reply is not a review the PR carries. For every review you perform, post BOTH:
+
+1. **A summary review comment** stating what you reviewed and the overall outcome (which surface, what you found, or that it is clean). This is what you leave at the "Finish your review" step.
+2. **A per-line inline comment for each finding**, anchored at `file:line` on the diff. Each states the PROBLEM only, the way a reviewer flags it before anyone has fixed it. Do NOT bake the resolution into the finding (ending a finding with "...Fixed." is wrong). The resolution is recorded separately, as a threaded reply, in the programmer half below. Post the won't-fix and false-positive findings as inline comments too, so the concern sits on the exact line; their reply carries the reason they are left as is.
+
+**Both go in ONE review object, via the reviews API, never as plain issue comments.** The summary and all its inline comments are submitted together with a single `POST /pulls/<N>/reviews` (the `--input review.json` call below). That is what makes GitHub render them as a grouped unit: the summary plus a `reviewed these changes - N comments` trail of the per-line comments beneath it. A review observation posted with `gh pr comment` (an issue comment) instead lands as a standalone box with NO trail, visually identical to a general comment, and disconnected from its inline notes. So: review content (summaries AND observations, every round) goes through the reviews API; `gh pr comment` issue comments are reserved for NON-review context (the design-rationale, decision, and follow-up notes from the section further down). Do not scatter review remarks across loose issue comments. If you catch yourself about to `gh pr comment` something that is really a review observation, fold it into the review summary instead. (Note: GitHub's mobile app tints every comment you author a light blue because of the `Author`/`Member` badge; that tint is author-association, NOT a review marker, so it is not a reliable signal. The reliable signal that something is a review is the `reviewed these changes` trail, which only a review object has.)
+
+**Voice: write every PR comment as the repo owner (vivek7405) would write it.** First person, plain, the way a person reviews code. The whole review trail (summary AND inline comments) must read as if the owner typed it, not as a bot reporting a procedure. This is non-negotiable and applies to every PR review, forever, not just the one in front of you.
+
+Hard rules:
+
+- **No AI/agent framing.** Never refer to yourself as an AI or agent, never say "self-review", never number the rounds ("Round 2", "round 3 of the loop"), never say "you requested a manual re-review" or otherwise narrate the review process.
+- **No machinery tells.** A human reviewer does NOT mention CI status ("CI is green", "all 5 gates pass"), test counts ("96 tests pass"), or meta-scaffolding ("Went over the X, Y, Z paths. Comments inline."). CI state lives in the checks UI, not in prose; the inline comments are obviously inline. Drop all of it.
+- **Inline findings are terse and state the problem, not the fix.** Point at what is wrong on that line, the way a reviewer flags it. "`expose as exp` won't match this, so the route 404s." / "Says it scans on boot, but this is lazy now." / "A same-mtime, same-size recreate could still serve a stale parse, does that need handling?" The fix and won't-fix reasons go in the threaded reply, never in the finding itself.
+- **Reference commits as clickable links, not bare SHAs.** GitHub does NOT auto-link a SHA inside a backtick code span, so `` `5fd02dc` `` renders as dead text. Always write a markdown link: `[`5fd02dc`](https://github.com/webjsdev/webjs/commit/5fd02dc)` (the short SHA resolves fine in the URL). Same for any commit referenced in a summary, reply, or context comment, e.g. "Fixed in [`<sha>`](https://github.com/webjsdev/webjs/commit/<sha>).". A reviewer wants to click straight to the diff.
+- **The summary may go broad.** Because the per-line comments carry the specifics, the summary is the place for an opinionated, architecture-level take: what the change does well, what you would keep an eye on, the one thing that actually matters. Still first person and plain, just not restricted to pointing at one line. Think of how you would brief a teammate on the PR in three or four sentences.
+
+The test for any comment: if it reads like a person who owns this repo wrote it offhand, it passes. If it reads like a status report or a tool's output, rewrite it.
+
+### Follow the real review flow: reviewer, then programmer, both roles
+
+GitHub's manual flow is: **Start a review**, add inline comments, **Finish your review**, leave a summary, **Submit review**. Then the author **fixes** each comment, **replies in the thread** that it is fixed, and **resolves** the thread. The reviewer and the programmer are the same person here, but that does NOT collapse the two roles into one comment. Reproduce the whole flow over the API every time, both halves.
+
+**Reviewer half (one review object).** Submit the summary plus all inline findings together with a single `POST /pulls/<N>/reviews`. That one call is Start-review + add-comments + Finish + Submit. Findings state the problem, not the fix.
+
+```sh
+gh api -X POST repos/webjsdev/webjs/pulls/<N>/reviews --input review.json
+# review.json: { "commit_id": "<head-sha>", "event": "COMMENT",
+#   "body": "<summary>",
+#   "comments": [ { "path": "<file>", "line": <n>, "side": "RIGHT", "body": "<the problem, no fix>" } ] }
+```
+
+Use `event: "COMMENT"` (GitHub forbids APPROVE / REQUEST_CHANGES on your own PR). Each inline `line` must be a line that is in the PR diff (a changed or added line), or the API rejects the whole review; if a finding sits on an unchanged line outside the diff, note it path-level in the summary. Verify with `gh api repos/webjsdev/webjs/pulls/<N>/comments`.
+
+**Programmer half (after the review is submitted).** For each finding:
+
+1. **Fix it** on the branch (commit + push), or decide it is a won't-fix.
+2. **Reply in the comment's thread** with the resolution. This is the "reply that it is fixed" step, not an edit of the finding:
+   ```sh
+   gh api -X POST repos/webjsdev/webjs/pulls/<N>/comments/<comment_id>/replies \
+     --input reply.json   # reply.json: { "body": "Fixed in [`<sha>`](https://github.com/webjsdev/webjs/commit/<sha>)." }
+   ```
+3. **Resolve the thread** once it is concluded (fixed, or won't-fix-with-reason). Threads resolve ONLY via GraphQL `resolveReviewThread`; REST cannot do it:
+   ```sh
+   # list unresolved review-thread node IDs
+   gh api graphql -f query='query{repository(owner:"webjsdev",name:"webjs"){pullRequest(number:<N>){reviewThreads(first:50){nodes{id isResolved}}}}}' \
+     --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false) | .id'
+   # resolve one
+   gh api graphql -f query='mutation($t:ID!){resolveReviewThread(input:{threadId:$t}){thread{isResolved}}}' -f t=<threadId>
+   ```
+
+**Every round repeats the whole flow.** Each round of the self-review loop, and each manual re-review the user asks for, is a NEW review object: a fresh `POST /pulls/<N>/reviews` carrying that round's summary and findings, followed by fix + reply + resolve for that round's threads. Never append a later round's findings into an earlier round's review, and never edit a prior finding to say it is fixed (reply instead). A round that finds nothing still posts a short summary review saying it is clean, with no inline comments.
+
+Banned prose glyphs (AGENTS.md invariant 11) apply to every comment, reply, and summary body, so keep them clean.
+
+### Capture significant design discussion as PR comments (standing, automatic)
+
+Beyond review findings, proactively record the *reasoning* behind a PR as comments on it, without being asked. The PR is the durable memory a future reader (an AI agent picking the work back up, or the owner months later) consults to understand WHY the code is the way it is. The git diff shows WHAT changed; the conversation that produced it (tradeoffs weighed, alternatives rejected, constraints discovered, "we chose X over Y because Z") is lost unless it is written onto the PR. The chat transcript is not durable PR context; the PR comment is.
+
+**Trigger (automatic, not on request):** whenever a conversation about an open PR produces a non-obvious design decision, a rejected alternative, a tradeoff accepted with eyes open, or context the diff alone does not explain, post it as a PR comment AS THE DISCUSSION HAPPENS. Use `gh pr comment <N> --body-file <f>` for cross-cutting narrative, or an inline `file:line` comment when it pertains to specific code. Same voice as review comments: first person, plain, owner's voice, no AI/agent framing, no machinery tells, no banned glyphs.
+
+**This runs continuously across the PR's whole life, not once.** Because the PR opens as a draft at the START (step 6), there is a place to post from the first commit onward, so keep adding context throughout: when a mid-work investigation changes the approach, when a reviewer finding is resolved a particular way, when an edge case is discovered, when something is deliberately deferred. The acceptance test is concrete: a future AI agent (or the owner) who opens ONLY this PR, with zero access to this chat, should find every non-obvious "why" already written on it. If reconstructing the reasoning would require the chat transcript, a context comment is missing. Do not save it all for a single end-of-work dump; that recreates the exact gap the early-draft-PR rule exists to close.
+
+**What's worth capturing (judgement, not a checklist):** why an approach won over a credible alternative; an experiment tried and reverted, with the reason; a tradeoff accepted knowingly (a cold-start cost, a known-small race window left in, a documented edge case); a constraint or invariant discovered mid-work; anything you would want explained if you returned to the PR with no memory of the conversation. Skip the trivial: routine fixes, mechanical edits, anything the diff already makes obvious. The bar is "would a future agent be missing important context without this", not "log everything". When the PR body already covers a decision, a short comment is fine or skip it; do not duplicate the whole body into a comment.
+
+### How the loop works
+
+The draft PR is already open (step 6), so reviews post to it from the first round. Do NOT mark it ready for review or report "ready for merge" yet. Run rounds of self-review until ONE round finds zero new issues. Each round must:
+
+1. **Spawn a fresh general-purpose subagent** (use the Agent tool with `subagent_type: "general-purpose"`). A fresh subagent has no prior context on the decisions you made, so it's less likely to share your blind spots.
+
+   **Working-tree safety (non-negotiable).** Review subagents share THIS session's working directory. A reviewer that runs `git checkout` / `switch` / `reset` / `stash` / `rebase` silently moves the main session's HEAD off the branch (it has happened: a reviewer ran `git checkout main` mid-loop and the local checkout regressed; commits were safe only because they were already pushed). Two defenses, apply BOTH:
+   - Spawn the reviewer with `isolation: "worktree"` so any git op it runs is contained in its own throwaway worktree, never the main checkout. (A read-only reviewer needs no shared state; `gh pr diff` reads from GitHub.)
+   - Include the read-only git prohibition in the prompt (it is baked into the template below). Belt and suspenders: isolation contains the damage, the prompt prevents the attempt.
+   - After EACH round returns, before acting on findings, run a one-line repo-health check and repair if needed (the worktree isolation in the first bullet has itself corrupted the main repo: spawning isolated reviewers flipped the main repo's `core.bare` to `true` and left a locked `.claude/worktrees/agent-*` worktree, after which `git checkout` failed with "this operation must be run in a work tree"). Check ALL of:
+     - `git rev-parse --is-inside-work-tree` is `true` and `git config --get core.bare` is NOT `true`. If the work tree is broken, repair with `git config core.bare false`, then `git worktree prune` (and `git worktree remove -f -f .claude/worktrees/agent-*` for any locked leftover). Do NOT touch the user's OWN unrelated worktrees (anything outside `.claude/worktrees/`).
+     - `git rev-parse --abbrev-ref HEAD` is still the feature branch and `git status` is clean. If HEAD moved (or points at a now-deleted branch / `0000000`), `git checkout -f <feature-branch>` (or `main` post-merge) restores it.
+     The merge / commits are always safe on GitHub regardless; this only repairs the LOCAL repo. Nothing is lost. If you cannot cleanly repair, `git checkout -f main && git pull` to resync, then continue.
+
+   Pass a prompt that:
+   - Names the PR number and branch.
+   - Tells it to fetch the diff (`gh pr diff <N> --repo webjsdev/webjs`) and read the changed files in context.
+   - Instructs it to look for: bugs, regressions, security issues, missed edge cases, broken invariants, doc drift, test gaps, stylistic problems against `AGENTS.md` and `CONVENTIONS.md` (root and per-package).
+   - Asks for a numbered list with `file:line` references. Problems only, no suggestions.
+   - Ends with: "If you find nothing genuinely wrong, say exactly `CLEAN` and stop. Do not pad."
+
+2. **For each finding the subagent reports**, do exactly ONE of these three. There is no fourth option, and "mention it and move on" is not allowed:
+   - **Fix it** on the branch (commit + push to update the PR), OR
+   - **Reject it** explicitly with a one-sentence reason written in your reply to the user and in the PR body. Rejection has to be defensible (e.g. "the agent flagged X as a security issue but X runs server-side only and never reaches user input"). False positives are real; reject them on the merits, don't just hand-wave. OR
+   - **File it** as a tracked issue when it is genuine but out of scope for THIS PR (a pre-existing bug, an unrelated dependency/hygiene problem, a separate feature). "Out of scope" is NOT a reason to drop a finding. Run the `webjs-file-issue` flow (`gh issue create --repo webjsdev/webjs --assignee vivek7405` + `gh project item-add 1 --owner webjsdev --url <url>`) and capture the issue number. Verify it landed (`gh project item-list`). A finding you call out-of-scope without an issue number is an unfiled finding, which is the exact mistake this clause exists to prevent. If unsure whether something is in-scope, default to fixing it in this PR; only file-and-defer when it is clearly separable and fixing it here would mean scope creep.
+
+   **Record every genuine finding as a comment ON THE PR, the way a human reviewer would.** The self-review trail must live on the PR, not only in your reply to the user (a finding that exists only in the chat transcript is invisible to anyone reading the PR later). For findings tied to specific lines, post an INLINE review comment at `file:line` (`gh api repos/webjsdev/webjs/pulls/<N>/comments -f body=... -f commit_id=<sha> -f path=<file> -F line=<n>`, or a `gh pr review` with line comments). For cross-cutting or round-summary notes, use `gh pr comment <N> --body-file <f>`. Each comment states the finding, its `file:line`, and its disposition (`fixed in <sha>` / `rejected because <reason>` / `filed as #<n>`). Post rejected findings and false positives too, so the reasoning is auditable on the PR. A `CLEAN` round can be noted briefly. Do this as part of the loop, not as an afterthought. (Reminder: em-dashes and the other banned glyphs in AGENTS.md invariant 11 apply to PR comment bodies too, since they go through the same tooling.)
+
+3. **If the round found any findings (even rejected ones)**, run another round with a fresh subagent. The new round picks a slightly different focus prompt: if round 1 was broad, round 2 zooms in on the file you most edited; if round 2 zoomed in, round 3 zooms out to cross-file consistency, etc. Rotate focus to avoid the agent rediscovering the same surface.
+
+4. **If the round reports `CLEAN`**, the loop is done.
+
+The minimum is TWO rounds. A clean first round is rare and usually means the review was too shallow; if round 1 is clean, spawn a second one with a sharper, narrower focus before believing the result.
+
+**The LAST round must be clean, always. A fix is never the end of the loop.** The moment a round surfaces a genuine finding and you fix it (or reject it), you have NOT finished: the fix changed the branch, so it needs its own round. Run another round on the new HEAD and keep going until one round finds zero issues. Do NOT report "fixed it" or "ready to merge" after a round that found something, even if the fix is obviously correct and tests pass. The recurring failure this prevents: review finds X, you fix X and immediately report done, having never re-reviewed the fix. If you ever notice you are about to report a result where the most recent review round found a finding, stop and run another round first.
+
+**A standalone "review the PR" request IS the loop, not a one-shot.** When the user asks you to review an existing PR (separately from the post-`gh pr create` flow), you re-enter this exact loop: spawn a fresh round, and if it finds anything, fix/reject/file it and run further rounds until the last one is clean, BEFORE you report back. "I reviewed it and fixed one thing" is not an acceptable stopping point; "I reviewed it in a loop and the last round was clean" is. The user should never have to ask "was the last review clean?" because you should not have stopped until it was.
+
+### When to skip the loop
+
+Skip only for PRs that change a single line of trivially-correct content (a doc typo, a renamed local variable, a one-token config bump). Anything that touches logic, public surface, the build, the importmap, security-relevant code, or multiple files goes through the loop without exception. A bias toward running the loop is correct; a bias toward skipping it is the exact failure mode this rule exists to prevent.
+
+### Reporting after the loop
+
+After the loop converges, report exactly this shape to the user:
+
+> PR #<N> is up at <URL>. Self-review loop ran <K> rounds; last round clean. Issues found and fixed during the loop: <one-line list, or "none" if rounds 2+ kept finding nothing>. Out-of-scope findings filed as follow-ups: <issue numbers, or "none">. Ready to merge.
+
+If you cannot honestly say "last round clean", you cannot say "ready to merge". If a finding is rejected as a false positive, mention it in the report so the user can second-guess the rejection. Every finding the loop surfaced must be accounted for in this report as fixed, rejected-with-reason, or filed-with-issue-number; if you reported an out-of-scope finding to the user but cannot point to its issue number, you have not finished the loop. Every genuine finding must ALSO appear as a comment on the PR (see step 2), so the report and the PR agree.
+
+**Merge is gated on green CI, enforced at the branch level, not by trust.** A PR must not merge until all CI checks pass. `main` branch protection requires the five `ci.yml` checks (Conventions, Unit+integration, Browser, E2E, Build) before any merge; if `gh api repos/webjsdev/webjs/branches/main/protection` shows `required_status_checks: null`, run `bash scripts/protect-main.sh` once (needs repo admin) to restore it. Do not work around a red or pending check; wait for green.
+
+### Subagent prompt template
+
+```
+Review PR #<N> at https://github.com/webjsdev/webjs/pull/<N> for bugs, regressions, security issues, missed edge cases, broken invariants, doc drift, test gaps, and style violations against the project's AGENTS.md and CONVENTIONS.md (root + per-package).
+
+HARD CONSTRAINT, read first: you are running in a SHARED working directory that the main session is actively using. You are a READ-ONLY reviewer. Do NOT run any command that changes git branch, HEAD, the index, or the working tree: no `git checkout`, `git switch`, `git reset`, `git restore`, `git stash`, `git pull`, `git fetch` that moves refs, `git merge`, `git rebase`, `git clean`, `git branch -f`, or `git worktree`. Any of these silently corrupts the main session's checkout (it moved HEAD off the branch and looked like lost work). You do NOT need to switch branches to review: the branch is already checked out, so read files in place; use `gh pr diff <N>` and `gh pr view <N>` (which read from GitHub, not the local tree) for the diff and metadata. The only git you may run is read-only inspection (`git log`, `git show`, `git diff` WITHOUT changing state, `git status`, `git blame`). If you think you need to change git state to do the review, you are wrong; report what you found instead.
+
+You start with no prior context on this PR. Steps:
+
+1. Run `gh pr diff <N> --repo webjsdev/webjs` to see the full diff.
+2. Run `gh pr view <N> --repo webjsdev/webjs --json title,body` to see what the author claims it does.
+3. Read every file the diff touches in its current state (not just the diff hunks) so you see edits in context.
+4. Read root AGENTS.md, the per-package AGENTS.md for each touched package, and CONVENTIONS.md if a scaffolded template was touched.
+5. Specifically check: <focus rotates per round, e.g. "edge cases in importmap routing for both dist and src modes" or "whether the regression test actually fails when the code change is reverted">.
+
+Report findings as a numbered list with file:line references. Problems only. No suggestions, no nits about style if the rule isn't enforceable. If you find nothing genuinely wrong, say exactly `CLEAN` on its own line and stop. Do not pad with "looks good overall" or summaries.
+```
+
+## After a merge: decide on a version bump, automatically
+
+After ANY PR that lands a user-facing change (a `feat` / `fix` / `perf` / `breaking` to a published package: `core`, `server`, `cli`, `ui`, `intellisense`, `mcp`; `intellisense` lives at `packages/editors/intellisense`, the rest at `packages/<pkg>`) merges into `main`, assess whether a release bump is owed and open a release PR WITHOUT being asked. The user should not have to ask "do we need to bump versions?". Docs-only / chore / scaffold-doc changes do NOT bump on their own; they ride to the next functional bump.
+
+**Decide per package, across ALL of them, not just the ones this PR touched.** Release debt accumulates: a package can carry unreleased `feat`/`fix` commits from earlier PRs that were never released. For EACH published package, compare its shipped binary/surface against its latest `changelog/<pkg>/<version>.md`:
+
+```sh
+# What is published vs what the changelog covers, per package:
+for p in core server cli ui mcp editors/intellisense; do
+  name=$(basename "$p")
+  echo "$name: pkg=$(node -p "require('./packages/$p/package.json').version") latest-changelog=$(ls changelog/$name 2>/dev/null | sort -V | tail -1)"
+done
+# For each package, are there feat/fix/perf/breaking commits touching its tree since the last release?
+git log --oneline <last-release-sha>..main -- packages/<pkg>/
+```
+
+If a package has qualifying commits since its last `changelog/<pkg>/<version>.md` that the changelog does not cover, it is owed a bump, EVEN IF the current PR did not touch it. (Real miss: a release PR for core+server shipped while `cli` had an unreleased `vendor --from`/`audit`/`outdated` surface from an earlier PR that no cli changelog covered. Surface every such debt to the user; do not silently leave it.)
+
+**Mechanics of the release PR** (also see Definition-of-done item 9):
+1. Branch `chore/release-<pkg>-<version>[-<pkg>-<version>]`.
+2. Bump `version` in each `packages/<pkg>/package.json` (edit ONLY the version line; do not reformat the file). Level: **patch** for a `fix`/`feat`/`perf` while the package stays in one minor line (dependents pin `^0.x.0`); **minor** only when you are also ready to widen every dependent's caret range; **major/breaking** for an actual breaking change.
+3. Dependent ranges: `grep -rn '"@webjsdev/<pkg>"' --include=package.json . | grep -v node_modules`. A patch stays within the existing caret, so no edits; a minor needs every dependent range widened.
+4. `npm install --package-lock-only` and stage `package-lock.json` (a desync reds CI's `npm ci`).
+5. Changelog: the pre-commit hook runs `scripts/backfill-changelog.js`, which parses `^(feat|fix|perf|breaking):` from commit subjects in the package's tree. **Squash-merge subjects are PR titles with no conventional prefix, so the generator finds nothing and the hook fails.** Hand-write `changelog/<pkg>/<version>.md` (match an existing file's frontmatter: `package`, `version`, `date`, `commit_count`; sections ordered Breaking, Features, Performance, Fixes; entries link the PR and the squash commit) and stage it; then the commit passes.
+6. Open the release PR. Note in the body that merging it adds the `changelog/**.md` files to `main`, which triggers `release.yml` to `npm publish` and cut GitHub Releases (idempotent).
+7. Run the self-review loop on it too (a release publishes to npm; a wrong bump level, missed package, or inaccurate changelog is worth catching). Merge is still user-gated.
+
+### Then: make sure the deployed Railway services actually picked it up
+
+A merge updates `main` and npm, but the four in-repo apps deployed to Railway (`examples/blog`, `website`, `docs`, `packages/ui/packages/website`) keep serving the OLD code until they redeploy. After merging a change that affects what those services serve (framework code in `core`/`server`, or an app's own files), verify each service is now running the new `main`, automatically, without being asked. A user-visible fix is not actually shipped until the running service has it.
+
+**Check (needs `railway login`; the Railway MCP):** for each service, `mcp__railway__list_deployments` and compare the latest SUCCESSFUL deployment's commit hash to `git rev-parse origin/main`. A service whose running commit is an ancestor of (behind) `main` is stale. If `mcp__railway__whoami` returns "Not authenticated", say so and ask the user to run `! railway login`; do not guess.
+
+**If a service is stale, trigger a redeploy.** Two mechanisms, in order of preference:
+1. If the Railway MCP is authenticated, `mcp__railway__deploy` the stale service directly. No commit, cleanest.
+2. Otherwise, the user has authorized a **zero-diff empty commit to `main`** as a deploy trigger: `git commit --allow-empty -m "chore: trigger Railway redeploy (<reason>)" && git push origin main`. THIS IS THE ONE SANCTIONED DIRECT PUSH TO `main` (everything else goes through a PR). It is explicitly NOT a code change and bypasses no review, because there is nothing to review; its sole purpose is to give Railway's auto-deploy a new commit to deploy.
+
+**Nuance, do not over-fire the empty commit.** Railway services connected to a GitHub branch auto-deploy on every push BY DEFAULT, so a real merge already triggered the redeploy and an empty commit right after would be redundant; only the version-bump/merge commit itself is needed. The empty commit is the fix for the narrower case where a service has Railway **watch-paths** configured (it only redeploys when files under its own path change), so a framework-only change (e.g. `packages/core`) did not trigger the app service. A no-diff empty commit also will NOT match a restrictive watch-path, so if the check shows a watch-path-filtered service still stale, prefer mechanism 1 (MCP `deploy`) or tell the user the service needs a manual redeploy / a watch-path that includes the framework packages. So: check first, redeploy ONLY the services the check proves are behind, and report which services you redeployed and how.
+
+## What this skill does NOT do
+
+- Opens the PR as a DRAFT at the START (step 6), not at the end. It is NOT created late once all the work is done. At draft-create time:
+  - The body MUST include `Closes #<N>` near the top so merging auto-closes the issue and the project card auto-moves to Done. If the work turns out to only partially address the issue, use a plain `#N` reference, not `Closes`.
+  - The PR MUST be assigned to vivek7405 (`gh pr create ... --assignee vivek7405`). Matches the project's per-issue-owner convention.
+  - It stays a draft until the Definition of done is satisfied and the self-review loop has converged; then `gh pr ready <N>` flips it to ready for review.
+- Does not make commits FOR you. Subsequent work follows the standard webjs git workflow (commit per logical unit, push after each, run tests before committing); those commits stream onto the already-open PR.
+- Does not merge. Merging is always user-approved per the project's git rules.
+
+## Failure handling
+
+- If `git status` is dirty: stop and ask the user to stash, commit, or abandon their pending work before creating the new branch. Never silently lose changes.
+- If the issue is already in `In progress` (someone else's work, or a prior branch left open): report this and ask the user whether to continue on the existing branch, branch off a fresh main, or pick a different issue.
+- If the local checkout regressed mid-loop (HEAD on `main` or a base commit, the feature branch's work seemingly "gone"): a review subagent mutated shared git state. Do NOT panic or redo work. The local feature-branch ref and `origin/<branch>` still point at the latest commit (every logical unit was pushed). Recover with `git checkout <feature-branch>`; confirm with `git log --oneline origin/main..HEAD` and `git status` clean. The PR on GitHub was never affected (the GitHub-reading reviewer still saw correct content), so no re-push or force-push is needed.
+- If the `gh project item-edit` call fails (auth scope, missing field): report the failure clearly and offer to do the move manually via the web UI. The branch creation still stands.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,12 @@ jobs:
           fi
       - name: No em-dash in source (invariant 11)
         run: |
-          # U+2014 is banned repo-wide. changelog/ is generated from commit
-          # history (pre-rule entries) so it is excluded.
-          hits=$(git grep -lP "\x{2014}" -- '*.js' '*.ts' '*.md' ':!changelog/' ':!**/node_modules/**' || true)
+          # U+2014 is banned repo-wide for webjs-AUTHORED prose. changelog/ is
+          # generated from commit history (pre-rule entries) so it is excluded,
+          # and .claude/skills/ holds vendored agent skills (e.g. the
+          # Anthropic-authored use-railway), which are external content not
+          # subject to our prose style, the same as node_modules.
+          hits=$(git grep -lP "\x{2014}" -- '*.js' '*.ts' '*.md' ':!changelog/' ':!**/node_modules/**' ':!.claude/skills/**' || true)
           if [ -n "$hits" ]; then
             echo "::error::em-dash (U+2014) found; replace per AGENTS.md invariant 11:"; echo "$hits"; exit 1
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,8 @@ Thumbs.db
 !.claude/settings.json
 !.claude/hooks/
 !.claude/hooks/**
+!.claude/skills/
+!.claude/skills/**
 
 # test artifacts
 coverage/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ Claude Code enforces step 1 via `.claude/hooks/guard-branch-context.sh`. Other a
 
 ### Skills are routed deterministically, never skipped
 
-A Skill is model-invoked, so it fires only when the model judges a match. The `.claude/hooks/route-skills.sh` `UserPromptSubmit` hook makes routing deterministic: it keyword-matches each prompt against every skill's documented triggers and injects a directive to invoke the matched skill before other work. Check the available skills and invoke a matching one before starting. Tests in `test/hooks/route-skills.test.mjs`.
+A Skill is model-invoked, so it fires only when the model judges a match. The `.claude/hooks/route-skills.sh` `UserPromptSubmit` hook makes routing deterministic: it keyword-matches each prompt against every skill's documented triggers and injects a directive to invoke the matched skill before other work. Check the available skills and invoke a matching one before starting. The skills themselves are committed under `.claude/skills/` (alongside the hooks), so a fresh clone has both the router and the skills it routes to (no machine-local dependency). Tests in `test/hooks/route-skills.test.mjs`, which also asserts every skill the hook references is committed in-repo.
 
 ### Autonomous mode (sandbox / bypass permissions)
 

--- a/test/hooks/route-skills.test.mjs
+++ b/test/hooks/route-skills.test.mjs
@@ -11,11 +11,13 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import { readFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const HOOK = resolve(here, '../../.claude/hooks/route-skills.sh');
+const REPO = resolve(here, '../..');
 
 /**
  * Run the hook with a prompt and return { code, ctx } where ctx is the
@@ -116,4 +118,21 @@ test('a single prompt routes each matched skill exactly once', () => {
   const { ctx } = run('file a task for dark mode');
   const count = (ctx.match(/^- webjs-file-issue:/gm) || []).length;
   assert.equal(count, 1);
+});
+
+test('every skill the hook can route to is committed in-repo (no dangling reference)', () => {
+  // The hook names skills it routes to; each MUST have a committed
+  // `.claude/skills/<name>/SKILL.md`, or a fresh clone routes a prompt at a
+  // skill that does not exist (the #543 portability bug). Extract the skill
+  // names from the hook source and assert each is present in the repo.
+  const hookSrc = readFileSync(HOOK, 'utf8');
+  const names = [...new Set((hookSrc.match(/\b(?:webjs-[a-z-]+|use-railway)\b/g) || []))];
+  assert.ok(names.length >= 4, `expected the hook to reference its skills; found ${names.join(', ')}`);
+  for (const name of names) {
+    const skillFile = resolve(REPO, '.claude/skills', name, 'SKILL.md');
+    assert.ok(
+      existsSync(skillFile),
+      `route-skills.sh routes to '${name}' but ${skillFile} is not committed; a clone would dangle`,
+    );
+  }
 });


### PR DESCRIPTION
Closes #543

The repo committed the hooks (`.claude/settings.json` + `.claude/hooks/`) but not the skills they route to. `webjs-file-issue`, `webjs-start-work`, `webjs-list-todos`, and `use-railway` lived only in the maintainer's machine-local `~/.claude/skills/`, so a fresh clone on another computer got the guardrail hooks (including `route-skills.sh`, which names those skills) but not the skills themselves, leaving the routing dangling.

This commits the four skills under `.claude/skills/` (Claude Code loads project-level skills from there) and un-ignores `.claude/skills/**` in `.gitignore`, mirroring the existing `hooks/` + `settings.json` un-ignores. A clone is now self-sufficient: the hooks and the skills they route to live in one place.

- `use-railway` is copied whole (SKILL.md + `references/` 11 files + `scripts/` 8 files).
- Non-destructive: the maintainer's `~/.claude` copies are untouched. And it is safe to leave them: project-level skills OVERRIDE same-named user-level ones, so the in-repo copies are canonical when working in this repo (no double-load, no double-route). Removing the home copies is an optional follow-up, not required.
- No secrets committed (the token/key mentions are documentation + env-var refs, no opaque values).
- The org-scoped steps (assign to vivek7405, the project board) would simply error for a contributor without write access, which is the correct behaviour of the prescribed org workflow, not a regression.

## Definition of done
- Tests: added a guard in `test/hooks/route-skills.test.mjs` that every skill name the hook references has a committed `.claude/skills/<name>/SKILL.md` (a real counterfactual: a future routed-but-uncommitted skill fails CI instead of dangling). All hook tests pass (23/23).
- Docs: `AGENTS.md` "Skills are routed deterministically" note updated to say the skills are now committed under `.claude/skills/` and the test asserts they exist.
- Browser / e2e / dogfood four-app / MCP / editor plugins / website / scaffold: N/A because this only adds committed skill files + a `.gitignore` negation + a test + a doc note; no framework code, served wire, published-package surface, or generated scaffold output changes.
