### PR TITLE
fix: prevent browser double-fetching PNG and SVG favicons

### DIFF
--- a/docs/app/layout.ts
+++ b/docs/app/layout.ts
@@ -40,7 +40,7 @@ export default function RootLayout({ children }: { children: unknown }) {
   const nonce = cspNonce();
   return html`
     <link rel="icon" href="/public/favicon.svg" type="image/svg+xml">
-    <link rel="icon" href="/public/favicon.png" type="image/png">
+    <link rel="icon" href="/public/favicon.png" type="image/png" sizes="any">
     <link rel="apple-touch-icon" href="/public/favicon.png">
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-3RC87HXJ3P" nonce="${nonce}"></script>

--- a/examples/blog/app/layout.ts
+++ b/examples/blog/app/layout.ts
@@ -62,7 +62,7 @@ export default function RootLayout({ children }: LayoutProps) {
   const nonce = cspNonce();
   return html`
     <link rel="icon" href="/public/favicon.svg" type="image/svg+xml">
-    <link rel="icon" href="/public/favicon.png" type="image/png">
+    <link rel="icon" href="/public/favicon.png" type="image/png" sizes="any">
     <link rel="apple-touch-icon" href="/public/favicon.png">
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-3RC87HXJ3P" nonce="${nonce}"></script>

--- a/packages/ui/packages/website/app/layout.ts
+++ b/packages/ui/packages/website/app/layout.ts
@@ -57,7 +57,7 @@ export default function Layout({ children }: { children: any }) {
   const nonce = cspNonce();
   return html`
     <link rel="icon" href="/public/favicon.svg" type="image/svg+xml" />
-    <link rel="icon" href="/public/favicon.png" type="image/png" />
+    <link rel="icon" href="/public/favicon.png" type="image/png" sizes="any" />
     <link rel="apple-touch-icon" href="/public/favicon.png" />
     <link rel="stylesheet" href="/public/tailwind.css" />
     <!-- Synchronous theme bootstrap: mirrors webjs.dev so saved themes

--- a/website/app/layout.ts
+++ b/website/app/layout.ts
@@ -56,7 +56,7 @@ export default function RootLayout({ children }: { children: unknown }) {
   const nonce = cspNonce();
   return html`
     <link rel="icon" href="/public/favicon.svg" type="image/svg+xml">
-    <link rel="icon" href="/public/favicon.png" type="image/png">
+    <link rel="icon" href="/public/favicon.png" type="image/png" sizes="any">
     <link rel="apple-touch-icon" href="/public/favicon.png">
 
     <!-- Self-hosted fonts (declared via @font-face in input.css), preloaded so


### PR DESCRIPTION
Closes #649

Adds `sizes="any"` to the PNG favicon link tags in layout files so that modern browsers can immediately prioritize the SVG favicon without double-fetching both.