### PR TITLE
chore: scrub Claude-Session trailers from published changelogs

### DIFF
--- a/changelog/cli/0.10.23.md
+++ b/changelog/cli/0.10.23.md
@@ -13,5 +13,3 @@ commit_count: 2
   cross-origin check on state-changing action requests: Sec-Fetch-Site
 - **advisory naming why a page or layout ships (the elision blocker)** ([#666](https://github.com/webjsdev/webjs/pull/666)) [`00f12fca`](https://github.com/webjsdev/webjs/commit/00f12fca)
   * chore: start elision-blocker advisory (#646)
-  
-  Claude-Session: https://claude.ai/code/session_01WnvcTojG7tYqmnmf4enSv3

--- a/changelog/server/0.8.34.md
+++ b/changelog/server/0.8.34.md
@@ -13,5 +13,3 @@ commit_count: 2
   cross-origin check on state-changing action requests: Sec-Fetch-Site
 - **advisory naming why a page or layout ships (the elision blocker)** ([#666](https://github.com/webjsdev/webjs/pull/666)) [`00f12fca`](https://github.com/webjsdev/webjs/commit/00f12fca)
   * chore: start elision-blocker advisory (#646)
-  
-  Claude-Session: https://claude.ai/code/session_01WnvcTojG7tYqmnmf4enSv3


### PR DESCRIPTION
The changelog auto-backfill surfaced a `Claude-Session:` session URL from two commit bodies into `changelog/cli/0.10.23.md` and `changelog/server/0.8.34.md` (the docs-site `/changelog` renders these). Remove them.

The trailer is no longer added to commits going forward, so future changelogs stay clean without manual scrubbing. Note: the trailer also lives in some already-merged commit BODIES on main; those cannot be removed without rewriting published history (a force-push to main, which is forbidden and would break changelog SHA links + release tags), so only the rendered changelog files are cleaned here.