### PR TITLE
chore: release core 0.7.24, server 0.8.34, cli 0.10.23

### DIFF
--- a/changelog/cli/0.10.23.md
+++ b/changelog/cli/0.10.23.md
@@ -1,0 +1,17 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.23
+date: 2026-06-20T17:36:09.322Z
+commit_count: 2
+---
+## Features
+
+- **Origin/Sec-Fetch-Site CSRF check so SSR pages are CDN-cacheable** ([#660](https://github.com/webjsdev/webjs/pull/660)) [`453d072e`](https://github.com/webjsdev/webjs/commit/453d072e)
+  * feat(server): Origin/Sec-Fetch-Site CSRF check, drop the token cookie
+  
+  Replace the per-request webjs_csrf double-submit cookie with a
+  cross-origin check on state-changing action requests: Sec-Fetch-Site
+- **advisory naming why a page or layout ships (the elision blocker)** ([#666](https://github.com/webjsdev/webjs/pull/666)) [`00f12fca`](https://github.com/webjsdev/webjs/commit/00f12fca)
+  * chore: start elision-blocker advisory (#646)
+  
+  Claude-Session: https://claude.ai/code/session_01WnvcTojG7tYqmnmf4enSv3

--- a/changelog/core/0.7.24.md
+++ b/changelog/core/0.7.24.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/core"
+version: 0.7.24
+date: 2026-06-20T17:36:09.225Z
+commit_count: 1
+---
+## Features
+
+- **Origin/Sec-Fetch-Site CSRF check so SSR pages are CDN-cacheable** ([#660](https://github.com/webjsdev/webjs/pull/660)) [`453d072e`](https://github.com/webjsdev/webjs/commit/453d072e)
+  * feat(server): Origin/Sec-Fetch-Site CSRF check, drop the token cookie
+  
+  Replace the per-request webjs_csrf double-submit cookie with a
+  cross-origin check on state-changing action requests: Sec-Fetch-Site

--- a/changelog/server/0.8.34.md
+++ b/changelog/server/0.8.34.md
@@ -1,0 +1,17 @@
+---
+package: "@webjsdev/server"
+version: 0.8.34
+date: 2026-06-20T17:36:09.273Z
+commit_count: 2
+---
+## Features
+
+- **Origin/Sec-Fetch-Site CSRF check so SSR pages are CDN-cacheable** ([#660](https://github.com/webjsdev/webjs/pull/660)) [`453d072e`](https://github.com/webjsdev/webjs/commit/453d072e)
+  * feat(server): Origin/Sec-Fetch-Site CSRF check, drop the token cookie
+  
+  Replace the per-request webjs_csrf double-submit cookie with a
+  cross-origin check on state-changing action requests: Sec-Fetch-Site
+- **advisory naming why a page or layout ships (the elision blocker)** ([#666](https://github.com/webjsdev/webjs/pull/666)) [`00f12fca`](https://github.com/webjsdev/webjs/commit/00f12fca)
+  * chore: start elision-blocker advisory (#646)
+  
+  Claude-Session: https://claude.ai/code/session_01WnvcTojG7tYqmnmf4enSv3

--- a/package-lock.json
+++ b/package-lock.json
@@ -7339,7 +7339,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.22",
+      "version": "0.10.23",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -7355,7 +7355,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.23",
+      "version": "0.7.24",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.25.0"
@@ -7403,7 +7403,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.33",
+      "version": "0.8.34",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.22",
+  "version": "0.10.23",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.23",
+  "version": "0.7.24",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.33",
+  "version": "0.8.34",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Release the unreleased work merged since #658.

## Bumps (all patch, dependents pin ^0.x.0 so no range edits)
- **@webjsdev/core 0.7.23 -> 0.7.24**: the `allowedOrigins` config type for the Origin/Sec-Fetch-Site CSRF model (#660).
- **@webjsdev/server 0.8.33 -> 0.8.34**: Origin/Sec-Fetch-Site CSRF check, SSR pages are CDN-cacheable (#660); the page/layout elision advisory verdict + `analyzeAppElision` (#666). (#664 was a `test:` only, so no changelog entry.)
- **@webjsdev/cli 0.10.23**: the `webjs doctor` carrier-hygiene advisory (#666); the scaffold templates also carry the #660 CSRF guidance.

ui / mcp / intellisense have no unreleased source changes, so they are not bumped.

Changelogs are auto-generated by the pre-commit backfill hook from the conventional commit subjects; lockfile regenerated. Merging adds the `changelog/**.md` files to main, which triggers `release.yml` to publish to npm and cut the GitHub Releases.

Release-PR CI is mostly redundant (only version lines + generated changelogs + the lockfile changed), so it is safe to merge once Conventions + Build + Unit are green.

https://claude.ai/code/session_01WnvcTojG7tYqmnmf4enSv3