### PR TITLE
chore: release cli 0.10.25

### DIFF
--- a/changelog/cli/0.10.25.md
+++ b/changelog/cli/0.10.25.md
@@ -1,0 +1,23 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.25
+date: 2026-06-24T19:18:59.843Z
+commit_count: 3
+---
+## Features
+
+- **pin Bun zero-install deps via an onLoad specifier-rewrite from package.json** ([#686](https://github.com/webjsdev/webjs/pull/686)) [`df2b03e8`](https://github.com/webjsdev/webjs/commit/df2b03e8)
+  * feat(server): add the bun zero-install specifier-pin transform core (#685)
+  
+  The runtime-neutral core that rewrites bare import specifiers of declared deps
+  to inline-versioned (name@version), so Bun auto-install fetches the pinned
+- **bun create skips install by default (zero-install dev); node unchanged** ([#691](https://github.com/webjsdev/webjs/pull/691)) [`24c5fb08`](https://github.com/webjsdev/webjs/commit/24c5fb08)
+  * feat(cli): bun create skips install by default (zero-install dev); node unchanged (#682)
+  
+  Per-runtime create-time install default: Node installs (needs node_modules to
+  run), Bun SKIPS (zero-install, 'bun run dev' resolves deps on the fly). A new
+- **exact-pin scaffold deps so npm and bun resolve identical versions (#692)** ([#693](https://github.com/webjsdev/webjs/pull/693)) [`236cecc4`](https://github.com/webjsdev/webjs/commit/236cecc4)
+  A bun zero-install scaffold resolves deps to absolute-latest (ignoring ranges,
+  #690), while npm install takes latest-in-range, so the two scaffolds diverged.
+  Worse, drizzle-orm's npm 'latest' tag is a 0.x line while the scaffold targets
+  the 1.0 relations-v2 RC, so bun pulled the WRONG major. Fix: exact-pin the

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.24",
+  "version": "0.10.25",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {


### PR DESCRIPTION
Release **@webjsdev/cli 0.10.25**. The only package with unreleased changes since #689 (core 0.7.26 / server 0.8.36 / mcp 0.1.5). core/server/mcp/ui/intellisense have no new commits.

### @webjsdev/cli 0.10.25 (3 feats)
- **#691**: `bun create` skips the install by default (zero-install dev); Node unchanged.
- **#693**: exact-pin scaffold deps so npm and bun resolve identical versions (also fixes the drizzle wrong-major bug).
- **#686**: the cli-side portion of the Bun zero-install specifier-pin (unreleased, since cli stayed 0.10.24 through #689).

Changelog `changelog/cli/0.10.25.md` generated by the pre-commit backfill. On merge, `release.yml` publishes `@webjsdev/cli@0.10.25` (plus the version-lockstep wrappers `create-webjs` / `webjsdev`) to npm.

https://claude.ai/code/session_01WnvcTojG7tYqmnmf4enSv3