### PR TITLE
feat(ui): 100% accessibility out of the box + AI-agent a11y contracts

### DIFF
--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -177,14 +177,48 @@ full per-directory breakdown.
 | 1b | `accordion` | `accordionClass`, `accordionItemClass`, `accordionTriggerClass`, `accordionContentClass`. Compose with `<details name="...">` + `<summary>`; `name` provides exclusive-open behavior natively. |
 | 1b | `collapsible` | `collapsibleClass`, `collapsibleTriggerClass`, `collapsibleContentClass`. Compose with `<details>` + `<summary>`. |
 | 1b | `progress` | `progressClass()`, apply to native `<progress value max>`. Browser draws the bar via `::-webkit-progress-value` and `::-moz-progress-bar`. Omit `value` for the indeterminate / pulse state. |
-| 2  | `toggle-group` | `<ui-toggle-group type value variant size>` + `<ui-toggle-group-item value>` |
-| 2  | `dialog` | `<ui-dialog>` + `<ui-dialog-trigger>` / `<ui-dialog-content>` / `<ui-dialog-close>`. Built on native `<dialog>.showModal()`, top-layer rendering, ::backdrop overlay, focus trap, Escape close, and focus restoration are all platform-provided. We add body-scroll lock + class helpers for `dialogHeader/Title/Description/Footer`. |
-| 2  | `alert-dialog` | Like dialog, role=alertdialog. Native Escape close is cancelled via the `cancel` event; no backdrop-click dismissal. `<ui-alert-dialog-action>` / `<ui-alert-dialog-cancel>`. |
-| 2  | `tooltip` | `<ui-tooltip delay-duration>`, hover/focus + delay. Content uses `popover="manual"` for top-layer rendering. |
-| 2  | `hover-card` | `<ui-hover-card open-delay close-delay>`, hover with linger-keep-open. Content uses `popover="manual"` for top-layer rendering. |
-| 2  | `tabs` | `<ui-tabs value orientation>` + List / Trigger / Content. Arrow-key keyboard nav. |
-| 2  | `dropdown-menu` | `<ui-dropdown-menu>` + Trigger / Content / Item (variant) / Label / Separator / Shortcut / Group. Content uses `popover="manual"` for top-layer rendering. ArrowUp/Down nav, Escape close. |
-| 2  | `sonner` | `<ui-sonner position>` + `toast()` / `toast.success` / `toast.error` / `toast.promise` API. |
+| 2  | `toggle-group` | `<ui-toggle-group type value variant size>` + `<ui-toggle-group-item value>`. Roving tabindex (one Tab stop) with Arrow / Home / End navigation, plus `aria-pressed` per item. |
+| 2  | `dialog` | `<ui-dialog>` + `<ui-dialog-trigger>` / `<ui-dialog-content>` / `<ui-dialog-close>`. Built on native `<dialog>.showModal()`, top-layer rendering, ::backdrop overlay, focus trap, Escape close, and focus restoration are all platform-provided. We add body-scroll lock + class helpers for `dialogHeader/Title/Description/Footer`. On open it wires `aria-labelledby` / `aria-describedby` to the `data-slot="dialog-title"` / `dialog-description` nodes (falling back to the first heading / paragraph). |
+| 2  | `alert-dialog` | Like dialog, role=alertdialog. Native Escape close is cancelled via the `cancel` event; no backdrop-click dismissal. `<ui-alert-dialog-action>` / `<ui-alert-dialog-cancel>`. Wires `aria-labelledby` / `aria-describedby` to its `alert-dialog-title` / `alert-dialog-description` the same way. |
+| 2  | `tooltip` | `<ui-tooltip delay-duration>`, hover/focus + delay. Content uses `popover="manual"` for top-layer rendering. The trigger references the tip via `aria-describedby` (APG tooltip wiring). |
+| 2  | `hover-card` | `<ui-hover-card open-delay close-delay>`, hover with linger-keep-open. Content uses `popover="manual"` for top-layer rendering. The trigger (focusable, also opens on focus) gets `aria-haspopup` / `aria-expanded` / `aria-controls`. |
+| 2  | `tabs` | `<ui-tabs value orientation>` + List / Trigger / Content. Arrow-key keyboard nav. Triggers carry `aria-controls`, panels `aria-labelledby` (cross-linked per group), the list `aria-orientation`, and an inactive panel is `inert`. |
+| 2  | `dropdown-menu` | `<ui-dropdown-menu>` + Trigger / Content / Item (variant) / Label / Separator / Shortcut / Group. Content uses `popover="manual"` for top-layer rendering. ArrowUp/Down nav, Escape close. Menu declares `aria-orientation`, a `data-disabled` item reflects `aria-disabled`, and the trigger gets `aria-haspopup` / `aria-expanded` / `aria-controls`. |
+| 2  | `sonner` | `<ui-sonner position>` + `toast()` / `toast.success` / `toast.error` / `toast.promise` API. The viewport is a persistent `aria-live` region so inserted toasts are announced (an `error` toast is `role=alert`). |
+
+## Accessibility
+
+The kit aims for 100% accessibility out of the box, but the responsibility
+splits by tier, and an agent MUST know which half it owns.
+
+**Tier-2 custom elements own their ARIA.** Because the element renders its own
+markup, it wires the WAI-ARIA pattern itself, with zero author effort: tabs
+cross-links triggers and panels (`aria-controls` / `aria-labelledby`), reports
+`aria-orientation`, and marks an inactive panel `inert`; toggle-group uses
+roving tabindex plus Arrow / Home / End; dropdown-menu declares
+`aria-orientation`, reflects `aria-disabled` on a `data-disabled` item, and
+gives the trigger `aria-haspopup` / `aria-expanded` / `aria-controls`; dialog
+and alert-dialog name themselves from their title and description on open;
+tooltip references its tip with `aria-describedby`; hover-card exposes the
+popup relationship on its (focus-openable) trigger; sonner is a persistent
+`aria-live` region. Do not hand-add these attributes; the element already has.
+
+**Tier-1 class helpers push their ARIA to YOU.** A helper returns only Tailwind
+classes, so the semantic element, role, and ARIA are the caller's job. Every
+Tier-1 component's JSDoc carries an `A11y (required for accessible output)`
+block stating exactly what to supply. The recurring obligations:
+
+- `button`: an icon-only button needs `aria-label`; an overlay trigger needs `aria-haspopup` + `aria-expanded`.
+- `alert`: choose `role="alert"` (urgent) or `role="status"` (polite).
+- `separator`: `role="separator"` + `aria-orientation`, or `role="none"` when decorative.
+- `skeleton`: `aria-hidden="true"` (or `aria-busy` on the region), since it is a placeholder.
+- `avatar`: an `alt` that names the person, plus the text fallback.
+- `table`: `scope="col"` / `scope="row"` on header cells, and a `<caption>`.
+- `pagination` / `breadcrumb`: a labelled `<nav>`, `aria-current="page"`, and hidden separators / icon-only control names.
+- `progress`: an `aria-label` (the native element supplies the role + value).
+
+Browser tests for the Tier-2 guarantees live in
+`test/components/browser/ui-a11y.test.js`.
 
 ## Public commands (binary: `webjsui`)
 

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -39,6 +39,23 @@ utility classes on authored children apply directly. The `webjsui add`
 CLI installs `@webjsdev/core` automatically when you add a Tier-2
 component.
 
