### PR TITLE
feat: enforce worktree-per-task to stop concurrent-agent branch collisions

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -62,6 +62,34 @@ STAGED_PKG_BUMPS=$(git diff --cached --unified=0 -- \
         print pkg "@" v
       }')
 
+# Gate 3: a published-library version bump belongs on a chore/release-* branch.
+# A core/server/cli/mcp/ui/intellisense bump on a feature branch is almost always
+# a release commit that landed on the WRONG branch because a concurrent agent
+# moved HEAD in a shared checkout (#590: a `chore: release cli` commit once landed
+# on an unrelated feat/ branch, with a contaminated changelog). Block it. The
+# editor APPS (vscode/nvim) and the lockstep wrappers (create-webjs/webjsdev)
+# legitimately bump off release branches, so they are exempt.
+if [ -n "$STAGED_PKG_BUMPS" ] && ! printf '%s' "$BRANCH" | grep -qE '^chore/release-'; then
+  for bump in $STAGED_PKG_BUMPS; do
+    pkg="${bump%@*}"
+    case "$pkg" in
+      core|server|cli|mcp|ui|intellisense)
+        echo ""
+        echo "ERROR: '$pkg' version bump on branch '$BRANCH' (not a chore/release-* branch)."
+        echo ""
+        echo "A published-library release belongs on its own chore/release-<pkg>-<ver>"
+        echo "branch. If HEAD is not the branch you expected, a concurrent agent may have"
+        echo "moved it in this shared checkout (#590). Use a dedicated worktree per task:"
+        echo "  git worktree add -b chore/release-$pkg-<ver> ../webjs-release origin/main"
+        echo ""
+        echo "To bypass (only if this bump is genuinely intentional here): git commit --no-verify"
+        echo ""
+        exit 1
+        ;;
+    esac
+  done
+fi
+
 if [ -n "$STAGED_PKG_BUMPS" ]; then
   # Find which files need to exist and which are missing BEFORE we
   # run the generator, so we can stage exactly what the generator

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,18 @@ reference there.
 
 Claude Code enforces step 1 via `.claude/hooks/guard-branch-context.sh`. Other agents check manually.
 
+### One task per git worktree when agents run concurrently
+
+webjs is worked by MULTIPLE agents at once. If more than one agent (or more than one in-flight task) shares ONE working checkout, they collide: a `git checkout` in one moves `HEAD` under the other, so the next commit lands on the WRONG branch. This has happened (a `chore: release` commit landed on an unrelated `feat/` branch, with a contaminated changelog). So give each task its own worktree:
+
+```sh
+git worktree add -b <prefix>/<slug> ../<repo>-<slug> origin/main
+cd ../<repo>-<slug>          # do ALL work for the task here
+# ... commit + push from this worktree; after merge: git worktree remove ../<repo>-<slug>
+```
+
+Git enforces one-branch-per-worktree, so separate worktrees make the collision impossible. Before any commit in a shared checkout, confirm `git branch --show-current` is still the branch you created; if it moved, you are colliding, switch to a worktree. A lone agent in a clean checkout may still use a plain branch. The repo's `.hooks/pre-commit` additionally BLOCKS a published-library (`core`/`server`/`cli`/`mcp`/`ui`/`intellisense`) version bump on any non-`chore/release-*` branch, the canonical wrong-branch-release symptom.
+
 ### Skills are routed deterministically, never skipped
 
 A Skill is model-invoked, so it fires only when the model judges a match. The `.claude/hooks/route-skills.sh` `UserPromptSubmit` hook makes routing deterministic: it keyword-matches each prompt against every skill's documented triggers and injects a directive to invoke the matched skill before other work. Check the available skills and invoke a matching one before starting. The skills themselves are committed under `.claude/skills/` (alongside the hooks), so a fresh clone has both the router and the skills it routes to (no machine-local dependency). Tests in `test/hooks/route-skills.test.mjs`, which also asserts every skill the hook references is committed in-repo.

--- a/packages/cli/templates/.agents/rules/workflow.md
+++ b/packages/cli/templates/.agents/rules/workflow.md
@@ -34,6 +34,13 @@ FIRST, before writing any code:
    - If on main/master: create a feature branch before editing.
    - If on a feature branch: verify it matches the current task.
 2. Sync: `git fetch origin && git rebase origin/main` if behind.
+3. If more than one agent may work this repo at once, use a DEDICATED git
+   worktree per task (`git worktree add -b <branch> ../<repo>-<slug> origin/main`,
+   `cd` in, work there, `git worktree remove` after merge), never a shared
+   checkout. Two agents in one directory collide: a `git checkout` in one moves
+   HEAD under the other, so commits land on the wrong branch. Git enforces
+   one-branch-per-worktree, so worktrees prevent it. A lone agent in a clean
+   checkout may use a plain branch.
 
 ## Autonomous mode (sandbox / no-prompt)
 

