### PR TITLE
feat: warn in dev when scroll-behavior: smooth is set on <html>

### DIFF
--- a/agent-docs/advanced.md
+++ b/agent-docs/advanced.md
@@ -875,7 +875,7 @@ restore matches a native page load (an instant jump), not a visible
 slide. The one nav scroll left smooth is a hash-anchor (`#section`)
 target, where smooth scrolling is the intent. So `scroll-behavior:
 smooth` on `<html>` only affects in-page anchors, not route
-transitions; in development the router logs a one-time console hint when
+transitions. In development the router logs a one-time console hint when
 it detects that setting (and notes that pairing it with a sticky
 `backdrop-filter` header can flash on iOS during navigation).
 

--- a/agent-docs/advanced.md
+++ b/agent-docs/advanced.md
@@ -873,7 +873,11 @@ scroll-to-top on a forward nav) is issued with `behavior: 'instant'`, so
 an app-level `html { scroll-behavior: smooth }` does not animate it. The
 restore matches a native page load (an instant jump), not a visible
 slide. The one nav scroll left smooth is a hash-anchor (`#section`)
-target, where smooth scrolling is the intent.
+target, where smooth scrolling is the intent. So `scroll-behavior:
+smooth` on `<html>` only affects in-page anchors, not route
+transitions; in development the router logs a one-time console hint when
+it detects that setting (and notes that pairing it with a sticky
+`backdrop-filter` header can flash on iOS during navigation).
 
 Inner scroll containers (e.g. `.docs-sidenav`) are preserved
 automatically by the outer-layout-DOM-identity invariant. They stay

--- a/docs/app/docs/client-router/page.ts
+++ b/docs/app/docs/client-router/page.ts
@@ -177,7 +177,7 @@ connectWS('/posts/' + id + '/feed', { onMessage: (m) =&gt; renderStream(m) });</
 
     <h2>Snapshot cache + back/forward</h2>
     <p>The router maintains a URL-keyed LRU cache of page snapshots (capacity 16). On back/forward via <code>popstate</code>, the cached DOM is applied instantly and the captured window-scroll position is restored. A background refetch then revalidates the snapshot quietly.</p>