+## Accessibility
+
+Tier-2 elements are accessible out of the box: they wire their own WAI-ARIA
+pattern, so you do not hand-add ARIA. Tabs cross-links triggers and panels and
+reports orientation, toggle-group uses roving tabindex with Arrow / Home / End,
+dropdown-menu declares orientation and reflects `aria-disabled`, dialog and
+alert-dialog name themselves from their title and description, tooltip wires
+`aria-describedby`, hover-card exposes `aria-haspopup` / `aria-expanded`, and
+sonner is a live region.
+
+Tier-1 class helpers return only classes, so the semantic element and ARIA are
+yours to supply. Each one's JSDoc carries an `A11y (required for accessible
+output)` block stating exactly what to add: a name on an icon-only button, a
+role on an alert, `scope` on table headers, `alt` on an avatar image, a
+labelled `<nav>` with `aria-current="page"` on pagination and breadcrumb, and
+so on. Follow that block and the markup is fully accessible.
+
 ## Install
 
 ### Option A : Webjs users (already have `@webjsdev/cli`)

--- a/packages/ui/packages/registry/components/alert-dialog.ts
+++ b/packages/ui/packages/registry/components/alert-dialog.ts
@@ -32,8 +32,8 @@
  *     </ui-alert-dialog-trigger>
  *     <ui-alert-dialog-content>
  *       <div class=${alertDialogHeaderClass()}>
- *         <h2 class=${alertDialogTitleClass()}>Delete account?</h2>
- *         <p class=${alertDialogDescriptionClass()}>This cannot be undone.</p>
+ *         <h2 data-slot="alert-dialog-title" class=${alertDialogTitleClass()}>Delete account?</h2>
+ *         <p data-slot="alert-dialog-description" class=${alertDialogDescriptionClass()}>This cannot be undone.</p>
  *       </div>
  *       <div class=${alertDialogFooterClass()}>
  *         <ui-alert-dialog-cancel>Cancel</ui-alert-dialog-cancel>
@@ -65,6 +65,7 @@
  */
 import { WebComponent, html, prop } from '@webjsdev/core';
 import { ref, createRef } from '@webjsdev/core/directives';
+import { ensureId } from '../lib/utils.ts';
 import { buttonClass, type ButtonVariant, type ButtonSize } from './button.ts';
 
 export const alertDialogContentClass = (): string =>
@@ -234,8 +235,31 @@ export class UiAlertDialogContent extends WebComponent({
   }
 
   showModal(): void {
+    this._wireLabels();
     const native = this.#dialog.value;
     if (native && !native.open) native.showModal();
+  }
+
+  // Wire the alertdialog's accessible name + description to its title /
+  // description nodes at open time (an alert dialog only ever appears via
+  // showModal(), so there is no SSR id-stability concern). The title is
+  // data-slot="alert-dialog-title" (falling back to the first heading); the
+  // description is data-slot="alert-dialog-description" (falling back to the
+  // first paragraph). Author-set ARIA always wins. Inlined rather than shared
+  // with dialog.ts so `webjs ui add alert-dialog` stays self-contained.
+  _wireLabels(): void {
+    const panel = this.querySelector('[data-slot="alert-dialog-content"]');
+    if (!panel) return;
+    const title =
+      this.querySelector('[data-slot="alert-dialog-title"]') ?? this.querySelector('h1, h2, h3');
+    const desc =
+      this.querySelector('[data-slot="alert-dialog-description"]') ?? this.querySelector('p');
+    if (title && !panel.hasAttribute('aria-labelledby')) {
+      panel.setAttribute('aria-labelledby', ensureId(title as HTMLElement, 'ui-alert-title'));
+    }
+    if (desc && !panel.hasAttribute('aria-describedby')) {
+      panel.setAttribute('aria-describedby', ensureId(desc as HTMLElement, 'ui-alert-desc'));
+    }
   }
 
   close(): void {

--- a/packages/ui/packages/registry/components/alert.ts
+++ b/packages/ui/packages/registry/components/alert.ts
@@ -25,6 +25,11 @@
  *     </div>
  *   </div>
  *
+ * A11y (required for accessible output): put role="alert" on the container
+ * for an urgent, interrupting message, or role="status" for a polite,
+ * non-urgent update. The class helper sets no role, so without one the
+ * banner is silent to assistive tech.
+ *
  * Design tokens used: --card, --card-foreground, --destructive, --muted-foreground.
  */
 import { cn } from '../lib/utils.ts';

--- a/packages/ui/packages/registry/components/avatar.ts
+++ b/packages/ui/packages/registry/components/avatar.ts
@@ -23,6 +23,11 @@
  *     <div class=${avatarGroupCountClass()}>+3</div>
  *   </div>
  *
+ * A11y (required for accessible output): the <img> MUST have an alt that
+ * names the person (alt="Vivek Khandelwal"), or alt="" when a visible text
+ * fallback already names them. Always provide the fallback <span> so the
+ * avatar is still named if the image fails to load.
+ *
  * Design tokens used: --muted, --muted-foreground, --primary, --background.
  */
 import { cn } from '../lib/utils.ts';

--- a/packages/ui/packages/registry/components/badge.ts
+++ b/packages/ui/packages/registry/components/badge.ts
@@ -14,6 +14,10 @@
  * The `[a&]:hover:...` hover styles only apply when the element is an `<a>`,
  * so a static `<span>` doesn't pick up an unwanted hover.
  *
+ * A11y (required for accessible output): render a static badge as a plain
+ * <span> (not focusable, no tabindex). Only an interactive badge (an <a>
+ * or <button>) is focusable, and an icon-only one needs an aria-label.
+ *
  * Design tokens used: --primary, --secondary, --destructive, --foreground,
  * --accent, --border, --ring.
  */

--- a/packages/ui/packages/registry/components/breadcrumb.ts
+++ b/packages/ui/packages/registry/components/breadcrumb.ts
@@ -26,6 +26,11 @@
  *     </ol>
  *   </nav>
  *
+ * A11y (required for accessible output): wrap the list in <nav
+ * aria-label="breadcrumb">, set aria-current="page" on the current-page
+ * element, and mark each separator role="presentation" aria-hidden="true".
+ * The class helpers emit none of these.
+ *
  * Design tokens used: --muted-foreground, --foreground.
  */
 

--- a/packages/ui/packages/registry/components/button.ts
+++ b/packages/ui/packages/registry/components/button.ts
@@ -17,6 +17,12 @@
  * shadcn React's `asChild` (Slot) prop has no equivalent here: just call
  * `buttonClass(...)` and spread the classes onto whatever element you want.
  *
+ * A11y (required for accessible output): an icon-only button (the `icon`,
+ * `icon-xs`, `icon-sm`, `icon-lg` sizes) has no visible text, so it MUST
+ * carry an accessible name via aria-label (or aria-labelledby). A button
+ * that opens an overlay should also set aria-haspopup and aria-expanded.
+ * Native <button> focus and keyboard activation are already correct.
+ *
  * Design tokens used: --primary, --primary-foreground, --destructive,
  * --secondary, --secondary-foreground, --accent, --accent-foreground,
  * --background, --input, --ring.

--- a/packages/ui/packages/registry/components/dialog.ts
+++ b/packages/ui/packages/registry/components/dialog.ts
@@ -29,8 +29,8 @@
  *     </ui-dialog-trigger>
  *     <ui-dialog-content>
  *       <div class=${dialogHeaderClass()}>
- *         <h2 class=${dialogTitleClass()}>Edit profile</h2>
- *         <p class=${dialogDescriptionClass()}>Make changes and click save.</p>
+ *         <h2 data-slot="dialog-title" class=${dialogTitleClass()}>Edit profile</h2>
+ *         <p data-slot="dialog-description" class=${dialogDescriptionClass()}>Make changes and click save.</p>
  *       </div>
  *       <div class="grid gap-3">
  *         <label class=${labelClass()} for="dlg-name">Name</label>
@@ -65,7 +65,30 @@
  */
 import { WebComponent, html, unsafeHTML, prop } from '@webjsdev/core';
 import { ref, createRef } from '@webjsdev/core/directives';
+import { ensureId } from '../lib/utils.ts';
 import { buttonClass } from './button.ts';
+
+// Wires a dialog panel's accessible name + description to its title /
+// description nodes. A dialog only ever appears via showModal() (JS), so
+// resolving the relationship at open time is correct and avoids any
+// SSR id-stability concern. The title is the element marked
+// data-slot="dialog-title" (falling back to the first heading); the
+// description is data-slot="dialog-description" (falling back to the first
+// paragraph). Author-set aria-labelledby / aria-describedby always win.
+export function wireDialogLabels(host: Element, panelSelector: string): void {
+  const panel = host.querySelector(panelSelector);
+  if (!panel) return;
+  const title =
+    host.querySelector('[data-slot="dialog-title"]') ?? host.querySelector('h1, h2, h3');
+  const desc =
+    host.querySelector('[data-slot="dialog-description"]') ?? host.querySelector('p');
+  if (title && !panel.hasAttribute('aria-labelledby')) {
+    panel.setAttribute('aria-labelledby', ensureId(title as HTMLElement, 'ui-dialog-title'));
+  }
+  if (desc && !panel.hasAttribute('aria-describedby')) {
+    panel.setAttribute('aria-describedby', ensureId(desc as HTMLElement, 'ui-dialog-desc'));
+  }
+}
 
 // --------------------------------------------------------------------------
 // Class helpers for subparts.
@@ -268,6 +291,7 @@ export class UiDialogContent extends WebComponent({
   }
 
   showModal(): void {
+    wireDialogLabels(this, '[data-slot="dialog-content"]');
     const native = this.#dialog.value;
     if (native && !native.open) native.showModal();
   }

--- a/packages/ui/packages/registry/components/dropdown-menu.ts
+++ b/packages/ui/packages/registry/components/dropdown-menu.ts
@@ -55,6 +55,9 @@
  *   `type`:    omit (default) | "checkbox" | "radio".
  *   `checked`: boolean. Applies to checkbox / radio items.
  *   `value`:   string. Identifier for radio items.
+ *   `data-disabled`: boolean. Skips keyboard focus and activation, dims the
+ *                    item, and sets aria-disabled. Same attribute on a
+ *                    <ui-dropdown-menu-sub-trigger> disables the submenu.
  *
  * Events:
  *   `ui-open-change` on <ui-dropdown-menu>: `{ detail: { open } }` after a transition.
@@ -75,6 +78,7 @@
  * --accent-foreground, --destructive, --muted-foreground, --border.
  */
 import { WebComponent, html, unsafeHTML, signal, prop } from '@webjsdev/core';
+import { ensureId } from '../lib/utils.ts';
 import { positionFloating, type PopoverSide, type PopoverAlign } from './popover.ts';
 
 // --------------------------------------------------------------------------
@@ -153,13 +157,53 @@ export class UiDropdownMenu extends WebComponent({
     queueMicrotask(() => this._afterRender());
   }
 
+  connectedCallback(): void {
+    super.connectedCallback?.();
+    // Children upgrade after this host; defer a microtask so the trigger
+    // button and the menu element exist before wiring ARIA between them.
+    queueMicrotask(() => this._wireAria());
+  }
+
   _afterRender(): void {
     const content = this._content();
     if (content) {
       this._syncContentPopover(content);
     }
+    this._wireAria();
     if (this.open) this._setup();
     else this._teardown();
+  }
+
+  // The trigger wraps an author-supplied control (usually a <button>). Expose
+  // the menu relationship on that focusable control: aria-haspopup announces
+  // it opens a menu, aria-expanded tracks open state, aria-controls points at
+  // the menu, and the menu is labelled back by the trigger. Done at runtime
+  // because the menu is JS-driven (never shown without script).
+  _triggerControl(): HTMLElement | null {
+    const trigger = this.querySelector('ui-dropdown-menu-trigger');
+    if (!trigger) return null;
+    return (
+      trigger.querySelector<HTMLElement>('button, [role="button"], a[href], [tabindex]') ??
+      (trigger as HTMLElement)
+    );
+  }
+
+  _menuEl(): HTMLElement | null {
+    return this.querySelector('ui-dropdown-menu-content [role="menu"]');
+  }
+
+  _wireAria(): void {
+    const control = this._triggerControl();
+    if (!control) return;
+    control.setAttribute('aria-haspopup', 'menu');
+    control.setAttribute('aria-expanded', String(this.open));
+    const menu = this._menuEl();
+    if (!menu) return;
+    const menuId = ensureId(menu, 'ui-menu');
+    control.setAttribute('aria-controls', menuId);
+    if (!menu.hasAttribute('aria-label') && !menu.hasAttribute('aria-labelledby')) {
+      menu.setAttribute('aria-labelledby', ensureId(control, 'ui-menu-trigger'));
+    }
   }
 
   _content(): HTMLElement | null {
@@ -326,6 +370,7 @@ export class UiDropdownMenuContent extends WebComponent {
     return html`<div
       data-slot="dropdown-menu-content"
       role="menu"
