### PR TITLE
fix: remove scroll-behavior:smooth from blog to stop mobile nav flicker

### DIFF
--- a/examples/blog/app/layout.ts
+++ b/examples/blog/app/layout.ts
@@ -167,7 +167,6 @@ export default function RootLayout({ children }: LayoutProps) {
          be reached by utility classes. A tiny decorative overlay, scrollbar
          colours, and selection tint also live here (no utility equivalent). */
       html, body { margin: 0; }
-      html { scroll-behavior: smooth; }
       body {
         position: relative;
         background: var(--bg);


### PR DESCRIPTION
## Why

#610 (mobile navbar flicker on forward client-router nav) was closed and deployed, but the flicker still reproduces on a real phone. I confirmed:

- The live `example-blog.webjs.dev` is current (header is opaque `bg-[var(--bg)]`, no `backdrop-blur`; uptime ~7 min). **Not a stale deploy.**
- So the backdrop-blur/opacity theory the prior PRs (#611/#612/#617 and the remove/restore-backdrop commits) chased was the wrong root cause.

## The unaddressed variable

`examples/blog/app/layout.ts` still set `html { scroll-behavior: smooth }` (layout L170). Every prior #610 PR changed the header's blur/opacity and left this in place.

- The client router forces `scrollTo({ behavior: 'instant' })` on a forward nav, but **iOS Safari has historically ignored that per-call override** when CSS `scroll-behavior: smooth` is set, animating the scroll-to-top over several frames.
- A **forward** nav scrolls all the way to `0` -- the point where the `position: sticky` header does its stuck->static handoff, the classic mobile sticky repaint. A **back** nav restores to a *non-zero* offset, so the header stays stuck and never flickers. This matches the reported forward-only / back-is-fine asymmetry exactly.
- The framework already warns about this combination (#614, the `scroll-behavior-smooth-html` dev hint) and the marketing **website already bans the same declaration** in `website/test/ssr/layout-ssr.test.ts`. The blog never got that treatment.

## Change

Remove the single `html { scroll-behavior: smooth }` declaration from the blog layout, so the nav scroll-to-top is a single instant jump on every engine (no multi-frame animation through the sticky handoff). The `.scroll-smooth` Tailwind utility (generated, unused) is untouched.

## Verification

- Local boot smoke: blog SSRs, header renders, `scroll-behavior: smooth` no longer in served HTML.
- **Manual on-device only** for the flicker itself: it is GPU/compositor-dependent and invisible to desktop + headless + DevTools device mode (per #610's own notes). Needs a real iOS Safari + Android Chrome check of forward nav (scroll the post list, tap a post).

No automated test added (same rationale as #610: the artifact is not reproducible headless). No docs/AGENTS change (blog-app CSS only).

Re #610.

https://claude.ai/code/session_01W8RLiSnkwKXDmnkoasQfZF