### PR TITLE
chore: release server 0.8.37, cli 0.10.26

### DIFF
--- a/changelog/cli/0.10.26.md
+++ b/changelog/cli/0.10.26.md
@@ -2,15 +2,10 @@
 package: "@webjsdev/cli"
 version: 0.10.26
 date: 2026-06-25T09:43:53.360Z
-commit_count: 2
+commit_count: 1
 ---
 ## Features
 
-- **forward inline-safe ranges in the bun zero-install pin rewrite** ([#698](https://github.com/webjsdev/webjs/pull/698)) [`143c82a7`](https://github.com/webjsdev/webjs/commit/143c82a7)
-  * feat: forward inline-safe ranges in the bun zero-install pin rewrite
-  
-  Bun's runtime auto-install ignores package.json for a bare import (it
-  fetches latest), so webjs rewrites a declared dep's specifier to an
 - **scaffold @webjsdev/* and pg as caret ranges, keep drizzle exact** ([#702](https://github.com/webjsdev/webjs/pull/702)) [`dce30f01`](https://github.com/webjsdev/webjs/commit/dce30f01)
   * feat: scaffold @webjsdev/* and pg as caret ranges, keep drizzle exact
   

--- a/changelog/cli/0.10.26.md
+++ b/changelog/cli/0.10.26.md
@@ -1,0 +1,18 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.26
+date: 2026-06-25T09:43:53.360Z
+commit_count: 2
+---
+## Features
+
+- **forward inline-safe ranges in the bun zero-install pin rewrite** ([#698](https://github.com/webjsdev/webjs/pull/698)) [`143c82a7`](https://github.com/webjsdev/webjs/commit/143c82a7)
+  * feat: forward inline-safe ranges in the bun zero-install pin rewrite
+  
+  Bun's runtime auto-install ignores package.json for a bare import (it
+  fetches latest), so webjs rewrites a declared dep's specifier to an
+- **scaffold @webjsdev/* and pg as caret ranges, keep drizzle exact** ([#702](https://github.com/webjsdev/webjs/pull/702)) [`dce30f01`](https://github.com/webjsdev/webjs/commit/dce30f01)
+  * feat: scaffold @webjsdev/* and pg as caret ranges, keep drizzle exact
+  
+  #692 pinned the scaffold's deps exact because a bun zero-install range
+  resolved to absolute latest. #698 fixed that (a normal caret resolves the

--- a/changelog/server/0.8.37.md
+++ b/changelog/server/0.8.37.md
@@ -1,0 +1,26 @@
+---
+package: "@webjsdev/server"
+version: 0.8.37
+date: 2026-06-25T09:43:53.299Z
+commit_count: 3
+---
+## Features
+
+- **forward inline-safe ranges in the bun zero-install pin rewrite** ([#698](https://github.com/webjsdev/webjs/pull/698)) [`143c82a7`](https://github.com/webjsdev/webjs/commit/143c82a7)
+  * feat: forward inline-safe ranges in the bun zero-install pin rewrite
+  
+  Bun's runtime auto-install ignores package.json for a bare import (it
+  fetches latest), so webjs rewrites a declared dep's specifier to an
+- **share the server's resolved dep versions with the zero-install importmap** ([#701](https://github.com/webjsdev/webjs/pull/701)) [`a7a654da`](https://github.com/webjsdev/webjs/commit/a7a654da)
+  * feat: share the server's resolved dep versions with the zero-install importmap
+  
+  Under Bun zero-install (no node_modules) getPackageVersion (require.resolve)
+  finds nothing, so vendorImportMapEntries dropped the vendor entry and a
+
+## Fixes
+
+- **don't forward a caret-prerelease range in the bun pin rewrite** ([#706](https://github.com/webjsdev/webjs/pull/706)) [`c6a20525`](https://github.com/webjsdev/webjs/commit/c6a20525)
+  isInlineableVersion (#698) accepted a range operator combined with a
+  prerelease suffix (^1.0.0-rc.3), which the rewrite then forwarded as an
+  inline specifier. But bun zero-install ENOENTs on a caret-prerelease
+  (verified: drizzle-orm@^1.0.0-rc.3 errors, the exact 1.0.0-rc.3 resolves),

--- a/package-lock.json
+++ b/package-lock.json
@@ -6975,7 +6975,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.24",
+      "version": "0.10.26",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -6991,7 +6991,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.25",
+      "version": "0.7.26",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.25.0"
@@ -7025,7 +7025,7 @@
     },
     "packages/mcp": {
       "name": "@webjsdev/mcp",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/server": "^0.8.0"
@@ -7039,7 +7039,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.35",
+      "version": "0.8.37",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.25",
+  "version": "0.10.26",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.36",
+  "version": "0.8.37",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Batched release for the bun zero-install version-resolution work.

## @webjsdev/server 0.8.37 (patch)
- feat: forward inline-safe ranges in the bun zero-install pin rewrite (#698)
- feat: share the server's resolved dep versions with the zero-install importmap (#699 via #701)
- fix: don't forward a caret-prerelease range in the bun pin rewrite (#703 via #706)

## @webjsdev/cli 0.10.26 (patch)
- feat: scaffold @webjsdev/* and pg as caret ranges, keep drizzle exact (#700 via #702)

## Notes
- Both are patch bumps within their existing minor line; every in-repo dependent pins `^0.8.0` / `^0.10.0`, so no dependent ranges need widening.
- `package-lock.json` regenerated (it also synced a pre-existing stale lock for core 0.7.26 / mcp 0.1.5).
- The cli changelog was hand-corrected to drop #698 (a server feat that only touched a cli template doc, so the generator mis-attributed it by tree-touch); cli's real change is #702.
- Merging this adds the `changelog/**.md` files to main, which triggers `release.yml` to npm-publish @webjsdev/server@0.8.37 and @webjsdev/cli@0.10.26 and cut the GitHub Releases.