+      aria-orientation="vertical"
       popover="manual"
       class=${dropdownMenuContentClass()}
     ><slot></slot></div>`;
@@ -340,6 +385,11 @@ UiDropdownMenuContent.register('ui-dropdown-menu-content');
 export class UiDropdownMenuItem extends WebComponent({
   variant: prop<'default' | 'destructive'>(String, { reflect: true }),
   inset: Boolean,
+  // `data-disabled` is the historical attribute (focus skips it, the click /
+  // pointer handlers bail on it); making it a reflected prop keeps that wire
+  // intact while letting render() also emit `aria-disabled` so the disabled
+  // state reaches assistive tech, not just CSS.
+  disabled: prop(Boolean, { reflect: true, attribute: 'data-disabled' }),
 }) {
   // Keyboard / pointer highlight state for the own-rendered menuitem. A
   // local signal bound with ?data-highlighted keeps the highlight in the
@@ -351,6 +401,7 @@ export class UiDropdownMenuItem extends WebComponent({
     super();
     this.variant = 'default';
     this.inset = false;
+    this.disabled = false;
   }
 
   render() {
@@ -360,6 +411,8 @@ export class UiDropdownMenuItem extends WebComponent({
       tabindex="-1"
       data-variant=${this.variant}
       ?data-inset=${this.inset}
+      ?data-disabled=${this.disabled}
+      aria-disabled=${this.disabled ? 'true' : 'false'}
       ?data-highlighted=${this.#highlighted.get()}
       class=${dropdownMenuItemClass()}
       @click=${this._onClick}
@@ -542,10 +595,14 @@ export class UiDropdownMenuSub extends WebComponent({
 }
 UiDropdownMenuSub.register('ui-dropdown-menu-sub');
 
-export class UiDropdownMenuSubTrigger extends WebComponent({ inset: Boolean }) {
+export class UiDropdownMenuSubTrigger extends WebComponent({
+  inset: Boolean,
+  disabled: prop(Boolean, { reflect: true, attribute: 'data-disabled' }),
+}) {
   constructor() {
     super();
     this.inset = false;
+    this.disabled = false;
   }
 
   // SSR-safe: linkedom doesn't implement closest() on custom elements.
@@ -562,8 +619,10 @@ export class UiDropdownMenuSubTrigger extends WebComponent({ inset: Boolean }) {
       tabindex="-1"
       aria-haspopup="menu"
       aria-expanded=${String(open)}
+      aria-disabled=${this.disabled ? 'true' : 'false'}
       data-state=${open ? 'open' : 'closed'}
       ?data-inset=${this.inset}
+      ?data-disabled=${this.disabled}
       class=${dropdownMenuSubTriggerClass()}
       @click=${this._onClick}
       @pointerenter=${this._onPointerEnter}
@@ -590,6 +649,7 @@ export class UiDropdownMenuSubContent extends WebComponent {
     return html`<div
       data-slot="dropdown-menu-sub-content"
       role="menu"
+      aria-orientation="vertical"
       popover="manual"
       class=${dropdownMenuSubContentClass()}
     ><slot></slot></div>`;

--- a/packages/ui/packages/registry/components/dropdown-menu.ts
+++ b/packages/ui/packages/registry/components/dropdown-menu.ts
@@ -159,9 +159,12 @@ export class UiDropdownMenu extends WebComponent({
 
   connectedCallback(): void {
     super.connectedCallback?.();
-    // Children upgrade after this host; defer a microtask so the trigger
-    // button and the menu element exist before wiring ARIA between them.
-    queueMicrotask(() => this._wireAria());
+    // webjs projects slotted light-DOM children in a pass after the first
+    // render, so the trigger button and the menu are not in place at
+    // connect. Defer to the next frame, when the projection has run.
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(() => this._wireAria());
+    }
   }
 
   _afterRender(): void {
@@ -385,11 +388,6 @@ UiDropdownMenuContent.register('ui-dropdown-menu-content');
 export class UiDropdownMenuItem extends WebComponent({
   variant: prop<'default' | 'destructive'>(String, { reflect: true }),
   inset: Boolean,
-  // `data-disabled` is the historical attribute (focus skips it, the click /
-  // pointer handlers bail on it); making it a reflected prop keeps that wire
-  // intact while letting render() also emit `aria-disabled` so the disabled
-  // state reaches assistive tech, not just CSS.
-  disabled: prop(Boolean, { reflect: true, attribute: 'data-disabled' }),
 }) {
   // Keyboard / pointer highlight state for the own-rendered menuitem. A
   // local signal bound with ?data-highlighted keeps the highlight in the
@@ -401,18 +399,22 @@ export class UiDropdownMenuItem extends WebComponent({
     super();
     this.variant = 'default';
     this.inset = false;
-    this.disabled = false;
   }
 
   render() {
+    // `data-disabled` on the host is the historical disabled marker (focus
+    // skips it, the click / pointer handlers bail on it). Mirror it onto the
+    // inner menuitem as both data-disabled (CSS) and aria-disabled, so the
+    // state also reaches assistive tech.
+    const disabled = typeof this.hasAttribute === 'function' && this.hasAttribute('data-disabled');
     return html`<div
       data-slot="dropdown-menu-item"
       role="menuitem"
       tabindex="-1"
       data-variant=${this.variant}
       ?data-inset=${this.inset}
