### PR TITLE
test: cover the Bun.serve idleTimeout mapping (server timeouts)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,12 @@ jobs:
       # under `npm test`.
       - name: webjs # path alias on Bun
         run: bun test/bun/path-alias.mjs
+      # Server timeout wiring on Bun (#663): the node:http requestTimeout /
+      # headersTimeout / keepAliveTimeout map onto Bun.serve's single idleTimeout
+      # (#511); this asserts startBunListener feeds the mapped value into
+      # Bun.serve. The pure mapping is also unit-tested under the matrix below.
+      - name: webjs server timeouts on Bun
+        run: bun test/bun/timeouts.mjs
       # The Bun test MATRIX (#509): run the runtime-sensitive node:test suite
       # (core + server + cross-package test/) under Bun, file by file, classifying
       # each result. Documented Node-only files + Bun-test-runner-quirk files are

--- a/agent-docs/testing.md
+++ b/agent-docs/testing.md
@@ -138,8 +138,10 @@ script already covers the surface AND you ran it under Bun).
   **skip(env)** (needs Redis / a DOM), and **genuine fail** (a real Bun
   failure, which fails the job). Set `WEBJS_BUN_TESTS=<substr,…>` to scope a
   local run.
-- CI runs it in the `bun` job alongside `test/bun/smoke.mjs` (#508) and
-  `test/bun/listener.mjs` (#511, the listener-shell parity).
+- CI runs it in the `bun` job alongside `test/bun/smoke.mjs` (#508),
+  `test/bun/listener.mjs` (#511, the listener-shell parity), and
+  `test/bun/timeouts.mjs` (#663, the `Bun.serve` `idleTimeout` wiring; the pure
+  ms-to-seconds mapping is unit-tested under the matrix too).
 - Two cross-runtime test scripts also run under BOTH runtimes: `test/bun/smoke.mjs`
   (boot + SSR + TS strip + a server-action RPC) and `test/bun/listener.mjs`
   (`startServer` over a real socket: SSR + route + SSE + WebSocket). Plain assert

--- a/packages/server/src/listener-bun.js
+++ b/packages/server/src/listener-bun.js
@@ -349,7 +349,7 @@ function maybeCompress(resp, req) {
  * on Bun too.
  * @param {{ requestTimeout?: number } | undefined} timeouts
  */
-function bunIdleTimeout(timeouts) {
+export function bunIdleTimeout(timeouts) {
   const reqMs = timeouts && timeouts.requestTimeout;
   if (reqMs === 0) return 0;
   let secs = Math.ceil((reqMs || 30_000) / 1000);

--- a/packages/server/test/body-limit/bun-idle-timeout.test.js
+++ b/packages/server/test/body-limit/bun-idle-timeout.test.js
@@ -1,0 +1,49 @@
+/**
+ * The Bun-shell timeout mapping (#663). On Bun, the server listener maps the
+ * configured node `requestTimeout` (ms, three-field on node:http) onto
+ * Bun.serve's single `idleTimeout` (seconds). This pure mapping is the part
+ * that can diverge across runtimes (Math.ceil + the clamps run on JSC vs V8),
+ * so it carries a unit test that the Bun matrix re-runs under bun. The wiring
+ * (startBunListener passing the result into Bun.serve) is asserted on the Bun
+ * shell by test/bun/timeouts.mjs.
+ *
+ * The node:http side (server.requestTimeout / headersTimeout / keepAliveTimeout)
+ * is covered by server-timeouts.test.js; that file is node-only and denylisted
+ * from the Bun matrix, which is exactly the gap this test closes.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { bunIdleTimeout } from '../../src/listener-bun.js';
+import { DEFAULT_REQUEST_TIMEOUT_MS } from '../../src/body-limit.js';
+
+test('no config maps to the 30s default (matches DEFAULT_REQUEST_TIMEOUT_MS)', () => {
+  assert.equal(DEFAULT_REQUEST_TIMEOUT_MS, 30_000);
+  assert.equal(bunIdleTimeout(undefined), 30);
+  assert.equal(bunIdleTimeout({}), 30);
+});
+
+test('an explicit requestTimeout converts ms to whole seconds', () => {
+  assert.equal(bunIdleTimeout({ requestTimeout: 45_000 }), 45);
+  assert.equal(bunIdleTimeout({ requestTimeout: 120_000 }), 120);
+});
+
+test('a fractional second rounds UP (ceil), so the idle window is never short', () => {
+  assert.equal(bunIdleTimeout({ requestTimeout: 30_500 }), 31);
+  assert.equal(bunIdleTimeout({ requestTimeout: 60_001 }), 61);
+});
+
+test('a sub-floor timeout clamps to 30s (above the 25s SSE keepalive)', () => {
+  // Below the floor a dev live-reload stream would be reaped as idle.
+  assert.equal(bunIdleTimeout({ requestTimeout: 10_000 }), 30);
+  assert.equal(bunIdleTimeout({ requestTimeout: 1 }), 30);
+});
+
+test('an over-ceiling timeout clamps to Bun\'s 255s max', () => {
+  assert.equal(bunIdleTimeout({ requestTimeout: 300_000 }), 255);
+  assert.equal(bunIdleTimeout({ requestTimeout: 10_000_000 }), 255);
+});
+
+test('0 (the node disable sentinel) disables the idle timeout on Bun too', () => {
+  assert.equal(bunIdleTimeout({ requestTimeout: 0 }), 0);
+});

--- a/test/bun/timeouts.mjs
+++ b/test/bun/timeouts.mjs
@@ -60,6 +60,11 @@ try {
   await c.close();
 } finally {
   Bun.serve = realServe;
+  // startBunListener registers a process SIGINT/SIGTERM handler per call that
+  // its close() does not remove; drop them so the 3 calls leave no listeners
+  // behind (this short-lived script installs none of its own).
+  process.removeAllListeners('SIGINT');
+  process.removeAllListeners('SIGTERM');
 }
 
 console.log(`OK  webjs Bun.serve idleTimeout wiring passed on bun ${process.versions.bun} (#663)`);

--- a/test/bun/timeouts.mjs
+++ b/test/bun/timeouts.mjs
@@ -1,0 +1,65 @@
+/**
+ * Cross-runtime WIRING test for the Bun-shell server timeout (#663). The pure
+ * ms->seconds mapping is unit-tested in packages/server/test/body-limit/
+ * bun-idle-timeout.test.js (which the Bun matrix re-runs under bun); THIS script
+ * proves the other half on the real Bun shell: that startBunListener actually
+ * feeds bunIdleTimeout(timeouts) into Bun.serve's `idleTimeout`. The node:http
+ * side (requestTimeout/headersTimeout/keepAliveTimeout) is a separate shell,
+ * covered by packages/server/test/body-limit/server-timeouts.test.js.
+ *
+ *   bun test/bun/timeouts.mjs   # the only shell with a Bun.serve to assert
+ *
+ * It stubs Bun.serve to capture the options (no real socket), so it is a Bun-
+ * only assertion; on node it is a no-op skip (the node shell has no Bun.serve).
+ */
+import assert from 'node:assert/strict';
+
+if (!process.versions.bun) {
+  console.log('SKIP (node): the Bun.serve idleTimeout wiring only exists on the Bun shell');
+  process.exit(0);
+}
+
+const { startBunListener } = await import('../../packages/server/src/listener-bun.js');
+
+const quiet = { info() {}, warn() {}, error() {}, debug() {} };
+const minimalCtx = (timeouts) => ({
+  app: { handle: async () => new Response(''), warmup() {} },
+  dev: false,
+  compress: false,
+  logger: quiet,
+  hub: { closeAll() {} },
+  port: 0,
+  basePathStr: '',
+  timeouts,
+  watcherAbort: null,
+});
+
+// Capture the options handed to Bun.serve without opening a real socket.
+const realServe = Bun.serve.bind(Bun);
+let captured = null;
+Bun.serve = (opts) => {
+  captured = opts;
+  return { port: 0, stop() {}, reload() {} };
+};
+
+try {
+  // 1. A configured requestTimeout reaches Bun.serve as the mapped idleTimeout.
+  const a = startBunListener(minimalCtx({ requestTimeout: 45_000 }));
+  assert.equal(captured.idleTimeout, 45, 'requestTimeout 45000ms must map to idleTimeout 45s');
+  assert.equal(captured.development, false, 'Bun dev error page stays off (webjs owns its overlay)');
+  await a.close();
+
+  // 2. The disable sentinel (0) passes through.
+  const b = startBunListener(minimalCtx({ requestTimeout: 0 }));
+  assert.equal(captured.idleTimeout, 0, 'requestTimeout 0 disables the idle timeout');
+  await b.close();
+
+  // 3. The default (no timeouts configured) is the 30s floor.
+  const c = startBunListener(minimalCtx(undefined));
+  assert.equal(captured.idleTimeout, 30, 'no requestTimeout falls back to the 30s default');
+  await c.close();
+} finally {
+  Bun.serve = realServe;
+}
+
+console.log(`OK  webjs Bun.serve idleTimeout wiring passed on bun ${process.versions.bun} (#663)`);


### PR DESCRIPTION
Closes #663

Close the one Bun-parity gap an audit of the run-bun-tests.js denylist surfaced: the server-timeout config was verified on Node only. The node:http timeout test (`server-timeouts.test.js`) asserts node:http server fields and is denylisted from the Bun matrix, and the Bun shell's `requestTimeout` -> `Bun.serve` `idleTimeout` mapping (#511) had no test.

## What changed
- Export `bunIdleTimeout` from `listener-bun.js` and unit-test the pure mapping in `packages/server/test/body-limit/bun-idle-timeout.test.js` (default 30s, ms-to-seconds ceil, the 30s floor above the SSE keepalive, the 255s Bun ceiling, the 0 disable sentinel). The Bun matrix re-runs this under bun, so the mapping is proven on both runtimes.
- `test/bun/timeouts.mjs` asserts the WIRING on the real Bun shell: `startBunListener` feeds `bunIdleTimeout(timeouts)` into `Bun.serve`'s `idleTimeout` (stubs `Bun.serve` to capture options; no socket). Skips on node (no Bun.serve shell there).
- Wired the new script into the CI bun job; noted it in `agent-docs/testing.md`.

## Tests
- Mapping unit test: 6/6 on Node AND under `bun test`.
- Wiring: `bun test/bun/timeouts.mjs` green; `node test/bun/timeouts.mjs` skips.

## Surfaces
- Docs: `agent-docs/testing.md` updated (the test/bun list). No user-facing behavior change (test-only + a one-line export), so docs-site / README / scaffold N/A.

https://claude.ai/code/session_01WnvcTojG7tYqmnmf4enSv3