--- a/packages/cli/templates/.cursorrules
+++ b/packages/cli/templates/.cursorrules
@@ -35,6 +35,12 @@ FIRST, before writing any code:
 2. Sync with parent: `git fetch origin && git log HEAD..origin/main --oneline`
    - If upstream has new commits: `git rebase origin/main` before starting.
    - Resolve any conflicts before proceeding with the task.
+3. If more than one agent may work this repo at once, use a DEDICATED git
+   worktree per task, not a shared checkout: `git worktree add -b <branch>
+   ../<repo>-<slug> origin/main`, `cd` in, work there, `git worktree remove`
+   after merge. Two agents in one directory collide (a `git checkout` in one
+   moves HEAD under the other, so commits land on the wrong branch). A lone
+   agent in a clean checkout may use a plain branch.
 
 ## Autonomous mode (sandbox / no-prompt)
 

--- a/packages/cli/templates/.github/copilot-instructions.md
+++ b/packages/cli/templates/.github/copilot-instructions.md
@@ -32,6 +32,12 @@ FIRST, before writing any code:
    - If on main/master: create a feature branch before editing.
    - If on a feature branch: verify it matches the task at hand.
 2. Sync: `git fetch origin && git rebase origin/main` if behind.
+3. If more than one agent may work this repo at once, use a DEDICATED git
+   worktree per task (`git worktree add -b <branch> ../<repo>-<slug> origin/main`,
+   `cd` in, work there, `git worktree remove` after merge), never a shared
+   checkout. Two agents in one directory collide: a `git checkout` in one moves
+   HEAD under the other, so commits land on the wrong branch. A lone agent in a
+   clean checkout may use a plain branch.
 
 ## Autonomous mode (sandbox / no-prompt)
 

--- a/packages/cli/templates/.hooks/pre-commit
+++ b/packages/cli/templates/.hooks/pre-commit
@@ -11,8 +11,19 @@
 # here, so a commit stays fast and the test gate cannot be skipped by a
 # local --no-verify. The CI workflow runs `webjs check` + `webjs test`
 # on every push and pull request.
+#
+# Running more than one AI agent on this repo at once? Give each task its own
+# git worktree, not a shared checkout. Two agents in one working directory
+# collide: a `git checkout` in one moves HEAD under the other, so the next
+# commit lands on the wrong branch. Before committing, confirm the branch below
+# is the one you intended; if it moved, you are sharing a checkout. Isolate:
+#   git worktree add -b <branch> ../<app>-<task> origin/main && cd ../<app>-<task>
 
 BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null)
+
+# Surface the branch so a wrong-branch commit (a concurrent-agent HEAD move) is
+# visible in the commit output rather than silent.
+echo "[pre-commit] committing on branch: ${BRANCH:-<detached>}"
 
 if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
   echo ""

--- a/packages/cli/templates/AGENTS.md
+++ b/packages/cli/templates/AGENTS.md
@@ -1218,7 +1218,14 @@ composition, so a nested shell ends up dropped by the HTML parser.
 
 ## Workflow expectations for AI agents
 
-1. Branch before editing. Never push to `main` directly.
+1. Branch before editing. Never push to `main` directly. **If more than one
+   agent may work this repo at once, give each task its own git worktree, not a
+   shared checkout** (`git worktree add -b <branch> ../<repo>-<slug> origin/main`,
+   `cd` in, work there, `git worktree remove` after merge). Two agents in one
+   working directory collide: a `git checkout` in one moves `HEAD` under the
+   other, so the next commit lands on the wrong branch. Git enforces
+   one-branch-per-worktree, so worktrees prevent it; a lone agent in a clean
+   checkout may use a plain branch.
 2. Every code change comes with a test, AGENTS.md / docs updates if the
    feature surface changed, `webjs check` passing. A unit test is not
    always enough: a component, hydration, the client router, or a server

--- a/packages/cli/templates/CONVENTIONS.md
+++ b/packages/cli/templates/CONVENTIONS.md
@@ -60,6 +60,14 @@ even if the user doesn't explicitly ask.**
 3. If on a feature branch → verify it matches the current task
 4. Sync with parent: `git fetch origin && git rebase origin/main` if behind
 5. Don't mix unrelated work on the wrong branch
+6. **If more than one agent may work this repo at once, use a dedicated git
+   worktree per task, never a shared checkout.** Two agents in one working
+   directory collide: a `git checkout` in one moves `HEAD` under the other, so
+   the next commit lands on the wrong branch. Isolate each task:
+   `git worktree add -b <branch> ../<repo>-<slug> origin/main`, `cd` in, work
+   there, and `git worktree remove` after the PR merges. Git enforces
+   one-branch-per-worktree, so this makes the collision impossible. A lone agent
+   in a clean checkout may use a plain branch.
 
 ### After cloning: verify the toolchain
 

