### PR TITLE
chore: release cli 0.10.29

### DIFF
--- a/changelog/cli/0.10.29.md
+++ b/changelog/cli/0.10.29.md
@@ -1,0 +1,11 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.29
+date: 2026-06-27T19:23:28.324Z
+commit_count: 1
+---
+## Features
+
+- **auto-apply migrations on dev (webjs.dev.before migrate)** ([#726](https://github.com/webjsdev/webjs/pull/726)) [`030de282`](https://github.com/webjsdev/webjs/commit/030de282)
+
+  Scaffolded apps add `webjs db migrate` as a `webjs.dev.before` step (mirroring `start.before`), so after you `db:generate` a migration, `npm run dev` applies it with no manual `db:migrate`. `.env` is now loaded before the dev before-steps too, so a Postgres dev migrate sees `DATABASE_URL`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.28",
+  "version": "0.10.29",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {


### PR DESCRIPTION
Releases the #726 `feat:` (auto-apply migrations on dev via `webjs.dev.before` migrate + the `.env`-before-dev-before-steps fix).

- @webjsdev/cli 0.10.28 -> 0.10.29

Changelog auto-backfilled from the feat: PR (cleaned of draft-commit + session-trailer noise). create-webjs follows in lockstep via the release workflow (not hand-bumped). On merge, the workflow publishes cli 0.10.29 to npm + a GitHub release.