### PR TITLE
fix: elide display-only components in the declare-free factory DX

### DIFF
--- a/packages/server/src/component-elision.js
+++ b/packages/server/src/component-elision.js
@@ -274,6 +274,15 @@ function hasModuleScopeSideEffect(src) {
     if (ident && /\bfunction\s*\*?\s*$/.test(frame.slice(0, m.index))) continue;
     // The component registration call is the one permitted top-level call.
     if (ident === 'register' || ident === 'define') continue;
+    // `extends WebComponent({ … })` is the declare-free reactive-prop DX (#597
+    // / #599): a class-declaration construct, not an independent side-effecting
+    // statement. Exempt it so a display-only factory-form component stays
+    // elidable; a genuinely interactive one still ships via the per-class and
+    // module-level signal checks below (events, slots, shadow, lifecycle, a
+    // non-state factory prop, a reactive import). Scoped to the `extends`
+    // position, so a top-level `WebComponent(...)` call used anywhere else
+    // still counts as a side effect (#604).
+    if (ident === 'WebComponent' && /\bextends\s+$/.test(frame.slice(0, m.index))) continue;
     return true;                                         // any other top-level call
   }
   return false;
@@ -572,8 +581,19 @@ function hasNonStateReactiveProperty(classBody) {
 }
 
 /**
- * True if the class factory argument declares any property that is NOT
- * marked `{ state: true }`.
+ * True if the class factory argument (`extends WebComponent({ … })`) declares
+ * any reactive property that is NOT `{ state: true }`. A non-state property
+ * rides an HTML attribute or a `.prop` hydration binding, the channel that
+ * forces the component to ship; a `state: true` property is component-local
+ * reactive state with no such channel, so a component whose only signal is
+ * state props stays elidable.
+ *
+ * A property value is treated as state ONLY when its text carries
+ * `state: true`, which covers both the bare descriptor `{ state: true }` and
+ * the `prop()` helper forms `prop({ state: true })` / `prop(Type, { state:
+ * true })`. Anything else (a bare type `Number`, `prop(Number)`, an options
+ * object without `state: true`) is non-state and ships. Conservative on a
+ * spread or an unbalanced brace (cannot prove every entry is state, so ship).
  *
  * @param {string} factoryArg
  * @returns {boolean}
@@ -582,21 +602,17 @@ function hasNonStateFactoryProperty(factoryArg) {
   if (!factoryArg) return false;
   const objStart = factoryArg.indexOf('{');
   if (objStart === -1) return false;
-  const objEnd = matchClosingBrace(factoryArg, objStart);
+  // matchClosingBrace starts at depth 1, so pass the index AFTER the brace.
+  const objEnd = matchClosingBrace(factoryArg, objStart + 1);
   if (objEnd === -1) return true;
   const obj = factoryArg.slice(objStart + 1, objEnd);
-  if (/\.\.\./.test(obj)) return true; // spread
+  if (/\.\.\./.test(obj)) return true; // spread: cannot prove all entries state
   for (const entry of topLevelPropertyValues(obj)) {
-    if (entry.startsWith('{')) {
-      const code = entry
-        .replace(/'[^'\n]*'/g, "''")
-        .replace(/"[^"\n]*"/g, '""')
-        .replace(/`[^`]*`/g, '``');
-      if (!/\bstate\s*:\s*true\b/.test(code)) return true;
-    } else {
-      // Shorthand like `count: Number` rides an attribute, not state
-      return true;
-    }
+    const code = entry
+      .replace(/'[^'\n]*'/g, "''")
+      .replace(/"[^"\n]*"/g, '""')
+      .replace(/`[^`]*`/g, '``');
+    if (!/\bstate\s*:\s*true\b/.test(code)) return true;
   }
   return false;
 }

--- a/packages/server/src/component-elision.js
+++ b/packages/server/src/component-elision.js
@@ -560,18 +560,11 @@ function hasNonStateReactiveProperty(classBody) {
   // see; ship rather than guess they are all { state: true }.
   if (/\.\.\./.test(obj)) return true;
   for (const entry of topLevelPropertyValues(obj)) {
-    // Object-literal descriptor: inert only when it carries state: true.
+    // Object-literal descriptor: inert only when it carries `state: true` at
+    // its top level (descriptorDeclaresState blanks strings and ignores a
+    // nested state flag, e.g. inside a converter, so it cannot be forged).
     if (entry.startsWith('{')) {
-      // Blank string / template bodies first. Redaction keeps quoted
-      // string contents verbatim (so register('tag') stays readable), so
-      // a descriptor like `{ attribute: 'data-state: true' }` would
-      // otherwise forge the state flag. The real `state: true` is code,
-      // not a string, so it survives this blanking.
-      const code = entry
-        .replace(/'[^'\n]*'/g, "''")
-        .replace(/"[^"\n]*"/g, '""')
-        .replace(/`[^`]*`/g, '``');
-      if (!/\bstate\s*:\s*true\b/.test(code)) return true;
+      if (!descriptorDeclaresState(entry)) return true;
     } else {
       // Shorthand like `count: Number` rides an attribute, not state.
       return true;
@@ -588,12 +581,13 @@ function hasNonStateReactiveProperty(classBody) {
  * reactive state with no such channel, so a component whose only signal is
  * state props stays elidable.
  *
- * A property value is treated as state ONLY when its text carries
- * `state: true`, which covers both the bare descriptor `{ state: true }` and
- * the `prop()` helper forms `prop({ state: true })` / `prop(Type, { state:
- * true })`. Anything else (a bare type `Number`, `prop(Number)`, an options
- * object without `state: true`) is non-state and ships. Conservative on a
- * spread or an unbalanced brace (cannot prove every entry is state, so ship).
+ * A property value is treated as state ONLY when its descriptor declares
+ * `state: true` at the TOP LEVEL (see `descriptorDeclaresState`), which covers
+ * the bare descriptor `{ state: true }` and the `prop()` helper forms
+ * `prop({ state: true })` / `prop(Type, { state: true })`. Anything else (a bare
+ * type `Number`, `prop(Number)`, an options object without `state: true`) is
+ * non-state and ships. Conservative on a spread or an unbalanced brace (cannot
+ * prove every entry is state, so ship).
  *
  * @param {string} factoryArg
  * @returns {boolean}
@@ -608,13 +602,42 @@ function hasNonStateFactoryProperty(factoryArg) {
   const obj = factoryArg.slice(objStart + 1, objEnd);
   if (/\.\.\./.test(obj)) return true; // spread: cannot prove all entries state
   for (const entry of topLevelPropertyValues(obj)) {
-    const code = entry
-      .replace(/'[^'\n]*'/g, "''")
-      .replace(/"[^"\n]*"/g, '""')
-      .replace(/`[^`]*`/g, '``');
-    if (!/\bstate\s*:\s*true\b/.test(code)) return true;
+    if (!descriptorDeclaresState(entry)) return true;
   }
   return false;
+}
+
+/**
+ * True if a reactive-property descriptor declares `state: true` at the TOP
+ * LEVEL of its options object (brace-depth 1). Restricting to depth 1 is a
+ * direction-of-safety fix: a `state: true` buried deeper (a converter /
+ * hasChanged body that happens to return `{ state: true }`) must NOT forge the
+ * flag, because wrongly treating an attribute-riding property as state would
+ * ELIDE an interactive component and break the page. Strings / templates are
+ * blanked first, so `attribute: 'data-state: true'` does not match, and the
+ * `\b` word boundary keeps a key like `firstate: true` from matching. In every
+ * legitimate shape (`{ state: true }`, `prop({ state: true })`,
+ * `prop(Type, { state: true })`) the descriptor object is the only brace group,
+ * so its `state` key sits at depth 1.
+ *
+ * @param {string} entry  the property VALUE text
+ * @returns {boolean}
+ */
+function descriptorDeclaresState(entry) {
+  const code = entry
+    .replace(/'[^'\n]*'/g, "''")
+    .replace(/"[^"\n]*"/g, '""')
+    .replace(/`[^`]*`/g, '``');
+  // Keep only text at brace-depth <= 1 (the descriptor's own level); blank
+  // deeper nesting so a nested `state: true` cannot count.
+  let depth = 0;
+  let shallow = '';
+  for (const c of code) {
+    if (c === '{') { depth++; if (depth <= 1) shallow += c; continue; }
+    if (c === '}') { if (depth <= 1) shallow += c; if (depth > 0) depth--; continue; }
+    if (depth <= 1) shallow += c;
+  }
+  return /\bstate\s*:\s*true\b/.test(shallow);
 }
 
 /**

--- a/packages/server/test/elision/analyze.test.js
+++ b/packages/server/test/elision/analyze.test.js
@@ -14,10 +14,14 @@ import {
   computeElidableComponents,
 } from '../../src/component-elision.js';
 
+// Canonical display-only fixture in the declare-free factory DX (#597 / #599):
+// a single { state: true } prop, so nothing rides an attribute and the
+// component is elidable. (The dedicated `static properties` tests below keep
+// covering the legacy analyser path, which #599 bans at runtime but the
+// analyser still classifies defensively.)
 const DISPLAY_ONLY = `
-import { WebComponent, html } from '@webjsdev/core';
-class StudentCard extends WebComponent {
-  static properties = { student: { type: Object, state: true } };
+import { WebComponent, html, prop } from '@webjsdev/core';
+class StudentCard extends WebComponent({ student: prop({ state: true }) }) {
   constructor() { super(); this.student = { name: '' }; }
   render() { return html\`<p>\${this.student.name}</p>\`; }
 }
@@ -37,6 +41,69 @@ test('component with no static properties at all is not interactive', () => {
     HelloWorld.register('hello-world');
   `;
   assert.equal(analyzeComponentSource(src).interactive, false);
+});
+
+// --- Declare-free factory DX, the enforced reactive-prop form (#604) ---------
+// Before #604 the factory CALL `extends WebComponent({ … })` was read as a
+// module-scope side effect by `hasModuleScopeSideEffect`, so EVERY factory-form
+// component shipped, even a display-only one. The exemption (scoped to the
+// `extends` position) plus the `hasNonStateFactoryProperty` fix make the
+// factory matrix classify the same way the legacy `static properties` form did.
+
+const factory = (header, body = 'render() { return html`<span>x</span>`; }') =>
+  `import { html, WebComponent, prop } from '@webjsdev/core';\n` +
+  `class B extends ${header} { ${body} }\nB.register('b-x');`;
+
+test('factory WebComponent({}) display-only is ELIDABLE (#604)', () => {
+  assert.equal(analyzeComponentSource(factory('WebComponent({})')).interactive, false);
+});
+
+test('factory state-only prop({ state: true }) is ELIDABLE (#604)', () => {
+  const r = analyzeComponentSource(factory('WebComponent({ n: prop({ state: true }) })'));
+  assert.equal(r.interactive, false);
+});
+
+test('factory prop(Type, { state: true }) is ELIDABLE (#604)', () => {
+  const r = analyzeComponentSource(factory('WebComponent({ n: prop(Number, { state: true }) })'));
+  assert.equal(r.interactive, false);
+});
+
+test('factory NON-state prop (bare type) ships (#604)', () => {
+  const r = analyzeComponentSource(factory('WebComponent({ n: Number })', 'render() { return html`<span>${this.n}</span>`; }'));
+  assert.equal(r.interactive, true);
+  assert.match(r.reason, /reactive property/);
+});
+
+test('factory prop(Number) (no state) ships (#604)', () => {
+  const r = analyzeComponentSource(factory('WebComponent({ n: prop(Number) })', 'render() { return html`<span>${this.n}</span>`; }'));
+  assert.equal(r.interactive, true);
+  assert.match(r.reason, /reactive property/);
+});
+
+test('factory mixed state + non-state ships (the non-state prop is the signal, #604)', () => {
+  const r = analyzeComponentSource(factory('WebComponent({ a: prop({ state: true }), b: Number })', 'render() { return html`<span>${this.b}</span>`; }'));
+  assert.equal(r.interactive, true);
+});
+
+test('factory {} with an @event ships (#604)', () => {
+  const r = analyzeComponentSource(factory('WebComponent({})', 'render() { return html`<button @click=${() => {}}>x</button>`; }'));
+  assert.equal(r.interactive, true);
+  assert.match(r.reason, /@event/);
+});
+
+test('factory {} with static shadow ships (#604)', () => {
+  const r = analyzeComponentSource(factory('WebComponent({})', 'static shadow = true; render() { return html`<span>x</span>`; }'));
+  assert.equal(r.interactive, true);
+  assert.match(r.reason, /shadow/);
+});
+
+test('the WebComponent exemption is scoped: a top-level non-extends WebComponent() call still ships (#604)', () => {
+  // A non-component module calling the factory at top level is a genuine
+  // module-scope side effect; only the `extends` position is exempt.
+  const src = `import { WebComponent } from '@webjsdev/core';\nconst Base = WebComponent({ n: Number });\nexport { Base };`;
+  const r = analyzeComponentSource(src);
+  assert.equal(r.interactive, true);
+  assert.match(r.reason, /module scope/);
 });
 
 test('@event binding forces interactive', () => {

--- a/packages/server/test/elision/analyze.test.js
+++ b/packages/server/test/elision/analyze.test.js
@@ -106,6 +106,18 @@ test('the WebComponent exemption is scoped: a top-level non-extends WebComponent
   assert.match(r.reason, /module scope/);
 });
 
+test('a non-state prop with a NESTED state:true (a converter) still ships (#604 direction-of-safety)', () => {
+  // The state flag counts only at the descriptor top level. A `state: true`
+  // buried in a converter body must NOT forge the flag, or an attribute-riding
+  // (interactive) prop would be wrongly elided and the page would break.
+  const r = analyzeComponentSource(factory(
+    'WebComponent({ n: prop(Number, { converter: { fromAttribute: () => ({ state: true }) } }) })',
+    'render() { return html`<span>${this.n}</span>`; }',
+  ));
+  assert.equal(r.interactive, true);
+  assert.match(r.reason, /reactive property/);
+});
+
 test('@event binding forces interactive', () => {
   const src = DISPLAY_ONLY.replace(
     '<p>${this.student.name}</p>',

--- a/packages/server/test/elision/serve.test.js
+++ b/packages/server/test/elision/serve.test.js
@@ -70,6 +70,39 @@ test('display-only import is stripped from the served page, interactive import k
   assert.match(code, /counter\.ts/, 'interactive counter import must survive');
 });
 
+// The same display-only component in the enforced declare-free factory DX
+// (#604): a state-only prop, no attribute / event / lifecycle. It must elide
+// through the real serve path exactly like the callless BADGE above, proving
+// the factory-form fix end to end (not just at the analyser).
+const FACTORY_BADGE = `
+import { WebComponent, html, prop } from '@webjsdev/core';
+class FactoryBadge extends WebComponent({ tone: prop({ state: true }) }) {
+  render() { return html\`<span class="badge">verified</span>\`; }
+}
+FactoryBadge.register('x-factory-badge');
+`;
+
+const FACTORY_PAGE = `
+import { html } from '@webjsdev/core';
+import '../components/factory-badge.ts';
+import '../components/counter.ts';
+export default () => html\`<x-factory-badge>hi</x-factory-badge><x-counter></x-counter>\`;
+`;
+
+test('a display-only FACTORY-form component is stripped from the served page (#604)', async () => {
+  const appDir = makeApp({
+    'app/page.ts': FACTORY_PAGE,
+    'components/factory-badge.ts': FACTORY_BADGE,
+    'components/counter.ts': COUNTER,
+  });
+  const app = await createRequestHandler({ appDir, dev: true });
+  const resp = await app.handle(new Request('http://x/app/page.ts'));
+  assert.equal(resp.status, 200, 'page module should be served');
+  const code = await resp.text();
+  assert.doesNotMatch(code, /factory-badge\.ts/, 'display-only factory component import must be elided');
+  assert.match(code, /counter\.ts/, 'interactive import must survive');
+});
+
 test('the elidable component module is still servable if requested directly', async () => {
   // Elision drops the import, not the file. A stray direct request still
   // resolves (harmless); nothing in the graph triggers it after stripping.


### PR DESCRIPTION
Closes #604

A display-only component written in the enforced declare-free factory DX
(`class X extends WebComponent({ ... })`) was never elided. The factory call at
module scope tripped `hasModuleScopeSideEffect` in
`packages/server/src/component-elision.js`, which shipped the module before the
per-class analysis ran. Since #599 the factory form is the only supported way to
declare reactive props, so this silently kept every such component (and its
on-hydration re-fetch) in the browser. Safe-direction (it only ever over-shipped),
so a missed-optimization regression, not a correctness break.

## What changed
- Exempt the `extends WebComponent(...)` factory call from
  `hasModuleScopeSideEffect`, scoped to the `extends` position so a top-level
  `WebComponent(...)` call anywhere else still counts as a side effect.
- Exposing the per-class path surfaced two latent bugs in the previously-dead
  `hasNonStateFactoryProperty`: it passed the wrong offset to
  `matchClosingBrace` (so `objEnd` was always `-1` and it always returned
  `true`), and it only recognised a bare `{ state: true }` descriptor, not the
  idiomatic `prop({ state: true })` helper. Both fixed, so a state-only factory
  component elides and a non-state one ships.

## Test plan
- Migrated the canonical `DISPLAY_ONLY` fixture to the factory DX and added a
  factory matrix to `analyze.test.js` (empty `{}`, state-only `prop({state:true})`,
  `prop(Type,{state:true})`, non-state bare type, `prop(Number)`, mixed, `@event`,
  `static shadow`, and the exemption-scoping case). Full elision suite green
  (160/160).
- Differential elision green: observable SSR output is byte-identical on vs off,
  so the change only drops redundant JS, never alters output.
- Counterfactual: neutralising the `extends WebComponent` exemption reds all 12
  factory-matrix tests (the components ship again); restoring it goes green.

## Docs / surfaces
- AGENTS.md / docs: N/A. The docs already describe factory components as
  elidable display-only modules (root AGENTS invariant 10, server AGENTS
  invariant 7); this makes the code match the documented intent, no surface change.
- Dogfood (four apps): website `/` 200 (6 preloads, none broken), docs `/` 302
  then `/docs/components` 200 (5 preloads), ui-website `/` 200 (4 preloads); blog
  e2e 88/89 (the one miss, `/blog/[slug]` title, is an unseeded-DB artifact that
  passes once the DB is seeded, confirmed by re-running it; not related to this
  change). No broken modulepreloads on any app.


