### PR TITLE
chore: release core 0.7.23, server 0.8.33, cli 0.10.22

### DIFF
--- a/changelog/cli/0.10.22.md
+++ b/changelog/cli/0.10.22.md
@@ -1,0 +1,32 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.22
+date: 2026-06-20T10:44:34.180Z
+commit_count: 5
+---
+## Features
+
+- **block raw custom elements extending HTMLElement with pretooluse hook** [`c1363eed`](https://github.com/webjsdev/webjs/commit/c1363eed)
+- **client router auto-enables from the bundle, drop layout imports** ([#628](https://github.com/webjsdev/webjs/pull/628)) [`dbaf3f43`](https://github.com/webjsdev/webjs/commit/dbaf3f43)
+  * feat: drop redundant client-router import from app layouts
+  
+  The client router auto-enables when @webjsdev/core loads in the browser
+  (router-client.js calls enableClientRouter() at module end, and the
+- **flag array-typed reactive props declared with Object** ([#632](https://github.com/webjsdev/webjs/pull/632)) [`257035d2`](https://github.com/webjsdev/webjs/commit/257035d2)
+  * feat(check): flag array-typed reactive props declared with Object
+  
+  An array-typed reactive prop (`prop<Tag[]>(...)`) should pass the `Array`
+  runtime constructor, not `Object`. The two share one converter in
+
+## Fixes
+
+- **drop dead customElements helpers from blog cn.ts so page elides** ([#630](https://github.com/webjsdev/webjs/pull/630)) [`6688c92a`](https://github.com/webjsdev/webjs/commit/6688c92a)
+  * fix: drop dead customElements helpers from blog cn.ts so page elides
+  
+  examples/blog/lib/utils/cn.ts mixed a pure class-name merger with dead
+  custom-element helpers (Base, defineElement, ServerHTMLElementStub) that
+- **use position:fixed for pinned headers (scaffold + website) + document (#610)** ([#648](https://github.com/webjsdev/webjs/pull/648)) [`d450352d`](https://github.com/webjsdev/webjs/commit/d450352d)
+  * fix: use position:fixed (not sticky) for pinned headers across apps + docs
+  
+  Propagate the #610 fix beyond the blog. A position:sticky header flickers
+  on iOS WebKit during a client-router nav; the fix is position:fixed with a

--- a/changelog/core/0.7.23.md
+++ b/changelog/core/0.7.23.md
@@ -1,0 +1,41 @@
+---
+package: "@webjsdev/core"
+version: 0.7.23
+date: 2026-06-20T10:44:34.069Z
+commit_count: 6
+---
+## Features
+
+- **warn in dev when scroll-behavior: smooth is set on <html>** ([#614](https://github.com/webjsdev/webjs/pull/614)) [`a7653b36`](https://github.com/webjsdev/webjs/commit/a7653b36)
+  * feat: warn in dev when scroll-behavior: smooth is set on <html>
+  
+  The client router forces an instant scroll-to-top on a forward nav
+  (matching a native page load), so an app-level scroll-behavior: smooth
+- **client router auto-enables from the bundle, drop layout imports** ([#628](https://github.com/webjsdev/webjs/pull/628)) [`dbaf3f43`](https://github.com/webjsdev/webjs/commit/dbaf3f43)
+  * feat: drop redundant client-router import from app layouts
+  
+  The client router auto-enables when @webjsdev/core loads in the browser
+  (router-client.js calls enableClientRouter() at module end, and the
+- **add webjs.clientRouter:false opt-out for the automatic client router** ([#643](https://github.com/webjsdev/webjs/pull/643)) [`2e451763`](https://github.com/webjsdev/webjs/commit/2e451763)
+  * feat: add webjs.clientRouter:false opt-out for the automatic client router
+  
+  #620 made the client router auto-enable whenever @webjsdev/core loads in the
+  browser (any page with a component), removing the only de-facto opt-out an app
+
+## Fixes
+
+- **force instant scroll on navigation so smooth CSS does not animate it** ([#603](https://github.com/webjsdev/webjs/pull/603)) [`5761e772`](https://github.com/webjsdev/webjs/commit/5761e772)
+  * fix: force instant scroll on nav so smooth CSS does not animate it
+  
+  The client router restored scroll with the 2-arg scrollTo(x, y) form,
+  which honors an app's html { scroll-behavior: smooth }. That made every
+- **gate data-navigating to kill iOS nav flash, revert app-CSS attempts (#610)** ([#624](https://github.com/webjsdev/webjs/pull/624)) [`e7d9ba04`](https://github.com/webjsdev/webjs/commit/e7d9ba04)
+  * fix: make the data-navigating loading hook opt-in to kill the iOS nav flash
+  
+  The client router wrote `data-navigating` on <html> on every nav past the
+  150ms defer. Toggling an attribute on the root re-runs global style
+- **use position:fixed for the blog header to end the iOS nav flicker (#610)** ([#640](https://github.com/webjsdev/webjs/pull/640)) [`02fbb845`](https://github.com/webjsdev/webjs/commit/02fbb845)
+  On-device isolation proved the root cause: a position:sticky header flickers
+  its background for one frame on iOS WebKit (both Safari and Chrome on iOS, all
+  WebKit) during a client-router forward nav. The post-swap scroll-to-top drives
+  a sticky stuck-to-static recompute that WebKit mis-repaints. It is iOS-only

--- a/changelog/server/0.8.33.md
+++ b/changelog/server/0.8.33.md
@@ -1,0 +1,40 @@
+---
+package: "@webjsdev/server"
+version: 0.8.33
+date: 2026-06-20T10:44:34.122Z
+commit_count: 6
+---
+## Features
+
+- **elide page/layout modules that only import components** ([#609](https://github.com/webjsdev/webjs/pull/609)) [`c89183b8`](https://github.com/webjsdev/webjs/commit/c89183b8)
+  * feat: elide page/layout modules that only import components
+  
+  Pages and layouts never hydrate, yet the boot script imported the page module
+  and every layout module on the client. For a typical route their only client
+- **flag array-typed reactive props declared with Object** ([#632](https://github.com/webjsdev/webjs/pull/632)) [`257035d2`](https://github.com/webjsdev/webjs/commit/257035d2)
+  * feat(check): flag array-typed reactive props declared with Object
+  
+  An array-typed reactive prop (`prop<Tag[]>(...)`) should pass the `Array`
+  runtime constructor, not `Object`. The two share one converter in
+- **add webjs.clientRouter:false opt-out for the automatic client router** ([#643](https://github.com/webjsdev/webjs/pull/643)) [`2e451763`](https://github.com/webjsdev/webjs/commit/2e451763)
+  * feat: add webjs.clientRouter:false opt-out for the automatic client router
+  
+  #620 made the client router auto-enable whenever @webjsdev/core loads in the
+  browser (any page with a component), removing the only de-facto opt-out an app
+
+## Fixes
+
+- **elide display-only components in the declare-free factory DX** ([#608](https://github.com/webjsdev/webjs/pull/608)) [`39111762`](https://github.com/webjsdev/webjs/commit/39111762)
+  * fix: elide display-only components in the declare-free factory DX
+  
+  A component written in the enforced factory form
+  `extends WebComponent({ ... })` was never elided, even when display-only:
+- **stop elision false-positives that pin page/layout modules** ([#625](https://github.com/webjsdev/webjs/pull/625)) [`79cb5bbc`](https://github.com/webjsdev/webjs/commit/79cb5bbc)
+  * fix: stop elision false-positives that pin page/layout modules
+  
+  Pages and layouts never hydrate, so the analyser can drop their modules
+  (inert #179 / import-only #605). In practice almost none qualified because
+- **elide route modules containing code samples** ([#635](https://github.com/webjsdev/webjs/pull/635)) [`a4c3902a`](https://github.com/webjsdev/webjs/commit/a4c3902a)
+  * fix: elide route modules containing code samples
+  
+  * fix: support backticks in scanner/elision, preserve comment delimiters, and add tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -7339,7 +7339,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.21",
+      "version": "0.10.22",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -7355,7 +7355,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.22",
+      "version": "0.7.23",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.25.0"
@@ -7403,7 +7403,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.32",
+      "version": "0.8.33",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.21",
+  "version": "0.10.22",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.22",
+  "version": "0.7.23",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.32",
+  "version": "0.8.33",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Releases the feat/fix work merged since the last release (#600) that was never published. Pre-existing debt, surfaced while releasing @webjsdev/ui (#657).

Merging adds the `changelog/**.md` files to main, triggering `release.yml` to publish all three to npm and cut GitHub Releases.

## Bumps (all patch; every dependent pins a caret range that these satisfy, so no dependent range changes)
- `@webjsdev/core` 0.7.22 -> 0.7.23: client-router auto-enable (#628) + `webjs.clientRouter:false` opt-out (#643), dev warn on smooth scroll (#614), iOS nav fixes (#640/#624/#603).
- `@webjsdev/server` 0.8.32 -> 0.8.33: elide page/layout-only-import modules (#609) + elision false-positive fixes (#625/#608) + route-with-code-samples elision (#635), array-prop check (#632).
- `@webjsdev/cli` 0.10.21 -> 0.10.22: check rules (#632), scaffold pinned-header fix (#648), blog elision fixes (#630), client-router scaffold update (#628).

Changelogs auto-generated by the pre-commit backfill from the conventional commit subjects. Lockfile updated.

https://claude.ai/code/session_01WnvcTojG7tYqmnmf4enSv3