### PR TITLE
chore: release server 0.8.31, cli 0.10.19

### DIFF
--- a/changelog/cli/0.10.19.md
+++ b/changelog/cli/0.10.19.md
@@ -1,0 +1,12 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.19
+date: 2026-06-18T03:51:27.085Z
+commit_count: 1
+---
+## Features
+
+- **# path-alias imports + convert in-repo apps & scaffold** ([#565](https://github.com/webjsdev/webjs/pull/565)) [`08ad8b87`](https://github.com/webjsdev/webjs/commit/08ad8b87)
+  * chore: start # path-alias imports (#555, #556)
+  
+  * feat: # path-alias import resolution (resolveImport + importmap) (#555)

--- a/changelog/server/0.8.31.md
+++ b/changelog/server/0.8.31.md
@@ -1,0 +1,12 @@
+---
+package: "@webjsdev/server"
+version: 0.8.31
+date: 2026-06-18T03:51:27.055Z
+commit_count: 1
+---
+## Features
+
+- **# path-alias imports + convert in-repo apps & scaffold** ([#565](https://github.com/webjsdev/webjs/pull/565)) [`08ad8b87`](https://github.com/webjsdev/webjs/commit/08ad8b87)
+  * chore: start # path-alias imports (#555, #556)
+  
+  * feat: # path-alias import resolution (resolveImport + importmap) (#555)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.18",
+  "version": "0.10.19",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.30",
+  "version": "0.8.31",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Release the `#` path-alias imports feature (#555/#556) shipped in #565.

## Bumps (patch, to keep `^0.x.0` workspace ranges satisfied)

- `@webjsdev/server` 0.8.30 to 0.8.31. Resolver across module graph, auth gate, elision, browser importmap, and asset-hash versioning.
- `@webjsdev/cli` 0.10.18 to 0.10.19. Scaffold emits `#`-aliased imports.

Changelogs were auto-generated by the pre-commit hook from the conventional commit on #565. No `Closes` line (this is a release, not an issue fix).
