### PR TITLE
chore: release server 0.8.38

### DIFF
--- a/changelog/server/0.8.38.md
+++ b/changelog/server/0.8.38.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/server"
+version: 0.8.38
+date: 2026-06-25T14:09:24.918Z
+commit_count: 1
+---
+## Fixes
+
+- **keep server-only @webjsdev packages out of the browser vendor path** ([#716](https://github.com/webjsdev/webjs/pull/716)) [`bcd453ea`](https://github.com/webjsdev/webjs/commit/bcd453ea)
+  * fix: keep server-only @webjsdev packages out of the browser vendor path
+  
+  A fresh bun zero-install `bun run dev` logged `could not vendor
+  '@webjsdev/cli@^0.10.27/bin/webjs.js' via jspm` and spent ~437ms on the failed

--- a/package-lock.json
+++ b/package-lock.json
@@ -7039,7 +7039,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.37",
+      "version": "0.8.38",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.37",
+  "version": "0.8.38",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Patch release for the bun zero-install vendor fix.

## @webjsdev/server 0.8.37 -> 0.8.38 (patch)
- fix: keep server-only @webjsdev packages out of the browser vendor path (#713 via #716)

Stops the importmap from sending server-only `@webjsdev/cli`/`server`/`mcp` to jspm under bun zero-install (the `could not vendor '@webjsdev/cli'` 503 + ~437ms cost), and also fixes the same latent leak in the docs app.

## Notes
- Patch bump within 0.8.x; every dependent pins `^0.8.0`, so no range widening.
- `package-lock.json` regenerated (server version line only).
- Only server owes a bump (sweep found core/cli/ui/mcp/intellisense clean since the last release).
- Merging adds `changelog/server/0.8.38.md` to main, triggering `release.yml` to npm-publish @webjsdev/server@0.8.38 + cut the GitHub Release.

The fix issue #713 already closed via #716.