### PR TITLE
fix: specify explicit sizes for png favicon to prevent browser double-fetching

### DIFF
--- a/docs/app/layout.ts
+++ b/docs/app/layout.ts
@@ -39,8 +39,8 @@ export function generateMetadata(ctx: { url: string }) {
 export default function RootLayout({ children }: { children: unknown }) {
   const nonce = cspNonce();
   return html`
-    <link rel="icon" href="/public/favicon.png" type="image/png" sizes="any">
-    <link rel="icon" href="/public/favicon.svg" type="image/svg+xml">
+    <link rel="icon" href="/public/favicon.svg" type="image/svg+xml" sizes="any">
+    <link rel="icon" href="/public/favicon.png" type="image/png" sizes="32x32">
     <link rel="apple-touch-icon" href="/public/favicon.png">
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-3RC87HXJ3P" nonce="${nonce}"></script>

--- a/examples/blog/app/layout.ts
+++ b/examples/blog/app/layout.ts
@@ -61,8 +61,8 @@ export default function RootLayout({ children }: LayoutProps) {
   // CSP nonce for inline scripts. Empty when no nonce in CSP.
   const nonce = cspNonce();
   return html`
-    <link rel="icon" href="/public/favicon.png" type="image/png" sizes="any">
-    <link rel="icon" href="/public/favicon.svg" type="image/svg+xml">
+    <link rel="icon" href="/public/favicon.svg" type="image/svg+xml" sizes="any">
+    <link rel="icon" href="/public/favicon.png" type="image/png" sizes="32x32">
     <link rel="apple-touch-icon" href="/public/favicon.png">
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-3RC87HXJ3P" nonce="${nonce}"></script>

--- a/packages/ui/packages/website/app/layout.ts
+++ b/packages/ui/packages/website/app/layout.ts
@@ -56,8 +56,8 @@ export default function Layout({ children }: { children: any }) {
   // the real <head>. Other markup goes into <body>.
   const nonce = cspNonce();
   return html`
-    <link rel="icon" href="/public/favicon.png" type="image/png" sizes="any" />
-    <link rel="icon" href="/public/favicon.svg" type="image/svg+xml" />
+    <link rel="icon" href="/public/favicon.svg" type="image/svg+xml" sizes="any" />
+    <link rel="icon" href="/public/favicon.png" type="image/png" sizes="32x32" />
     <link rel="apple-touch-icon" href="/public/favicon.png" />
     <link rel="stylesheet" href="/public/tailwind.css" />
     <!-- Synchronous theme bootstrap: mirrors webjs.dev so saved themes

--- a/website/app/layout.ts
+++ b/website/app/layout.ts
@@ -55,8 +55,8 @@ const panelLink = 'text-fg-muted no-underline font-medium text-sm px-3 py-[10px]
 export default function RootLayout({ children }: { children: unknown }) {
   const nonce = cspNonce();
   return html`
-    <link rel="icon" href="/public/favicon.png" type="image/png" sizes="any">
-    <link rel="icon" href="/public/favicon.svg" type="image/svg+xml">
+    <link rel="icon" href="/public/favicon.svg" type="image/svg+xml" sizes="any">
+    <link rel="icon" href="/public/favicon.png" type="image/png" sizes="32x32">
     <link rel="apple-touch-icon" href="/public/favicon.png">
 
     <!-- Self-hosted fonts (declared via @font-face in input.css), preloaded so


### PR DESCRIPTION
Closes #649