### PR TITLE
fix: use position:fixed for the blog header to end the iOS nav flicker (#610)

### DIFF
--- a/agent-docs/styling.md
+++ b/agent-docs/styling.md
@@ -234,3 +234,20 @@ More files you write, more discipline required, slight rename cost (2
 textual edits when a route folder moves). In exchange: no browser-
 runtime script, no `@theme` block, idiomatic CSS, plain cascade you can
 debug with any tool.
+
+## Gotcha: a sticky header flickers on iOS, use `position: fixed`
+
+A `position: sticky` header (the common `sticky top-0` pattern) flickers its
+background for one frame on iOS WebKit (every iOS browser, since they all use
+WebKit) during a client-router FORWARD navigation. The scroll-to-top the router
+runs after the content swap drives a sticky stuck-to-static recompute that
+WebKit mis-repaints. It is iOS-only (fine on desktop and Android, and invisible
+in DevTools device emulation, so it shows only on a real device). #610 confirmed
+on-device that neither compositor promotion (`translateZ(0)` / `will-change`)
+nor changing the swap paint timing fixes it.
+
+The fix is `position: fixed` instead of sticky. A fixed header is always pinned
+and never does the scroll-relative recompute, so the repaint bug never fires.
+Because fixed leaves normal flow, reserve the header height on the content below
+it (a `padding-top` on `body` equal to the header height). The example blog's
+root layout does exactly this (`examples/blog/app/layout.ts`).

--- a/examples/blog/app/layout.ts
+++ b/examples/blog/app/layout.ts
@@ -57,21 +57,9 @@ export function generateMetadata(ctx: { url: string }): Metadata {
  * that can't live on a classable element, and selection/scrollbar
  * pseudo-elements.
  */
-export default function RootLayout({ children, url }: LayoutProps) {
+export default function RootLayout({ children }: LayoutProps) {
   // CSP nonce for inline scripts. Empty when no nonce in CSP.
   const nonce = cspNonce();
-  // #610 on-device isolation. The header is preserved across a soft nav, so
-  // the class set on the full page load persists through the forward nav under
-  // test. `?h=static` drops position:sticky to tell whether the flash is the
-  // sticky recalc or a page-level repaint. The router paint-timing flags
-  // (`?raf`, `?scrollfirst`) are read client-side into window.__webjsDiag by
-  // the inline script below.
-  const headerVariant = (() => {
-    try {
-      const v = new URL(String(url)).searchParams.get('h') || '';
-      return ['static', 'opaque', 'fixed'].includes(v) ? ' hv-' + v : '';
-    } catch { return ''; }
-  })();
   return html`
     <link rel="icon" href="/public/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/public/favicon.png" type="image/png">
@@ -91,13 +79,6 @@ export default function RootLayout({ children, url }: LayoutProps) {
           if (t === 'light' || t === 'dark') {
             document.documentElement.dataset.theme = t;
           }
-        } catch (_) {}
-        // #610 router paint-timing isolation. Read once on the full page load;
-        // the client router reads these flags on every soft nav (the flag is
-        // lost from the URL on the nav itself, so it must be captured here).
-        try {
-          var p = new URLSearchParams(location.search);
-          window.__webjsDiag = { raf: p.has('raf'), scrollfirst: p.has('scrollfirst') };
         } catch (_) {}
       })();
       // Mobile menu auto-close: close on link click (inside the panel)
@@ -187,6 +168,14 @@ export default function RootLayout({ children, url }: LayoutProps) {
       html, body { margin: 0; }
       html { scroll-behavior: smooth; }
       body {
+        /* #610: the header is position:fixed (NOT sticky). iOS WebKit (every
+           iOS browser) flickers a sticky header's background for one frame on a
+           client-router forward nav, because the scroll-to-top drives a sticky
+           stuck-to-static recompute WebKit mis-repaints. It is iOS-only (fine on
+           desktop and Android, invisible in emulation) and confirmed fixed by
+           switching to position:fixed on-device. fixed leaves normal flow, so
+           reserve the 61px header height here. */
+        padding-top: 61px;
         background: var(--bg);
         color: var(--fg);
         font: 16px/1.65 var(--font-sans);
@@ -220,30 +209,9 @@ export default function RootLayout({ children, url }: LayoutProps) {
       .mobile-menu > summary .close-icon { display: none; }
       .mobile-menu[open] > summary .open-icon { display: none; }
       .mobile-menu[open] > summary .close-icon { display: inline-block; }
-
-      /* #610 isolation: the h=static query param drops position:sticky
-         (overriding the Tailwind sticky utility) so an on-device test can tell
-         whether the flash is the sticky-position recalc or a page-level
-         repaint. The GPU compositor promotion was tried and made no difference
-         on-device, so it is intentionally NOT here. */
-      .site-header.hv-static {
-        position: static !important;
-      }
-      /* sticky kept, but no backdrop-filter (tests the sticky + backdrop combo) */
-      .site-header.hv-opaque {
-        background: var(--bg) !important;
-        backdrop-filter: none !important;
-        -webkit-backdrop-filter: none !important;
-      }
-      /* fixed instead of sticky: always pinned, never does the stuck-to-static
-         recompute. Content overlap at the top is expected for this test. */
-      .site-header.hv-fixed {
-        position: fixed !important;
-        top: 0; left: 0; right: 0;
-      }
     </style>
 
-    <header class="site-header${headerVariant} sticky top-0 z-20 flex items-center justify-between gap-4 px-4 sm:px-6 py-3 border-b border-border bg-[color-mix(in_oklch,var(--bg)_75%,transparent)] backdrop-blur-[18px] backdrop-saturate-[180%]">
+    <header class="site-header fixed inset-x-0 top-0 z-20 flex items-center justify-between gap-4 px-4 sm:px-6 py-3 border-b border-border bg-[color-mix(in_oklch,var(--bg)_75%,transparent)] backdrop-blur-[18px] backdrop-saturate-[180%]">
       <a href="/" class="inline-flex items-center gap-2 no-underline text-fg font-semibold text-[15px] leading-none tracking-tight">
         <span class="inline-block w-[22px] h-[22px] rounded-md bg-gradient-to-br from-accent to-[color-mix(in_oklch,var(--accent)_55%,var(--fg))] shadow-[inset_0_0_0_1px_oklch(1_0_0/0.15),0_1px_4px_var(--accent-tint)]"></span>
         <span>webjs</span>

--- a/packages/core/src/router-client.js
+++ b/packages/core/src/router-client.js
@@ -619,18 +619,6 @@ function warnOnce(key, message) {
  * style flush) to AT MOST ONCE per page, so a dev session does not pay a
  * per-navigation reflow after the first forward nav.
  */
-/**
- * #610 diagnostic, TEMPORARY. Reads a guarded paint-timing flag an app sets on
- * `window.__webjsDiag` (e.g. `{ raf: true, scrollfirst: true }`) to A/B the iOS
- * WebKit sticky-header flash + back-swipe-blank on-device. Default off, so the
- * production nav path is byte-for-byte unchanged. Removed once the root fix
- * lands.
- */
-function diagFlag(name) {
-  try { return !!(typeof window !== 'undefined' && window.__webjsDiag && window.__webjsDiag[name]); }
-  catch { return false; }
-}
-
 let smoothScrollChecked = false;
 function warnIfSmoothScrollOnHtml() {
   if (typeof process !== 'undefined' && process.env && process.env.NODE_ENV === 'production') return;
@@ -864,12 +852,6 @@ async function performNavigation(href, isPopState, frameId) {
       if (cached) {
         const cachedDoc = parseHTML(cached.html);
         if (cachedDoc) {
-          // #610 diagnostic: wait a frame before the popstate swap so WebKit
-          // paints at a frame boundary (candidate fix for the iOS back-swipe
-          // blank). Guarded; default path unchanged.
-          if (diagFlag('raf') && typeof requestAnimationFrame === 'function') {
-            await new Promise((r) => requestAnimationFrame(() => r(undefined)));
-          }
           applySwap(cachedDoc, frameId, /* revalidating */ true, /* href */ null);
           // Restore window scroll to where the user left it. Use
           // behavior:'instant' so an app-level `scroll-behavior: smooth`
@@ -1773,19 +1755,6 @@ async function fetchAndApply(href, frameId, recordHistory, optimisticState, meth
   // recover in place rather than a destructive full reload.
   if (!doc) { restoreOptimistic(optimisticState); handleNavigationError(href, null, new Error('navigation response did not parse as HTML')); return { ok: false, status: respStatus, aborted: false }; }
 
-  // #610 diagnostic (guarded; default path unchanged). An app sets
-  // window.__webjsDiag to A/B the iOS forward-nav paint timing:
-  //  - scrollfirst: scroll-to-top BEFORE the swap, so a preserved sticky
-  //    header un-sticks against the OLD tall content and never sees a content
-  //    height change while it is stuck.
-  //  - raf: wait one frame before the swap, so WebKit paints at a frame
-  //    boundary (the timing Turbo uses for its render).
-  if (recordHistory && diagFlag('scrollfirst')) {
-    try { if (!new URL(finalUrl).hash) window.scrollTo({ left: 0, top: 0, behavior: 'instant' }); } catch { /* non-DOM */ }
-  }
-  if (diagFlag('raf') && typeof requestAnimationFrame === 'function') {
-    await new Promise((r) => requestAnimationFrame(() => r(undefined)));
-  }
   applySwap(doc, frameId, false, finalUrl, incomingBuild);
 
   if (recordHistory) history.pushState(null, '', finalUrl);


### PR DESCRIPTION
## Root cause (confirmed on-device)

A position:sticky header flickers its background for one frame on iOS WebKit (both Safari and Chrome on iOS) during a client-router forward nav: the post-swap scroll-to-top drives a sticky stuck-to-static recompute WebKit mis-repaints. iOS-only (fine on desktop and Android, invisible in emulation).

On-device A/B (temporary ?h= / ?raf / ?scrollfirst flags, #637/#638) was decisive: ?h=static and ?h=fixed were clean; ?h=opaque, translateZ promotion (#636), ?raf, and ?scrollfirst all still flashed. So it is the position:sticky recompute specifically.

## Fix

The blog header is now position:fixed (always pinned, no scroll-relative recompute). Since fixed leaves normal flow, a 61px padding-top on body reserves its height (measured identical at mobile and desktop). All temporary diagnostic scaffolding removed; the router reverts to its original swap path. Gotcha documented in agent-docs/styling.md.

## Verification
Blog SSR 200 (header fixed, padding-top 61px, no __webjsDiag); webjs check clean; router unit tests 150/150.

## Note
The separate back-swipe-blank symptom (also iOS-only) is NOT addressed here (router/paint issue, not the header) and will be filed as its own issue.

Closes #610.

https://claude.ai/code/session_01W8RLiSnkwKXDmnkoasQfZF
