### PR TITLE
fix: use position:fixed for pinned headers (scaffold + website) + document (#610)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -317,7 +317,7 @@ type ActionResult<T> =
 
 ## Styling: Tailwind-first
 
-**Tailwind is the strong default for pages AND light-DOM components.** The lit reflex to scope CSS in a shadow root with `static styles` is the habit to resist in light DOM. When a class bundle repeats, extract it into a `lib/utils/ui.ts` helper returning an `` html`...` `` fragment (SSR-time), NOT a CSS class (no `@apply`). Reserve raw CSS for what utilities cannot express (design tokens / `@theme`, `@property` + `@keyframes`, scrollbar, `prefers-reduced-motion`, complex `color-mix()` / gradients); in light DOM the tag-prefix invariant (#7) still holds, and shadow-DOM components legitimately use `static styles = css\`\``. See `agent-docs/styling.md`.
+**Tailwind is the strong default for pages AND light-DOM components.** The lit reflex to scope CSS in a shadow root with `static styles` is the habit to resist in light DOM. When a class bundle repeats, extract it into a `lib/utils/ui.ts` helper returning an `` html`...` `` fragment (SSR-time), NOT a CSS class (no `@apply`). Reserve raw CSS for what utilities cannot express (design tokens / `@theme`, `@property` + `@keyframes`, scrollbar, `prefers-reduced-motion`, complex `color-mix()` / gradients); in light DOM the tag-prefix invariant (#7) still holds, and shadow-DOM components legitimately use `static styles = css\`\``. **Pin a header with `position: fixed`, never `position: sticky`** (a sticky header flickers on iOS WebKit during a client-router nav, #610, because the preserved header plus the scroll-to-top trips a WebKit sticky-repaint bug that the GPU-promotion hacks do NOT fix, so reserve the header height on the content with a `--header-height` offset). See `agent-docs/styling.md`.
 
 ---
 

--- a/docs/app/docs/styling/page.ts
+++ b/docs/app/docs/styling/page.ts
@@ -231,7 +231,7 @@ import { html, css } from '@webjsdev/core';
 
 const STYLES = css\`
   .layout-root {
-    .header { position: sticky; top: 0; }
+    .header { position: fixed; inset-inline: 0; top: 0; } /* fixed, NOT sticky (see note) */
     .nav    { display: flex; gap: 16px; }
   }
 \`;
@@ -247,6 +247,8 @@ export default function RootLayout({ children }: { children: unknown }) {
     &lt;/div&gt;
   \`;
 }</pre>
+
+    <p><strong>Pin a header with <code>position: fixed</code>, never <code>position: sticky</code>.</strong> A sticky header flickers its background for one frame on iOS WebKit (every iOS browser) during a client-router navigation: the preserved header plus the scroll-to-top trips a WebKit sticky-repaint bug, and the GPU-promotion hacks (<code>translateZ</code>, <code>will-change</code>) do not fix it. Use <code>position: fixed</code> and reserve the header height on the content with a <code>--header-height</code> CSS variable (kept exact by a <code>ResizeObserver</code>). It is iOS-only and invisible on desktop, Android, and in DevTools emulation, so it shows only on a real device.</p>
 
     <h3>Component scope</h3>
     <pre>// components/my-card.ts

--- a/packages/cli/lib/create.js
+++ b/packages/cli/lib/create.js
@@ -974,6 +974,26 @@ export default function RootLayout({ children }: { children: unknown }) {
           mq.addEventListener('change', apply);
         } catch (_) {}
       })();
+      // The header is position:fixed (not sticky): a sticky header flickers on
+      // iOS WebKit during a client-router nav. fixed leaves normal flow, so
+      // --header-h reserves its height for the content below. Measured here so
+      // it tracks the real (responsive) height; degrades fine with no JS via
+      // the :root default.
+      (function(){
+        function measure(){
+          try {
+            var hdr = document.querySelector('header');
+            if (!hdr) return;
+            var apply = function(){
+              document.documentElement.style.setProperty('--header-h', hdr.offsetHeight + 'px');
+            };
+            apply();
+            if (window.ResizeObserver) new ResizeObserver(apply).observe(hdr);
+          } catch (_) {}
+        }
+        if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', measure);
+        else measure();
+      })();
     </script>
     <script src="/public/tailwind-browser.js"></script>
     <!--
@@ -1063,7 +1083,9 @@ ${SHADCN_THEME}
       }
       /* Body + pseudo-elements utility classes can't reach. */
       html, body { margin: 0; }
+      :root { --header-h: 56px; } /* fixed-header offset, kept exact by the script above */
       body {
+        padding-top: var(--header-h);
         background: var(--bg);
         color: var(--fg);
         font: 16px/1.65 var(--font-sans);
@@ -1072,7 +1094,7 @@ ${SHADCN_THEME}
       ::selection { background: var(--accent-tint); color: var(--fg); }
     </style>
 
-    <header class="sticky top-0 z-20 flex items-center gap-6 px-4 sm:px-6 py-3 border-b border-border bg-[color-mix(in_oklch,var(--bg)_75%,transparent)] backdrop-blur-[18px]">
+    <header class="fixed inset-x-0 top-0 z-20 flex items-center gap-6 px-4 sm:px-6 py-3 border-b border-border bg-[color-mix(in_oklch,var(--bg)_75%,transparent)] backdrop-blur-[18px]">
       <a href="/" class="mr-auto inline-flex items-center gap-2 no-underline text-fg font-semibold text-[15px] leading-none tracking-tight">
         <span>${name}</span>
       </a>

--- a/packages/cli/templates/CONVENTIONS.md
+++ b/packages/cli/templates/CONVENTIONS.md
@@ -730,6 +730,17 @@ color (via the `@theme` tokens), typography, borders, radius, shadows,
 and interaction states (hover/focus/active/disabled, dark mode). Light
 DOM does not scope styles, so utilities apply directly.
 
+**Pin a header with `position: fixed`, never `position: sticky`.** A
+sticky header flickers its background for one frame on iOS WebKit (every
+iOS browser) during a client-router navigation, because the preserved
+header plus the scroll-to-top trips a WebKit sticky-repaint bug that the
+usual GPU-promotion hacks (`translateZ`, `will-change`) do NOT fix. Use
+`position: fixed` and reserve the header height on the content with a
+`--header-height` variable (the scaffolded `app/layout.ts` does exactly
+this, kept exact by a `ResizeObserver`). It is iOS-only, invisible on
+desktop, Android, and in DevTools emulation, so it shows only on a real
+device.
+
 **The lit muscle-memory trap.** If you have written lit, the habit is to
 scope CSS in a shadow root (`static styles = css\`\``) or write an inline
 `<style>` with semantic class names (`.hero`, `.feature`, `.card`) for

--- a/website/app/layout.ts
+++ b/website/app/layout.ts
@@ -97,6 +97,23 @@ export default function RootLayout({ children }: { children: unknown }) {
           if (t === 'light' || t === 'dark') document.documentElement.dataset.theme = t;
         } catch (_) {}
       })();
