### PR TITLE
fix: promote blog sticky header to its own compositor layer (#610)

### DIFF
--- a/examples/blog/app/layout.ts
+++ b/examples/blog/app/layout.ts
@@ -205,9 +205,21 @@ export default function RootLayout({ children }: LayoutProps) {
       .mobile-menu > summary .close-icon { display: none; }
       .mobile-menu[open] > summary .open-icon { display: none; }
       .mobile-menu[open] > summary .close-icon { display: inline-block; }
+
+      /* Promote the sticky header to its own compositor layer so the
+         stuck-to-static handoff on a forward-nav scroll-to-top does not
+         trigger a one-frame repaint on weaker mobile GPUs (iOS Safari
+         most of all). A static translateZ promotion, not a permanent
+         will-change, to keep the layer cheap on memory. */
+      .site-header {
+        transform: translateZ(0);
+        -webkit-transform: translateZ(0);
+        backface-visibility: hidden;
+        -webkit-backface-visibility: hidden;
+      }
     </style>
 
-    <header class="sticky top-0 z-20 flex items-center justify-between gap-4 px-4 sm:px-6 py-3 border-b border-border bg-[var(--bg)]">
+    <header class="site-header sticky top-0 z-20 flex items-center justify-between gap-4 px-4 sm:px-6 py-3 border-b border-border bg-[var(--bg)]">
       <a href="/" class="inline-flex items-center gap-2 no-underline text-fg font-semibold text-[15px] leading-none tracking-tight">
         <span class="inline-block w-[22px] h-[22px] rounded-md bg-gradient-to-br from-accent to-[color-mix(in_oklch,var(--accent)_55%,var(--fg))] shadow-[inset_0_0_0_1px_oklch(1_0_0/0.15),0_1px_4px_var(--accent-tint)]"></span>
         <span>webjs</span>


### PR DESCRIPTION
## Why

Third attempt at #610. The first three fixes all targeted the header's **fill** and all failed on-device (verified each time that the live deploy was current):

- remove `backdrop-blur` / make header opaque (#611, #612, #617)
- remove `html { scroll-behavior: smooth }` (#618). The live site now has 0 occurrences and the flicker still reproduces.

That rules out the header's blur/opacity/scroll as the cause.

## The untried lever

#610's own notes said to **try the compositor hint first** (`translateZ(0)` / `will-change`), and fall back to trimming the blur only if it persisted. The PRs did the opposite: they did the fallback and never applied the primary fix.

- A forward nav scrolls to `0`, where `position: sticky` does its stuck-to-static handoff, the point a weak mobile compositor (iOS Safari especially) can drop a one-frame repaint.
- A back nav restores a non-zero offset, so the header stays stuck the whole time. This matches the forward-only asymmetry, and the desktop-never / mobile-only split (a desktop GPU composites the handoff fast enough to hide it).

## Change

Add a static `transform: translateZ(0)` (plus `-webkit-` and `backface-visibility: hidden`) to the header via a `.site-header` rule in the layout's inline `<style>` block, so the header lives on a permanent compositor layer and the handoff has no layer to create or destroy. Inline (not a Tailwind utility) so a prod Tailwind rebuild cannot drop it. A static `translateZ` rather than a permanent `will-change`, to keep the layer cheap on memory (per #610's note).

## Verification

- Local boot smoke: blog SSRs, header renders, `.site-header` rule present.
- **Manual on-device only**. The artifact is invisible to desktop, headless, and DevTools device mode.

If this also fails on-device, the evidence will have conclusively excluded blog CSS, and the cause is the framework router (nav scroll/repaint sequence), a different class of fix.

Re #610.

https://claude.ai/code/session_01W8RLiSnkwKXDmnkoasQfZF