### PR TITLE
chore: release cli 0.10.28, server 0.8.39, core 0.7.27, mcp 0.1.6

### DIFF
--- a/changelog/cli/0.10.28.md
+++ b/changelog/cli/0.10.28.md
@@ -1,0 +1,17 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.28
+date: 2026-06-27T16:54:58.000Z
+commit_count: 1
+---
+## Changes
+
+- **remove Bun zero-install: `bun create` now runs `bun install` like Node** ([#722](https://github.com/webjsdev/webjs/pull/722)) [`71f204e3`](https://github.com/webjsdev/webjs/commit/71f204e3)
+
+  Bun apps now install with `bun install` (a `node_modules`), the same as Node,
+  rather than resolving deps on the fly. The scaffold no longer skips the install
+  on Bun, drops the `webjs-bun.mjs` auto-install bootstrap (bun scripts are
+  `bun --bun webjs dev`), and removes the cli's `@webjsdev/*` import-retry.
+
+  Migration: run `bun install` in a Bun app (the scaffold does this for you on
+  `bun create`). Bun stays a first-class runtime.

--- a/changelog/core/0.7.27.md
+++ b/changelog/core/0.7.27.md
@@ -1,0 +1,12 @@
+---
+package: "@webjsdev/core"
+version: 0.7.27
+date: 2026-06-27T16:54:58.000Z
+commit_count: 1
+---
+## Changes
+
+- **remove the `webjs.pin` config key (Bun zero-install)** ([#722](https://github.com/webjsdev/webjs/pull/722)) [`71f204e3`](https://github.com/webjsdev/webjs/commit/71f204e3)
+
+  The `pin` key is removed from the `WebjsConfig` type and the JSON schema, since
+  the Bun zero-install pin shim it gated is gone (Bun installs like Node now).

--- a/changelog/mcp/0.1.6.md
+++ b/changelog/mcp/0.1.6.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/mcp"
+version: 0.1.6
+date: 2026-06-27T16:54:58.000Z
+commit_count: 1
+---
+## Changes
+
+- **resolve @webjsdev from node_modules, not the Bun cache** ([#722](https://github.com/webjsdev/webjs/pull/722)) [`71f204e3`](https://github.com/webjsdev/webjs/commit/71f204e3)
+
+  The source tool no longer falls back to resolving `@webjsdev/*` from Bun's
+  global install cache (a Bun zero-install path); it resolves from `node_modules`
+  like Node, which a Bun app now has.

--- a/changelog/server/0.8.39.md
+++ b/changelog/server/0.8.39.md
@@ -1,0 +1,15 @@
+---
+package: "@webjsdev/server"
+version: 0.8.39
+date: 2026-06-27T16:54:58.000Z
+commit_count: 1
+---
+## Changes
+
+- **remove the Bun zero-install dependency pin shim** ([#722](https://github.com/webjsdev/webjs/pull/722)) [`71f204e3`](https://github.com/webjsdev/webjs/commit/71f204e3)
+
+  Drops the `onLoad` specifier-rewrite that pinned bare imports to package.json
+  versions for Bun auto-install, and the importmap version-sharing that fed it.
+  Bun resolves dependencies from `node_modules` now, the same as Node. The
+  `webjs.pin` config key and the `WEBJS_PIN` env switch are removed. SSR action
+  seeding (#472) on Bun is unaffected.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.27",
+  "version": "0.10.28",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.26",
+  "version": "0.7.27",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/mcp",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "description": "The webjs Model Context Protocol server: live app introspection (routes / actions / components / check) plus the framework knowledge layer (docs, recipes, source) for AI coding agents",
   "bin": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.38",
+  "version": "0.8.39",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",

--- a/packages/wrappers/create-webjs/package.json
+++ b/packages/wrappers/create-webjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-webjs",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "description": "Scaffold a new webjs app. `npm create webjs@latest my-app`.",
   "bin": {


### PR DESCRIPTION
Ships the Bun zero-install removal (#721, merged in #722): Bun apps now install with `bun install` like Node.

Bumps (forward from current npm, monotonic):
- @webjsdev/cli 0.10.27 -> 0.10.28
- @webjsdev/server 0.8.38 -> 0.8.39
- @webjsdev/core 0.7.26 -> 0.7.27
- @webjsdev/mcp 0.1.5 -> 0.1.6
- create-webjs 0.9.0 -> 0.9.1

Changelogs are hand-written because #722 merged as `refactor:`, which the auto-backfill skips. On merge, the release workflow publishes the 4 @webjsdev packages from the new changelog files. (create-webjs has no changelog dir; bumped so its install-behavior change can be republished.)