### PR TITLE
docs: align the landing action sample to getPost (matches the SSR page)

### DIFF
--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -69,14 +69,16 @@ class LikeButton extends WebComponent {
 LikeButton.register('like-button');`;
 
 const ACTION_SAMPLE = `'use server';
+import { eq } from 'drizzle-orm';
 import { db } from '#db/connection.server.ts';
 import { posts } from '#db/schema.server.ts';
 
-// Import this from a client component. webjs rewrites the
-// import into a typed RPC stub. No fetch by hand.
-export async function createPost(input) {
-  const [post] = await db.insert(posts).values(input).returning();
-  return { success: true, data: post };
+// Import this from a page or client component. webjs rewrites
+// the import into a typed RPC stub (the real call at SSR). No
+// fetch by hand.
+export async function getPost(id) {
+  const [post] = await db.select().from(posts).where(eq(posts.id, id));
+  return post;
 }`;
 
 const PAGE_SAMPLE = `export default async function Post({ params }) {
@@ -229,7 +231,7 @@ export default function LandingPage() {
           </div>
           <div class="flex flex-col min-w-0">
             <p class="font-mono font-semibold text-[11px] leading-[1.4] tracking-[0.12em] uppercase text-fg-subtle mb-[10px] ml-1">Server action (RPC)</p>
-            ${codeWindow('actions/create-post.server.ts', ACTION_SAMPLE)}
+            ${codeWindow('actions/get-post.server.ts', ACTION_SAMPLE)}
           </div>
           <div class="flex flex-col min-w-0">
             <p class="font-mono font-semibold text-[11px] leading-[1.4] tracking-[0.12em] uppercase text-fg-subtle mb-[10px] ml-1">SSR page</p>


### PR DESCRIPTION
The landing 'Show, don't tell' trio showed a `createPost` server action but the SSR page sample called `getPost(params.id)`, so the two didn't match. Rewrite the action sample as a `getPost` read (returns the post directly) and rename the code-window file to `get-post.server.ts`, so the page's `await getPost(params.id)` calls the exact function shown.

Marketing-copy only; landing page boots 200, `getPost` present, `createPost` gone.

https://claude.ai/code/session_01WnvcTojG7tYqmnmf4enSv3