### PR TITLE
chore: release core 0.7.26, server 0.8.36, mcp 0.1.5

### DIFF
--- a/changelog/core/0.7.26.md
+++ b/changelog/core/0.7.26.md
@@ -1,0 +1,11 @@
+---
+package: "@webjsdev/core"
+version: 0.7.26
+date: 2026-06-24T12:25:47.548Z
+commit_count: 1
+---
+## Features
+
+- **Add the `webjs.pin` config key to the `WebjsConfig` type** ([#686](https://github.com/webjsdev/webjs/pull/686)) [`df2b03e8`](https://github.com/webjsdev/webjs/commit/df2b03e8)
+
+  Declares the Bun zero-install version-pinning switch (`webjs.pin`, default true) in the typed config, so the config object accepts it. The pinning behavior itself ships in `@webjsdev/server` (#685).

--- a/changelog/mcp/0.1.5.md
+++ b/changelog/mcp/0.1.5.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/mcp"
+version: 0.1.5
+date: 2026-06-24T12:25:47.663Z
+commit_count: 1
+---
+## Fixes
+
+- **source tool resolves @webjsdev from the Bun cache under zero-install** ([#688](https://github.com/webjsdev/webjs/pull/688)) [`8505e82b`](https://github.com/webjsdev/webjs/commit/8505e82b)
+  * fix(mcp): source tool resolves @webjsdev from Bun cache under zero-install (#687)
+  
+  The source tool's resolveFrameworkRoots walked the require.resolve node_modules
+  dirs, so under Bun zero-install (no node_modules, #675) it found nothing and

--- a/changelog/server/0.8.36.md
+++ b/changelog/server/0.8.36.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/server"
+version: 0.8.36
+date: 2026-06-24T12:25:47.572Z
+commit_count: 1
+---
+## Features
+
+- **pin Bun zero-install deps via an onLoad specifier-rewrite from package.json** ([#686](https://github.com/webjsdev/webjs/pull/686)) [`df2b03e8`](https://github.com/webjsdev/webjs/commit/df2b03e8)
+  * feat(server): add the bun zero-install specifier-pin transform core (#685)
+  
+  The runtime-neutral core that rewrites bare import specifiers of declared deps
+  to inline-versioned (name@version), so Bun auto-install fetches the pinned

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.25",
+  "version": "0.7.26",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/mcp",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "description": "The webjs Model Context Protocol server: live app introspection (routes / actions / components / check) plus the framework knowledge layer (docs, recipes, source) for AI coding agents",
   "bin": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.35",
+  "version": "0.8.36",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Cuts a release bundling the unreleased work since #678:

- **@webjsdev/server 0.8.36** (feat): Bun zero-install version pinning via the onLoad specifier-rewrite (#685).
- **@webjsdev/core 0.7.26** (feat): the `webjs.pin` config key on the `WebjsConfig` type (so the typed config accepts the switch the server feature reads).
- **@webjsdev/mcp 0.1.5** (fix): the `source` tool resolves `@webjsdev/*` from Bun's global cache under zero-install (#687).

cli / ui / intellisense unchanged, not bumped. Changelogs auto-generated by the pre-commit hook (core curated to its type-only change). Merging adds the changelog/**.md files, which triggers release.yml (npm publish + GitHub Releases).

https://claude.ai/code/session_01WnvcTojG7tYqmnmf4enSv3