### PR TITLE
fix: stabilize sticky backdrop-blur headers on mobile nav scroll

### DIFF
--- a/docs/app/docs/layout.ts
+++ b/docs/app/docs/layout.ts
@@ -192,7 +192,7 @@ export default function DocsLayout({ children }: { children: unknown }) {
       }
     </style>
 
-    <header class="hidden max-[860px]:flex sticky top-0 z-[25] items-center gap-4 px-4 py-3 border-b border-border bg-[color-mix(in_oklch,var(--bg)_85%,transparent)] backdrop-blur-[18px] backdrop-saturate-[180%]">
+    <header class="hidden max-[860px]:flex sticky top-0 z-[25] items-center gap-4 px-4 py-3 border-b border-border bg-[color-mix(in_oklch,var(--bg)_85%,transparent)] backdrop-blur-[18px] backdrop-saturate-[180%] [transform:translateZ(0)]">
       <a href="/" class="mr-auto inline-flex items-center gap-2 no-underline text-fg font-semibold text-[15px] leading-none tracking-tight">
         <span class="inline-block w-[22px] h-[22px] rounded-md bg-gradient-to-br from-accent to-[color-mix(in_oklch,var(--accent)_55%,var(--fg))] shadow-[inset_0_0_0_1px_oklch(1_0_0/0.15),0_1px_4px_var(--accent-tint)]"></span>
         <span>webjs docs</span>

--- a/examples/blog/app/layout.ts
+++ b/examples/blog/app/layout.ts
@@ -204,7 +204,7 @@ export default function RootLayout({ children }: LayoutProps) {
       .mobile-menu[open] > summary .close-icon { display: inline-block; }
     </style>
 
-    <header class="sticky top-0 z-20 flex items-center justify-between gap-4 px-4 sm:px-6 py-3 border-b border-border bg-[color-mix(in_oklch,var(--bg)_75%,transparent)] backdrop-blur-[18px] backdrop-saturate-[180%]">
+    <header class="sticky top-0 z-20 flex items-center justify-between gap-4 px-4 sm:px-6 py-3 border-b border-border bg-[color-mix(in_oklch,var(--bg)_75%,transparent)] backdrop-blur-[18px] backdrop-saturate-[180%] [transform:translateZ(0)]">
       <a href="/" class="inline-flex items-center gap-2 no-underline text-fg font-semibold text-[15px] leading-none tracking-tight">
         <span class="inline-block w-[22px] h-[22px] rounded-md bg-gradient-to-br from-accent to-[color-mix(in_oklch,var(--accent)_55%,var(--fg))] shadow-[inset_0_0_0_1px_oklch(1_0_0/0.15),0_1px_4px_var(--accent-tint)]"></span>
         <span>webjs</span>

--- a/website/app/layout.ts
+++ b/website/app/layout.ts
@@ -231,7 +231,7 @@ export default function RootLayout({ children }: { children: unknown }) {
       <a href=${UI_URL} target="_blank" rel="noopener noreferrer" class="text-accent-hover font-semibold no-underline hover:underline">Introducing the AI-first component library <span aria-hidden="true">&rarr;</span>${NEW_TAB}</a>
     </div>
 
-    <header class="sticky top-0 z-20 backdrop-blur-md bg-[color-mix(in_oklch,var(--color-bg)_78%,transparent)] border-b border-border">
+    <header class="sticky top-0 z-20 backdrop-blur-md bg-[color-mix(in_oklch,var(--color-bg)_78%,transparent)] border-b border-border [transform:translateZ(0)]">
       <div class="max-w-[1080px] mx-auto px-6 py-[13px] flex items-center gap-4">
         <a class="mr-auto inline-flex items-center gap-[9px] no-underline text-fg font-display font-extrabold text-[17px] leading-none tracking-[-0.02em]" href="/">
           <span class="w-[22px] h-[22px] rounded-[7px] bg-gradient-to-br from-accent-live to-[color-mix(in_oklch,var(--accent-live)_55%,var(--fg))] shadow-[0_2px_10px_var(--accent-tint)]"></span>


### PR DESCRIPTION
Closes #610

On real mobile devices (iOS Safari + Android Chrome), the example-blog top navbar flickered on a FORWARD client-router navigation but not on Back. The navbar DOM is preserved correctly by the router (it sits outside the `wj:children` slot), so this is a paint artifact, not a layout-recreation bug. The header is `position: sticky` + `backdrop-blur`, and after #603 the forward scroll-to-top is `behavior: 'instant'` (was animated before). On a large single-frame scroll jump the sticky header's `backdrop-filter` must re-rasterize its blurred backdrop in one frame, which weaker mobile GPUs render with a one-frame flicker. Desktop and DevTools device mode composite it fast enough to hide it (and device mode runs Blink, not WebKit, so it cannot reproduce Safari at all).

Fix: promote each sticky backdrop-blur header to its own compositor layer with `[transform:translateZ(0)]`, so the blur composites cleanly through the instant scroll. The #603 instant scroll is correct and is NOT reverted.

Audited all four in-repo apps for the same pattern:
- **blog** (`examples/blog/app/layout.ts`): sticky + `backdrop-blur-[18px]` -> fixed.
- **website** (`website/app/layout.ts`): sticky + `backdrop-blur-md` -> fixed.
- **docs** (`docs/app/docs/layout.ts`): the mobile header (`max-[860px]:flex sticky` + `backdrop-blur-[18px]`) -> fixed. The docs sidebar is sticky but has no blur, so no flicker risk, left alone.
- **ui-website**: header is neither sticky nor blurred -> no change needed.

## Test plan
- [x] website / docs / ui-website boot 200 in prod mode; the `translateZ(0)` hint is present in the website + docs served header HTML and correctly absent from ui-website.
- [ ] **MANUAL, ON A REAL PHONE (required, I cannot do this from here):** verify no navbar flicker on forward nav in iOS Safari AND Android Chrome on the blog, website, and docs; confirm Back still has no flicker and the header blur/translucency is visually unchanged on desktop.

## Docs / surfaces
- N/A: dogfood-app CSS only (no published-package, docs-site, scaffold, MCP, or editor surface). No automated test: the flicker is GPU/compositor-dependent and invisible to headless/emulated browsers (noted in #610).

> Staying a draft until the on-device check passes, since it cannot be verified on this machine.