-    <p>Nav scroll restoration (both the back/forward restore and the scroll-to-top on a forward nav) is forced <code>behavior: 'instant'</code>, so setting <code>html { scroll-behavior: smooth }</code> in your app does not make navigation visibly animate the scroll. It jumps like a native page load. A hash-anchor (<code>#section</code>) link still scrolls smoothly when you opt into it.</p>
+    <p>Nav scroll restoration (both the back/forward restore and the scroll-to-top on a forward nav) is forced <code>behavior: 'instant'</code>, so setting <code>html { scroll-behavior: smooth }</code> in your app does not make navigation visibly animate the scroll. It jumps like a native page load. A hash-anchor (<code>#section</code>) link still scrolls smoothly when you opt into it. Because route transitions ignore <code>scroll-behavior: smooth</code> (it only affects in-page anchors), the router logs a one-time dev-only console hint if it detects that setting on <code>&lt;html&gt;</code>, and notes that combining it with a sticky <code>backdrop-filter</code> header can flash on iOS during navigation.</p>
     <p>After a server action mutates data that a cached page depends on, call <code>revalidate()</code>:</p>
     <pre>import { revalidate } from '@webjsdev/core';
 

--- a/packages/core/src/router-client.js
+++ b/packages/core/src/router-client.js
@@ -606,6 +606,32 @@ function warnOnce(key, message) {
   if (typeof console !== 'undefined' && console.warn) console.warn(message);
 }
 
+/**
+ * Dev-only, fire-once hint: the router forces an INSTANT scroll-to-top on a
+ * forward navigation (matching a native page load), so an app-level
+ * `scroll-behavior: smooth` on <html> does not affect route transitions (it
+ * still applies to in-page #anchor links via `scrollIntoView`). A developer
+ * who set smooth expecting smooth nav scrolling would otherwise be puzzled.
+ * Also flags the iOS sticky-`backdrop-filter` flash this combination can
+ * cause (#610). Never warns in production, never throws.
+ */
+function warnIfSmoothScrollOnHtml() {
+  if (typeof process !== 'undefined' && process.env && process.env.NODE_ENV === 'production') return;
+  if (typeof document === 'undefined' || typeof getComputedStyle !== 'function') return;
+  const root = document.documentElement;
+  if (!root) return;
+  let behavior;
+  try { behavior = getComputedStyle(root).scrollBehavior; } catch { return; }
+  if (behavior !== 'smooth') return;
+  warnOnce(
+    'scroll-behavior-smooth-html',
+    '[webjs] Detected `scroll-behavior: smooth` on <html>. The client router scrolls ' +
+    'to the top instantly on navigation (like a native page load), so route transitions ' +
+    'are not affected by it. It still applies to in-page #anchor links. Pairing it with a ' +
+    'sticky `backdrop-filter` header can also flash on iOS during navigation.'
+  );
+}
+
 /* ====================================================================
  * Marker discovery (the heart of the partial-swap mechanism)
  * ==================================================================== */
@@ -1725,10 +1751,11 @@ async function fetchAndApply(href, frameId, recordHistory, optimisticState, meth
       // `#section` link is exactly where an app's `scroll-behavior: smooth`
       // is wanted, and native browsers animate it too.
       if (t) t.scrollIntoView();
-      else window.scrollTo({ left: 0, top: 0, behavior: 'instant' });
+      else { warnIfSmoothScrollOnHtml(); window.scrollTo({ left: 0, top: 0, behavior: 'instant' }); }
     } else {
       // Scroll-to-top on a forward nav. behavior:'instant' so an app-level
       // `scroll-behavior: smooth` does not animate it (match native nav).
+      warnIfSmoothScrollOnHtml();
       window.scrollTo({ left: 0, top: 0, behavior: 'instant' });
     }
   }
@@ -3206,6 +3233,8 @@ export function _bumpNavToken() { return ++currentNavigationToken; }
 export function _currentPageUrl() { return currentPageUrl; }
 /** Test-only: set the tracker (simulates being on a specific page). */
 export function _setCurrentPageUrl(u) { currentPageUrl = u; }
+/** Test-only: clear the fire-once warning guard so a case can be re-exercised. */
+export function _resetWarnOnce() { warnedKeys.clear(); }
 
 /**
  * Predicate used by the onClick handler to decide whether a same-origin

--- a/packages/core/src/router-client.js
+++ b/packages/core/src/router-client.js
@@ -614,12 +614,19 @@ function warnOnce(key, message) {
  * who set smooth expecting smooth nav scrolling would otherwise be puzzled.
  * Also flags the iOS sticky-`backdrop-filter` flash this combination can
  * cause (#610). Never warns in production, never throws.
+ *
+ * The `smoothScrollChecked` flag gates the `getComputedStyle` read (a forced
+ * style flush) to AT MOST ONCE per page, so a dev session does not pay a
+ * per-navigation reflow after the first forward nav.
  */
+let smoothScrollChecked = false;
 function warnIfSmoothScrollOnHtml() {
   if (typeof process !== 'undefined' && process.env && process.env.NODE_ENV === 'production') return;
+  if (smoothScrollChecked) return;
   if (typeof document === 'undefined' || typeof getComputedStyle !== 'function') return;
   const root = document.documentElement;
   if (!root) return;
+  smoothScrollChecked = true;
   let behavior;
   try { behavior = getComputedStyle(root).scrollBehavior; } catch { return; }
   if (behavior !== 'smooth') return;
@@ -3233,8 +3240,8 @@ export function _bumpNavToken() { return ++currentNavigationToken; }
 export function _currentPageUrl() { return currentPageUrl; }
 /** Test-only: set the tracker (simulates being on a specific page). */
 export function _setCurrentPageUrl(u) { currentPageUrl = u; }
-/** Test-only: clear the fire-once warning guard so a case can be re-exercised. */
-export function _resetWarnOnce() { warnedKeys.clear(); }
+/** Test-only: clear the fire-once warning guards so a case can be re-exercised. */
+export function _resetWarnOnce() { warnedKeys.clear(); smoothScrollChecked = false; }
 
 /**
  * Predicate used by the onClick handler to decide whether a same-origin

--- a/packages/core/test/routing/router-client.test.js
+++ b/packages/core/test/routing/router-client.test.js
@@ -30,7 +30,7 @@ let _collect, _longest, _keyOf, _diffEl, _reconcile,
   _snapshotCache, _LIVE_ATTRS, _blurOutgoingFocus,
   _onSubmit, _getSubmitMethod, _getSubmitAction, _buildSubmitFormData,
   _restoreOptimistic, _navToken, _bumpNavToken,
-  _currentPageUrl, _setCurrentPageUrl,
+  _currentPageUrl, _setCurrentPageUrl, _resetWarnOnce,
   _eligibleAnchorHref, _prefetchSuppressed, _prefetchMode, _prefetchHasHoverPointer, _prefetch, _prefetchTake,
   _prefetchSaysSaveData, _prefetchPeek, _prefetchInflightSize, _resetPrefetch,
   _viewTransitionsEnabled, _runWithTransition, _regraftPermanentElements,
@@ -97,6 +97,7 @@ before(async () => {
     _bumpNavToken,
     _currentPageUrl,
     _setCurrentPageUrl,
+    _resetWarnOnce,
     _eligibleAnchorHref,
     _prefetchSuppressed,
     _prefetchMode,
@@ -1369,6 +1370,53 @@ test('navigate: a found hash anchor stays SMOOTH, not forced instant (#601)', as
     restore();
     globalThis.HTMLElement.prototype.scrollIntoView = origInto;
     if (globalThis.window) globalThis.window.scrollTo = origWinScrollTo;
+    document.body.innerHTML = '';
+  }
+});
+
+test('warns once in dev when <html> has scroll-behavior: smooth, suppressed in prod (#613)', async () => {
+  const origGCS = globalThis.getComputedStyle;
+  const origWinScrollTo = globalThis.window?.scrollTo;
+  const origNodeEnv = process.env.NODE_ENV;
+  const origWarn = console.warn;
+  const warnings = [];
+  console.warn = (...a) => { warnings.push(a.join(' ')); };
+  if (globalThis.window) globalThis.window.scrollTo = () => {};
+  globalThis.scrollTo = () => {};
+  document.body.innerHTML = '<!--wj:children:/-->before<!--/wj:children-->';
+  const smoothWarns = () => warnings.filter((w) => /scroll-behavior: smooth/.test(w)).length;
+  const navMock = () => installNavigationMocks({
+    contentType: 'text/html',
+    body: '<!doctype html><html><head></head><body><!--wj:children:/-->after<!--/wj:children--></body></html>',
+  });
+  try {
+    // dev + smooth => warns exactly once across two navs (fire-once guard)
+    process.env.NODE_ENV = 'development';
+    globalThis.getComputedStyle = () => ({ scrollBehavior: 'smooth' });
+    _resetWarnOnce();
+    let m = navMock(); globalThis.scrollTo = () => {}; await navigate('http://localhost/p1'); m.restore();
+    assert.equal(smoothWarns(), 1, 'warns once on a smooth-scroll forward nav in dev');
+    m = navMock(); globalThis.scrollTo = () => {}; await navigate('http://localhost/p2'); m.restore();
+    assert.equal(smoothWarns(), 1, 'fire-once: a second nav does not warn again');
+
+    // scroll-behavior auto => no warn
+    _resetWarnOnce(); warnings.length = 0;
+    globalThis.getComputedStyle = () => ({ scrollBehavior: 'auto' });
+    m = navMock(); globalThis.scrollTo = () => {}; await navigate('http://localhost/p3'); m.restore();
+    assert.equal(smoothWarns(), 0, 'no warning when scroll-behavior is not smooth');
+
+    // production => suppressed even with smooth
+    _resetWarnOnce(); warnings.length = 0;
+    globalThis.getComputedStyle = () => ({ scrollBehavior: 'smooth' });
+    process.env.NODE_ENV = 'production';
+    m = navMock(); globalThis.scrollTo = () => {}; await navigate('http://localhost/p4'); m.restore();
+    assert.equal(smoothWarns(), 0, 'suppressed in production');
+  } finally {
+    console.warn = origWarn;
+    globalThis.getComputedStyle = origGCS;
+    if (globalThis.window) globalThis.window.scrollTo = origWinScrollTo;
+    if (origNodeEnv === undefined) delete process.env.NODE_ENV; else process.env.NODE_ENV = origNodeEnv;
+    _resetWarnOnce();
     document.body.innerHTML = '';
   }
 });


### PR DESCRIPTION
Closes #613

The client router forces an instant scroll-to-top on a forward navigation (matching a native page load), so an app-level `html { scroll-behavior: smooth }` does not affect route transitions. It only applies to in-page `#anchor` links (via the untouched `scrollIntoView` path). A developer who set it expecting smooth nav scrolling would otherwise be puzzled by the silent override.

This adds a one-time, dev-only `console.warn` from the client router when it detects computed `scroll-behavior: smooth` on `<html>` at navigation time, mirroring Next.js's `disable-smooth-scroll` dev warning. The message explains route transitions are forced instant and notes that pairing the setting with a sticky `backdrop-filter` header can flash on iOS during navigation (the lesson from #610). Never warns in production, never throws, fires at most once (reuses the existing `warnOnce` guard).

## Implementation
- `router-client.js`: new `warnIfSmoothScrollOnHtml()` (dev-gated via the same `typeof process !== 'undefined' && process.env.NODE_ENV === 'production'` idiom as `render-server.js`), called only at the two force-instant scroll branches, not the hash-anchor (`scrollIntoView`) branch where smooth is intended.
- Test-only `_resetWarnOnce()` export for isolation.

## Test plan
- [x] Unit (`router-client.test.js`): warns once on a smooth forward nav in dev; fire-once on a second nav; no warn when scroll-behavior is `auto`; suppressed when `NODE_ENV==='production'`.
- [x] Counterfactual: the test fails when the warn call is neutered, passes when restored.
- [x] Full routing suite green (150 tests).

## Docs / surfaces
- Updated `agent-docs/advanced.md` (scroll-restoration section) and `docs/app/docs/client-router/page.ts` with the smooth-only-affects-anchors note + the dev hint.
- N/A: no scaffold / MCP / editor surface; no published-package API shape change (internal dev behavior). The `feat:` prefix adds a core changelog entry on the next release.