### PR TITLE
fix(mcp): source tool resolves @webjsdev from the Bun cache under zero-install

### DIFF
--- a/packages/mcp/AGENTS.md
+++ b/packages/mcp/AGENTS.md
@@ -55,7 +55,9 @@ src/
                          source from node_modules/@webjsdev/*/src (read-only,
                          traversal-guarded via realpath, loads no module).
                          resolveFrameworkRoots locates each package by probing
-                         the require.resolve node_modules dirs.
+                         the require.resolve node_modules dirs, then (when none
+                         is found) Bun's global cache (#687), so the tool works
+                         under Bun zero-install where there is no node_modules.
   check-report.js        projectCheck(violations) -> { violations, summary }.
                          The shared shape returned by BOTH the MCP `check` tool
                          and `webjs check --json` (the CLI imports it from

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -34,7 +34,9 @@ subcommand) delegates to this same server, so both routes run identical code.
   MCP `resources` (the `agent-docs/*` corpus + `AGENTS.md` as `webjs-docs://*`),
   and `prompts` (the recipes as guided workflows).
 - **`source` tool**: reads the framework's own no-build source from
-  `node_modules/@webjsdev/*/src` (read-only, traversal-guarded).
+  `node_modules/@webjsdev/*/src` (read-only, traversal-guarded). Under Bun
+  zero-install (no `node_modules`) it falls back to Bun's global cache, where the
+  packages live, so it works without an install.
 
 The docs corpus is bundled into the package at `prepack`, so `npx @webjsdev/mcp`
 is self-contained; in the monorepo it falls back to the live repo-root docs.

--- a/packages/mcp/src/mcp-source.js
+++ b/packages/mcp/src/mcp-source.js
@@ -126,28 +126,32 @@ function resolveFromBunCache(pkg, fsDeps) {
 }
 
 /**
- * Compare two semver-ish version strings numerically (so `0.10.0` > `0.9.0`).
- * Splits on `.`, `-`, `+` and compares segment by segment: numeric segments
- * numerically, others lexically; a missing segment (a release vs its
- * prerelease) sorts lower. Returns negative / 0 / positive like a comparator.
+ * Compare two semver-ish version strings numerically (so `0.10.0` > `0.9.0`),
+ * with a release ranking ABOVE its prerelease (`1.0.0` > `1.0.0-rc.1`). Compares
+ * the release core (`major.minor.patch`) segment by segment numerically; on a
+ * tie, a version WITHOUT a prerelease tag sorts higher, else the prerelease tags
+ * compare lexically. The build suffix (`+...`) is ignored, per semver. Returns
+ * negative / 0 / positive like a comparator.
  * @param {string} a
  * @param {string} b
  * @returns {number}
  */
 function compareVersions(a, b) {
-  const seg = (v) => v.split(/[.+-]/).map((s) => (/^\d+$/.test(s) ? Number(s) : s));
-  const pa = seg(a);
-  const pb = seg(b);
-  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
-    const x = pa[i];
-    const y = pb[i];
-    if (x === y) continue;
-    if (x === undefined) return -1;
-    if (y === undefined) return 1;
-    if (typeof x === 'number' && typeof y === 'number') return x - y;
-    return String(x) < String(y) ? -1 : 1;
+  const parse = (v) => {
+    const [core, pre = ''] = v.split('+')[0].split('-');
+    return { nums: core.split('.').map(Number), pre };
+  };
+  const A = parse(a);
+  const B = parse(b);
+  for (let i = 0; i < Math.max(A.nums.length, B.nums.length); i++) {
+    const x = A.nums[i] || 0;
+    const y = B.nums[i] || 0;
+    if (x !== y) return x - y;
   }
-  return 0;
+  if (A.pre === B.pre) return 0;
+  if (!A.pre) return 1; // a release outranks any prerelease of the same core
+  if (!B.pre) return -1;
+  return A.pre < B.pre ? -1 : 1;
 }
 
 /**

--- a/packages/mcp/src/mcp-source.js
+++ b/packages/mcp/src/mcp-source.js
@@ -48,8 +48,15 @@ const MAX_FILES = 4000;
  * reliable. The source dir is `src/`, or `lib/` for the cli. A package that is
  * not installed is skipped (not every app depends on every `@webjsdev/*`).
  *
+ * Under Bun ZERO-INSTALL (no `node_modules`, #675) the packages live only in
+ * Bun's global install cache (`<bunCacheDir>/@webjsdev/<pkg>@<version>@@@<n>/`,
+ * which holds the full source). When the `node_modules` walk finds nothing and a
+ * `bunCacheDir` + `readdir` are supplied, fall back to scanning that scope dir
+ * for the package's versioned entry (highest version wins, best-effort), so the
+ * tool works whether the package is installed OR resolved from the Bun cache.
+ *
  * @param {string} cwd
- * @param {{ exists: (p: string) => boolean }} fsDeps
+ * @param {{ exists: (p: string) => boolean, readdir?: (d: string) => Array<{ name: string, isDir: boolean }>, bunCacheDir?: string | null }} fsDeps
  * @returns {Array<{ pkg: string, root: string, src: string }>}
  */
 export function resolveFrameworkRoots(cwd, fsDeps) {
@@ -69,6 +76,8 @@ export function resolveFrameworkRoots(cwd, fsDeps) {
       const cand = join(base, '@webjsdev', pkg);
       if (fsDeps.exists(join(cand, 'package.json'))) { root = cand; break; }
     }
+    // Zero-install fallback: no node_modules, so look in Bun's global cache.
+    if (!root) root = resolveFromBunCache(pkg, fsDeps);
     if (!root) continue;
     // Most packages keep source in `src/`; the cli keeps it in `lib/`. Use
     // whichever exists so every framework package's source is reachable.
@@ -80,6 +89,38 @@ export function resolveFrameworkRoots(cwd, fsDeps) {
     if (src) out.push({ pkg, root, src });
   }
   return out;
+}
+
+/**
+ * Locate `@webjsdev/<pkg>` in Bun's global install cache (the zero-install
+ * fallback). Bun caches a scoped package at `<bunCacheDir>/@webjsdev/<pkg>@<ver>@@@<n>/`
+ * (the versioned dir holds the full source; a sibling unversioned `<pkg>/` dir is
+ * metadata, skipped). Picks the lexically-highest versioned dir (best-effort:
+ * the latest cached version), and returns its path only if it carries a
+ * `package.json`. Returns '' when there is no cache dir, no `readdir`, or no
+ * matching entry.
+ *
+ * @param {string} pkg
+ * @param {{ exists: (p: string) => boolean, readdir?: (d: string) => Array<{ name: string, isDir: boolean }>, bunCacheDir?: string | null }} fsDeps
+ * @returns {string}
+ */
+function resolveFromBunCache(pkg, fsDeps) {
+  const { bunCacheDir, readdir, exists } = fsDeps;
+  if (!bunCacheDir || typeof readdir !== 'function') return '';
+  const scopeDir = join(bunCacheDir, '@webjsdev');
+  if (!exists(scopeDir)) return '';
+  let entries;
+  try { entries = readdir(scopeDir); } catch { return ''; }
+  const prefix = `${pkg}@`;
+  const versioned = entries
+    .filter((e) => e.isDir && e.name.startsWith(prefix) && e.name.includes('@@@'))
+    .map((e) => e.name)
+    .sort((a, b) => (a < b ? 1 : a > b ? -1 : 0)); // descending, latest-ish first
+  for (const name of versioned) {
+    const cand = join(scopeDir, name);
+    if (exists(join(cand, 'package.json'))) return cand;
+  }
+  return '';
 }
 
 /**

--- a/packages/mcp/src/mcp-source.js
+++ b/packages/mcp/src/mcp-source.js
@@ -95,8 +95,8 @@ export function resolveFrameworkRoots(cwd, fsDeps) {
  * Locate `@webjsdev/<pkg>` in Bun's global install cache (the zero-install
  * fallback). Bun caches a scoped package at `<bunCacheDir>/@webjsdev/<pkg>@<ver>@@@<n>/`
  * (the versioned dir holds the full source; a sibling unversioned `<pkg>/` dir is
- * metadata, skipped). Picks the lexically-highest versioned dir (best-effort:
- * the latest cached version), and returns its path only if it carries a
+ * metadata, skipped). Picks the highest cached version (semver-aware, so
+ * `0.10.0` beats `0.9.0`), and returns its path only if it carries a
  * `package.json`. Returns '' when there is no cache dir, no `readdir`, or no
  * matching entry.
  *
@@ -112,15 +112,42 @@ function resolveFromBunCache(pkg, fsDeps) {
   let entries;
   try { entries = readdir(scopeDir); } catch { return ''; }
   const prefix = `${pkg}@`;
+  // A cache dir is `<pkg>@<version>@@@<n>`; extract <version> (between the name
+  // and the `@@@` cache-key suffix) and sort by it, highest first.
   const versioned = entries
     .filter((e) => e.isDir && e.name.startsWith(prefix) && e.name.includes('@@@'))
-    .map((e) => e.name)
-    .sort((a, b) => (a < b ? 1 : a > b ? -1 : 0)); // descending, latest-ish first
-  for (const name of versioned) {
+    .map((e) => ({ name: e.name, version: e.name.slice(prefix.length).split('@@@')[0] }))
+    .sort((a, b) => compareVersions(b.version, a.version));
+  for (const { name } of versioned) {
     const cand = join(scopeDir, name);
     if (exists(join(cand, 'package.json'))) return cand;
   }
   return '';
+}
+
+/**
+ * Compare two semver-ish version strings numerically (so `0.10.0` > `0.9.0`).
+ * Splits on `.`, `-`, `+` and compares segment by segment: numeric segments
+ * numerically, others lexically; a missing segment (a release vs its
+ * prerelease) sorts lower. Returns negative / 0 / positive like a comparator.
+ * @param {string} a
+ * @param {string} b
+ * @returns {number}
+ */
+function compareVersions(a, b) {
+  const seg = (v) => v.split(/[.+-]/).map((s) => (/^\d+$/.test(s) ? Number(s) : s));
+  const pa = seg(a);
+  const pb = seg(b);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const x = pa[i];
+    const y = pb[i];
+    if (x === y) continue;
+    if (x === undefined) return -1;
+    if (y === undefined) return 1;
+    if (typeof x === 'number' && typeof y === 'number') return x - y;
+    return String(x) < String(y) ? -1 : 1;
+  }
+  return 0;
 }
 
 /**

--- a/packages/mcp/src/mcp.js
+++ b/packages/mcp/src/mcp.js
@@ -21,7 +21,8 @@
  */
 
 import { createInterface } from 'node:readline';
