### PR TITLE
fix: pin the cli's @webjsdev/* imports under bun zero-install

### DIFF
--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -104,8 +104,8 @@ lib/
                          `webjs-bun.mjs` bootstrap under `--bun` (#675), so Bun
                          auto-install resolves deps and a Bun app serves with no
                          `bun install`. The cli pins its own `@webjsdev/*`
-                         imports to the app-declared version under zero-install
-                         (`importWebjsdev`, #709), since a bare
+                         imports to the app-declared (else the cli's own) version
+                         under zero-install (`importWebjsdev`, #709), since a bare
                          `import('@webjsdev/server')` would otherwise ENOENT
                          (Bun's auto-install ignores the cli's range and flakily
                          fetches latest). The test/check/typecheck tooling stays

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -103,7 +103,12 @@ lib/
                          dev/start/db SCRIPTS run through a generated
                          `webjs-bun.mjs` bootstrap under `--bun` (#675), so Bun
                          auto-install resolves deps and a Bun app serves with no
-                         `bun install`; the test/check/typecheck tooling stays
+                         `bun install`. The cli pins its own `@webjsdev/*`
+                         imports to the app-declared version under zero-install
+                         (`importWebjsdev`, #709), since a bare
+                         `import('@webjsdev/server')` would otherwise ENOENT
+                         (Bun's auto-install ignores the cli's range and flakily
+                         fetches latest). The test/check/typecheck tooling stays
                          plain `webjs` on Node (spawns `node --test` / tsc) and
                          still expects an install.
                          No parallel bun template, so no drift. compose.yaml is

--- a/packages/cli/bin/webjs.js
+++ b/packages/cli/bin/webjs.js
@@ -6,6 +6,7 @@ import { resolveBin } from '../lib/resolve-bin.js';
 import { checkNodeInline, nodeInlineMessage } from '../lib/node-preflight.js';
 import { loadAppEnv, resolvePort } from '../lib/port.js';
 import { planDevSupervisor } from '../lib/dev-supervisor.js';
+import { importWebjsdev } from '../lib/import-webjsdev.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const [cmd, ...rest] = process.argv.slice(2);
@@ -121,7 +122,7 @@ async function main() {
   // instead of crashing cryptically later. `help` is exempt so a user on an
   // old Node can still read usage.
   if (cmd !== 'help' && cmd !== undefined) {
-    const { assertNodeVersion } = await import('@webjsdev/server');
+    const { assertNodeVersion } = await importWebjsdev('@webjsdev/server');
     assertNodeVersion({ onFail: 'exit' });
   }
   switch (cmd) {
@@ -129,7 +130,7 @@ async function main() {
       // If we're already inside the reload child (node --watch or bun --hot),
       // start the server directly.
       if (process.env.__WEBJS_DEV_CHILD === '1') {
-        const { startServer } = await import('@webjsdev/server');
+        const { startServer } = await importWebjsdev('@webjsdev/server');
         // Load `.env` BEFORE resolving the port so a `PORT` set there is in
         // process.env at resolution time (#447). The server loads `.env`
         // too, but that runs too late to affect the port the CLI computes.
@@ -165,7 +166,7 @@ async function main() {
       });
 
       if (plan.mode === 'inline') {
-        const { startServer } = await import('@webjsdev/server');
+        const { startServer } = await importWebjsdev('@webjsdev/server');
         loadAppEnv(process.cwd());
         const port = resolvePort(flag(rest, '--port'));
         await startServer({ appDir: process.cwd(), port, dev: true });
@@ -182,7 +183,7 @@ async function main() {
       break;
     }
     case 'start': {
-      const { startServer } = await import('@webjsdev/server');
+      const { startServer } = await importWebjsdev('@webjsdev/server');
       // Load `.env` BEFORE resolving the port so a `PORT` set there wins over
       // the 8080 default (#447), same as for `dev`.
       loadAppEnv(process.cwd());
@@ -364,7 +365,7 @@ async function main() {
       break;
     }
     case 'check': {
-      const { checkConventions, RULES } = await import('@webjsdev/server/check');
+      const { checkConventions, RULES } = await importWebjsdev('@webjsdev/server/check');
 
       if (rest.includes('--rules')) {
         console.log('webjs check, correctness rules:');
@@ -390,7 +391,7 @@ async function main() {
       if (rest.includes('--json')) {
         // The projector lives in @webjsdev/mcp (the MCP `check` tool's home),
         // so `check --json` and the MCP tool stay byte-identical (#415).
-        const { projectCheck } = await import('@webjsdev/mcp/check-report');
+        const { projectCheck } = await importWebjsdev('@webjsdev/mcp/check-report');
         console.log(JSON.stringify(projectCheck(violations)));
         if (violations.length > 0) process.exit(1);
         break;
@@ -447,7 +448,7 @@ async function main() {
       // narrowing the @webjsdev/core `Route` href union + per-route `params`.
       // Opt-in codegen: the static types in @webjsdev/core work without it
       // (un-generated apps see `Route = string`).
-      const { generateRouteTypes } = await import('@webjsdev/server');
+      const { generateRouteTypes } = await importWebjsdev('@webjsdev/server');
       const { mkdir, writeFile } = await import('node:fs/promises');
       const appDir = process.cwd();
       const text = await generateRouteTypes(appDir);
@@ -545,7 +546,7 @@ Full docs: https://docs.webjs.com`);
       const sub = rest[0];
       const args = rest.slice(1);
       const appDir = process.cwd();
-      const { pinAll, unpinPackage, listPinned, auditPinned, findOutdated, updatePinned, readPinFile, ensureVendorCommittable, SUPPORTED_PROVIDERS } = await import('@webjsdev/server');
+      const { pinAll, unpinPackage, listPinned, auditPinned, findOutdated, updatePinned, readPinFile, ensureVendorCommittable, SUPPORTED_PROVIDERS } = await importWebjsdev('@webjsdev/server');
 
       // Parse `--from <provider>` once at the top so subcommands share it.
       // Mirrors importmap-rails's `bin/importmap pin foo --from jsdelivr`.
@@ -808,7 +809,7 @@ Full docs: https://docs.webjs.com`);
       // runnable directly as `npx @webjsdev/mcp`); `webjs mcp` delegates to it
       // for back-compat. The version advertised in the initialize handshake is
       // @webjsdev/mcp's own, resolved by its bin, so this passes none.
-      const { runMcpServer } = await import('@webjsdev/mcp');
+      const { runMcpServer } = await importWebjsdev('@webjsdev/mcp');
       const { createRequire } = await import('node:module');
       const require = createRequire(import.meta.url);
       let version = '0.0.0';

--- a/packages/cli/lib/import-webjsdev.js
+++ b/packages/cli/lib/import-webjsdev.js
@@ -8,7 +8,12 @@
 // only when the bare import fails, so Node and installed apps are unaffected.
 
 import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// The cli's OWN package.json (one level up from this lib), used as the fallback
+// pin source for `@webjsdev/*` packages the app does not declare (mcp, ui).
+const CLI_PKG = join(dirname(fileURLToPath(import.meta.url)), '..', 'package.json');
 
 /**
  * Whether a declared version is a Bun inline-safe specifier: an exact version or
@@ -25,15 +30,15 @@ export function inlineSafeVersion(v) {
 }
 
 /**
- * The version the app's `package.json` (in `cwd`) declares for `name`, when it
- * is inline-safe; else null.
+ * The version a `package.json` at `pkgPath` declares for `name`, when it is
+ * inline-safe; else null.
  * @param {string} name
- * @param {string} [cwd]
+ * @param {string} pkgPath  absolute path to a package.json
  * @returns {string | null}
  */
-export function appDeclaredVersion(name, cwd = process.cwd()) {
+function declaredIn(name, pkgPath) {
   try {
-    const pkg = JSON.parse(readFileSync(join(cwd, 'package.json'), 'utf8'));
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
     const v = { ...pkg.dependencies, ...pkg.devDependencies }[name];
     if (inlineSafeVersion(v)) return v;
   } catch { /* no readable package.json */ }
@@ -41,10 +46,37 @@ export function appDeclaredVersion(name, cwd = process.cwd()) {
 }
 
 /**
+ * The inline-safe version to pin `name` to: the app's `package.json` (in `cwd`)
+ * first (it declares `@webjsdev/server` etc.), else the cli's OWN package.json
+ * (for `@webjsdev/*` the app does not declare, like `mcp` / `ui`). Null if
+ * neither has an inline-safe declaration.
+ * @param {string} name
+ * @param {string} [cwd]
+ * @returns {string | null}
+ */
+export function appDeclaredVersion(name, cwd = process.cwd()) {
+  return declaredIn(name, join(cwd, 'package.json')) || declaredIn(name, CLI_PKG);
+}
+
+/**
+ * Whether an import error is a resolution / not-found failure (so a version
+ * retry is warranted), vs a genuine load-time throw from the module's own code
+ * (which we must NOT retry, to avoid masking it and re-running side effects).
+ * @param {unknown} err
+ * @returns {boolean}
+ */
+function isResolutionError(err) {
+  if (err && /** @type {any} */ (err).code === 'ERR_MODULE_NOT_FOUND') return true;
+  const msg = err && String(/** @type {any} */ (err).message || err);
+  return !!msg && /ENOENT|cannot find|cannot resolve|resolving package|module not found/i.test(msg);
+}
+
+/**
  * Import an `@webjsdev/*` module, pinning the version under Bun zero-install. On
  * Node or an installed app the bare specifier resolves from `node_modules` (no
- * retry). On a bare-import failure (Bun zero-install), retry with the app's
- * declared version inline. A subpath (`/check`) is preserved across the rewrite.
+ * retry). On a RESOLUTION failure (Bun zero-install), retry with the app's (else
+ * the cli's own) declared version inline. A real load-time throw is rethrown,
+ * not retried. A subpath (`/check`) is preserved across the rewrite.
  * @param {string} spec  e.g. `@webjsdev/server` or `@webjsdev/server/check`
  * @param {(s: string) => Promise<any>} [importer]  injectable for tests
  * @returns {Promise<any>}
@@ -53,6 +85,7 @@ export async function importWebjsdev(spec, importer = (s) => import(s)) {
   try {
     return await importer(spec);
   } catch (err) {
+    if (!isResolutionError(err)) throw err;
     const m = /^(@webjsdev\/[^/]+)(\/.*)?$/.exec(spec);
     const pkg = m && m[1];
     const sub = (m && m[2]) || '';

--- a/packages/cli/lib/import-webjsdev.js
+++ b/packages/cli/lib/import-webjsdev.js
@@ -68,7 +68,10 @@ export function appDeclaredVersion(name, cwd = process.cwd()) {
 function isResolutionError(err) {
   if (err && /** @type {any} */ (err).code === 'ERR_MODULE_NOT_FOUND') return true;
   const msg = err && String(/** @type {any} */ (err).message || err);
-  return !!msg && /ENOENT|cannot find|cannot resolve|resolving package|module not found/i.test(msg);
+  // Narrow on purpose: Node sets the code above; Bun's auto-install miss is
+  // `ENOENT while resolving package '...'`. A broad "cannot find" would match
+  // ordinary runtime errors ("Cannot find user") and wrongly trigger a retry.
+  return !!msg && /ENOENT|resolving package|module not found/i.test(msg);
 }
 
 /**

--- a/packages/cli/lib/import-webjsdev.js
+++ b/packages/cli/lib/import-webjsdev.js
@@ -1,0 +1,63 @@
+// Pin `@webjsdev/*` imports under Bun zero-install (#709).
+//
+// Under Bun zero-install a bare `import('@webjsdev/server')` from the cli (run
+// out of the global cache) ENOENTs: Bun's runtime auto-install ignores the cli's
+// declared range and flakily fetches latest, which fails. An INLINE-versioned
+// specifier (`@webjsdev/server@^0.8.0`) resolves reliably. So we read the version
+// the APP declares (the scaffold adds `@webjsdev/*` to its deps) and retry inline
+// only when the bare import fails, so Node and installed apps are unaffected.
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Whether a declared version is a Bun inline-safe specifier: an exact version or
+ * a single caret / tilde / comparator range, but NOT a range over a prerelease
+ * (`^1.0.0-rc.3`, which Bun ENOENTs on, #703), a wildcard, a multi-token range,
+ * or a protocol range (`workspace:` / `file:`).
+ * @param {unknown} v
+ * @returns {boolean}
+ */
+export function inlineSafeVersion(v) {
+  if (typeof v !== 'string') return false;
+  const m = /^(>=|<=|>|<|=|\^|~)?(\d+(?:\.\d+){0,2})([-+][0-9A-Za-z.-]+)?$/.exec(v);
+  return !!m && !(m[1] && m[3]);
+}
+
+/**
+ * The version the app's `package.json` (in `cwd`) declares for `name`, when it
+ * is inline-safe; else null.
+ * @param {string} name
+ * @param {string} [cwd]
+ * @returns {string | null}
+ */
+export function appDeclaredVersion(name, cwd = process.cwd()) {
+  try {
+    const pkg = JSON.parse(readFileSync(join(cwd, 'package.json'), 'utf8'));
+    const v = { ...pkg.dependencies, ...pkg.devDependencies }[name];
+    if (inlineSafeVersion(v)) return v;
+  } catch { /* no readable package.json */ }
+  return null;
+}
+
+/**
+ * Import an `@webjsdev/*` module, pinning the version under Bun zero-install. On
+ * Node or an installed app the bare specifier resolves from `node_modules` (no
+ * retry). On a bare-import failure (Bun zero-install), retry with the app's
+ * declared version inline. A subpath (`/check`) is preserved across the rewrite.
+ * @param {string} spec  e.g. `@webjsdev/server` or `@webjsdev/server/check`
+ * @param {(s: string) => Promise<any>} [importer]  injectable for tests
+ * @returns {Promise<any>}
+ */
+export async function importWebjsdev(spec, importer = (s) => import(s)) {
+  try {
+    return await importer(spec);
+  } catch (err) {
+    const m = /^(@webjsdev\/[^/]+)(\/.*)?$/.exec(spec);
+    const pkg = m && m[1];
+    const sub = (m && m[2]) || '';
+    const v = pkg && appDeclaredVersion(pkg);
+    if (v) return await importer(pkg + '@' + v + sub);
+    throw err;
+  }
+}

--- a/packages/cli/test/import-webjsdev/import-webjsdev.test.mjs
+++ b/packages/cli/test/import-webjsdev/import-webjsdev.test.mjs
@@ -13,14 +13,17 @@ test('inlineSafeVersion: accepts exact + single range, rejects caret-prerelease/
   for (const v of ['^1.0.0-rc.3', '*', 'x', 'latest', 'workspace:*', 'file:../x', '>=1 <2', '']) assert.equal(inlineSafeVersion(v), false, v);
 });
 
-test('appDeclaredVersion: reads the cwd package.json dep, returns null when missing/unsafe', () => {
+test('appDeclaredVersion: app pkg first, then the cli pkg fallback, null when neither', () => {
   const dir = mkdtempSync(join(tmpdir(), 'webjs-iw-'));
   writeFileSync(join(dir, 'package.json'), JSON.stringify({
     dependencies: { '@webjsdev/server': '^0.8.0', local: 'workspace:*' },
   }));
-  assert.equal(appDeclaredVersion('@webjsdev/server', dir), '^0.8.0');
+  assert.equal(appDeclaredVersion('@webjsdev/server', dir), '^0.8.0', 'app declares it -> app version');
   assert.equal(appDeclaredVersion('local', dir), null, 'workspace: is not inline-safe');
-  assert.equal(appDeclaredVersion('@webjsdev/missing', dir), null);
+  // @webjsdev/mcp is NOT in the app deps, but the cli's own package.json declares
+  // it, so the fallback supplies the cli-declared range (covers webjs mcp / check --json).
+  assert.match(appDeclaredVersion('@webjsdev/mcp', dir) || '', /^[\^~]?\d/, 'cli-own fallback for an undeclared @webjsdev/* dep');
+  assert.equal(appDeclaredVersion('@webjsdev/does-not-exist', dir), null, 'neither declares it -> null');
 });
 
 test('importWebjsdev: bare success returns it, no retry', async () => {
@@ -41,12 +44,26 @@ test('importWebjsdev: bare ENOENT retries with the app-declared inline version (
   assert.deepEqual(r, { ok: '@webjsdev/server@^0.8.0/check' });
 });
 
-test('importWebjsdev: bare ENOENT with no declared version rethrows', async (t) => {
+test('importWebjsdev: a non-resolution (load-time) throw is rethrown WITHOUT a retry', async (t) => {
   const cwd = mkdtempSync(join(tmpdir(), 'webjs-iw3-'));
+  writeFileSync(join(cwd, 'package.json'), JSON.stringify({ dependencies: { '@webjsdev/server': '^0.8.0' } }));
+  t.mock.method(process, 'cwd', () => cwd);
+  let calls = 0;
+  // A real error from inside the module's eval (not ENOENT): must NOT retry, or
+  // it would re-run the module's side effects and mask the real error.
+  await assert.rejects(
+    importWebjsdev('@webjsdev/server', () => { calls++; return Promise.reject(new TypeError('x is not a function')); }),
+    /not a function/,
+  );
+  assert.equal(calls, 1, 'no retry on a non-resolution error');
+});
+
+test('importWebjsdev: a resolution error for a dep NEITHER app nor cli declares rethrows', async (t) => {
+  const cwd = mkdtempSync(join(tmpdir(), 'webjs-iw4-'));
   writeFileSync(join(cwd, 'package.json'), JSON.stringify({ dependencies: {} }));
   t.mock.method(process, 'cwd', () => cwd);
   await assert.rejects(
-    importWebjsdev('@webjsdev/server', () => Promise.reject(new Error('boom'))),
-    /boom/,
+    importWebjsdev('@webjsdev/does-not-exist', () => Promise.reject(new Error('ENOENT'))),
+    /ENOENT/,
   );
 });

--- a/packages/cli/test/import-webjsdev/import-webjsdev.test.mjs
+++ b/packages/cli/test/import-webjsdev/import-webjsdev.test.mjs
@@ -58,6 +58,18 @@ test('importWebjsdev: a non-resolution (load-time) throw is rethrown WITHOUT a r
   assert.equal(calls, 1, 'no retry on a non-resolution error');
 });
 
+test('importWebjsdev: a runtime "Cannot find ..." error is NOT mistaken for a resolution miss', async (t) => {
+  const cwd = mkdtempSync(join(tmpdir(), 'webjs-iw5-'));
+  writeFileSync(join(cwd, 'package.json'), JSON.stringify({ dependencies: { '@webjsdev/server': '^0.8.0' } }));
+  t.mock.method(process, 'cwd', () => cwd);
+  let calls = 0;
+  await assert.rejects(
+    importWebjsdev('@webjsdev/server', () => { calls++; return Promise.reject(new Error('Cannot find user in the database')); }),
+    /Cannot find user/,
+  );
+  assert.equal(calls, 1, 'a top-level "Cannot find ..." throw must not trigger a version retry');
+});
+
 test('importWebjsdev: a resolution error for a dep NEITHER app nor cli declares rethrows', async (t) => {
   const cwd = mkdtempSync(join(tmpdir(), 'webjs-iw4-'));
   writeFileSync(join(cwd, 'package.json'), JSON.stringify({ dependencies: {} }));

--- a/packages/cli/test/import-webjsdev/import-webjsdev.test.mjs
+++ b/packages/cli/test/import-webjsdev/import-webjsdev.test.mjs
@@ -1,0 +1,52 @@
+// #709: under Bun zero-install a bare @webjsdev/server import ENOENTs; the cli
+// retries with the version the app declares, inline. These test the pure logic
+// with an injected importer (no network).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { inlineSafeVersion, appDeclaredVersion, importWebjsdev } from '../../lib/import-webjsdev.js';
+
+test('inlineSafeVersion: accepts exact + single range, rejects caret-prerelease/wildcard/protocol', () => {
+  for (const v of ['0.8.37', '^0.8.0', '~0.8', '>=0.8.0', '1.0.0-rc.3']) assert.equal(inlineSafeVersion(v), true, v);
+  for (const v of ['^1.0.0-rc.3', '*', 'x', 'latest', 'workspace:*', 'file:../x', '>=1 <2', '']) assert.equal(inlineSafeVersion(v), false, v);
+});
+
+test('appDeclaredVersion: reads the cwd package.json dep, returns null when missing/unsafe', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'webjs-iw-'));
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({
+    dependencies: { '@webjsdev/server': '^0.8.0', local: 'workspace:*' },
+  }));
+  assert.equal(appDeclaredVersion('@webjsdev/server', dir), '^0.8.0');
+  assert.equal(appDeclaredVersion('local', dir), null, 'workspace: is not inline-safe');
+  assert.equal(appDeclaredVersion('@webjsdev/missing', dir), null);
+});
+
+test('importWebjsdev: bare success returns it, no retry', async () => {
+  let calls = 0;
+  const r = await importWebjsdev('@webjsdev/server', (s) => { calls++; return Promise.resolve({ spec: s }); });
+  assert.deepEqual(r, { spec: '@webjsdev/server' });
+  assert.equal(calls, 1, 'no retry on success');
+});
+
+test('importWebjsdev: bare ENOENT retries with the app-declared inline version (subpath preserved)', async (t) => {
+  const cwd = mkdtempSync(join(tmpdir(), 'webjs-iw2-'));
+  writeFileSync(join(cwd, 'package.json'), JSON.stringify({ dependencies: { '@webjsdev/server': '^0.8.0' } }));
+  t.mock.method(process, 'cwd', () => cwd);
+  const seen = [];
+  const importer = (s) => { seen.push(s); if (s.includes('@^') || s.includes('@0.')) return Promise.resolve({ ok: s }); return Promise.reject(new Error('ENOENT')); };
+  const r = await importWebjsdev('@webjsdev/server/check', importer);
+  assert.deepEqual(seen, ['@webjsdev/server/check', '@webjsdev/server@^0.8.0/check']);
+  assert.deepEqual(r, { ok: '@webjsdev/server@^0.8.0/check' });
+});
+
+test('importWebjsdev: bare ENOENT with no declared version rethrows', async (t) => {
+  const cwd = mkdtempSync(join(tmpdir(), 'webjs-iw3-'));
+  writeFileSync(join(cwd, 'package.json'), JSON.stringify({ dependencies: {} }));
+  t.mock.method(process, 'cwd', () => cwd);
+  await assert.rejects(
+    importWebjsdev('@webjsdev/server', () => Promise.reject(new Error('boom'))),
+    /boom/,
+  );
+});

--- a/packages/cli/test/node-preflight/node-preflight.test.js
+++ b/packages/cli/test/node-preflight/node-preflight.test.js
@@ -35,13 +35,16 @@ test('webjs.js imports @webjsdev/server dynamically, never statically (the guard
   // defeat the inline check on Node below 24.
   const { readFile } = await import('node:fs/promises');
   const { fileURLToPath } = await import('node:url');
-  const binPath = fileURLToPath(new URL('../../bin/webjs.js', import.meta.url));
-  const src = await readFile(binPath, 'utf8');
+  const src = await readFile(fileURLToPath(new URL('../../bin/webjs.js', import.meta.url)), 'utf8');
   // No static `import ... from '@webjsdev/server...'` (a dynamic await import is fine).
   const staticServerImport = /(^|\n)\s*import\b[^\n]*\bfrom\s*['"]@webjsdev\/server/;
   assert.equal(staticServerImport.test(src), false, 'webjs.js must not statically import @webjsdev/server');
-  // It DOES reach the server via a dynamic import.
-  assert.ok(/await\s+import\(\s*['"]@webjsdev\/server/.test(src), 'webjs.js should dynamically import @webjsdev/server');
+  // It reaches the server via the dynamic `importWebjsdev` helper (#709).
+  assert.ok(/await\s+importWebjsdev\(\s*['"]@webjsdev\/server/.test(src), 'webjs.js should reach @webjsdev/server via importWebjsdev');
+  // The guard moved into the helper, so it must NOT statically import the server
+  // either (a static import there would link-fail on old Node before the guard).
+  const helper = await readFile(fileURLToPath(new URL('../../lib/import-webjsdev.js', import.meta.url)), 'utf8');
+  assert.equal(staticServerImport.test(helper), false, 'import-webjsdev.js must not statically import @webjsdev/server');
 });
 
 test('checkNodeInline sources the minimum from the engines range', () => {


### PR DESCRIPTION
Closes #709

A fresh `bun create webjs my-app && bun run dev` (no install) ENOENTs: the cli, run from the bun global cache, does a bare `await import('@webjsdev/server')`, and bun's runtime auto-install ignores the cli's declared `^0.8.0` range, goes for *latest*, and **flakily fails to fetch it** -> ENOENT. The cached satisfying `0.8.36` is never considered (the range is ignored, #698 finding).

## Root cause (verified)
With `@webjsdev/server` cached, both the bare and the inline-exact import load fine (126 exports). The failure is purely the fetch of the bare-latest. An INLINE specifier (`@webjsdev/server@^0.8.0`) resolves reliably where the bare import does not, the same gap from #698.

## Fix
`importWebjsdev(spec)` (in `packages/cli/lib/import-webjsdev.js`): try the bare specifier (so Node and installed apps are unchanged), and on a RESOLUTION error retry with the version the APP declares inline (else the cli's OWN declared version, covering `@webjsdev/mcp` / `ui` which the app does not declare). A genuine load-time throw is rethrown, never retried. Subpaths (`/check`) preserved. The 9 bare `@webjsdev/*` import sites in `webjs.js` route through it. The cli's own package.json keeps its `^` ranges (no workspace-link break).

## Why not a bunfig preload
The issue floated a scaffold bunfig preload. I verified it works but it conflicts with the server's existing first-match-wins #685 onLoad (would starve the pin/seed) and has to be self-contained (chicken-and-egg, it cannot import @webjsdev/server). The try-bare-then-inline retry in the cli is simpler, with no onLoad conflict and no workspace-link break.

## Test plan
- Unit (`import-webjsdev.test.mjs`, 7 tests): inlineSafeVersion (#703-aware), appDeclaredVersion app-then-cli fallback, and importWebjsdev's bare-success / resolution-retry-inline (subpath preserved) / cli-own-fallback / non-resolution-rethrow / "Cannot find" not-retried paths, with an injected importer.
- Guard test (`node-preflight.test.js`) updated for the refactor (no static @webjsdev/server import in webjs.js OR the helper; reaches the server via the dynamic helper).
- Node regression: bare path unchanged when node_modules exists (verified: importWebjsdev resolves @webjsdev/server + /check, cli boots).
- End to end on a real fresh bun app: PENDING (needs the FIXED cli published; `bun create` pulls the published cli). The inline-resolution half is verified on Bun 1.3.14.
- Honest caveat (#705): the cold-cache fetch of `@webjsdev/server@^0.8.0` is still bun's auto-install path, far more reliable than the bare-latest fetch (an inline specifier resolves where bare does not), but not 100% guaranteed.
- Docs: updated packages/cli/AGENTS.md. The broader auto-install doc audit is #710.
- Dogfood: N/A because this is a cli-only change and the in-repo apps run on Node with node_modules, where the bare path is unchanged.

Relates to #698, #703, #704, #705, #710.
