### PR TITLE
fix: compare old vs new version in pre-commit bump detection

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -46,21 +46,42 @@ if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
   exit 1
 fi
 
-# Gate 2: when a packages/<pkg>/package.json version bumped, auto-
-# generate the matching changelog/<pkg>/<version>.md and stage it so
-# the version-bump commit ships with its release notes in one shot.
-# Bumps are detected by scanning the staged diff for a `+ "version":`
-# line in any packages/*/package.json.
-STAGED_PKG_BUMPS=$(git diff --cached --unified=0 -- \
-    'packages/*/package.json' 'packages/editors/*/package.json' 'packages/wrappers/*/package.json' 2>/dev/null \
-  | awk '
-      # pkg = the directory immediately containing package.json, at any depth
-      # (so a grouped package like packages/editors/intellisense maps to "intellisense").
-      /^diff --git/ { match($0, /[A-Za-z0-9_-]+\/package\.json/); pkg = substr($0, RSTART, RLENGTH-13); next }
-      pkg && /^\+\s*"version":\s*"[^"]+"/ {
-        match($0, /"[0-9]+\.[0-9]+\.[0-9]+[^"]*"/); v = substr($0, RSTART+1, RLENGTH-2);
-        print pkg "@" v
-      }')
+# Gate 2/3 share this: detect packages/<pkg>/package.json files whose
+# "version" VALUE actually changed. We read the OLD (HEAD) value and the NEW
+# (staged) value for each changed manifest and register a bump only when they
+# DIFFER, emitting `<pkgdir>@<newversion>` (the shape gate 2 + gate 3 consume).
+#
+# The old heuristic scanned `git diff --unified=0` for an added `+ "version":`
+# line. With --unified=0, an edit ADJACENT to the version line can re-emit the
+# value-unchanged version line as a `+` (e.g. appending a field after a
+# last-position version line adds a trailing comma to it, so git re-emits the
+# whole line), which spuriously registered a bump and blocked a legit
+# non-version manifest edit on a feature branch (#592). Comparing values fixes
+# both gates at once.
+pkgjson_version() {
+  # read a package.json blob on stdin, print the top-level "version" value
+  # (empty when the manifest has no version line).
+  grep -E -m1 '^[[:space:]]*"version"[[:space:]]*:' \
+    | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/'
+}
+STAGED_PKG_BUMPS=""
+for pkgmanifest in $(git diff --cached --name-only -- \
+    'packages/*/package.json' 'packages/editors/*/package.json' 'packages/wrappers/*/package.json' 2>/dev/null); do
+  # pkg = the directory immediately containing package.json (so a grouped
+  # package like packages/editors/intellisense maps to "intellisense").
+  pkg=$(basename "$(dirname "$pkgmanifest")")
+  newver=$(git show ":$pkgmanifest" 2>/dev/null | pkgjson_version)
+  oldver=$(git show "HEAD:$pkgmanifest" 2>/dev/null | pkgjson_version)
+  # A brand-new manifest (no HEAD blob, so oldver is empty) is the initial add
+  # of a package, NOT a release bump: skip it, so adding a package on a feature
+  # branch is not mistaken for a wrong-branch release (#592).
+  [ -z "$oldver" ] && continue
+  if [ -n "$newver" ] && [ "$newver" != "$oldver" ]; then
+    STAGED_PKG_BUMPS="$STAGED_PKG_BUMPS $pkg@$newver"
+  fi
+done
+# Trim the leading separator so `[ -n "$STAGED_PKG_BUMPS" ]` is false when empty.
+STAGED_PKG_BUMPS=$(printf '%s' "$STAGED_PKG_BUMPS" | sed -E 's/^ +//')
 
 # Gate 3: a published-library version bump belongs on a chore/release-* branch.
 # A core/server/cli/mcp/ui/intellisense bump on a feature branch is almost always

--- a/test/hooks/release-branch-guard.test.mjs
+++ b/test/hooks/release-branch-guard.test.mjs
@@ -38,6 +38,27 @@ function runHook(pkgPath, branch) {
   return { code: r.status, out: `${r.stdout}${r.stderr}` };
 }
 