-import { relative } from 'node:path';
+import { relative, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
 
 import {
   resolveDocsLocation,
@@ -35,6 +36,29 @@ import {
 import { resolveFrameworkRoots, runSourceTool } from './mcp-source.js';
 
 const PROTOCOL_VERSION = '2024-11-05';
+
+/**
+ * Best-effort path to Bun's global install cache, for the zero-install `source`
+ * fallback (#687): under Bun zero-install an app has no `node_modules`, so
+ * `@webjsdev/*` lives only in this cache. Prefers `bun pm cache` (authoritative),
+ * then `$BUN_INSTALL/install/cache`, then `~/.bun/install/cache`. Returns null
+ * when none exists (e.g. Bun is not installed), which leaves the tool on the
+ * node_modules path with no behavior change.
+ * @param {(p: string) => boolean} exists
+ * @returns {string | null}
+ */
+function resolveBunCacheDir(exists) {
+  try {
+    const out = spawnSync('bun', ['pm', 'cache'], { encoding: 'utf8' });
+    const dir = out && out.status === 0 && out.stdout ? out.stdout.trim() : '';
+    if (dir && exists(dir)) return dir;
+  } catch { /* bun not on PATH */ }
+  const candidates = [];
+  if (process.env.BUN_INSTALL) candidates.push(join(process.env.BUN_INSTALL, 'install', 'cache'));
+  if (process.env.HOME) candidates.push(join(process.env.HOME, '.bun', 'install', 'cache'));
+  for (const c of candidates) { if (exists(c)) return c; }
+  return null;
+}
 
 // Mirrors packages/server/src/action-config.js. A drift test in
 // packages/mcp/test/mcp.test.mjs asserts these stay in sync with the source.
@@ -485,7 +509,7 @@ export async function runMcpServer(opts) {
     const { readdirSync, existsSync, realpathSync } = await import('node:fs');
     const readdir = (d) => readdirSync(d, { withFileTypes: true }).map((e) => ({ name: e.name, isDir: e.isDirectory() }));
     sourceDeps = {
-      roots: resolveFrameworkRoots(cwd, { exists: existsSync }),
+      roots: resolveFrameworkRoots(cwd, { exists: existsSync, readdir, bunCacheDir: resolveBunCacheDir(existsSync) }),
       readFile,
       readdir,
       realpath: realpathSync,

--- a/packages/mcp/test/mcp-source.test.mjs
+++ b/packages/mcp/test/mcp-source.test.mjs
@@ -196,6 +196,22 @@ test('resolveFrameworkRoots: cache version pick is semver-aware (0.10.0 > 0.9.0)
   assert.equal(roots[0].root, join(scope, 'cli@0.10.0@@@1'), '0.10.0 beats 0.9.0 (numeric, not lexical)');
 });
 
+test('resolveFrameworkRoots: a release outranks its prerelease (1.0.0 > 1.0.0-rc.1)', () => {
+  const cache = join('/fakebun', 'cache');
+  const scope = join(cache, '@webjsdev');
+  const present = new Set([
+    scope,
+    join(scope, 'core@1.0.0@@@1', 'package.json'),
+    join(scope, 'core@1.0.0@@@1', 'src'),
+  ]);
+  const exists = (p) => present.has(p);
+  const readdir = (d) => (d === scope
+    ? [{ name: 'core@1.0.0-rc.1@@@1', isDir: true }, { name: 'core@1.0.0@@@1', isDir: true }]
+    : []);
+  const roots = resolveFrameworkRoots('/some/app', { exists, readdir, bunCacheDir: cache });
+  assert.equal(roots[0].root, join(scope, 'core@1.0.0@@@1'), 'the release wins over its prerelease');
+});
+
 test('resolveFrameworkRoots: bunCacheDir set but no @webjsdev scope yields nothing (no throw)', () => {
   // The cache dir exists but holds no @webjsdev packages: empty, not an error.
   const roots = resolveFrameworkRoots('/some/app', { exists: () => false, readdir: () => [], bunCacheDir: '/empty/cache' });

--- a/packages/mcp/test/mcp-source.test.mjs
+++ b/packages/mcp/test/mcp-source.test.mjs
@@ -155,3 +155,33 @@ test('resolveFrameworkRoots: fail-soft when nothing resolves', () => {
   const roots = resolveFrameworkRoots('/nonexistent-xyz', { exists: () => false });
   assert.deepEqual(roots, []);
 });
+
+test('resolveFrameworkRoots: zero-install fallback finds a package in the Bun cache (#687)', () => {
+  // No node_modules anywhere (every search-path base is absent), but the Bun
+  // global cache holds @webjsdev/core@<ver>@@@<n>/ with its source.
+  const cache = join('/fakebun', 'cache');
+  const scope = join(cache, '@webjsdev');
+  const present = new Set([
+    scope,
+    join(scope, 'core@1.0.0@@@1', 'package.json'),
+    join(scope, 'core@1.0.0@@@1', 'src'),
+  ]);
+  const exists = (p) => present.has(p); // all node_modules bases absent
+  const readdir = (d) => (d === scope
+    ? [
+        { name: 'core@0.9.0@@@1', isDir: true },
+        { name: 'core@1.0.0@@@1', isDir: true },
+        { name: 'core', isDir: true }, // unversioned metadata dir, skipped
+      ]
+    : []);
+  const roots = resolveFrameworkRoots('/some/app', { exists, readdir, bunCacheDir: cache });
+  assert.deepEqual(roots.map((r) => r.pkg), ['core'], 'only core is in the cache');
+  assert.equal(roots[0].root, join(scope, 'core@1.0.0@@@1'), 'picks the highest cached version');
+  assert.match(roots[0].src, /core@1\.0\.0@@@1[/\\]src$/);
+});
+
+test('resolveFrameworkRoots: no cache fallback when bunCacheDir/readdir are absent', () => {
+  // Omitting the cache deps keeps the original node_modules-only behavior.
+  const roots = resolveFrameworkRoots('/nonexistent-xyz', { exists: () => false });
+  assert.deepEqual(roots, []);
+});

--- a/packages/mcp/test/mcp-source.test.mjs
+++ b/packages/mcp/test/mcp-source.test.mjs
@@ -180,8 +180,24 @@ test('resolveFrameworkRoots: zero-install fallback finds a package in the Bun ca
   assert.match(roots[0].src, /core@1\.0\.0@@@1[/\\]src$/);
 });
 
-test('resolveFrameworkRoots: no cache fallback when bunCacheDir/readdir are absent', () => {
-  // Omitting the cache deps keeps the original node_modules-only behavior.
-  const roots = resolveFrameworkRoots('/nonexistent-xyz', { exists: () => false });
+test('resolveFrameworkRoots: cache version pick is semver-aware (0.10.0 > 0.9.0)', () => {
+  const cache = join('/fakebun', 'cache');
+  const scope = join(cache, '@webjsdev');
+  const present = new Set([
+    scope,
+    join(scope, 'cli@0.10.0@@@1', 'package.json'),
+    join(scope, 'cli@0.10.0@@@1', 'lib'),
+  ]);
+  const exists = (p) => present.has(p);
+  const readdir = (d) => (d === scope
+    ? [{ name: 'cli@0.9.0@@@1', isDir: true }, { name: 'cli@0.10.0@@@1', isDir: true }]
+    : []);
+  const roots = resolveFrameworkRoots('/some/app', { exists, readdir, bunCacheDir: cache });
+  assert.equal(roots[0].root, join(scope, 'cli@0.10.0@@@1'), '0.10.0 beats 0.9.0 (numeric, not lexical)');
+});
+
+test('resolveFrameworkRoots: bunCacheDir set but no @webjsdev scope yields nothing (no throw)', () => {
+  // The cache dir exists but holds no @webjsdev packages: empty, not an error.
+  const roots = resolveFrameworkRoots('/some/app', { exists: () => false, readdir: () => [], bunCacheDir: '/empty/cache' });
   assert.deepEqual(roots, []);
 });


### PR DESCRIPTION
Closes #687

The MCP `source` tool walked `node_modules` to find `@webjsdev/*/src`, so under Bun zero-install (no `node_modules`, #675) it returned an empty package list. Adds a Bun-global-cache fallback (`<cache>/@webjsdev/<pkg>@<ver>@@@<n>/`) when the node_modules walk finds nothing; the cache dir is resolved via `bun pm cache`. No Bun => unchanged.

Proven in a Bun sprite: node_modules removed, the tool resolves core/server/cli/ui from the cache. 11/11 mcp-source + 57/57 full mcp suite green.

https://claude.ai/code/session_01WnvcTojG7tYqmnmf4enSv3