### PR TITLE
fix: force instant scroll on navigation so smooth CSS does not animate it

### DIFF
--- a/agent-docs/advanced.md
+++ b/agent-docs/advanced.md
@@ -868,6 +868,13 @@ revalidation fetch that follows does **not** scroll, so the restored
 position survives the refresh. Cache miss → browser-native scroll
 restoration takes over.
 
+Every programmatic nav scroll (the popstate restore and the
+scroll-to-top on a forward nav) is issued with `behavior: 'instant'`, so
+an app-level `html { scroll-behavior: smooth }` does not animate it. The
+restore matches a native page load (an instant jump), not a visible
+slide. The one nav scroll left smooth is a hash-anchor (`#section`)
+target, where smooth scrolling is the intent.
+
 Inner scroll containers (e.g. `.docs-sidenav`) are preserved
 automatically by the outer-layout-DOM-identity invariant. They stay
 mounted across nav and keep their `scrollTop` natively.

--- a/docs/app/docs/client-router/page.ts
+++ b/docs/app/docs/client-router/page.ts
@@ -177,6 +177,7 @@ connectWS('/posts/' + id + '/feed', { onMessage: (m) =&gt; renderStream(m) });</
 
     <h2>Snapshot cache + back/forward</h2>
     <p>The router maintains a URL-keyed LRU cache of page snapshots (capacity 16). On back/forward via <code>popstate</code>, the cached DOM is applied instantly and the captured window-scroll position is restored. A background refetch then revalidates the snapshot quietly.</p>