+      // #610: the announcement banner + header are position:fixed together (not
+      // sticky, which flickers on iOS WebKit during a client-router nav).
+      // --header-h reserves the pinned bar's height; measured here so it tracks
+      // the real height, with a :root default for no-JS / first paint.
+      (function(){
+        function measure(){
+          try {
+            var bar = document.querySelector('.site-top');
+            if (!bar) return;
+            var apply = function(){ document.documentElement.style.setProperty('--header-h', bar.offsetHeight + 'px'); };
+            apply();
+            if (window.ResizeObserver) new ResizeObserver(apply).observe(bar);
+          } catch (_) {}
+        }
+        if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', measure);
+        else measure();
+      })();
       document.addEventListener('click', function (e) {
         var t = e.target;
         if (!t || !t.closest) return;
@@ -177,7 +194,9 @@ export default function RootLayout({ children }: { children: unknown }) {
         *, *::before, *::after { animation-duration: 0.001ms !important; animation-iteration-count: 1 !important; transition-duration: 0.001ms !important; scroll-behavior: auto !important; }
       }
       html, body { margin: 0; }
+      :root { --header-h: 88px; } /* #610 fixed banner+header offset, kept exact by the script above */
       body {
+        padding-top: var(--header-h);
         background: var(--bg); color: var(--fg);
         font: 400 16px/1.65 var(--font-sans);
         -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility; overflow-x: hidden;
@@ -225,12 +244,13 @@ export default function RootLayout({ children }: { children: unknown }) {
 
     <div class="glow-layer" aria-hidden="true"></div>
 
+    <div class="site-top fixed inset-x-0 top-0 z-20">
     <div class="relative z-[3] text-center font-medium text-[13px] leading-[1.4] py-[9px] px-4 border-b border-border bg-accent-tint">
       <span class="font-mono font-bold text-[10px] leading-none tracking-[0.12em] uppercase text-accent-hover bg-bg-elev rounded-full px-2 py-[3px] mr-2 align-middle">New</span>
       <a href=${UI_URL} target="_blank" rel="noopener noreferrer" class="text-accent-hover font-semibold no-underline hover:underline">Introducing the AI-first component library <span aria-hidden="true">&rarr;</span>${NEW_TAB}</a>
     </div>
 
-    <header class="sticky top-0 z-20 backdrop-blur-md bg-[color-mix(in_oklch,var(--color-bg)_78%,transparent)] border-b border-border">
+    <header class="backdrop-blur-md bg-[color-mix(in_oklch,var(--color-bg)_78%,transparent)] border-b border-border">
       <div class="max-w-[1080px] mx-auto px-6 py-[13px] flex items-center gap-4">
         <a class="mr-auto inline-flex items-center gap-[9px] no-underline text-fg font-display font-extrabold text-[17px] leading-none tracking-[-0.02em]" href="/">
           <span class="w-[22px] h-[22px] rounded-[7px] bg-gradient-to-br from-accent-live to-[color-mix(in_oklch,var(--accent-live)_55%,var(--fg))] shadow-[0_2px_10px_var(--accent-tint)]"></span>
@@ -255,6 +275,7 @@ export default function RootLayout({ children }: { children: unknown }) {
         </div>
       </div>
     </header>
+    </div>
 
     <div class="relative z-[1]">
       ${children}


### PR DESCRIPTION
Propagates the #610 fix (use position:fixed, not sticky, for a pinned header) beyond the blog, and documents the pattern for agents.

**Code fixes:**
- **Scaffold generator** (`packages/cli/lib/create.js`): every new app's `app/layout.ts` now ships the fixed header + `--header-h` + ResizeObserver pattern (highest leverage, since all future apps inherit it).
- **website**: the announcement banner + header are pinned together in a `fixed` wrapper.

**Docs (for AI agents):**
- `AGENTS.md` styling section + the scaffold's `CONVENTIONS.md`: state the rule (use `fixed`, never `sticky`, and why the GPU hacks fail).
- `agent-docs/styling.md`: the full pattern (shipped earlier in #644).
- docs site `styling` page: corrected its `position: sticky` example to `fixed` and added the gotcha note.

**Scope:** `ui-website` has no sticky header. The **docs app** (a two-layout grid with a mobile-only header) is filed as #647 for a careful cross-layout fix rather than rushed here.

Verification: scaffold `node --check` passes; website + docs SSR 200; `webjs check` clean on website + docs.

Re #610.

https://claude.ai/code/session_01W8RLiSnkwKXDmnkoasQfZF
