### PR TITLE
fix: use position:fixed for the docs mobile header (iOS flicker, #610)

### DIFF
--- a/docs/app/docs/layout.ts
+++ b/docs/app/docs/layout.ts
@@ -189,10 +189,14 @@ export default function DocsLayout({ children }: { children: unknown }) {
         }
         body[data-menu-open] .menu-backdrop { opacity: 1; pointer-events: auto; }
         body[data-menu-open] { overflow: hidden; }
+        /* #647: the mobile header is position:fixed (out of flow), so reserve its
+           height on the content plus the normal top breathing room. --header-h is
+           the measured bar height (set in the root layout). */
+        .docs-main { padding-top: calc(var(--header-h) + 1.5rem); }
       }
     </style>
 
-    <header class="hidden max-[860px]:flex sticky top-0 z-[25] items-center gap-4 px-4 py-3 border-b border-border bg-[color-mix(in_oklch,var(--bg)_85%,transparent)] backdrop-blur-[18px] backdrop-saturate-[180%]">
+    <header class="hidden max-[860px]:flex fixed inset-x-0 top-0 z-[25] items-center gap-4 px-4 py-3 border-b border-border bg-[color-mix(in_oklch,var(--bg)_85%,transparent)] backdrop-blur-[18px] backdrop-saturate-[180%]">
       <a href="/" class="mr-auto inline-flex items-center gap-2 no-underline text-fg font-semibold text-[15px] leading-none tracking-tight">
         <span class="inline-block w-[22px] h-[22px] rounded-md bg-gradient-to-br from-accent to-[color-mix(in_oklch,var(--accent)_55%,var(--fg))] shadow-[inset_0_0_0_1px_oklch(1_0_0/0.15),0_1px_4px_var(--accent-tint)]"></span>
         <span>webjs docs</span>
@@ -233,7 +237,7 @@ export default function DocsLayout({ children }: { children: unknown }) {
           `)}
         </nav>
       </aside>
-      <main class="min-w-0 max-w-[800px] px-6 pt-12 pb-16 max-[860px]:pt-6">
+      <main class="docs-main min-w-0 max-w-[800px] px-6 pt-12 pb-16">
         <div class="prose-docs">${children}</div>
       </main>
     </div>

--- a/docs/app/layout.ts
+++ b/docs/app/layout.ts
@@ -63,6 +63,26 @@ export default function RootLayout({ children }: { children: unknown }) {
         } catch (_) {}
       })();
     </script>
+    <script nonce="${nonce}">
+      // #647: the docs mobile header is position:fixed; measure it so --header-h
+      // reserves the exact height. No-op when absent (the homepage has no header),
+      // which leaves the :root media-query default for the mobile first paint.
+      (function () {
+        function measure() {
+          try {
+            var bar = document.querySelector('header');
+            if (!bar) return;
+            var apply = function () {
+              document.documentElement.style.setProperty('--header-h', bar.offsetHeight + 'px');
+            };
+            apply();
+            if (window.ResizeObserver) new ResizeObserver(apply).observe(bar);
+          } catch (_) {}
+        }
+        if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', measure);
+        else measure();
+      })();
+    </script>
     <link rel="stylesheet" href="/public/tailwind.css">
     <style>
       :root {
@@ -149,6 +169,13 @@ export default function RootLayout({ children }: { children: unknown }) {
       }
 
       html, body { margin: 0; }
+      /* #610/#647: the docs mobile header is position:fixed (sticky flickers on
+         iOS WebKit during a client-router nav). --header-h reserves the bar's
+         height on the /docs content. It is 0 by default (the homepage has no
+         header, and the bar is display:none on desktop), the mobile bar height
+         under the breakpoint, then measured exactly by the script in <head>. */
+      :root { --header-h: 0px; }
+      @media (max-width: 860px) { :root { --header-h: 61px; } }
       body {
         background: var(--bg);
         color: var(--fg);


### PR DESCRIPTION
Closes #647

Apply the #610 iOS sticky-header flicker fix (use `position: fixed`, not `sticky`) to the docs app, the last app still on a sticky mobile header after the blog / website / scaffold got it.

## What changed
- `docs/app/docs/layout.ts`: the mobile header (`hidden max-[860px]:flex`) goes from `sticky top-0` to `fixed inset-x-0 top-0`. The desktop sticky SIDEBAR (`docs-sidebar`) is desktop-only and untouched (out of scope per #647).
- Reserve the header height on the content: `<main>` gets `padding-top: calc(var(--header-h) + 1.5rem)` under `max-width: 860px` (raw CSS in the sub-layout style block, so it is scoped to /docs and needs no Tailwind rebuild quirk).
- `docs/app/layout.ts`: a `:root` `--header-h` (0 default, 61px under the breakpoint for the mobile first paint) plus a ResizeObserver script that measures the real header height. The script no-ops when there is no header.

## Why the offset is on the sub-layout main, not `body`
The issue suggested `body { padding-top: var(--header-h) }` in the root layout. But the docs homepage (`/` redirects, and any headerless page) has NO mobile header, so a global body padding would add a phantom top gap there. Scoping the offset to the sub-layout `main` (which only renders under /docs, where the header exists) reserves the space exactly where the fixed header is and leaves every headerless page untouched. Same end result on /docs, no regression elsewhere.

## Verification
- Boot (prod mode): `/` redirects (302), `/docs/components` and `/docs/architecture` serve 200 with the header now `fixed inset-x-0 top-0`, `--header-h` present, and the measuring script in the head. No broken modulepreloads.
- The flicker itself is iOS-WebKit-only and not reproducible headless / in DevTools emulation (per #610), so the on-device check is the headline acceptance and is yours to confirm.

## Surfaces
- Docs: the `position: fixed` header pattern is already documented in `agent-docs/styling.md` (from #610), so no new doc surface. Other 3 apps unaffected (docs-only change). No framework package touched.

https://claude.ai/code/session_01WnvcTojG7tYqmnmf4enSv3