### PR TITLE
chore: release ui 0.3.6

### DIFF
--- a/changelog/ui/0.3.6.md
+++ b/changelog/ui/0.3.6.md
@@ -1,0 +1,16 @@
+---
+package: "@webjsdev/ui"
+version: 0.3.6
+date: 2026-06-20T10:40:00.000Z
+commit_count: 1
+---
+## Features
+
+- **100% accessibility out of the box + AI-agent a11y contracts** ([#656](https://github.com/webjsdev/webjs/pull/656)) [`8f193aca`](https://github.com/webjsdev/webjs/commit/8f193aca)
+  * Tier-2 custom elements now wire their own WAI-ARIA pattern with zero author effort: tabs cross-links triggers and panels (`aria-controls` / `aria-labelledby`), reports `aria-orientation`, and marks an inactive panel `inert`; toggle-group uses a roving tabindex with Arrow / Home / End; dropdown-menu declares `aria-orientation`, reflects `aria-disabled`, and gives the trigger `aria-haspopup` / `aria-expanded` / `aria-controls`; dialog and alert-dialog name themselves from their title and description on open; tooltip references its tip via `aria-describedby`; hover-card exposes the popup relationship on its (focus-openable) trigger; sonner is a persistent `aria-live` region.
+  * Tier-1 class helpers gained an `A11y (required for accessible output)` JSDoc block stating exactly the markup and ARIA the caller must supply.
+
+## Fixes
+
+- **declare sibling-component registry dependencies so `webjs ui add` copies them** ([#656](https://github.com/webjsdev/webjs/pull/656)) [`8f193aca`](https://github.com/webjsdev/webjs/commit/8f193aca)
+  * The add resolver walks `registryDependencies` only (it does not follow relative imports, apart from the special-cased `../lib/utils.ts` rewrite). `dialog`, `dropdown-menu`, `hover-card`, `tooltip`, and `toggle-group` imported a sibling component without declaring it, so `webjs ui add` copied a file with a broken import. All five are declared now, with a guard test that fails on any future sibling-import gap.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7439,7 +7439,7 @@
     },
     "packages/ui": {
       "name": "@webjsdev/ui",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/ui",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "type": "module",
   "description": "An AI-first component library - class-helper functions for visuals, custom elements only where state matters. Source-copied into your repo, you own it. Works with any Tailwind v4 project.",
   "bin": {


### PR DESCRIPTION
Releases `@webjsdev/ui@0.3.6`, shipping the #656 accessibility work in the npm package.

Merging this adds `changelog/ui/0.3.6.md` to main, which triggers `release.yml` to `npm publish` @webjsdev/ui and cut the GitHub Release.

## Contents (all from #656, already on main)
- Tier-2 components wire their own WAI-ARIA (tabs, toggle-group, dropdown-menu, dialog, alert-dialog, tooltip, hover-card, sonner).
- Tier-1 helpers carry an agent-facing `A11y (required for accessible output)` JSDoc contract.
- Fix: declare sibling-component `registryDependencies` so `webjs ui add` copies them (dialog->button, dropdown/hover-card/tooltip->popover, toggle-group->toggle), with a guard test.

## Bump
- `@webjsdev/ui` 0.3.5 -> 0.3.6 (patch). The one dependent (`@webjsdev/cli`) pins `^0.3.1`, which 0.3.6 satisfies, so no dependent range change. Lockfile updated.

https://claude.ai/code/session_01WnvcTojG7tYqmnmf4enSv3