### PR TITLE
fix: opaque sticky headers to kill the mobile nav-scroll flicker

### DIFF
--- a/docs/app/docs/layout.ts
+++ b/docs/app/docs/layout.ts
@@ -192,7 +192,7 @@ export default function DocsLayout({ children }: { children: unknown }) {
       }
     </style>
 
-    <header class="hidden max-[860px]:flex sticky top-0 z-[25] items-center gap-4 px-4 py-3 border-b border-border bg-[color-mix(in_oklch,var(--bg)_85%,transparent)] backdrop-blur-[18px] backdrop-saturate-[180%] [transform:translateZ(0)]">
+    <header class="hidden max-[860px]:flex sticky top-0 z-[25] items-center gap-4 px-4 py-3 border-b border-border bg-[var(--bg)]">
       <a href="/" class="mr-auto inline-flex items-center gap-2 no-underline text-fg font-semibold text-[15px] leading-none tracking-tight">
         <span class="inline-block w-[22px] h-[22px] rounded-md bg-gradient-to-br from-accent to-[color-mix(in_oklch,var(--accent)_55%,var(--fg))] shadow-[inset_0_0_0_1px_oklch(1_0_0/0.15),0_1px_4px_var(--accent-tint)]"></span>
         <span>webjs docs</span>

--- a/examples/blog/app/layout.ts
+++ b/examples/blog/app/layout.ts
@@ -204,7 +204,7 @@ export default function RootLayout({ children }: LayoutProps) {
       .mobile-menu[open] > summary .close-icon { display: inline-block; }
     </style>
 
-    <header class="sticky top-0 z-20 flex items-center justify-between gap-4 px-4 sm:px-6 py-3 border-b border-border bg-[color-mix(in_oklch,var(--bg)_75%,transparent)] backdrop-blur-[18px] backdrop-saturate-[180%] [transform:translateZ(0)]">
+    <header class="sticky top-0 z-20 flex items-center justify-between gap-4 px-4 sm:px-6 py-3 border-b border-border bg-[var(--bg)]">
       <a href="/" class="inline-flex items-center gap-2 no-underline text-fg font-semibold text-[15px] leading-none tracking-tight">
         <span class="inline-block w-[22px] h-[22px] rounded-md bg-gradient-to-br from-accent to-[color-mix(in_oklch,var(--accent)_55%,var(--fg))] shadow-[inset_0_0_0_1px_oklch(1_0_0/0.15),0_1px_4px_var(--accent-tint)]"></span>
         <span>webjs</span>

--- a/website/app/layout.ts
+++ b/website/app/layout.ts
@@ -231,7 +231,7 @@ export default function RootLayout({ children }: { children: unknown }) {
       <a href=${UI_URL} target="_blank" rel="noopener noreferrer" class="text-accent-hover font-semibold no-underline hover:underline">Introducing the AI-first component library <span aria-hidden="true">&rarr;</span>${NEW_TAB}</a>
     </div>
 
-    <header class="sticky top-0 z-20 backdrop-blur-md bg-[color-mix(in_oklch,var(--color-bg)_78%,transparent)] border-b border-border [transform:translateZ(0)]">
+    <header class="sticky top-0 z-20 bg-[var(--color-bg)] border-b border-border">
       <div class="max-w-[1080px] mx-auto px-6 py-[13px] flex items-center gap-4">
         <a class="mr-auto inline-flex items-center gap-[9px] no-underline text-fg font-display font-extrabold text-[17px] leading-none tracking-[-0.02em]" href="/">
           <span class="w-[22px] h-[22px] rounded-[7px] bg-gradient-to-br from-accent-live to-[color-mix(in_oklch,var(--accent-live)_55%,var(--fg))] shadow-[0_2px_10px_var(--accent-tint)]"></span>


### PR DESCRIPTION
Closes #610

The `translateZ(0)` compositor hint (PR #611) did not stop the navbar flicker on a real iOS device, which confirmed the cause: the sticky header's `backdrop-filter` re-samples its backdrop when the scroll position changes, and the instant nav scroll-to-top (#603) makes one stale frame visible on WebKit/iOS (every iOS browser is WebKit, hence both Safari and Chrome). The public web documents no fully reliable CSS fix for this, and the GPU-hack (translateZ(0)) is exactly what we already tried.

Fix: replace the translucent-background + `backdrop-filter` on the three sticky headers (blog, website, docs) with an opaque background. With no backdrop-filter there is nothing to re-sample, so the flash cannot occur. The now-useless `translateZ(0)` hint is dropped. The non-sticky install-command box on the website landing page keeps its blur (it scrolls with the content, so it does not flicker).

## Framework was confirmed correct, not changed
The instant nav scroll is the right behavior and is unchanged. Surveyed the cloned routers: Astro uses the byte-identical `scrollTo({ left: 0, top: 0, behavior: 'instant' })`; Next.js forces instant equivalently (temp-disables `scroll-behavior: smooth`, then `scrollTop = 0`); Remix 2/3 and Qwik use the 2-arg `scrollTo(0, 0)` (instant by default). None special-case `backdrop-filter`, because it is a WebKit rendering limitation, not a router concern. Full comparison is recorded on #610.

## Test plan
- [x] website / docs / ui-website boot 200 in prod mode; no `backdrop-filter` remains on any sticky header (the website landing-page install box, non-sticky, intentionally keeps its blur).
- [ ] **MANUAL, ON A REAL iOS PHONE (required, cannot verify here):** forward nav after scrolling down shows no navbar flicker on the blog, website, and docs in Safari AND Chrome; Back still has none; headers look right on desktop.

## Docs / surfaces
- N/A: dogfood-app CSS only. No published-package, docs-site-content, scaffold, MCP, or editor surface. No automated test (the artifact is GPU/compositor-dependent and invisible to headless/emulated browsers, noted on #610).

> Draft until the on-device check passes.