### PR TITLE
chore: release cli 0.10.20

### DIFF
--- a/changelog/cli/0.10.20.md
+++ b/changelog/cli/0.10.20.md
@@ -1,0 +1,18 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.20
+date: 2026-06-18T08:59:36.610Z
+commit_count: 2
+---
+## Features
+
+- **make webjs db/test commands runtime-native (Bun-safe, no npx)** ([#571](https://github.com/webjsdev/webjs/pull/571)) [`026710aa`](https://github.com/webjsdev/webjs/commit/026710aa)
+  * feat: webjs db resolves drizzle-kit + spawns with the runtime (drop npx)
+  
+  webjs db <generate|migrate|push|studio> shelled 'npx drizzle-kit', which fails
+  in a pure oven/bun image (no npx). Resolve the app's drizzle-kit bin via its
+- **Bun-first scaffold mode (--runtime bun) across all 3 templates** ([#569](https://github.com/webjsdev/webjs/pull/569)) [`92d544cb`](https://github.com/webjsdev/webjs/commit/92d544cb)
+  * feat: --runtime bun scaffold mode (core plumbing + deploy/CI/docs rewrites)
+  
+  Add a runtime axis orthogonal to --template (the 3-templates invariant is
+  untouched). `webjs create --runtime bun` (and `bun create webjs`, auto-detected

--- a/package-lock.json
+++ b/package-lock.json
@@ -7339,7 +7339,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.18",
+      "version": "0.10.20",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -7403,7 +7403,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.30",
+      "version": "0.8.31",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.19",
+  "version": "0.10.20",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {


### PR DESCRIPTION
Release the unreleased `@webjsdev/cli` feature work.

## Bump (patch; dependents pin `^0.10.0`, satisfied)
- `@webjsdev/cli` 0.10.19 → 0.10.20

## What it ships
- **#571** webjs db/test commands are runtime-native (resolve drizzle-kit/wtr, spawn with the current runtime; `bun test` on Bun), dropping the hard `npx`/`node --test`. This is the npx-free CLI that makes a pure `oven/bun` scaffold image viable.
- **#569** Bun-first scaffold (`webjs create --runtime bun` / `bun create webjs`).

Changelog auto-generated by the pre-commit hook from the conventional commit subjects. Merging this adds `changelog/cli/0.10.20.md` to main, which triggers `release.yml` to npm-publish `@webjsdev/cli@0.10.20` (and lockstep-publish the `create-webjs` / `webjsdev` wrappers) and cut the GitHub Release. Only `@webjsdev/cli` is owed a bump (server 0.8.31 / core 0.7.21 / mcp 0.1.3 are current; #569/#571 touched only cli).