-      ?data-disabled=${this.disabled}
-      aria-disabled=${this.disabled ? 'true' : 'false'}
+      ?data-disabled=${disabled}
+      aria-disabled=${disabled ? 'true' : 'false'}
       ?data-highlighted=${this.#highlighted.get()}
       class=${dropdownMenuItemClass()}
       @click=${this._onClick}
@@ -595,14 +597,10 @@ export class UiDropdownMenuSub extends WebComponent({
 }
 UiDropdownMenuSub.register('ui-dropdown-menu-sub');
 
-export class UiDropdownMenuSubTrigger extends WebComponent({
-  inset: Boolean,
-  disabled: prop(Boolean, { reflect: true, attribute: 'data-disabled' }),
-}) {
+export class UiDropdownMenuSubTrigger extends WebComponent({ inset: Boolean }) {
   constructor() {
     super();
     this.inset = false;
-    this.disabled = false;
   }
 
   // SSR-safe: linkedom doesn't implement closest() on custom elements.
@@ -613,16 +611,17 @@ export class UiDropdownMenuSubTrigger extends WebComponent({
 
   render() {
     const open = !!this._sub()?.open;
+    const disabled = typeof this.hasAttribute === 'function' && this.hasAttribute('data-disabled');
     return html`<div
       data-slot="dropdown-menu-sub-trigger"
       role="menuitem"
       tabindex="-1"
       aria-haspopup="menu"
       aria-expanded=${String(open)}
-      aria-disabled=${this.disabled ? 'true' : 'false'}
+      aria-disabled=${disabled ? 'true' : 'false'}
       data-state=${open ? 'open' : 'closed'}
       ?data-inset=${this.inset}
-      ?data-disabled=${this.disabled}
+      ?data-disabled=${disabled}
       class=${dropdownMenuSubTriggerClass()}
       @click=${this._onClick}
       @pointerenter=${this._onPointerEnter}

--- a/packages/ui/packages/registry/components/hover-card.ts
+++ b/packages/ui/packages/registry/components/hover-card.ts
@@ -39,6 +39,7 @@
  * Design tokens used: --popover, --popover-foreground, --border.
  */
 import { WebComponent, html, prop } from '@webjsdev/core';
+import { ensureId } from '../lib/utils.ts';
 import { positionFloating, type PopoverSide, type PopoverAlign } from './popover.ts';
 
 // `fixed m-0` opts out of the UA `[popover]` auto-centering margin so
@@ -69,6 +70,32 @@ export class UiHoverCard extends WebComponent({
     this.closeDelay = 300;
   }
 
+  connectedCallback(): void {
+    super.connectedCallback?.();
+    queueMicrotask(() => this._wireAria());
+  }
+
+  // The trigger also opens on focus (see the @focusin handler), so it is
+  // keyboard-reachable: expose the popup relationship on the focusable
+  // control. aria-expanded is refreshed on every open transition.
+  _control(): HTMLElement | null {
+    const t = this.querySelector('ui-hover-card-trigger');
+    if (!t) return null;
+    return (
+      t.querySelector<HTMLElement>('a[href], button, [tabindex], [role="button"]') ??
+      (t as HTMLElement)
+    );
+  }
+
+  _wireAria(): void {
+    const control = this._control();
+    if (!control) return;
+    control.setAttribute('aria-haspopup', 'dialog');
+    control.setAttribute('aria-expanded', String(this.open));
+    const content = this.querySelector<HTMLElement>('ui-hover-card-content [role="dialog"]');
+    if (content) control.setAttribute('aria-controls', ensureId(content, 'ui-hovercard'));
+  }
+
   // Back-compat getter.
   get isOpen(): boolean { return this.open; }
 
@@ -93,8 +120,12 @@ export class UiHoverCard extends WebComponent({
     if (!changedProperties.has('open')) return;
     if (changedProperties.get('open') === undefined) return;
     // Wait one microtask for <ui-hover-card-content>'s inner [popover]
-    // element to commit; we drive its showPopover() / hidePopover().
-    queueMicrotask(() => this._syncContent());
+    // element to commit; we drive its showPopover() / hidePopover() and
+    // refresh the trigger's aria-expanded.
+    queueMicrotask(() => {
+      this._wireAria();
+      this._syncContent();
+    });
   }
 
   _syncContent(): void {

--- a/packages/ui/packages/registry/components/hover-card.ts
+++ b/packages/ui/packages/registry/components/hover-card.ts
@@ -72,7 +72,12 @@ export class UiHoverCard extends WebComponent({
 
   connectedCallback(): void {
     super.connectedCallback?.();
-    queueMicrotask(() => this._wireAria());
+    // webjs projects slotted light-DOM children after the first render, so
+    // the trigger control is not in place at connect. Defer to the next
+    // frame, when the projection has run.
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(() => this._wireAria());
+    }
   }
 
   // The trigger also opens on focus (see the @focusin handler), so it is

--- a/packages/ui/packages/registry/components/pagination.ts
+++ b/packages/ui/packages/registry/components/pagination.ts
@@ -23,6 +23,11 @@
  *     </ul>
  *   </nav>
  *
+ * A11y (required for accessible output): wrap the list in <nav
+ * aria-label="pagination">, set aria-current="page" on the active page
+ * link, give an icon-only Previous / Next control an aria-label, and mark
+ * the ellipsis aria-hidden="true". The class helpers emit none of these.
+ *
  * Design tokens used: inherited from buttonClass.
  */
 import { cn } from '../lib/utils.ts';

--- a/packages/ui/packages/registry/components/progress.ts
+++ b/packages/ui/packages/registry/components/progress.ts
@@ -16,6 +16,11 @@
  *   <!-- Indeterminate (no `value` attribute): -->
  *   <progress class=${progressClass()}></progress>
  *
+ * A11y (required for accessible output): give the <progress> an accessible
+ * name with aria-label (or a <label for>), e.g. aria-label="Upload
+ * progress". The native element supplies the role and value; only the name
+ * is the author's responsibility.
+ *
  * Design tokens used: --primary.
  */
 

--- a/packages/ui/packages/registry/components/separator.ts
+++ b/packages/ui/packages/registry/components/separator.ts
@@ -13,6 +13,11 @@
  *        class=${separatorClass({ orientation: 'vertical' })}
  *        data-orientation="vertical"></div>
  *
+ * A11y (required for accessible output): a meaningful divider needs
+ * role="separator" plus aria-orientation. A purely decorative one needs
+ * role="none" (or aria-hidden="true") so assistive tech does not announce
+ * an empty separator.
+ *
  * Design tokens used: --border.
  */
 import { cn } from '../lib/utils.ts';

--- a/packages/ui/packages/registry/components/skeleton.ts
+++ b/packages/ui/packages/registry/components/skeleton.ts
@@ -10,6 +10,11 @@
  *   <div class=${cn(skeletonClass(), 'h-4 w-32')}></div>
  *   <div class=${cn(skeletonClass(), 'h-12 w-12 rounded-full')}></div>
  *
+ * A11y (required for accessible output): a skeleton is a decorative
+ * placeholder, so hide it from assistive tech with aria-hidden="true" (or
+ * mark the loading region aria-busy="true"). Announce the real content
+ * once it replaces the skeleton.
+ *
  * Design tokens used: --accent.
  */
 

--- a/packages/ui/packages/registry/components/sonner.ts
+++ b/packages/ui/packages/registry/components/sonner.ts
@@ -188,8 +188,18 @@ export class UiSonner extends WebComponent({
 
   render() {
     const pos = POSITIONS[this.position] ?? POSITIONS['bottom-right'];
+    // The container is a persistent live region: it is in the DOM from the
+    // first render (even with zero toasts), so a screen reader announces
+    // each toast as it is inserted. It defaults to polite; an `error` toast
+    // carries its own role="alert" (assertive) and that innermost live
+    // region wins for that item.
     return html`<div
       data-slot="sonner"
+      role="region"
+      aria-label="Notifications"
+      aria-live="polite"
+      aria-relevant="additions text"
+      aria-atomic="false"
       class=${`pointer-events-none fixed z-[100] flex flex-col gap-2 ${pos}`}
     >
       ${repeat(

--- a/packages/ui/packages/registry/components/table.ts
+++ b/packages/ui/packages/registry/components/table.ts
@@ -18,8 +18,8 @@
  *     <table class=${tableClass()}>
  *       <thead class=${tableHeaderClass()}>
  *         <tr class=${tableRowClass()}>
- *           <th class=${tableHeadClass()}>Name</th>
- *           <th class=${tableHeadClass()}>Status</th>
+ *           <th scope="col" class=${tableHeadClass()}>Name</th>
+ *           <th scope="col" class=${tableHeadClass()}>Status</th>
  *         </tr>
  *       </thead>
  *       <tbody class=${tableBodyClass()}>
@@ -31,6 +31,11 @@
  *       <caption class=${tableCaptionClass()}>Users</caption>
  *     </table>
  *   </div>
+ *
+ * A11y (required for accessible output): every header cell needs a scope
+ * (scope="col" on a column header, scope="row" on a row header) so screen
+ * readers map cells to their headers. Add a <caption> naming the table's
+ * purpose (it can be visually hidden if a heading already names it).
  *
  * Design tokens used: --muted, --muted-foreground, --foreground.
  */

--- a/packages/ui/packages/registry/components/tabs.ts
+++ b/packages/ui/packages/registry/components/tabs.ts
@@ -44,7 +44,10 @@
  * --input, --ring.
  */
 import { WebComponent, html, prop } from '@webjsdev/core';
-import { cn } from '../lib/utils.ts';
+import { cn, ensureId } from '../lib/utils.ts';
+
+// A tab `value` becomes part of an id, so reduce it to id-safe characters.
+const idSafe = (s: string): string => s.replace(/[^A-Za-z0-9_-]/g, '-');
 
 // --------------------------------------------------------------------------
 // Class helpers
@@ -102,6 +105,19 @@ export class UiTabs extends WebComponent({
     this.orientation = 'horizontal';
   }
 
+  // Stable per-instance scope so a trigger and its panel agree on the
+  // shared id stem (`<scope>-trigger-<value>` / `<scope>-panel-<value>`)
+  // even when several tab sets reuse the same `value` names on one page.
+  get scopeId(): string {
+    return ensureId(this, 'ui-tabs');
+  }
+
+  // Builds the trigger / panel id pair a child derives from its `value`.
+  idsFor(value: string): { trigger: string; panel: string } {
+    const v = idSafe(value);
+    return { trigger: `${this.scopeId}-trigger-${v}`, panel: `${this.scopeId}-panel-${v}` };
+  }
+
   render() {
     return html`<div
       data-slot="tabs"
@@ -126,7 +142,7 @@ export class UiTabs extends WebComponent({
 
   _broadcast(): void {
     this.querySelectorAll<WebComponent>(
-      'ui-tabs-trigger, ui-tabs-content',
+      'ui-tabs-list, ui-tabs-trigger, ui-tabs-content',
     ).forEach((el) => el.requestUpdate?.());
   }
 }
@@ -144,10 +160,17 @@ export class UiTabsList extends WebComponent({
     this.variant = 'default';
   }
 
+  get _tabs(): UiTabs | null {
+    if (typeof this.closest !== 'function') return null;
+    return this.closest('ui-tabs') as UiTabs | null;
+  }
+
   render() {
+    const orientation = this._tabs?.orientation ?? 'horizontal';
     return html`<div
       data-slot="tabs-list"
       role="tablist"
+      aria-orientation=${orientation}
       data-variant=${this.variant}
       class=${tabsListClass({ variant: this.variant })}
     ><slot></slot></div>`;
@@ -178,10 +201,13 @@ export class UiTabsTrigger extends WebComponent({
   render() {
     const tabs = this._tabs;
     const active = !!tabs && tabs.value === this.value && this.value !== '';
+    const ids = tabs && this.value ? tabs.idsFor(this.value) : null;
     return html`<button
       type="button"
       role="tab"
       data-slot="tabs-trigger"
+      id=${ids ? ids.trigger : ''}
+      aria-controls=${ids ? ids.panel : ''}
       data-state=${active ? 'active' : 'inactive'}
       aria-selected=${String(active)}
       tabindex=${active ? '0' : '-1'}
@@ -241,14 +267,20 @@ export class UiTabsContent extends WebComponent({
   render() {
     const tabs = this._tabs;
     const active = !!tabs && tabs.value === this.value && this.value !== '';
+    const ids = tabs && this.value ? tabs.idsFor(this.value) : null;
     // The host needs to be hidden when inactive so its rendered <section>
     // is removed from layout (light DOM has no :host CSS to scope this).
     // Use the native `hidden` IDL property rather than imperative
-    // setAttribute, so it reads as a property assignment.
+    // setAttribute, so it reads as a property assignment. `inert` on the
+    // host additionally pulls an inactive panel (and anything focusable
+    // inside it) out of the tab order and the accessibility tree.
     this.hidden = !active;
+    this.inert = !active;
     return html`<section
       data-slot="tabs-content"
       role="tabpanel"
+      id=${ids ? ids.panel : ''}
+      aria-labelledby=${ids ? ids.trigger : ''}
       tabindex="0"
       data-state=${active ? 'active' : 'inactive'}
       class=${TABS_CONTENT_CLASS}

--- a/packages/ui/packages/registry/components/toggle-group.ts
+++ b/packages/ui/packages/registry/components/toggle-group.ts
@@ -41,7 +41,9 @@
  * Events:
  *   `ui-value-change` on <ui-toggle-group>: `{ detail: { value } }` after selection changes.
  *
- * Keyboard: Enter / Space toggles the focused item (native button activation).
+ * Keyboard: Arrow keys move focus between items (roving tabindex, so the
+ * group is a single Tab stop), Home / End jump to the first / last item, and
+ * Enter / Space toggles the focused item.
  *
  * Design tokens used: inherited from toggleClass (--muted, --accent, --ring,
  * --input, --destructive).
@@ -109,9 +111,15 @@ export class UiToggleGroup extends WebComponent({
     queueMicrotask(() => this._reflectItems());
   }
 
+  _items(): UiToggleGroupItem[] {
+    return Array.from(this.querySelectorAll<UiToggleGroupItem>('ui-toggle-group-item'));
+  }
+
   _reflectItems(): void {
     const values = this._values;
-    this.querySelectorAll<UiToggleGroupItem>('ui-toggle-group-item').forEach((item) => {
+    const items = this._items();
+    const current = items.find((el) => el.tabIndex === 0);
+    items.forEach((item) => {
       const on = !!item.value && values.has(item.value);
       // Reflect both on the host (for CSS sibling selectors like
       // data-[spacing=0]:first:rounded-l-md that need to target the host
@@ -119,6 +127,31 @@ export class UiToggleGroup extends WebComponent({
       // item's render() refreshes its inner styling.
       item.pressed = on;
     });
+    this._roving(items, current);
+  }
+
+  // Roving tabindex (APG): exactly one item is in the tab order. Prefer the
+  // currently-focused item, then whichever was tabbable, then the first
+  // selected item, then the first item. Arrow keys move focus and shift the
+  // single tabbable slot via `focusItem`.
+  _roving(items: UiToggleGroupItem[], current?: UiToggleGroupItem): void {
+    if (!items.length) return;
+    const values = this._values;
+    const active =
+      typeof document !== 'undefined' ? (document.activeElement as Element | null) : null;
+    const focused = active ? items.find((i) => i === active) : undefined;
+    const selected = items.find((i) => !!i.value && values.has(i.value));
+    const tabbable = focused ?? current ?? selected ?? items[0];
+    items.forEach((item) => {
+      item.tabIndex = item === tabbable ? 0 : -1;
+    });
+  }
+
+  focusItem(item: UiToggleGroupItem): void {
+    this._items().forEach((el) => {
+      el.tabIndex = el === item ? 0 : -1;
+    });
+    item.focus();
   }
 
   _onItemClick = (e: Event): void => {
@@ -181,7 +214,10 @@ export class UiToggleGroupItem extends WebComponent({
   connectedCallback(): void {
     this.dataset.slot = 'toggle-group-item';
     this.role = 'button';
-    this.tabIndex = 0;
+    // Roving tabindex: start outside the tab order. The group promotes
+    // exactly one item to tabindex 0 in _reflectItems (runs after first
+    // render); Arrow keys move focus and the tabbable slot from there.
+    this.tabIndex = -1;
     this.addEventListener('click', this._onClick);
     this.addEventListener('keydown', this._onKeyDown);
     super.connectedCallback?.();
@@ -218,6 +254,24 @@ export class UiToggleGroupItem extends WebComponent({
     if (e.key === ' ' || e.key === 'Enter') {
       e.preventDefault();
       this._onClick();
+      return;
+    }
+    const group = this._group;
+    if (!group) return;
+    const horizontal = group.orientation !== 'vertical';
+    const nextKey = horizontal ? 'ArrowRight' : 'ArrowDown';
+    const prevKey = horizontal ? 'ArrowLeft' : 'ArrowUp';
+    const items = group._items();
+    const idx = items.indexOf(this);
+    if (idx === -1) return;
+    let target: UiToggleGroupItem | null = null;
+    if (e.key === nextKey) target = items[(idx + 1) % items.length] ?? null;
+    else if (e.key === prevKey) target = items[(idx - 1 + items.length) % items.length] ?? null;
+    else if (e.key === 'Home') target = items[0] ?? null;
+    else if (e.key === 'End') target = items[items.length - 1] ?? null;
+    if (target) {
+      e.preventDefault();
+      group.focusItem(target);
     }
   };
 }

--- a/packages/ui/packages/registry/components/tooltip.ts
+++ b/packages/ui/packages/registry/components/tooltip.ts
@@ -81,9 +81,13 @@ export class UiTooltip extends WebComponent({
 
   connectedCallback(): void {
     super.connectedCallback?.();
-    // Children upgrade after this host; defer so the trigger control and
-    // the tooltip content both exist before linking them.
-    queueMicrotask(() => this._wireAria());
+    // webjs projects slotted light-DOM children in a pass after the first
+    // render, so the trigger's focusable control is not in place yet at
+    // connect / firstUpdated. Defer to the next frame, by which point the
+    // projection has run and both the control and the tip content exist.
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(() => this._wireAria());
+    }
   }
 
   // APG tooltip wiring: the focusable trigger references the tip via

--- a/packages/ui/packages/registry/components/tooltip.ts
+++ b/packages/ui/packages/registry/components/tooltip.ts
@@ -41,6 +41,7 @@
  * Design tokens used: --foreground, --background.
  */
 import { WebComponent, html, prop } from '@webjsdev/core';
+import { ensureId } from '../lib/utils.ts';
 import { positionFloating, type PopoverSide, type PopoverAlign } from './popover.ts';
 
 // UA `[popover]` defaults paint a bordered, padded panel centered with
@@ -76,6 +77,32 @@ export class UiTooltip extends WebComponent({
     this.open = false;
     this.delayDuration = 700;
     this.skipDelayDuration = 300;
+  }
+
+  connectedCallback(): void {
+    super.connectedCallback?.();
+    // Children upgrade after this host; defer so the trigger control and
+    // the tooltip content both exist before linking them.
+    queueMicrotask(() => this._wireAria());
+  }
+
+  // APG tooltip wiring: the focusable trigger references the tip via
+  // aria-describedby, so a screen reader appends the tip text to the
+  // trigger's own name ("Help, button, Helpful tip"). The tip is JS-driven,
+  // so doing this at runtime is correct.
+  _wireAria(): void {
+    const triggerHost = this.querySelector('ui-tooltip-trigger');
+    const content = this.querySelector<HTMLElement>('ui-tooltip-content [role="tooltip"]');
+    if (!triggerHost || !content) return;
+    const control =
+      triggerHost.querySelector<HTMLElement>('button, a[href], [tabindex], [role="button"]') ??
+      (triggerHost as HTMLElement);
+    const id = ensureId(content, 'ui-tooltip');
+    const existing = control.getAttribute('aria-describedby');
+    if (!existing) control.setAttribute('aria-describedby', id);
+    else if (!existing.split(/\s+/).includes(id)) {
+      control.setAttribute('aria-describedby', `${existing} ${id}`);
+    }
   }
 
   // Back-compat getter for tests + external code that read `el.isOpen`

--- a/packages/ui/packages/registry/lib/utils.ts
+++ b/packages/ui/packages/registry/lib/utils.ts
@@ -101,6 +101,33 @@ function variantPrefix(token: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Stable DOM ids for wiring ARIA relationships (aria-controls /
+// aria-labelledby / aria-describedby) between sibling light-DOM nodes.
+// A monotonic counter is fine for uniqueness within a document: the id is
+// only consumed as an attribute value, never persisted. When SSR emits an
+// id on a host element, the upgraded element reuses it (ensureId is a no-op
+// when an id is already present), so the server and client agree.
+// ---------------------------------------------------------------------------
+
+let _idSeq = 0;
+
+/** A fresh, document-unique id string with a readable prefix. */
+export function domId(prefix = 'ui'): string {
+  _idSeq += 1;
+  return `${prefix}-${_idSeq}`;
+}
+
+/**
+ * Returns `el.id`, assigning a generated one (prefix-based) when absent.
+ * Idempotent, so an id already present (author-set, or carried over from
+ * SSR) is reused unchanged.
+ */
+export function ensureId(el: { id: string }, prefix = 'ui'): string {
+  if (!el.id) el.id = domId(prefix);
+  return el.id;
+}
+
+// ---------------------------------------------------------------------------
 // Custom-element base: SSR-safe. In the browser `Base = HTMLElement`. On
 // the server (Node, during SSR) `HTMLElement` is undefined; we substitute
 // a stub class so that `class Foo extends Base { … }` doesn't throw at

--- a/packages/ui/packages/registry/registry.json
+++ b/packages/ui/packages/registry/registry.json
@@ -188,7 +188,8 @@
       "name": "dialog",
       "type": "registry:ui",
       "registryDependencies": [
-        "lib-utils"
+        "lib-utils",
+        "button"
       ],
       "dependencies": [
         "@webjsdev/core"
@@ -203,6 +204,9 @@
     {
       "name": "dropdown-menu",
       "type": "registry:ui",
+      "registryDependencies": [
+        "popover"
+      ],
       "dependencies": [
         "@webjsdev/core"
       ],
@@ -216,6 +220,9 @@
     {
       "name": "hover-card",
       "type": "registry:ui",
+      "registryDependencies": [
+        "popover"
+      ],
       "dependencies": [
         "@webjsdev/core"
       ],
@@ -452,6 +459,9 @@
     {
       "name": "toggle-group",
       "type": "registry:ui",
+      "registryDependencies": [
+        "toggle"
+      ],
       "dependencies": [
         "@webjsdev/core"
       ],
@@ -465,6 +475,9 @@
     {
       "name": "tooltip",
       "type": "registry:ui",
+      "registryDependencies": [
+        "popover"
+      ],
       "dependencies": [
         "@webjsdev/core"
       ],

--- a/packages/ui/packages/website/app/docs/page.ts
+++ b/packages/ui/packages/website/app/docs/page.ts
@@ -87,10 +87,29 @@ npx webjsui add button card dialog</code></pre>
     &lt;button class={buttonClass({ variant: 'outline' })}&gt;Edit profile&lt;/button&gt;
   &lt;/ui-dialog-trigger&gt;
   &lt;ui-dialog-content&gt;
-    &lt;h2 class={dialogTitleClass()}&gt;Edit profile&lt;/h2&gt;
+    &lt;h2 data-slot="dialog-title" class={dialogTitleClass()}&gt;Edit profile&lt;/h2&gt;
     &lt;form action="/profile" method="post"&gt;&hellip;&lt;/form&gt;
   &lt;/ui-dialog-content&gt;
 &lt;/ui-dialog&gt;</code></pre>
+      <h2>Accessibility</h2>
+      <p>
+        Tier-2 elements are accessible out of the box. Each one wires its own
+        WAI-ARIA pattern, so you do not hand-add ARIA: tabs cross-links its triggers
+        and panels and reports orientation, toggle-group uses a roving tabindex with
+        Arrow / Home / End, dropdown-menu declares orientation and reflects
+        <code>aria-disabled</code>, dialog and alert-dialog name themselves from their
+        title (<code>data-slot="dialog-title"</code>) and description, tooltip wires
+        <code>aria-describedby</code>, hover-card exposes
+        <code>aria-haspopup</code> / <code>aria-expanded</code>, and sonner is a live region.
+      </p>
+      <p>
+        Tier-1 class helpers return only classes, so the semantic element and ARIA are
+        yours. Each helper's JSDoc carries an <code>A11y (required for accessible output)</code>
+        block naming exactly what to supply: a name on an icon-only button, a role on an
+        alert, <code>scope</code> on table headers, <code>alt</code> on an avatar image, a
+        labelled <code>&lt;nav&gt;</code> with <code>aria-current="page"</code> on pagination
+        and breadcrumb. Follow that block and the output is fully accessible.
+      </p>
       <h2>Framework support</h2>
       <p>
         Tier-1 helpers are pure functions, no runtime dependency. Tier-2 custom elements

--- a/packages/ui/test/components/browser/ui-a11y.test.js
+++ b/packages/ui/test/components/browser/ui-a11y.test.js
@@ -1,0 +1,299 @@
+/**
+ * Accessibility browser tests for @webjsdev/ui Tier-2 custom elements.
+ * Runs in real Chromium via WTR + Playwright.
+ *
+ * These assert the ARIA wiring the components now provide out of the box
+ * (#655): the relationships and roving focus an author would otherwise have
+ * to hand-wire. Each assertion is a counterfactual for its fix: it fails if
+ * the corresponding attribute / behaviour is removed from the component.
+ *
+ * Tier-1 class helpers (button, alert, table, ...) push their ARIA to the
+ * caller by design, so their contract is documented in JSDoc rather than
+ * enforced here.
+ */
+import { html } from '../../../../core/src/html.js';
+import { render } from '../../../../core/src/render-client.js';
+
+const assert = {
+  ok: (v, msg) => { if (!v) throw new Error(msg || `Expected truthy, got ${v}`); },
+  equal: (a, b, msg) => { if (a !== b) throw new Error(msg || `Expected ${b}, got ${a}`); },
+};
+
+const COMPONENTS_DIR = '/packages/ui/packages/registry/components';
+
+/** Two RAFs so connectedCallback + queueMicrotask wiring settles. */
+const tick = () => new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+
+async function mount(tpl) {
+  const root = document.createElement('div');
+  document.body.appendChild(root);
+  render(tpl, root);
+  await tick();
+  await tick();
+  return root;
+}
+
+suite('ui-tabs a11y', () => {
+  suiteSetup(async () => { await import(`${COMPONENTS_DIR}/tabs.ts`); });
+
+  test('trigger aria-controls + panel aria-labelledby cross-link by value', async () => {
+    const root = await mount(html`
+      <ui-tabs value="a">
+        <ui-tabs-list>
+          <ui-tabs-trigger value="a">A</ui-tabs-trigger>
+          <ui-tabs-trigger value="b">B</ui-tabs-trigger>
+        </ui-tabs-list>
+        <ui-tabs-content value="a">PANE A</ui-tabs-content>
+        <ui-tabs-content value="b">PANE B</ui-tabs-content>
+      </ui-tabs>
+    `);
+    const trigger = root.querySelector('ui-tabs-trigger[value="a"] [role="tab"]');
+    const panel = root.querySelector('ui-tabs-content[value="a"] [role="tabpanel"]');
+    assert.ok(trigger.id, 'trigger has an id');
+    assert.ok(panel.id, 'panel has an id');
+    assert.equal(trigger.getAttribute('aria-controls'), panel.id, 'aria-controls -> panel');
+    assert.equal(panel.getAttribute('aria-labelledby'), trigger.id, 'aria-labelledby -> trigger');
+    root.remove();
+  });
+
+  test('list reports aria-orientation; inactive panel is inert + hidden', async () => {
+    const root = await mount(html`
+      <ui-tabs value="a" orientation="vertical">
+        <ui-tabs-list>
+          <ui-tabs-trigger value="a">A</ui-tabs-trigger>
+          <ui-tabs-trigger value="b">B</ui-tabs-trigger>
+        </ui-tabs-list>
+        <ui-tabs-content value="a">PANE A</ui-tabs-content>
+        <ui-tabs-content value="b">PANE B</ui-tabs-content>
+      </ui-tabs>
+    `);
+    const list = root.querySelector('ui-tabs-list [role="tablist"]');
+    assert.equal(list.getAttribute('aria-orientation'), 'vertical');
+    const paneB = root.querySelector('ui-tabs-content[value="b"]');
+    assert.ok(paneB.hidden, 'inactive panel hidden');
+    assert.ok(paneB.inert, 'inactive panel inert');
+    root.remove();
+  });
+
+  test('ids are unique across two tab groups reusing the same value', async () => {
+    const root = await mount(html`
+      <ui-tabs value="x">
+        <ui-tabs-list><ui-tabs-trigger value="x">X</ui-tabs-trigger></ui-tabs-list>
+        <ui-tabs-content value="x">ONE</ui-tabs-content>
+      </ui-tabs>
+      <ui-tabs value="x">
+        <ui-tabs-list><ui-tabs-trigger value="x">X</ui-tabs-trigger></ui-tabs-list>
+        <ui-tabs-content value="x">TWO</ui-tabs-content>
+      </ui-tabs>
+    `);
+    const triggers = root.querySelectorAll('ui-tabs-trigger [role="tab"]');
+    assert.ok(triggers[0].id && triggers[1].id, 'both have ids');
+    assert.ok(triggers[0].id !== triggers[1].id, 'ids differ across groups');
+    root.remove();
+  });
+});
+
+suite('ui-toggle-group a11y', () => {
+  suiteSetup(async () => { await import(`${COMPONENTS_DIR}/toggle-group.ts`); });
+
+  test('roving tabindex: exactly one item is in the tab order', async () => {
+    const root = await mount(html`
+      <ui-toggle-group type="single" value="bold">
+        <ui-toggle-group-item value="bold">B</ui-toggle-group-item>
+        <ui-toggle-group-item value="italic">I</ui-toggle-group-item>
+        <ui-toggle-group-item value="underline">U</ui-toggle-group-item>
+      </ui-toggle-group>
+    `);
+    const items = [...root.querySelectorAll('ui-toggle-group-item')];
+    const tabbable = items.filter((i) => i.tabIndex === 0);
+    assert.equal(tabbable.length, 1, 'one tabbable item');
+    assert.equal(tabbable[0].getAttribute('value'), 'bold', 'selected item is the tab stop');
+    root.remove();
+  });
+
+  test('ArrowRight moves focus and the tab stop to the next item', async () => {
+    const root = await mount(html`
+      <ui-toggle-group type="single" value="bold">
+        <ui-toggle-group-item value="bold">B</ui-toggle-group-item>
+        <ui-toggle-group-item value="italic">I</ui-toggle-group-item>
+      </ui-toggle-group>
+    `);
+    const items = [...root.querySelectorAll('ui-toggle-group-item')];
+    items[0].focus();
+    items[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    await tick();
+    assert.equal(document.activeElement, items[1], 'focus moved to item 2');
+    assert.equal(items[1].tabIndex, 0, 'item 2 is now the tab stop');
+    assert.equal(items[0].tabIndex, -1, 'item 1 left the tab order');
+    root.remove();
+  });
+
+  test('End jumps focus to the last item', async () => {
+    const root = await mount(html`
+      <ui-toggle-group type="multiple">
+        <ui-toggle-group-item value="a">a</ui-toggle-group-item>
+        <ui-toggle-group-item value="b">b</ui-toggle-group-item>
+        <ui-toggle-group-item value="c">c</ui-toggle-group-item>
+      </ui-toggle-group>
+    `);
+    const items = [...root.querySelectorAll('ui-toggle-group-item')];
+    items[0].focus();
+    items[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+    await tick();
+    assert.equal(document.activeElement, items[2], 'focus on last item');
+    root.remove();
+  });
+});
+
+suite('ui-dropdown-menu a11y', () => {
+  suiteSetup(async () => { await import(`${COMPONENTS_DIR}/dropdown-menu.ts`); });
+
+  test('menu declares orientation; disabled item exposes aria-disabled', async () => {
+    const root = await mount(html`
+      <ui-dropdown-menu>
+        <ui-dropdown-menu-trigger><button>Options</button></ui-dropdown-menu-trigger>
+        <ui-dropdown-menu-content>
+          <ui-dropdown-menu-item>Profile</ui-dropdown-menu-item>
+          <ui-dropdown-menu-item data-disabled>Billing</ui-dropdown-menu-item>
+        </ui-dropdown-menu-content>
+      </ui-dropdown-menu>
+    `);
+    const menu = root.querySelector('ui-dropdown-menu-content [role="menu"]');
+    assert.equal(menu.getAttribute('aria-orientation'), 'vertical');
+    const disabled = root.querySelector('ui-dropdown-menu-item[data-disabled] [role="menuitem"]');
+    assert.equal(disabled.getAttribute('aria-disabled'), 'true');
+    root.remove();
+  });
+
+  test('trigger control gets haspopup, controls, and live aria-expanded', async () => {
+    const root = await mount(html`
+      <ui-dropdown-menu>
+        <ui-dropdown-menu-trigger><button>Options</button></ui-dropdown-menu-trigger>
+        <ui-dropdown-menu-content>
+          <ui-dropdown-menu-item>Profile</ui-dropdown-menu-item>
+        </ui-dropdown-menu-content>
+      </ui-dropdown-menu>
+    `);
+    const btn = root.querySelector('ui-dropdown-menu-trigger button');
+    const menu = root.querySelector('ui-dropdown-menu-content [role="menu"]');
+    assert.equal(btn.getAttribute('aria-haspopup'), 'menu');
+    assert.equal(btn.getAttribute('aria-controls'), menu.id);
+    assert.equal(btn.getAttribute('aria-expanded'), 'false', 'closed -> false');
+    root.querySelector('ui-dropdown-menu').show();
+    await tick();
+    assert.equal(btn.getAttribute('aria-expanded'), 'true', 'open -> true');
+    root.remove();
+  });
+});
+
+suite('ui-dialog a11y', () => {
+  suiteSetup(async () => { await import(`${COMPONENTS_DIR}/dialog.ts`); });
+
+  test('open dialog is labelled by its title and described by its description', async () => {
+    const root = await mount(html`
+      <ui-dialog>
+        <ui-dialog-content>
+          <div>
+            <h2 data-slot="dialog-title">Edit profile</h2>
+            <p data-slot="dialog-description">Make changes.</p>
+          </div>
+        </ui-dialog-content>
+      </ui-dialog>
+    `);
+    root.querySelector('ui-dialog').show();
+    await tick();
+    await tick();
+    const panel = root.querySelector('[data-slot="dialog-content"]');
+    const title = root.querySelector('[data-slot="dialog-title"]');
+    const desc = root.querySelector('[data-slot="dialog-description"]');
+    assert.ok(title.id, 'title got an id');
+    assert.equal(panel.getAttribute('aria-labelledby'), title.id);
+    assert.equal(panel.getAttribute('aria-describedby'), desc.id);
+    root.querySelector('ui-dialog').hide();
+    root.remove();
+  });
+});
+
+suite('ui-alert-dialog a11y', () => {
+  suiteSetup(async () => { await import(`${COMPONENTS_DIR}/alert-dialog.ts`); });
+
+  test('open alertdialog is labelled by its title and described by its description', async () => {
+    const root = await mount(html`
+      <ui-alert-dialog>
+        <ui-alert-dialog-content>
+          <div>
+            <h2 data-slot="alert-dialog-title">Delete account?</h2>
+            <p data-slot="alert-dialog-description">This cannot be undone.</p>
+          </div>
+        </ui-alert-dialog-content>
+      </ui-alert-dialog>
+    `);
+    root.querySelector('ui-alert-dialog').show();
+    await tick();
+    await tick();
+    const panel = root.querySelector('[data-slot="alert-dialog-content"]');
+    const title = root.querySelector('[data-slot="alert-dialog-title"]');
+    const desc = root.querySelector('[data-slot="alert-dialog-description"]');
+    assert.ok(title.id);
+    assert.equal(panel.getAttribute('aria-labelledby'), title.id);
+    assert.equal(panel.getAttribute('aria-describedby'), desc.id);
+    root.querySelector('ui-alert-dialog').hide();
+    root.remove();
+  });
+});
+
+suite('ui-tooltip a11y', () => {
+  suiteSetup(async () => { await import(`${COMPONENTS_DIR}/tooltip.ts`); });
+
+  test('trigger references the tip via aria-describedby', async () => {
+    const root = await mount(html`
+      <ui-tooltip>
+        <ui-tooltip-trigger><button aria-label="Help">?</button></ui-tooltip-trigger>
+        <ui-tooltip-content>Helpful tip</ui-tooltip-content>
+      </ui-tooltip>
+    `);
+    const btn = root.querySelector('ui-tooltip-trigger button');
+    const content = root.querySelector('ui-tooltip-content [role="tooltip"]');
+    assert.ok(content.id, 'tip got an id');
+    assert.equal(btn.getAttribute('aria-describedby'), content.id);
+    root.remove();
+  });
+});
+
+suite('ui-hover-card a11y', () => {
+  suiteSetup(async () => { await import(`${COMPONENTS_DIR}/hover-card.ts`); });
+
+  test('trigger gets haspopup + controls and aria-expanded tracks open', async () => {
+    const root = await mount(html`
+      <ui-hover-card>
+        <ui-hover-card-trigger><a href="/u">@vivek</a></ui-hover-card-trigger>
+        <ui-hover-card-content>Card body</ui-hover-card-content>
+      </ui-hover-card>
+    `);
+    const link = root.querySelector('ui-hover-card-trigger a');
+    const content = root.querySelector('ui-hover-card-content [role="dialog"]');
+    assert.equal(link.getAttribute('aria-haspopup'), 'dialog');
+    assert.equal(link.getAttribute('aria-controls'), content.id);
+    assert.equal(link.getAttribute('aria-expanded'), 'false');
+    root.querySelector('ui-hover-card').open = true;
+    await tick();
+    assert.equal(link.getAttribute('aria-expanded'), 'true');
+    root.remove();
+  });
+});
+
+suite('ui-sonner a11y', () => {
+  suiteSetup(async () => { await import(`${COMPONENTS_DIR}/sonner.ts`); });
+
+  test('viewport is a persistent polite live region; error toast is assertive', async () => {
+    const root = await mount(html`<ui-sonner></ui-sonner>`);
+    const region = root.querySelector('[data-slot="sonner"]');
+    assert.equal(region.getAttribute('role'), 'region');
+    assert.equal(region.getAttribute('aria-live'), 'polite');
+    root.querySelector('ui-sonner').addToast('Boom', {}, 'error');
+    await tick();
+    const alert = region.querySelector('[role="alert"]');
+    assert.ok(alert, 'error toast carries role=alert');
+    root.remove();
+  });
+});

--- a/packages/ui/test/registry-deps.test.js
+++ b/packages/ui/test/registry-deps.test.js
@@ -1,0 +1,64 @@
+/**
+ * Registry dependency completeness: a component copied by `webjs ui add`
+ * only brings the files declared in its `registryDependencies` tree (the
+ * resolver walks that field, it does NOT follow relative imports). So a
+ * component that imports a SIBLING component (`./other.ts`) must declare
+ * that sibling, or the copied file lands with a broken import.
+ *
+ * `../lib/utils.ts` is the one exception: the add command rewrites that
+ * specific import to the project's configured utils path (written by
+ * `webjsui init`), so it does not need a `lib-utils` registry dependency.
+ *
+ * This guards the #655 class of bug where tooltip / hover-card /
+ * dropdown-menu imported `./popover.ts`, toggle-group imported
+ * `./toggle.ts`, and dialog imported `./button.ts` without declaring them.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', 'packages', 'registry');
+const COMPONENTS_DIR = join(ROOT, 'components');
+
+const manifest = JSON.parse(readFileSync(join(ROOT, 'registry.json'), 'utf8'));
+
+// Map a component file path (as listed in the manifest) to its item name.
+const fileToItem = new Map();
+for (const item of manifest.items) {
+  for (const f of item.files || []) fileToItem.set(f.path, item.name);
+}
+
+test('every sibling-component import is declared in registryDependencies', () => {
+  const gaps = [];
+  for (const file of readdirSync(COMPONENTS_DIR)) {
+    if (!file.endsWith('.ts')) continue;
+    const relPath = `components/${file}`;
+    const name = fileToItem.get(relPath);
+    if (!name) continue; // not a registry item (e.g. an internal helper)
+    const src = readFileSync(join(COMPONENTS_DIR, file), 'utf8');
+    const siblings = new Set(
+      [...src.matchAll(/from '\.\/([a-z0-9-]+)\.ts'/g)].map((m) => m[1]),
+    );
+    const declared = new Set(
+      (manifest.items.find((i) => i.name === name).registryDependencies) || [],
+    );
+    for (const sib of siblings) {
+      if (!declared.has(sib)) gaps.push(`${name} imports ./${sib}.ts but does not declare it`);
+    }
+  }
+  assert.deepEqual(gaps, [], `registry dependency gaps:\n${gaps.join('\n')}`);
+});
+
+test('declared registryDependencies reference real registry items', () => {
+  const names = new Set(manifest.items.map((i) => i.name));
+  // `lib-utils` is a registry:lib item; include any non-component items too.
+  const unknown = [];
+  for (const item of manifest.items) {
+    for (const dep of item.registryDependencies || []) {
+      if (!names.has(dep)) unknown.push(`${item.name} -> ${dep}`);
+    }
+  }
+  assert.deepEqual(unknown, [], `unknown registry dependencies:\n${unknown.join('\n')}`);
+});

--- a/packages/ui/test/registry-deps.test.js
+++ b/packages/ui/test/registry-deps.test.js
@@ -38,8 +38,9 @@ test('every sibling-component import is declared in registryDependencies', () =>
     const name = fileToItem.get(relPath);
     if (!name) continue; // not a registry item (e.g. an internal helper)
     const src = readFileSync(join(COMPONENTS_DIR, file), 'utf8');
+    // Match a same-directory sibling import under either quote style.
     const siblings = new Set(
-      [...src.matchAll(/from '\.\/([a-z0-9-]+)\.ts'/g)].map((m) => m[1]),
+      [...src.matchAll(/from\s+['"]\.\/([a-z0-9-]+)\.ts['"]/g)].map((m) => m[1]),
     );
     const declared = new Set(
       (manifest.items.find((i) => i.name === name).registryDependencies) || [],


### PR DESCRIPTION
Closes #655

Make `@webjsdev/ui` accessible by default, and give AI agents an explicit, machine-followable a11y contract for the parts they own.

## What changed

**Tier-2 custom elements now wire their own WAI-ARIA pattern (zero author effort).**
- `tabs`: triggers carry `aria-controls`, panels `aria-labelledby` (cross-linked via a stable per-group id scope so two tab sets reusing the same `value` do not collide), the list reports `aria-orientation`, and an inactive panel is `inert`.
- `toggle-group`: roving tabindex (one Tab stop) with Arrow / Home / End navigation.
- `dropdown-menu`: menu + sub-menu declare `aria-orientation`, a `data-disabled` item reflects `aria-disabled`, and the trigger gets `aria-haspopup` / `aria-expanded` / `aria-controls`.
- `dialog` / `alert-dialog`: on open, the panel is named by its title (`data-slot="dialog-title"`, falling back to the first heading) and described by its description.
- `tooltip`: the trigger references the tip via `aria-describedby` (APG tooltip wiring).
- `hover-card`: the trigger (also opens on focus) gets `aria-haspopup` / `aria-expanded` / `aria-controls`.
- `sonner`: the viewport is a persistent `aria-live` region so inserted toasts are announced.

The overlays wire at runtime (they are JS-only, never shown without script), deferring to the next animation frame because webjs projects slotted light-DOM children after `firstUpdated`. Tabs/toggle-group emit their relationships at render time (their content is meaningful with JS off).

**Tier-1 class helpers gained an agent-facing `A11y (required for accessible output)` JSDoc block** (button, badge, alert, separator, skeleton, avatar, table, pagination, breadcrumb, progress) stating exactly the ARIA/markup the caller must supply, since a helper only returns classes.

**Registry install fix (surfaced during review).** `webjs ui add` walks `registryDependencies` only (it does not follow relative imports, apart from the special-cased `../lib/utils.ts` rewrite). `dialog`→`button`, `dropdown-menu`/`hover-card`/`tooltip`→`popover`, and `toggle-group`→`toggle` imported a sibling without declaring it, so `add` copied a broken file. Declared all five and added a guard test.

## Test plan
- [x] Browser tests (`test/components/browser/ui-a11y.test.js`, 13 assertions): tabs cross-link + inert + cross-group id uniqueness, toggle-group roving + Arrow/End, dropdown orientation/disabled/trigger, dialog + alert-dialog labelling, tooltip describedby, hover-card haspopup/expanded, sonner live region. Each is a counterfactual for its fix.
- [x] Full ui browser suite green (48/48), node suite green (138/138, incl. the new registry-deps guard).
- [x] Dogfood: ui-website boots in prod mode and `/`, `/docs`, `/docs/components/{tabs,dropdown-menu,dialog}` all SSR at 200 (confirms no SSR regression from the new wiring).

## Docs
- [x] `packages/ui/AGENTS.md`: new Accessibility section + Tier-2 inventory notes.
- [x] `packages/ui/README.md`: Accessibility section.
- [x] ui-website docs landing page: Accessibility section + `data-slot="dialog-title"` in the example.
- N/A: framework `docs/` + root `AGENTS.md` (this is the separate `@webjsdev/ui` package, documented under `packages/ui/`); scaffold templates (no scaffold change).

https://claude.ai/code/session_01WnvcTojG7tYqmnmf4enSv3
