### PR TITLE
fix: bun zero-install breaks spawned-subprocess commands (db/test/seed/typecheck); pin at the spawn layer

### DIFF
--- a/packages/server/src/bun-pin-preload.js
+++ b/packages/server/src/bun-pin-preload.js
@@ -1,0 +1,24 @@
+/**
+ * Bun `--preload` entry that registers the #685 inline-pin `onLoad` for a
+ * SPAWNED subprocess (drizzle-kit via `webjs db`, `bun test`, the app's `tsc`,
+ * a dev task, etc.), so the subprocess's bare dependency imports resolve the
+ * package.json-pinned version instead of `latest`.
+ *
+ * Why this is needed: Bun's runtime auto-install forces a BARE import (`import
+ * 'drizzle-orm'`) to the `latest` dist-tag, ignoring package.json, when there is
+ * no `node_modules` (a confirmed Bun bug, oven-sh/bun#21832: the resolver's
+ * `with_auto_version` substitutes `latest` for an empty inline version). The
+ * webjs server already works around this by rewriting bare imports to inline
+ * EXACT specifiers (#685) in its own process. A tool webjs SPAWNS runs in a
+ * fresh Bun process with no such hook, so it hits the bug directly and pulls the
+ * wrong major. Passing this module to `bun --preload` installs the same rewrite
+ * in that process BEFORE the tool's entry loads.
+ *
+ * Pin-only: SSR action-result seeding (#472) is the server's concern and is left
+ * off here. `process.cwd()` is the app root (the spawn sets `cwd`). On Node this
+ * is a no-op (the inline-version pin is Bun-specific and seeding is off), so the
+ * same `--preload` is harmless if ever used cross-runtime.
+ */
+import { registerSeedHooks } from './action-seed.js';
+
+await registerSeedHooks({ appDir: process.cwd(), seedEnabled: false, pinEnabled: true });


### PR DESCRIPTION
Closes #695

Bun runtime auto-install forces a bare import to `latest`, ignoring package.json (confirmed bug oven-sh/bun#21832; see #690 for the source-of-truth research). #685 fixes this in the webjs server process, but every command that SPAWNS a tool (`webjs db`, `db seed`, `test --server/--browser`, `typecheck`, dev tasks) runs a fresh bun process with no hook, so it pulls the wrong major.

This fixes it at the spawn layer: a shared bun-aware spawn helper injects `--preload <pin-registrar>` (the #685 mechanism, verified to work in a spawned process) and pins `resolveBin` tool versions, so all current and future bun-loaded subprocess commands are covered by construction.

WIP. Building incrementally: registrar (done) -> bin-version pin -> shared spawn helper -> wire db/test/typecheck/seed -> tests + docs.

https://claude.ai/code/session_01WnvcTojG7tYqmnmf4enSv3