### PR TITLE
chore: release cli 0.11.0, server 0.9.0, mcp 0.2.0

### DIFF
--- a/changelog/cli/0.10.18.md
+++ b/changelog/cli/0.10.18.md
@@ -1,0 +1,21 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.18
+date: 2026-06-17T20:39:43.326Z
+commit_count: 3
+---
+## Features
+
+- **make SSR action-result seeding work on Bun (#529)** ([#534](https://github.com/webjsdev/webjs/pull/534)) [`e2c7c7a1`](https://github.com/webjsdev/webjs/commit/e2c7c7a1)
+  * feat: install SSR action seeding on Bun via Bun.plugin
+  
+  Seeding (#472) rode Node's module.registerHooks, which Bun lacks, so it was off
+  on Bun and every shipping async-render component re-fetched on hydration. Extract
+- **unify webjs dev/start/db with npm-script behavior via a tasks config** ([#554](https://github.com/webjsdev/webjs/pull/554)) [`f22ac7d3`](https://github.com/webjsdev/webjs/commit/f22ac7d3)
+  * feat: orchestrate dev/start tasks from the webjs config block (#550)
+  
+  * feat: add dev.before + scaffold tasks config, route db scripts via webjs db (#550)
+- **switch the default ORM from Prisma to Drizzle** ([#558](https://github.com/webjsdev/webjs/pull/558)) [`5938ab67`](https://github.com/webjsdev/webjs/commit/5938ab67)
+  * chore: remove orphaned prisma-preflight (dead since #550, Prisma leaving in #551)
+  
+  * feat: point webjs db at drizzle-kit instead of prisma

--- a/changelog/mcp/0.1.3.md
+++ b/changelog/mcp/0.1.3.md
@@ -1,0 +1,12 @@
+---
+package: "@webjsdev/mcp"
+version: 0.1.3
+date: 2026-06-17T20:39:43.394Z
+commit_count: 1
+---
+## Features
+
+- **switch the default ORM from Prisma to Drizzle** ([#558](https://github.com/webjsdev/webjs/pull/558)) [`5938ab67`](https://github.com/webjsdev/webjs/commit/5938ab67)
+  * chore: remove orphaned prisma-preflight (dead since #550, Prisma leaving in #551)
+  
+  * feat: point webjs db at drizzle-kit instead of prisma

--- a/changelog/server/0.8.30.md
+++ b/changelog/server/0.8.30.md
@@ -1,0 +1,16 @@
+---
+package: "@webjsdev/server"
+version: 0.8.30
+date: 2026-06-17T20:39:43.298Z
+commit_count: 2
+---
+## Features
+
+- **unify webjs dev/start/db with npm-script behavior via a tasks config** ([#554](https://github.com/webjsdev/webjs/pull/554)) [`f22ac7d3`](https://github.com/webjsdev/webjs/commit/f22ac7d3)
+  * feat: orchestrate dev/start tasks from the webjs config block (#550)
+  
+  * feat: add dev.before + scaffold tasks config, route db scripts via webjs db (#550)
+- **switch the default ORM from Prisma to Drizzle** ([#558](https://github.com/webjsdev/webjs/pull/558)) [`5938ab67`](https://github.com/webjsdev/webjs/commit/5938ab67)
+  * chore: remove orphaned prisma-preflight (dead since #550, Prisma leaving in #551)
+  
+  * feat: point webjs db at drizzle-kit instead of prisma

--- a/package-lock.json
+++ b/package-lock.json
@@ -7339,7 +7339,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.17",
+      "version": "0.10.18",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -7389,7 +7389,7 @@
     },
     "packages/mcp": {
       "name": "@webjsdev/mcp",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/server": "^0.8.0"
@@ -7403,7 +7403,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.29",
+      "version": "0.8.30",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.17",
+  "version": "0.10.18",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/mcp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "description": "The webjs Model Context Protocol server: live app introspection (routes / actions / components / check) plus the framework knowledge layer (docs, recipes, source) for AI coding agents",
   "bin": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.29",
+  "version": "0.8.30",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Release the published packages with their accumulated unreleased changes.

## Versions
- `@webjsdev/cli` 0.10.17 → **0.11.0** (minor): the Prisma→Drizzle scaffold + `--db sqlite|postgres` flag + `webjs db`→drizzle-kit (#558), the Bun SSR-seeding install (#534), and the dev/start/db task-config unification (#554).
- `@webjsdev/server` 0.8.29 → **0.9.0** (minor): the dev file-watcher now ignores `db/` instead of `prisma/`, the served config/JSDoc examples, and the #554 task-config support.
- `@webjsdev/mcp` 0.1.2 → **0.2.0** (minor): the served server-action recipe now shows Drizzle (#558).

`@webjsdev/core` is intentionally NOT bumped: its only #558 change was a comment in a `.d.ts` (no behavior/type change).

Changelogs were generated by `scripts/backfill-changelog.js` from the conventional commits touching each package; versions bumped in package.json + package-lock.json (3 lines, no `npm install`).

Standard release PR; no code changes.