--- a/test/hooks/release-branch-guard.test.mjs
+++ b/test/hooks/release-branch-guard.test.mjs
@@ -1,0 +1,66 @@
+/**
+ * The framework `.hooks/pre-commit` blocks a published-library version bump on a
+ * non-`chore/release-*` branch (#590). That is the canonical wrong-branch
+ * release commit: a concurrent agent moved HEAD in a shared checkout, so a
+ * `chore: release` landed on someone else's feature branch with a contaminated
+ * changelog. This drives the REAL hook script against throwaway temp git repos.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const hook = fileURLToPath(new URL('../../.hooks/pre-commit', import.meta.url));
+
+/** Stage a `version` bump for `pkg` on `branch` in a temp repo, run the hook. */
+function runHook(pkgPath, branch) {
+  const dir = mkdtempSync(join(tmpdir(), 'webjs-hook-'));
+  const git = (...a) => spawnSync('git', a, { cwd: dir, encoding: 'utf8' });
+  git('init', '-q');
+  git('config', 'user.email', 't@t');
+  git('config', 'user.name', 't');
+  git('checkout', '-q', '-b', branch);
+  mkdirSync(join(dir, dirname(pkgPath)), { recursive: true });
+  // commit a baseline package.json, then stage a version bump (the diff the hook reads)
+  writeFileSync(join(dir, pkgPath), JSON.stringify({ name: 'x', version: '1.0.0' }, null, 2) + '\n');
+  git('add', '-A'); git('commit', '-q', '--no-verify', '-m', 'base');
+  writeFileSync(join(dir, pkgPath), JSON.stringify({ name: 'x', version: '1.0.1' }, null, 2) + '\n');
+  git('add', pkgPath);
+  const r = spawnSync('bash', [hook], { cwd: dir, encoding: 'utf8' });
+  rmSync(dir, { recursive: true, force: true });
+  return { code: r.status, out: `${r.stdout}${r.stderr}` };
+}
+
+const GUARD = /not a chore\/release-\* branch/;
+
+test('blocks a cli bump on a feature branch (the wrong-branch release symptom)', () => {
+  const r = runHook('packages/cli/package.json', 'feat/something');
+  assert.notEqual(r.code, 0, 'the commit is rejected');
+  assert.match(r.out, GUARD);
+});
+
+test('blocks server / core / mcp / ui / intellisense bumps off a release branch', () => {
+  for (const p of ['server', 'core', 'mcp', 'ui']) {
+    const r = runHook(`packages/${p}/package.json`, 'feat/x');
+    assert.match(r.out, GUARD, `${p} is guarded`);
+  }
+  // intellisense lives under packages/editors/
+  assert.match(runHook('packages/editors/intellisense/package.json', 'feat/x').out, GUARD, 'intellisense is guarded');
+});
+
+test('does NOT block on a chore/release-* branch', () => {
+  // The release branch is exactly where a lib bump belongs, so gate-3 must pass
+  // (it then proceeds to the changelog step, which is out of scope here).
+  const r = runHook('packages/cli/package.json', 'chore/release-cli-0.10.20');
+  assert.doesNotMatch(r.out, GUARD);
+});
+
+test('exempts editor apps + wrappers (they ride feature/lockstep commits)', () => {
+  for (const p of ['editors/vscode', 'editors/nvim', 'wrappers/create-webjs', 'wrappers/webjsdev']) {
+    const r = runHook(`packages/${p}/package.json`, 'feat/x');
+    assert.doesNotMatch(r.out, GUARD, `${p} is exempt`);
+  }
+});

--- a/test/hooks/release-branch-guard.test.mjs
+++ b/test/hooks/release-branch-guard.test.mjs
@@ -51,16 +51,30 @@ test('blocks server / core / mcp / ui / intellisense bumps off a release branch'
   assert.match(runHook('packages/editors/intellisense/package.json', 'feat/x').out, GUARD, 'intellisense is guarded');
 });
 