+/** Stage an arbitrary old->new edit (raw file contents) for `pkgPath` on
+ * `branch`, run the hook. Lets a test reproduce a non-version manifest edit. */
+function runHookRaw(pkgPath, branch, oldContent, newContent) {
+  const dir = mkdtempSync(join(tmpdir(), 'webjs-hook-'));
+  const git = (...a) => spawnSync('git', a, { cwd: dir, encoding: 'utf8' });
+  git('init', '-q');
+  git('config', 'user.email', 't@t');
+  git('config', 'user.name', 't');
+  git('checkout', '-q', '-b', branch);
+  mkdirSync(join(dir, dirname(pkgPath)), { recursive: true });
+  writeFileSync(join(dir, pkgPath), oldContent);
+  git('add', '-A'); git('commit', '-q', '--no-verify', '-m', 'base');
+  writeFileSync(join(dir, pkgPath), newContent);
+  git('add', pkgPath);
+  const env = { ...process.env };
+  delete env.GITHUB_ACTIONS;
+  const r = spawnSync('bash', [hook], { cwd: dir, encoding: 'utf8', env });
+  rmSync(dir, { recursive: true, force: true });
+  return { code: r.status, out: `${r.stdout}${r.stderr}` };
+}
+
 const GUARD = /not a chore\/release-\* branch/;
 
 test('blocks a cli bump on a feature branch (the wrong-branch release symptom)', () => {
@@ -81,4 +102,25 @@ test('exempts lockstep wrappers (skipped by the changelog step, clean pass)', ()
     assert.doesNotMatch(r.out, GUARD, `${p} is not guarded`);
     assert.equal(r.code, 0, `${p} passes the hook (no changelog required)`);
   }
+});
+
+// A last-position "version" field that gains a trailing comma when a sibling
+// field is appended makes `git diff --unified=0` re-emit the value-unchanged
+// version line as a `+`. The old heuristic mistook that for a bump and blocked
+// a legit non-version manifest edit on a feature branch. (#592)
+const ADJACENT_BASE = '{\n  "name": "core",\n  "version": "1.0.0"\n}\n';
+
+test('does NOT block a non-version manifest edit adjacent to the version line (#592)', () => {
+  const edited = '{\n  "name": "core",\n  "version": "1.0.0",\n  "private": true\n}\n';
+  const r = runHookRaw('packages/core/package.json', 'feat/x', ADJACENT_BASE, edited);
+  assert.equal(r.code, 0, 'a non-version edit on a feature branch passes the hook');
+  assert.doesNotMatch(r.out, GUARD, 'the value did not change, so it is not a bump');
+});
+
+test('still detects a real version change with the same adjacent edit (#592 counterfactual)', () => {
+  // Identical adjacency, but the version VALUE actually changes: gate 3 must
+  // still catch it on a feature branch (proves the fix did not over-correct).
+  const bumped = '{\n  "name": "core",\n  "version": "1.0.1",\n  "private": true\n}\n';
+  const r = runHookRaw('packages/core/package.json', 'feat/x', ADJACENT_BASE, bumped);
+  assert.match(r.out, GUARD, 'a genuine version change is still detected');
 });


### PR DESCRIPTION
Closes #592

`.hooks/pre-commit` detected a staged version bump by scanning `git diff --cached --unified=0` for an added `"version":` line in a `packages/*/package.json`. With `--unified=0`, an edit ADJACENT to a last-position version line re-emits the value-unchanged version line as a `+` (appending a sibling field adds a trailing comma to the version line, so git re-emits the whole line). That spuriously registered a bump, which then fired gate 2 (changelog generator, which finds no bump commit and fails) and gate 3 (#590/#591 wrong-branch-release block). So a legit non-version manifest edit, made adjacent to the version line on a feature branch, was rejected (escape was `--no-verify`).

Fix: read the OLD (HEAD) and NEW (staged) version VALUE for each changed manifest and register a bump only when they differ. A brand-new manifest (no HEAD blob) is the initial add of a package, not a release bump, so it is skipped deliberately. The output shape (`<pkgdir>@<version>`) is unchanged, so gates 2 and 3 are untouched downstream.

## Test plan
- [x] Unit (`test/hooks/release-branch-guard.test.mjs`): a non-version edit adjacent to the version line on a feature branch is NOT blocked; a real version change with the same adjacency IS still detected.
- [x] Counterfactual: the 'does NOT block' test fails against the old hook (proving the bug) and passes with the fix; real-bump detection holds both ways.
- [x] Existing guard tests (gate 3 block / release-branch pass / editor + wrapper exemptions) still green.

## Docs / surfaces
- N/A: `.hooks/pre-commit` is repo tooling, not a published package or user-facing surface; no changelog, docs-site, scaffold, MCP, or editor surface changes.