### PR TITLE
chore: release core 0.7.25, server 0.8.35, cli 0.10.24, intellisense 0.5.3

### DIFF
--- a/changelog/cli/0.10.24.md
+++ b/changelog/cli/0.10.24.md
@@ -1,0 +1,17 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.24
+date: 2026-06-24T06:15:53.570Z
+commit_count: 3
+---
+## Features
+
+- **remove better-sqlite3, scaffold uses the built-in SQLite** ([#670](https://github.com/webjsdev/webjs/pull/670)) [`2613d909`](https://github.com/webjsdev/webjs/commit/2613d909)
+  * The scaffold no longer depends on the native `better-sqlite3`. SQLite uses the runtime's built-in driver via Drizzle: `node:sqlite` on Node, `bun:sqlite` on Bun. No native module build, no `trustedDependencies`.
+- **zero-install dev/start on Bun via an auto-install bootstrap** ([#676](https://github.com/webjsdev/webjs/pull/676)) [`b3ffb3c2`](https://github.com/webjsdev/webjs/commit/b3ffb3c2)
+  * A Bun scaffold's `dev` / `start` / `db` scripts (and the `start.before` migrate) run through a generated `webjs-bun.mjs` bootstrap under `bun --bun`, so Bun auto-install resolves deps on demand and a fresh app serves with no `bun install` (install becomes optional, for editor types / offline). Node path unchanged.
+
+## Fixes
+
+- **set busy_timeout + WAL on the SQLite connection to stop "database is locked"** ([#674](https://github.com/webjsdev/webjs/pull/674)) [`55b9b369`](https://github.com/webjsdev/webjs/commit/55b9b369)
+  * `node:sqlite` and `bun:sqlite` both default `busy_timeout` to 0, so a contended write threw `database is locked` immediately (better-sqlite3 used 5000ms). The generated connection now sets `PRAGMA busy_timeout = 5000` + WAL.

--- a/changelog/core/0.7.25.md
+++ b/changelog/core/0.7.25.md
@@ -1,0 +1,10 @@
+---
+package: "@webjsdev/core"
+version: 0.7.25
+date: 2026-06-24T06:15:53.479Z
+commit_count: 1
+---
+## Features
+
+- **implement the reactive-prop `default` and custom `attribute` options** ([#672](https://github.com/webjsdev/webjs/pull/672)) [`6ebb044d`](https://github.com/webjsdev/webjs/commit/6ebb044d)
+  * Both were documented but never consumed. `default` now sets a prop's initial value (a value, or a function called per instance for fresh objects/arrays; a constructor assignment still overrides it). A custom `attribute` name is now honored in `observedAttributes`, reflection, and `attributeChangedCallback` (lit-parity). Works for both the bare `{ count: Number }` and `prop(Number, {...})` declaration forms.

--- a/changelog/intellisense/0.5.3.md
+++ b/changelog/intellisense/0.5.3.md
@@ -1,0 +1,10 @@
+---
+package: "@webjsdev/intellisense"
+version: 0.5.3
+date: 2026-06-24T06:15:53.639Z
+commit_count: 1
+---
+## Features
+
+- **derive template attribute completions from a prop's custom `attribute` option** ([#672](https://github.com/webjsdev/webjs/pull/672)) [`6ebb044d`](https://github.com/webjsdev/webjs/commit/6ebb044d)
+  * In-template attribute completions and hover now read a reactive prop's custom `attribute` option instead of always kebab-casing the property name, matching the runtime. A prop declared `prop(Boolean, { attribute: 'is-open' })` completes `is-open`, not `open`.

--- a/changelog/nvim/0.2.2.md
+++ b/changelog/nvim/0.2.2.md
@@ -1,0 +1,11 @@
+---
+package: "webjs.nvim"
+version: 0.2.2
+date: 2026-06-24T06:15:53.720Z
+commit_count: 1
+npm: false
+---
+## Features
+
+- **bundled intellisense tracks custom prop `attribute` completions** ([#672](https://github.com/webjsdev/webjs/pull/672)) [`6ebb044d`](https://github.com/webjsdev/webjs/commit/6ebb044d)
+  * Republish: the plugin vendors `@webjsdev/intellisense`, which now derives template attribute completions / hover from a reactive prop's custom `attribute` option (0.5.3). The vendored copy was refreshed; this version bump ships it.

--- a/changelog/server/0.8.35.md
+++ b/changelog/server/0.8.35.md
@@ -1,0 +1,10 @@
+---
+package: "@webjsdev/server"
+version: 0.8.35
+date: 2026-06-24T06:15:53.522Z
+commit_count: 1
+---
+## Features
+
+- **resolve a custom prop `attribute` to its property during SSR** ([#672](https://github.com/webjsdev/webjs/pull/672)) [`6ebb044d`](https://github.com/webjsdev/webjs/commit/6ebb044d)
+  * `applyAttrsToInstance` (the SSR path) now honors a reactive prop's custom `attribute` option, so a parent-rendered `<el is-open>` gets the right property value in the JS-off first paint, matching the client. Part of implementing the previously-documented-but-unimplemented `default` + custom `attribute` prop options.

--- a/changelog/vscode/0.2.2.md
+++ b/changelog/vscode/0.2.2.md
@@ -1,0 +1,11 @@
+---
+package: "webjs (VS Code extension)"
+version: 0.2.2
+date: 2026-06-24T06:15:53.720Z
+commit_count: 1
+npm: false
+---
+## Features
+
+- **bundled intellisense tracks custom prop `attribute` completions** ([#672](https://github.com/webjsdev/webjs/pull/672)) [`6ebb044d`](https://github.com/webjsdev/webjs/commit/6ebb044d)
+  * Republish: the extension bundles `@webjsdev/intellisense`, which now derives template attribute completions / hover from a reactive prop's custom `attribute` option (0.5.3). No extension-source change; the version bump ships the refreshed bundle.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3331,7 +3331,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -3644,7 +3644,7 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -4421,7 +4421,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/internal-ip": {
@@ -5488,7 +5488,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -5807,7 +5807,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -6167,7 +6167,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6213,7 +6213,7 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
       "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6879,7 +6879,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ws": {
@@ -6975,7 +6975,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.23",
+      "version": "0.10.24",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -6991,7 +6991,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.24",
+      "version": "0.7.25",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.25.0"
@@ -6999,7 +6999,7 @@
     },
     "packages/editors/intellisense": {
       "name": "@webjsdev/intellisense",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT",
       "peerDependencies": {
         "typescript": ">=5.0.0"
@@ -7007,11 +7007,11 @@
     },
     "packages/editors/nvim": {
       "name": "webjs.nvim",
-      "version": "0.2.1"
+      "version": "0.2.2"
     },
     "packages/editors/vscode": {
       "name": "webjs",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/intellisense": "^0.5.0"
@@ -7039,7 +7039,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.34",
+      "version": "0.8.35",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.23",
+  "version": "0.10.24",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.24",
+  "version": "0.7.25",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/editors/intellisense/package.json
+++ b/packages/editors/intellisense/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/intellisense",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "type": "commonjs",
   "description": "Standalone TypeScript language-service plugin for webjs (no Lit dependency). Adds in-template intelligence inside html`` templates: go-to-definition on tags / attributes / CSS classes, binding-aware completions, value/binding diagnostics, and hover, all driven by its own template parser and gated on import-graph reachability.",
   "main": "src/index.js",

--- a/packages/editors/nvim/package.json
+++ b/packages/editors/nvim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webjs.nvim",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "description": "Neovim editor support for webjs apps (html/css/svg template highlighting + in-template intelligence via the bundled @webjsdev/intellisense). NOT an npm package: ships to the webjsdev/webjs.nvim git repo via subtree split, installed by lazy.nvim. This manifest exists only as the version source for the unified changelog (changelog/nvim/<version>.md); see PUBLISHING.md."
 }

--- a/packages/editors/vscode/package.json
+++ b/packages/editors/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webjs",
   "displayName": "webjs",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "All-in-one webjs support: html/css template highlighting, language-service intelligence, snippets, and commands. No Lit extension required.",
   "publisher": "webjsdev",
   "private": true,

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Accumulated package changes since the last release (#667). All patch bumps (each package stays in its minor line; dependents pin `^0.x`, so no range edits).

| Package | From → To | Changes |
|---|---|---|
| `@webjsdev/core` | 0.7.24 → 0.7.25 | #672 reactive-prop `default` + custom `attribute` options |
| `@webjsdev/server` | 0.8.34 → 0.8.35 | #672 SSR custom-attribute resolution |
| `@webjsdev/cli` | 0.10.23 → 0.10.24 | #670 better-sqlite3 removal, #676 zero-install Bun, #674 busy_timeout fix |
| `@webjsdev/intellisense` | 0.5.2 → 0.5.3 | #672 custom-`attribute` completions |
| `webjs.nvim` | 0.2.1 → 0.2.2 | republish (bundled intellisense, `npm: false`) |
| `webjs` (VS Code) | 0.2.1 → 0.2.2 | republish (bundled intellisense, `npm: false`) |

`@webjsdev/ui` and `@webjsdev/mcp` had no changes since the release, so no bump.

Changelog curation: dropped #670 from the **server** changelog (its `server/src` change there was a comment-only edit, not a behavior change) and #672 from the **cli** changelog (its `cli` footprint was a templates-doc wording change, not cli code/output). The editor-plugin entries are hand-written republish notes (`npm: false`).

Merging adds the `changelog/**.md` files to `main`, which triggers `release.yml` to `npm publish` core/server/cli/intellisense and cut GitHub Releases. The editor plugins are `npm: false` (GitHub Release only); webjs.nvim's subtree mirror push + the VS Code Marketplace publish are the separate manual steps after merge.

https://claude.ai/code/session_01WnvcTojG7tYqmnmf4enSv3