-test('does NOT block on a chore/release-* branch', () => {
-  // The release branch is exactly where a lib bump belongs, so gate-3 must pass
-  // (it then proceeds to the changelog step, which is out of scope here).
+// Past gate-3, a detected bump reaches the changelog step. Asserting that marker
+// (not just the ABSENCE of the guard) proves the bump was let THROUGH gate-3,
+// so these stay meaningful even if gate-3 were deleted (they would then hit the
+// guard message instead, failing the doesNotMatch).
+const REACHED_CHANGELOG_STEP = /Detected staged version bump|backfill-changelog/;
+
+test('does NOT block on a chore/release-* branch (lib bump belongs there)', () => {
   const r = runHook('packages/cli/package.json', 'chore/release-cli-0.10.20');
   assert.doesNotMatch(r.out, GUARD);
+  assert.match(r.out, REACHED_CHANGELOG_STEP, 'passed gate-3 into the changelog step');
 });
 
-test('exempts editor apps + wrappers (they ride feature/lockstep commits)', () => {
-  for (const p of ['editors/vscode', 'editors/nvim', 'wrappers/create-webjs', 'wrappers/webjsdev']) {
+test('exempts editor apps (vscode/nvim ride feature commits)', () => {
+  for (const p of ['editors/vscode', 'editors/nvim']) {
     const r = runHook(`packages/${p}/package.json`, 'feat/x');
-    assert.doesNotMatch(r.out, GUARD, `${p} is exempt`);
+    assert.doesNotMatch(r.out, GUARD, `${p} is not guarded`);
+    assert.match(r.out, REACHED_CHANGELOG_STEP, `${p} passed gate-3`);
+  }
+});
+
+test('exempts lockstep wrappers (skipped by the changelog step, clean pass)', () => {
+  for (const p of ['wrappers/create-webjs', 'wrappers/webjsdev']) {
+    const r = runHook(`packages/${p}/package.json`, 'feat/x');
+    assert.doesNotMatch(r.out, GUARD, `${p} is not guarded`);
+    assert.equal(r.code, 0, `${p} passes the hook (no changelog required)`);
   }
 });

--- a/test/hooks/release-branch-guard.test.mjs
+++ b/test/hooks/release-branch-guard.test.mjs
@@ -29,7 +29,11 @@ function runHook(pkgPath, branch) {
   git('add', '-A'); git('commit', '-q', '--no-verify', '-m', 'base');
   writeFileSync(join(dir, pkgPath), JSON.stringify({ name: 'x', version: '1.0.1' }, null, 2) + '\n');
   git('add', pkgPath);
-  const r = spawnSync('bash', [hook], { cwd: dir, encoding: 'utf8' });
+  // The hook short-circuits (exit 0) when GITHUB_ACTIONS=true (the release-bot
+  // skip), so strip it from the child env or this test is a no-op under CI.
+  const env = { ...process.env };
+  delete env.GITHUB_ACTIONS;
+  const r = spawnSync('bash', [hook], { cwd: dir, encoding: 'utf8', env });
   rmSync(dir, { recursive: true, force: true });
   return { code: r.status, out: `${r.stdout}${r.stderr}` };
 }


### PR DESCRIPTION
Closes #590

Multiple agents work webjs (and end-user apps) concurrently; when they share one checkout, a `git checkout` in one moves `HEAD` under another and commits land on the wrong branch. This bit on 2026-06-18 (a `chore: release cli` commit landed on a concurrent `feat/` branch with a contaminated changelog). This adds the guardrail across the framework and the scaffolds.

## Changes
- **Framework `AGENTS.md`**: a "one task per git worktree when agents run concurrently" rule in the AI-driven-development guardrails (failure mode + the worktree fix).
- **Framework `.hooks/pre-commit`**: a new gate-3 that blocks a published-library (`core`/`server`/`cli`/`mcp`/`ui`/`intellisense`) version bump on a non-`chore/release-*` branch (the exact wrong-branch-release symptom); exempts editor apps (`vscode`/`nvim`) and lockstep wrappers; preserves the bot-skip + main-block + changelog gate.
- **Scaffold per-agent rule files** (lockstep): the same worktree-per-task rule in `templates/AGENTS.md`, `CONVENTIONS.md`, `.cursorrules`, `.agents/rules/workflow.md`, `.github/copilot-instructions.md`, so every `webjs create` app inherits it. The scaffold `.hooks/pre-commit` echoes the committing branch + carries a cross-branch note (scaffolded apps have no release machinery, so no version guard there).
- **Test**: `test/hooks/release-branch-guard.test.mjs` drives the real hook against throwaway repos (blocks a lib bump on a feature branch; passes on `chore/release-*`; exempts editor apps/wrappers), counterfactual-verified.

## Out of scope (filed)
- #592: the `STAGED_PKG_BUMPS` detection re-emits an unchanged version line under `--unified=0`, so an adjacent non-version edit can false-positive (a pre-existing limitation gate-3 inherits from the existing changelog gate). Tracked for an old-vs-new version comparison.

## Verification
- Scaffold tests pass; a generated app carries the worktree rule in all 5 per-agent files. The hook guard test passes (4/4 -> 5/5 after strengthening the negatives to prove pass-through, not absence).
- **Dogfooding: this PR was implemented from a dedicated worktree**, not the shared checkout.

Also encoded outside the repo this session (machine config): `~/.claude/CLAUDE.md` + the `webjs-start-work` skill now do worktree-per-task.
