### PR TITLE
refactor: de-duplicate WebComponent static members into shared type

### DIFF
--- a/packages/core/src/component.d.ts
+++ b/packages/core/src/component.d.ts
@@ -146,10 +146,14 @@ export type InferProps<S> = {
   [K in keyof S]: S[K] extends PropertyDeclaration<infer T> ? T : Infer<S[K]>
 };
 
-export interface WebComponentConstructor {
-  new (): WebComponentBase;
-  prototype: WebComponentBase;
-
+/**
+ * The static surface every `WebComponent` constructor carries (the bare base,
+ * a factory-produced base, and a registered subclass alike). Declared ONCE
+ * here and referenced from both `WebComponentConstructor` and the factory-call
+ * return type below, so adding or changing a static can never let the two
+ * positions drift. Mirrors the `static` members on `WebComponentBase`.
+ */
+interface WebComponentStatics {
   shadow: boolean;
   hydrate: 'visible' | undefined;
   properties: Record<string, PropertyDeclaration>;
@@ -157,18 +161,15 @@ export interface WebComponentConstructor {
   lazy?: boolean;
   register(tag: string): void;
   readonly observedAttributes: string[];
+}
 
-  <S extends Record<string, any>>(shape: S): {
+export interface WebComponentConstructor extends WebComponentStatics {
+  new (): WebComponentBase;
+  prototype: WebComponentBase;
+
+  <S extends Record<string, any>>(shape: S): WebComponentStatics & {
     new (): WebComponentBase & InferProps<S>;
     prototype: WebComponentBase & InferProps<S>;
-
-    shadow: boolean;
-    hydrate: 'visible' | undefined;
-    properties: Record<string, PropertyDeclaration>;
-    styles: CSSResult | CSSResult[] | null;
-    lazy?: boolean;
-    register(tag: string): void;
-    readonly observedAttributes: string[];
   };
 }
 

--- a/test/types/component-types.test-d.ts
+++ b/test/types/component-types.test-d.ts
@@ -73,6 +73,10 @@ const _lazy: boolean | undefined = Counter.lazy;
 const _observed: readonly string[] = Counter.observedAttributes;
 Counter.register('my-counter-instance');
 void _shadow; void _hydrate; void _properties; void _styles; void _lazy; void _observed;
+// `lazy` must stay OPTIONAL (`lazy?`), not merely `boolean | undefined`: an
+// empty object is assignable only when the key is optional, so this reds if the
+// modifier is ever dropped from the shared declaration.
+type _LazyStaysOptional = Assert<{} extends Pick<typeof Counter, 'lazy'> ? true : false>;
 
 /* ------------- prop() with options preserves the type ------------- */
 

--- a/test/types/component-types.test-d.ts
+++ b/test/types/component-types.test-d.ts
@@ -61,6 +61,19 @@ type _Count = Assert<Equal<typeof counter.count, number>>;
 type _Label = Assert<Equal<typeof counter.label, string>>;
 type _Open = Assert<Equal<typeof counter.open, boolean>>;
 
+/* ------------- The factory-produced base carries the FULL static surface -------------
+ * Regression net for the de-duplicated `WebComponentStatics` (#602): both the
+ * constructor type and the factory-call return type reference the one shared
+ * declaration, so dropping any static from it must red this block. */
+const _shadow: boolean = Counter.shadow;
+const _hydrate: 'visible' | undefined = Counter.hydrate;
+const _properties: Record<string, PropertyDeclaration> = Counter.properties;
+const _styles = Counter.styles;
+const _lazy: boolean | undefined = Counter.lazy;
+const _observed: readonly string[] = Counter.observedAttributes;
+Counter.register('my-counter-instance');
+void _shadow; void _hydrate; void _properties; void _styles; void _lazy; void _observed;
+
 /* ------------- prop() with options preserves the type ------------- */
 
 class Toggle extends WebComponent({ pressed: prop(Boolean, { reflect: true }) }) {}


### PR DESCRIPTION
Closes #602

The factory type surface in `packages/core/src/component.d.ts` declared the same
seven static members twice: once on the `WebComponentConstructor` interface and
again, identically, on the factory-call return type. Changing a static meant
editing both, or they silently drift.

This declares the surface once as a local `WebComponentStatics` interface and
references it from both positions (`extends` on the constructor interface, an
intersection on the factory-call return type). It mirrors the `static` members
on `WebComponentBase`. Type-only overlay change with zero runtime effect.
`component.js` is untouched.

I chose the issue's lower-risk Option 1 (extract and reference) over Option 2
(`Omit<typeof WebComponentBase, 'new'>`), which would have coupled the
constructor type to the base-class statics and required exporting
`WebComponentBase`. `WebComponentStatics` is left non-exported, matching how
`WebComponentBase` itself is local to this file, so there is no new public
export and the export-coverage guard is unaffected.

## Test plan
- Extended `test/types/component-types.test-d.ts` to read the full static
  surface off a factory-produced base, and to lock `lazy`'s optional modifier,
  so dropping any member (or its `?`) from the shared declaration reds the
  fixture.
- Counterfactuals verified: removing `register` reds with `TS2339` on every
  factory class; making `lazy` required reds the optionality assertion with
  `TS2344`. Both go green on restore.
- Full type-fixtures suite green (10/10), including `server-exports.test-d.ts`.

## Docs / surfaces
- N/A: no public-surface change (the new interface is non-exported), no runtime
  change, and a `.d.ts` overlay ships nothing to the browser, so no
  AGENTS.md / docs-site / scaffold / MCP / editor / dogfood-app updates apply.
