### PR TITLE
chore: release cli 0.10.27

### DIFF
--- a/changelog/cli/0.10.27.md
+++ b/changelog/cli/0.10.27.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.27
+date: 2026-06-25T11:01:32.866Z
+commit_count: 1
+---
+## Fixes
+
+- **pin the cli's @webjsdev/* imports under bun zero-install** ([#711](https://github.com/webjsdev/webjs/pull/711)) [`5454ecb4`](https://github.com/webjsdev/webjs/commit/5454ecb4)
+  * fix: pin the cli's @webjsdev/* imports under bun zero-install (#709)
+  
+  A fresh bun zero-install `bun run dev` failed: the cli (run from the global
+  cache) does a bare `import('@webjsdev/server')`, and bun's runtime auto-install

--- a/package-lock.json
+++ b/package-lock.json
@@ -6975,7 +6975,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.26",
+      "version": "0.10.27",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.26",
+  "version": "0.10.27",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {


### PR DESCRIPTION
Patch release for the bun zero-install dev-bootstrap fix.

## @webjsdev/cli 0.10.26 -> 0.10.27 (patch)
- fix: pin the cli's @webjsdev/* imports under bun zero-install (#709 via #711)

This is the fix users actually need: until it ships, a fresh `bun create webjs && bun run dev` fails (the cached cli can't resolve @webjsdev/server). cli@0.10.27 makes the cli pin its @webjsdev/* imports to the app-declared (else cli-own) inline version under zero-install.

## Notes
- Patch bump within the 0.10.x line; every dependent pins `^0.10.0`, so no range widening.
- `package-lock.json` regenerated (only the cli version line).
- Only cli owes a bump (the sweep found core/server/ui/mcp/intellisense all clean since 0.10.26).
- Merging adds `changelog/cli/0.10.27.md` to main, triggering `release.yml` to npm-publish @webjsdev/cli@0.10.27 and cut the GitHub Release.

Closes nothing new (the fix issue #709 already closed via #711).