### PR TITLE
chore: sync create-webjs repo version to its npm lockstep (0.10.28)

### DIFF
--- a/packages/wrappers/create-webjs/package.json
+++ b/packages/wrappers/create-webjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-webjs",
-  "version": "0.9.1",
+  "version": "0.10.28",
   "type": "module",
   "description": "Scaffold a new webjs app. `npm create webjs@latest my-app`.",
   "bin": {


### PR DESCRIPTION
`create-webjs` is a version-lockstep mirror of `@webjsdev/cli` (published at 0.10.28). The repo's `package.json` had drifted to 0.9.1 (the release pin used a hand-set value; the publish ignores that field and ships at the cli version). This sets the repo to 0.10.28 so it reflects the published reality.

No code change, no publish impact (the wrapper version is computed from the cli at publish time).