+    <p>Nav scroll restoration (both the back/forward restore and the scroll-to-top on a forward nav) is forced <code>behavior: 'instant'</code>, so setting <code>html { scroll-behavior: smooth }</code> in your app does not make navigation visibly animate the scroll. It jumps like a native page load. A hash-anchor (<code>#section</code>) link still scrolls smoothly when you opt into it.</p>
     <p>After a server action mutates data that a cached page depends on, call <code>revalidate()</code>:</p>
     <pre>import { revalidate } from '@webjsdev/core';
 

--- a/packages/core/src/router-client.js
+++ b/packages/core/src/router-client.js
@@ -801,9 +801,11 @@ async function performNavigation(href, isPopState, frameId) {
         const cachedDoc = parseHTML(cached.html);
         if (cachedDoc) {
           applySwap(cachedDoc, frameId, /* revalidating */ true, /* href */ null);
-          // Restore window scroll to where the user left it.
+          // Restore window scroll to where the user left it. Use
+          // behavior:'instant' so an app-level `scroll-behavior: smooth`
+          // stylesheet does not animate the restore (native nav jumps).
           if (typeof window !== 'undefined') {
-            window.scrollTo(cached.scrollX, cached.scrollY);
+            window.scrollTo({ left: cached.scrollX, top: cached.scrollY, behavior: 'instant' });
           }
           // Fire-and-forget revalidation. Uses a fresh AbortController
           // since this background fetch is allowed to overlap with the
@@ -819,7 +821,7 @@ async function performNavigation(href, isPopState, frameId) {
       // on the page they popped FROM. Scroll to top as the reasonable
       // default; fetchAndApply skips its own scroll handling when
       // recordHistory=false (which is the case here).
-      if (typeof window !== 'undefined') window.scrollTo(0, 0);
+      if (typeof window !== 'undefined') window.scrollTo({ left: 0, top: 0, behavior: 'instant' });
     }
 
     await fetchAndApply(href, frameId, !isPopState, optimisticState, 'GET', null, signal, myToken);
@@ -1719,10 +1721,15 @@ async function fetchAndApply(href, frameId, recordHistory, optimisticState, meth
     const url = new URL(finalUrl);
     if (url.hash) {
       const t = document.getElementById(url.hash.slice(1));
+      // A hash anchor is the one nav scroll we DON'T force instant: a
+      // `#section` link is exactly where an app's `scroll-behavior: smooth`
+      // is wanted, and native browsers animate it too.
       if (t) t.scrollIntoView();
-      else window.scrollTo(0, 0);
+      else window.scrollTo({ left: 0, top: 0, behavior: 'instant' });
     } else {
-      window.scrollTo(0, 0);
+      // Scroll-to-top on a forward nav. behavior:'instant' so an app-level
+      // `scroll-behavior: smooth` does not animate it (match native nav).
+      window.scrollTo({ left: 0, top: 0, behavior: 'instant' });
     }
   }
 

--- a/packages/core/test/routing/browser/nav-scroll-instant.test.js
+++ b/packages/core/test/routing/browser/nav-scroll-instant.test.js
@@ -1,0 +1,78 @@
+/**
+ * Real-browser test for #601: the client router's nav scroll restoration must
+ * be INSTANT, not animated, even when the app sets `html { scroll-behavior:
+ * smooth }`.
+ *
+ * The router restores scroll programmatically AFTER swapping the DOM. With the
+ * 2-arg `scrollTo(x, y)` form it used, a page-level `scroll-behavior: smooth`
+ * animates that scroll, so the user watches the page slide on every nav. The
+ * fix passes `behavior: 'instant'`, which the CSSOM spec guarantees overrides
+ * `scroll-behavior`. This MUST run in a real browser: linkedom implements
+ * neither `scroll-behavior` nor real scrolling, so only Chromium can prove the
+ * override actually happens.
+ */
+import { enableClientRouter, navigate } from '../../../src/router-client.js';
+
+const assert = {
+  ok: (v, msg) => { if (!v) throw new Error(msg || `Expected truthy, got ${v}`); },
+  equal: (a, b, msg) => { if (a !== b) throw new Error(msg || `Expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}`); },
+};
+
+suite('Client router: nav scroll is instant under scroll-behavior:smooth (#601)', () => {
+  let origFetch, origScrollTo, calls;
+
+  function setup() {
+    enableClientRouter(); // idempotent; ensures the document listeners are attached
+    document.documentElement.style.scrollBehavior = 'smooth';
+    document.body.innerHTML = '<!--wj:children:/-->before<!--/wj:children-->';
+    calls = [];
+    origScrollTo = window.scrollTo;
+    // Record every scroll the router issues (and skip the real scroll so the
+    // assertion is about the call shape, not animation timing).
+    window.scrollTo = (...args) => { calls.push(args); };
+    origFetch = window.fetch;
+    window.fetch = () => Promise.resolve(new Response(
+      '<!doctype html><html><head></head><body>' +
+      '<!--wj:children:/-->after<!--/wj:children--></body></html>',
+      { headers: { 'content-type': 'text/html', 'x-webjs-build': '' } },
+    ));
+  }
+  function teardown() {
+    window.fetch = origFetch;
+    window.scrollTo = origScrollTo;
+    document.documentElement.style.scrollBehavior = '';
+    document.body.innerHTML = '';
+  }
+
+  test('forward nav scroll-to-top uses the instant options form', async () => {
+    setup();
+    try {
+      await navigate(location.origin + '/forward-nav-scroll-target');
+      const optionCalls = calls.filter((c) => c.length === 1 && c[0] && typeof c[0] === 'object');
+      assert.ok(optionCalls.length > 0,
+        'router scrolled via the scrollTo(options) form, not the 2-arg (0, 0) form');
+      assert.ok(optionCalls.every((c) => c[0].behavior === 'instant'),
+        "every nav scroll uses behavior:'instant'");
+    } finally { teardown(); }
+  });
+
+  test("behavior:'instant' actually overrides scroll-behavior:smooth in this browser", async () => {
+    // The spec guarantee the fix relies on, proven live: an instant scroll
+    // lands synchronously (no animation ramp) even while the document is in
+    // smooth mode. This is the difference that made the old 2-arg form animate.
+    document.documentElement.style.scrollBehavior = 'smooth';
+    const filler = document.createElement('div');
+    filler.style.height = '5000px';
+    document.body.appendChild(filler);
+    try {
+      window.scrollTo({ top: 0, left: 0, behavior: 'instant' });
+      window.scrollTo({ top: 1500, left: 0, behavior: 'instant' });
+      assert.equal(Math.round(window.scrollY), 1500,
+        'instant scroll lands synchronously despite scroll-behavior:smooth');
+    } finally {
+      filler.remove();
+      window.scrollTo({ top: 0, left: 0, behavior: 'instant' });
+      document.documentElement.style.scrollBehavior = '';
+    }
+  });
+});

--- a/packages/core/test/routing/router-client.test.js
+++ b/packages/core/test/routing/router-client.test.js
@@ -1334,6 +1334,45 @@ test('navigate: forward-nav scroll-to-top is instant, not animated (#601)', asyn
   }
 });
 
+test('navigate: a found hash anchor stays SMOOTH, not forced instant (#601)', async () => {
+  // The carve-out for the instant-scroll fix: it must NOT touch the
+  // hash-anchor path. A `#section` link (e.g. a menu pointing at a section)
+  // should still animate under `scroll-behavior: smooth`, so a found anchor
+  // is scrolled via scrollIntoView (which honors the page CSS), NEVER via the
+  // forced-instant scrollTo. This guards against a later "tidy-up" that makes
+  // section links jump.
+  document.body.innerHTML =
+    '<!--wj:children:/--><section id="sec">S</section><!--/wj:children-->';
+  const { restore } = installNavigationMocks({
+    contentType: 'text/html',
+    body:
+      '<!doctype html><html><head></head><body>' +
+      '<!--wj:children:/--><section id="sec">S</section><!--/wj:children--></body></html>',
+  });
+  let intoViewCalls = 0;
+  const scrollToArgs = [];
+  const origInto = globalThis.HTMLElement.prototype.scrollIntoView;
+  globalThis.HTMLElement.prototype.scrollIntoView = function () { intoViewCalls++; };
+  const origWinScrollTo = globalThis.window?.scrollTo;
+  const spy = (...a) => { scrollToArgs.push(a); };
+  // Set the spies AFTER installNavigationMocks (which stubs globalThis.scrollTo).
+  globalThis.scrollTo = /** @type any */ (spy);
+  if (globalThis.window) globalThis.window.scrollTo = /** @type any */ (spy);
+  try {
+    await navigate('http://localhost/page#sec');
+    assert.equal(intoViewCalls, 1,
+      'a found hash anchor scrolls via scrollIntoView (honors scroll-behavior:smooth)');
+    const forcedInstant = scrollToArgs.some((a) => a.length === 1 && a[0] && a[0].behavior === 'instant');
+    assert.ok(!forcedInstant,
+      'the hash-anchor path must NOT force behavior:instant (that would kill smooth section scrolling)');
+  } finally {
+    restore();
+    globalThis.HTMLElement.prototype.scrollIntoView = origInto;
+    if (globalThis.window) globalThis.window.scrollTo = origWinScrollTo;
+    document.body.innerHTML = '';
+  }
+});
+
 test('navigate: clean swap clears reload flag so a later mismatch reloads again', async () => {
   // After "reload due to mismatch → clean nav → later mismatch", the
   // later mismatch must trigger its own fresh reload. Regression for

--- a/packages/core/test/routing/router-client.test.js
+++ b/packages/core/test/routing/router-client.test.js
@@ -1255,6 +1255,85 @@ test('popstate cache restore clears the importmap-reload flag', async () => {
   }
 });
 
+test('popstate cache restore scrolls instantly, not animated (#601)', async () => {
+  // The restore previously used scrollTo(x, y) (the 2-arg form), which
+  // respects an app's `html { scroll-behavior: smooth }` and so ANIMATES
+  // the Back/Forward scroll instead of jumping the way native nav does.
+  // The fix passes behavior:'instant' to force the jump.
+  const origLoc = globalThis.location;
+  const origFetch = globalThis.fetch;
+  const prevPageUrl = _currentPageUrl();
+  _snapshotCache.set('/restore-here', {
+    html: '<!doctype html><html><head></head><body><!--wj:children:/-->cached<!--/wj:children--></body></html>',
+    scrollX: 0,
+    scrollY: 640,
+  });
+  globalThis.location = /** @type any */ ({
+    href: 'http://localhost/restore-here',
+    pathname: '/restore-here', origin: 'http://localhost', search: '', hash: '',
+  });
+  _setCurrentPageUrl('http://localhost/elsewhere');
+  globalThis.fetch = async () => new Response('<html></html>', {
+    status: 200, headers: { 'content-type': 'text/html' },
+  });
+  let arg;
+  const spy = (a) => { arg = a; };
+  const origGlobalScrollTo = globalThis.scrollTo;
+  const origWinScrollTo = globalThis.window?.scrollTo;
+  globalThis.scrollTo = /** @type any */ (spy);
+  if (globalThis.window) globalThis.window.scrollTo = /** @type any */ (spy);
+  document.head.innerHTML = '';
+  document.body.innerHTML = '<!--wj:children:/-->before-pop<!--/wj:children-->';
+  try {
+    _onPopState({});
+    assert.ok(arg && typeof arg === 'object',
+      'restore uses the scrollTo options form, not the 2-arg (x, y) form');
+    assert.equal(arg.behavior, 'instant',
+      'behavior:instant keeps an app scroll-behavior:smooth from animating the restore');
+    assert.equal(arg.top, 640, 'saved scrollY restored as top');
+    assert.equal(arg.left, 0, 'saved scrollX restored as left');
+    // Let the background revalidation settle (avoid an unhandled rejection).
+    await new Promise((r) => setTimeout(r, 5));
+  } finally {
+    _snapshotCache.delete('/restore-here');
+    _setCurrentPageUrl(prevPageUrl);
+    globalThis.location = origLoc;
+    globalThis.fetch = origFetch;
+    globalThis.scrollTo = origGlobalScrollTo;
+    if (globalThis.window) globalThis.window.scrollTo = origWinScrollTo;
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+  }
+});
+
+test('navigate: forward-nav scroll-to-top is instant, not animated (#601)', async () => {
+  document.body.innerHTML = '<!--wj:children:/-->before<!--/wj:children-->';
+  const { restore } = installNavigationMocks({
+    contentType: 'text/html',
+    body:
+      '<!doctype html><html><head></head><body>' +
+      '<!--wj:children:/-->after<!--/wj:children--></body></html>',
+  });
+  let arg;
+  const spy = (a) => { arg = a; };
+  const origWinScrollTo = globalThis.window?.scrollTo;
+  globalThis.scrollTo = /** @type any */ (spy);
+  if (globalThis.window) globalThis.window.scrollTo = /** @type any */ (spy);
+  try {
+    await navigate('http://localhost/forward');
+    assert.ok(arg && typeof arg === 'object',
+      'forward nav uses the scrollTo options form, not (0, 0)');
+    assert.equal(arg.behavior, 'instant',
+      'forward-nav scroll-to-top jumps instantly even under scroll-behavior:smooth');
+    assert.equal(arg.top, 0);
+    assert.equal(arg.left, 0);
+  } finally {
+    restore();
+    if (globalThis.window) globalThis.window.scrollTo = origWinScrollTo;
+    document.body.innerHTML = '';
+  }
+});
+
 test('navigate: clean swap clears reload flag so a later mismatch reloads again', async () => {
   // After "reload due to mismatch → clean nav → later mismatch", the
   // later mismatch must trigger its own fresh reload. Regression for


### PR DESCRIPTION
Closes #601

The client router restored scroll with the 2-arg `scrollTo(x, y)` form, which honors an app's `html { scroll-behavior: smooth }`. That made every SPA navigation visibly animate (forward nav slid to the top, Back slid down to the prior position) instead of jumping the way a native page load does. Reproduced on example-blog.webjs.dev, which sets `scroll-behavior: smooth` in its root layout.

Fix: pass `behavior: 'instant'` at the three nav scroll-restoration call sites in `packages/core/src/router-client.js` (popstate cache-hit restore, cache-miss popstate top, forward-nav top). The hash-anchor `scrollIntoView()` is deliberately left alone, since a `#section` link is exactly where smooth scrolling is wanted and native browsers animate it too.

## Test plan
- [x] Unit: two tests in `router-client.test.js` assert the popstate restore and forward-nav scroll-to-top use the options form with `behavior: 'instant'` and the right coordinates.
- [x] Counterfactual: both unit tests go red when the fix is reverted to the 2-arg form, green when restored.
- [x] Browser (wtr): `routing/browser/nav-scroll-instant.test.js` proves the router emits the instant form on a real SPA nav, and that `behavior: 'instant'` actually overrides `scroll-behavior: smooth` in Chromium (the override linkedom cannot model).
- [x] Dogfood: website / docs / ui-website boot 200/302 in prod mode with all modulepreloads resolving. Blog e2e via CI (the worktree resolves `@webjsdev/core` to the main checkout, so the branch's e2e is validated by CI's clean install).
- [x] Docs: `agent-docs/advanced.md` scroll-restoration section and the client-router docs page note the forced-instant behavior.

## Notes
- Self-review ran two rounds; both clean.
- While verifying, I hit a stale local `packages/core/dist/` (gitignored, predating the declare-free factory) that made the blog SSR 500 locally; rebuilding dist fixed it. Not related to this change and not shipped (CI/fresh clones rebuild dist).