### PR TITLE
refactor: drive the fixed-header offset from a --header-height variable (#610)

### DIFF
--- a/agent-docs/styling.md
+++ b/agent-docs/styling.md
@@ -248,6 +248,32 @@ nor changing the swap paint timing fixes it.
 
 The fix is `position: fixed` instead of sticky. A fixed header is always pinned
 and never does the scroll-relative recompute, so the repaint bug never fires.
-Because fixed leaves normal flow, reserve the header height on the content below
-it (a `padding-top` on `body` equal to the header height). The example blog's
-root layout does exactly this (`examples/blog/app/layout.ts`).
+There is no reliable CSS-only fix that KEEPS `position: sticky` (the GPU-promotion
+hacks `translateZ(0)` / `translate3d` / `will-change` / a wrapper element are all
+variants that do NOT reliably work, confirmed on-device for #610). Preserving the
+header across nav is correct and standard (Next.js, Remix, SvelteKit all preserve
+nested layouts); only the `sticky` positioning is the problem.
+
+Because fixed leaves normal flow, reserve the header height on the content below.
+Use a single `--header-height` custom property as the source of truth rather than
+a hardcoded number, and keep it exact with a `ResizeObserver` so it tracks
+responsive / dynamic headers (degrades fine with no JS via the default):
+
+```css
+:root  { --header-h: 56px; }              /* sane SSR first-paint default */
+header { position: fixed; inset-inline: 0; top: 0; }
+body   { padding-top: var(--header-h); }
+```
+```js
+// refine the default to the header's real height (and on resize)
+const hdr = document.querySelector('header');
+const apply = () => document.documentElement.style.setProperty('--header-h', hdr.offsetHeight + 'px');
+apply();
+new ResizeObserver(apply).observe(hdr);
+```
+
+The example blog's root layout does exactly this (`examples/blog/app/layout.ts`).
+For an app/dashboard layout, an alternative is an app-shell scroll container (a
+non-scrolling `100dvh` flex column with `<main>` as the internal scroller), which
+needs no offset at all but changes the scroll model (the window no longer
+scrolls, so the iOS URL bar stays visible).

--- a/examples/blog/app/layout.ts
+++ b/examples/blog/app/layout.ts
@@ -81,6 +81,26 @@ export default function RootLayout({ children }: LayoutProps) {
           }
         } catch (_) {}
       })();
+      // #610: keep --header-h equal to the fixed header's real height. The
+      // :root default is a sane SSR first-paint value; this refines it once the
+      // header exists and on any resize, so the content offset never drifts
+      // (responsive headers, font swaps, a wrapped nav). Degrades fine with no
+      // JS (the :root default holds).
+      (function(){
+        function measure(){
+          try {
+            var hdr = document.querySelector('.site-header');
+            if (!hdr) return;
+            var apply = function(){
+              document.documentElement.style.setProperty('--header-h', hdr.offsetHeight + 'px');
+            };
+            apply();
+            if (window.ResizeObserver) new ResizeObserver(apply).observe(hdr);
+          } catch (_) {}
+        }
+        if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', measure);
+        else measure();
+      })();
       // Mobile menu auto-close: close on link click (inside the panel)
       // AND on any click outside the menu. Delegated on document so
       // it survives client-router navigations without rebinding.
@@ -103,6 +123,7 @@ export default function RootLayout({ children }: LayoutProps) {
     <style>
       :root {
         color-scheme: light dark;
+        --header-h: 61px; /* #610 fixed-header offset, kept exact by the ResizeObserver below */
 
         /* ---------- dark (default) ---------- */
         --fg:            oklch(0.96 0.015 60);
@@ -168,14 +189,15 @@ export default function RootLayout({ children }: LayoutProps) {
       html, body { margin: 0; }
       html { scroll-behavior: smooth; }
       body {
-        /* #610: the header is position:fixed (NOT sticky). iOS WebKit (every
-           iOS browser) flickers a sticky header's background for one frame on a
-           client-router forward nav, because the scroll-to-top drives a sticky
-           stuck-to-static recompute WebKit mis-repaints. It is iOS-only (fine on
-           desktop and Android, invisible in emulation) and confirmed fixed by
-           switching to position:fixed on-device. fixed leaves normal flow, so
-           reserve the 61px header height here. */
-        padding-top: 61px;
+        /* #610: the header is position:fixed (NOT sticky), because iOS WebKit
+           (every iOS browser) flickers a sticky header's background for one
+           frame on a client-router forward nav (the scroll-to-top drives a
+           sticky stuck-to-static recompute WebKit mis-repaints, iOS-only, fine
+           on desktop and Android, confirmed on-device). fixed leaves normal
+           flow, so offset the content by the header height. --header-h is the
+           single source of truth: a sane SSR first-paint default in :root,
+           kept exact and responsive by the ResizeObserver inline script. */
+        padding-top: var(--header-h);
         background: var(--bg);
         color: var(--fg);
         font: 16px/1.65 var(--font-sans);


### PR DESCRIPTION
Addresses the DX cost of the #610 fix (the hardcoded 61px offset). The blog header offset is now a single `--header-h` custom property (SSR default in :root) kept exact by a ResizeObserver, so it tracks the real responsive height with no magic numbers and degrades fine with no JS. Documents the --header-height pattern + the app-shell alternative in agent-docs/styling.md.

Research conclusion (recorded in the #610 research issue #642): no reliable CSS-only fix keeps position:sticky on iOS (GPU-promotion hacks all failed on-device); preserving the header across nav is correct and standard (Next/Remix/SvelteKit all do it); only sticky is the problem. Blog + docs only, no framework change.

Re #610.

https://claude.ai/code/session_01W8RLiSnkwKXDmnkoasQfZF