### PR TITLE
chore: release core 0.7.22, server 0.8.32, cli 0.10.21, mcp 0.1.4, intellisense 0.5.2

### DIFF
--- a/changelog/cli/0.10.21.md
+++ b/changelog/cli/0.10.21.md
@@ -1,0 +1,27 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.21
+date: 2026-06-18T16:09:28.477Z
+commit_count: 4
+---
+## Features
+
+- **enforce worktree-per-task to stop concurrent-agent branch collisions** ([#591](https://github.com/webjsdev/webjs/pull/591)) [`88e87bfd`](https://github.com/webjsdev/webjs/commit/88e87bfd)
+  * feat: worktree-per-task guardrail + block lib release bumps off release branch
+  
+  Concurrent agents sharing one checkout collide: a git checkout in one moves
+  HEAD under another, so commits land on the wrong branch (#590; a chore: release
+- **declare-free reactive-prop DX via dual-role WebComponent** ([#597](https://github.com/webjsdev/webjs/pull/597)) [`2b409c51`](https://github.com/webjsdev/webjs/commit/2b409c51)
+  * feat: implement declare-free reactive properties via factory
+  
+  Introduce a callable WebComponent constructor that acts as a class factory and can be invoked with a property shape object. This allows properties to be fully typed without needing a manual declare line, while keeping full backward compatibility with the existing static properties field structure.
+- **pure oven/bun:1 scaffold Dockerfile (bun runtime)** ([#596](https://github.com/webjsdev/webjs/pull/596)) [`60c46e1b`](https://github.com/webjsdev/webjs/commit/60c46e1b)
+  * feat: bun scaffold Dockerfile is now a pure oven/bun:1 base
+  
+  Now that @webjsdev/cli@0.10.20 (#570, npx-free webjs db/test) is the published
+  latest, a freshly scaffolded bun app's boot-time webjs db migrate runs under
+- **enforce declare-free factory DX (drop static properties + declare)** ([#599](https://github.com/webjsdev/webjs/pull/599)) [`2ce2e0db`](https://github.com/webjsdev/webjs/commit/2ce2e0db)
+  * feat: enforce declare-free factory DX at runtime + in webjs check
+  
+  Reactive properties must now be declared via the extends WebComponent({…})
+  factory. A hand-written `static properties` in a class body throws at

--- a/changelog/core/0.7.22.md
+++ b/changelog/core/0.7.22.md
@@ -1,0 +1,30 @@
+---
+package: "@webjsdev/core"
+version: 0.7.22
+date: 2026-06-18T16:09:28.392Z
+commit_count: 5
+---
+## Features
+
+- **unify webjs dev/start/db with npm-script behavior via a tasks config** ([#554](https://github.com/webjsdev/webjs/pull/554)) [`f22ac7d3`](https://github.com/webjsdev/webjs/commit/f22ac7d3)
+  * feat: orchestrate dev/start tasks from the webjs config block (#550)
+  
+  * feat: add dev.before + scaffold tasks config, route db scripts via webjs db (#550)
+- **switch the default ORM from Prisma to Drizzle** ([#558](https://github.com/webjsdev/webjs/pull/558)) [`5938ab67`](https://github.com/webjsdev/webjs/commit/5938ab67)
+  * chore: remove orphaned prisma-preflight (dead since #550, Prisma leaving in #551)
+  
+  * feat: point webjs db at drizzle-kit instead of prisma
+- **declare-free reactive-prop DX via dual-role WebComponent** ([#597](https://github.com/webjsdev/webjs/pull/597)) [`2b409c51`](https://github.com/webjsdev/webjs/commit/2b409c51)
+  * feat: implement declare-free reactive properties via factory
+  
+  Introduce a callable WebComponent constructor that acts as a class factory and can be invoked with a property shape object. This allows properties to be fully typed without needing a manual declare line, while keeping full backward compatibility with the existing static properties field structure.
+- **device-adaptive link prefetch, viewport-safe on mobile** ([#594](https://github.com/webjsdev/webjs/pull/594)) [`c6eae7ba`](https://github.com/webjsdev/webjs/commit/c6eae7ba)
+  * feat: device-adaptive link prefetch, viewport-safe on mobile
+  
+  The client router's default prefetch was always 'intent' (hover/focus/
+  touch-start). On touch there is no hover and touchstart fires at tap
+- **enforce declare-free factory DX (drop static properties + declare)** ([#599](https://github.com/webjsdev/webjs/pull/599)) [`2ce2e0db`](https://github.com/webjsdev/webjs/commit/2ce2e0db)
+  * feat: enforce declare-free factory DX at runtime + in webjs check
+  
+  Reactive properties must now be declared via the extends WebComponent({…})
+  factory. A hand-written `static properties` in a class body throws at

--- a/changelog/intellisense/0.5.2.md
+++ b/changelog/intellisense/0.5.2.md
@@ -1,0 +1,17 @@
+---
+package: "@webjsdev/intellisense"
+version: 0.5.2
+date: 2026-06-18T16:09:28.541Z
+commit_count: 2
+---
+## Features
+
+- **declare-free reactive-prop DX via dual-role WebComponent** ([#597](https://github.com/webjsdev/webjs/pull/597)) [`2b409c51`](https://github.com/webjsdev/webjs/commit/2b409c51)
+  * feat: implement declare-free reactive properties via factory
+  
+  Introduce a callable WebComponent constructor that acts as a class factory and can be invoked with a property shape object. This allows properties to be fully typed without needing a manual declare line, while keeping full backward compatibility with the existing static properties field structure.
+- **enforce declare-free factory DX (drop static properties + declare)** ([#599](https://github.com/webjsdev/webjs/pull/599)) [`2ce2e0db`](https://github.com/webjsdev/webjs/commit/2ce2e0db)
+  * feat: enforce declare-free factory DX at runtime + in webjs check
+  
+  Reactive properties must now be declared via the extends WebComponent({…})
+  factory. A hand-written `static properties` in a class body throws at

--- a/changelog/mcp/0.1.4.md
+++ b/changelog/mcp/0.1.4.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/mcp"
+version: 0.1.4
+date: 2026-06-18T16:09:28.576Z
+commit_count: 1
+---
+## Features
+
+- **enforce declare-free factory DX (drop static properties + declare)** ([#599](https://github.com/webjsdev/webjs/pull/599)) [`2ce2e0db`](https://github.com/webjsdev/webjs/commit/2ce2e0db)
+  * feat: enforce declare-free factory DX at runtime + in webjs check
+  
+  Reactive properties must now be declared via the extends WebComponent({…})
+  factory. A hand-written `static properties` in a class body throws at

--- a/changelog/nvim/0.2.1.md
+++ b/changelog/nvim/0.2.1.md
@@ -1,0 +1,22 @@
+---
+package: "webjs.nvim"
+version: 0.2.1
+date: 2026-06-18T16:20:00.076Z
+commit_count: 3
+npm: false
+---
+## Features
+
+- **flag duplicate custom-element tag registrations (check rule + editor 9004)** ([#444](https://github.com/webjsdev/webjs/pull/444)) [`5ff76b63`](https://github.com/webjsdev/webjs/commit/5ff76b63)
+  * feat: add no-duplicate-tag webjs check rule (#364)
+  
+  * feat: flag duplicate custom-element tag registrations in editor (#364)
+- **declare-free reactive-prop DX via dual-role WebComponent** ([#597](https://github.com/webjsdev/webjs/pull/597)) [`2b409c51`](https://github.com/webjsdev/webjs/commit/2b409c51)
+  * feat: implement declare-free reactive properties via factory
+  
+  Introduce a callable WebComponent constructor that acts as a class factory and can be invoked with a property shape object. This allows properties to be fully typed without needing a manual declare line, while keeping full backward compatibility with the existing static properties field structure.
+- **enforce declare-free factory DX (drop static properties + declare)** ([#599](https://github.com/webjsdev/webjs/pull/599)) [`2ce2e0db`](https://github.com/webjsdev/webjs/commit/2ce2e0db)
+  * feat: enforce declare-free factory DX at runtime + in webjs check
+  
+  Reactive properties must now be declared via the extends WebComponent({…})
+  factory. A hand-written `static properties` in a class body throws at

--- a/changelog/server/0.8.32.md
+++ b/changelog/server/0.8.32.md
@@ -1,0 +1,17 @@
+---
+package: "@webjsdev/server"
+version: 0.8.32
+date: 2026-06-18T16:09:28.434Z
+commit_count: 2
+---
+## Features
+
+- **declare-free reactive-prop DX via dual-role WebComponent** ([#597](https://github.com/webjsdev/webjs/pull/597)) [`2b409c51`](https://github.com/webjsdev/webjs/commit/2b409c51)
+  * feat: implement declare-free reactive properties via factory
+  
+  Introduce a callable WebComponent constructor that acts as a class factory and can be invoked with a property shape object. This allows properties to be fully typed without needing a manual declare line, while keeping full backward compatibility with the existing static properties field structure.
+- **enforce declare-free factory DX (drop static properties + declare)** ([#599](https://github.com/webjsdev/webjs/pull/599)) [`2ce2e0db`](https://github.com/webjsdev/webjs/commit/2ce2e0db)
+  * feat: enforce declare-free factory DX at runtime + in webjs check
+  
+  Reactive properties must now be declared via the extends WebComponent({…})
+  factory. A hand-written `static properties` in a class body throws at

--- a/changelog/vscode/0.2.1.md
+++ b/changelog/vscode/0.2.1.md
@@ -1,0 +1,24 @@
+---
+package: "webjs (VS Code extension)"
+version: 0.2.1
+date: 2026-06-18T16:20:00.047Z
+commit_count: 3
+npm: false
+---
+## Features
+
+- **editor plugin Phase 3: drop ts-lit-plugin dep, standalone @webjsdev/ts-plugin** ([#393](https://github.com/webjsdev/webjs/pull/393)) [`cbb309fd`](https://github.com/webjsdev/webjs/commit/cbb309fd)
+  * test: remove obsolete ts-lit suppression tests (Phase 3)
+  
+  Phase 3 (#386) removes the ts-lit-plugin dependency, so the tests that
+  simulated ts-lit diagnostics and asserted the suppression path no longer
+- **track vscode + nvim editor packages in the changelog feed** ([#414](https://github.com/webjsdev/webjs/pull/414)) [`5727a075`](https://github.com/webjsdev/webjs/commit/5727a075)
+  * feat: track vscode + nvim editor packages in the changelog (#413)
+  
+  Of the three editor packages only @webjsdev/ts-plugin appeared in the
+  unified /changelog feed; the VS Code extension (private, ships via
+- **enforce declare-free factory DX (drop static properties + declare)** ([#599](https://github.com/webjsdev/webjs/pull/599)) [`2ce2e0db`](https://github.com/webjsdev/webjs/commit/2ce2e0db)
+  * feat: enforce declare-free factory DX at runtime + in webjs check
+  
+  Reactive properties must now be declared via the extends WebComponent({…})
+  factory. A hand-written `static properties` in a class body throws at

--- a/package-lock.json
+++ b/package-lock.json
@@ -7339,7 +7339,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.20",
+      "version": "0.10.21",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -7355,7 +7355,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.21",
+      "version": "0.7.22",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.25.0"
@@ -7363,7 +7363,7 @@
     },
     "packages/editors/intellisense": {
       "name": "@webjsdev/intellisense",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "peerDependencies": {
         "typescript": ">=5.0.0"
@@ -7389,7 +7389,7 @@
     },
     "packages/mcp": {
       "name": "@webjsdev/mcp",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/server": "^0.8.0"
@@ -7403,7 +7403,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.31",
+      "version": "0.8.32",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7371,11 +7371,11 @@
     },
     "packages/editors/nvim": {
       "name": "webjs.nvim",
-      "version": "0.2.0"
+      "version": "0.2.1"
     },
     "packages/editors/vscode": {
       "name": "webjs",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/intellisense": "^0.5.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.20",
+  "version": "0.10.21",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.21",
+  "version": "0.7.22",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/editors/intellisense/package.json
+++ b/packages/editors/intellisense/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/intellisense",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "commonjs",
   "description": "Standalone TypeScript language-service plugin for webjs (no Lit dependency). Adds in-template intelligence inside html`` templates: go-to-definition on tags / attributes / CSS classes, binding-aware completions, value/binding diagnostics, and hover, all driven by its own template parser and gated on import-graph reachability.",
   "main": "src/index.js",

--- a/packages/editors/nvim/package.json
+++ b/packages/editors/nvim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webjs.nvim",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "Neovim editor support for webjs apps (html/css/svg template highlighting + in-template intelligence via the bundled @webjsdev/intellisense). NOT an npm package: ships to the webjsdev/webjs.nvim git repo via subtree split, installed by lazy.nvim. This manifest exists only as the version source for the unified changelog (changelog/nvim/<version>.md); see PUBLISHING.md."
 }

--- a/packages/editors/vscode/package.json
+++ b/packages/editors/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webjs",
   "displayName": "webjs",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "All-in-one webjs support: html/css template highlighting, language-service intelligence, snippets, and commands. No Lit extension required.",
   "publisher": "webjsdev",
   "private": true,

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/mcp",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "description": "The webjs Model Context Protocol server: live app introspection (routes / actions / components / check) plus the framework knowledge layer (docs, recipes, source) for AI coding agents",
   "bin": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Release batch for the work merged since the last cut.

## npm packages (all patch, dependents pin `^`, no range edits)

| Package | From | To | Covers |
|---|---|---|---|
| `@webjsdev/core` | 0.7.21 | **0.7.22** | #554, #558, #594, #597, #599 |
| `@webjsdev/server` | 0.8.31 | **0.8.32** | #597, #599 |
| `@webjsdev/cli` | 0.10.20 | **0.10.21** | #596 (+ tooling) |
| `@webjsdev/mcp` | 0.1.3 | **0.1.4** | #599 |
| `@webjsdev/intellisense` | 0.5.1 | **0.5.2** | #597, #599 |

`@webjsdev/ui` is intentionally NOT bumped (no `src` changes since 0.3.5).

## Editor plugins (not npm; `npm: false`, so release.yml skips the registry)

| Plugin | From | To | Covers | Publish |
|---|---|---|---|---|
| `webjs.nvim` | 0.2.0 | **0.2.1** | #444, #597, #599 | git subtree to `webjsdev/webjs.nvim` + tag (handled here) |
| `webjs` (VS Code) | 0.2.0 | **0.2.1** | #420, #443, #599 | VS Marketplace / Open VSX (owner-handled) |

Both bundle `@webjsdev/intellisense`, whose #597/#599 changes alter the authoring intelligence, so their bundles are refreshed.

## Heads-up: #599 is a behavior change for component authors

`feat: enforce declare-free factory DX (drop static properties + declare)` changes how reactive props are declared. Classified as a feature and shipped as a patch because the repo has no external consumers yet, but it IS a breaking authoring change. Migration lives in #599 + the AGENTS docs.

## Mechanics

- Versions bumped on the `chore/release-*` branch (the only branch the pre-commit hook permits a published-library bump on).
- Changelogs auto-generated by `scripts/backfill-changelog.js`; editor-plugin changelogs carry `npm: false` so `publish-npm.js` skips the registry and only a GitHub Release is cut.
- `package-lock.json` regenerated; the only diff is the workspace versions.
- Merging lands the `changelog/**.md` files on `main`, triggering `release.yml` to `npm publish` the 5 npm packages and cut GitHub Releases (idempotent). The nvim subtree push and the VS Code Marketplace upload are separate manual steps after merge.
