### PR TITLE
chore: diag v2 - dialog visibility + no scroll lock (#730)

### DIFF
--- a/packages/ui/packages/website/app/diag/page.ts
+++ b/packages/ui/packages/website/app/diag/page.ts
@@ -2,14 +2,13 @@
  * TEMPORARY on-device diagnostic route for #730 (Tier-2 components dead on
  * iOS). Not linked from anywhere; removed once the root cause is confirmed.
  *
- * It side-effect-loads every Tier-2 module (so a module that throws at load
- * on iOS WebKit surfaces in the early error handler), renders a real
- * slot-using <ui-dialog>, and prints a visible readout of: any window error,
- * which custom elements registered, whether the dialog upgraded, whether the
- * light-DOM slot polyfill installed + projected, feature support, and whether
- * tapping / programmatically opening the dialog actually works. Plain inline
- * scripts (NOT a webjs component), so the diagnostic itself does not depend on
- * the slot hydration it is testing.
+ * v2: the user reported "can't scroll, especially after the diagnostic runs."
+ * That is the dialog's body-scroll-lock firing, which means the dialog DOES
+ * open on iOS (interactivity fires) but renders invisibly. So this version
+ * opens the dialog, MEASURES whether its content panel is actually visible
+ * (rect / display / on-screen) and whether the native <dialog> + scroll lock
+ * engaged, then CLOSES it and confirms scroll is unlocked, so the page is
+ * never left scroll-locked. Plain inline scripts (not a webjs component).
  */
 import { html, unsafeHTML } from '@webjsdev/core';
 import { buttonClass } from '#components/ui/button.ts';
@@ -24,8 +23,6 @@ import '#components/ui/toggle.ts';
 import '#components/ui/toggle-group.ts';
 import '#components/ui/sonner.ts';
 
-// Installed FIRST (classic inline script runs during parse, before the
-// deferred module boot), so it catches a Tier-2 module throwing at load.
 const EARLY = `<script>
 window.__wjd={e:[]};
 addEventListener('error',function(ev){__wjd.e.push((ev.message||ev.type)+' @@ '+String(ev.filename||'').split('/').slice(-2).join('/')+':'+(ev.lineno||0))});
@@ -37,9 +34,6 @@ setTimeout(function(){
   var T=['ui-dialog','ui-dialog-trigger','ui-dialog-content','ui-alert-dialog','ui-tabs','ui-tabs-trigger','ui-tooltip','ui-tooltip-trigger','ui-hover-card','ui-dropdown-menu','ui-toggle','ui-toggle-group','ui-sonner'];
   function g(t){try{return customElements.get(t)?'Y':'n'}catch(e){return 'E'}}
   var dlg=document.querySelector('ui-dialog');
-  var trg=document.querySelector('ui-dialog-trigger');
-  var slot=trg?trg.querySelector('slot'):null;
-  var btn=trg?trg.querySelector('button'):null;
   var anchor;try{anchor=(window.CSS&&CSS.supports)?(CSS.supports('anchor-name','--x')?'Y':'n'):'noCSS'}catch(e){anchor='E'}
   var rep={
     ua:navigator.userAgent,
@@ -47,36 +41,56 @@ setTimeout(function(){
     registered:T.map(function(t){return t+':'+g(t)}).join('  '),
     dialogUpgraded: dlg?(typeof dlg.show==='function'?'Y':'n'):'noEl',
     slotPatchName:(window.HTMLSlotElement&&HTMLSlotElement.prototype.assignedNodes)?HTMLSlotElement.prototype.assignedNodes.name:'noSlotProto',
-    slotProjection: slot?(String(slot.getAttribute('data-projection'))+' kids='+slot.children.length):'noSlot',
-    btnInsideTrigger:(btn&&trg)?(trg.contains(btn)?'Y':'n'):'noBtn',
     feat_showPopover:('showPopover' in HTMLElement.prototype)?'Y':'n',
     feat_showModal:(window.HTMLDialogElement&&HTMLDialogElement.prototype.showModal)?'Y':'n',
-    feat_anchorPos:anchor,
-    feat_slotEl:(typeof HTMLSlotElement!=='undefined')?'Y':'n'
+    feat_anchorPos:anchor
   };
-  try{ if(btn){btn.click(); rep.afterBtnClickImmediate=dlg?(dlg.hasAttribute('open')?'Y':'n'):'noEl';} else {rep.afterBtnClickImmediate='noBtn';} }catch(e){rep.clickThrew=e.message;}
+  function measure(){
+    var native=document.querySelector('ui-dialog-content dialog');
+    var panel=document.querySelector('ui-dialog-content [data-slot="dialog-content"]');
+    var pr=panel?panel.getBoundingClientRect():null;
+    var nr=native?native.getBoundingClientRect():null;
+    var pcs=panel?getComputedStyle(panel):null;
+    var ncs=native?getComputedStyle(native):null;
+    return {
+      dialogOpenAttr: dlg?(dlg.hasAttribute('open')?'Y':'n'):null,
+      bodyOverflow: document.body.style.overflow||'(unset)',
+      nativeDialogOpenProp: native?(native.open?'Y':'n'):'noNative',
+      nativeRect: nr?(Math.round(nr.width)+'x'+Math.round(nr.height)+' @'+Math.round(nr.left)+','+Math.round(nr.top)):'noNative',
+      nativeDisplay: ncs?ncs.display:null,
+      panelRect: pr?(Math.round(pr.width)+'x'+Math.round(pr.height)+' @'+Math.round(pr.left)+','+Math.round(pr.top)):'noPanel',
+      panelDisplay: pcs?pcs.display:null,
+      panelVisibility: pcs?pcs.visibility:null,
+      panelOpacity: pcs?pcs.opacity:null,
+      panelPosition: pcs?pcs.position:null,
+      viewport: innerWidth+'x'+innerHeight,
+      panelOnScreen: pr?((pr.width>0&&pr.height>0&&pr.top<innerHeight&&pr.bottom>0&&pr.left<innerWidth&&pr.right>0)?'Y':'n'):'noPanel'
+    };
+  }
+  try{ if(dlg&&dlg.show) dlg.show(); else rep.showMissing=true; }catch(e){rep.showThrew=e.message;}
   setTimeout(function(){
-    rep.afterBtnClick300=dlg?(dlg.hasAttribute('open')?'Y':'n'):'noEl';
-    try{ if(dlg&&dlg.show){dlg.show(); rep.afterProgrammaticShow=dlg.hasAttribute('open')?'Y':'n';} else {rep.afterProgrammaticShow='noShowMethod';} }catch(e){rep.showThrew=e.message;}
-    document.getElementById('wjdiag').textContent=JSON.stringify(rep,null,2);
-  },500);
-},2000);
+    rep.WHEN_OPEN=measure();
+    try{ if(dlg&&dlg.hide) dlg.hide(); }catch(e){rep.hideThrew=e.message;}
+    setTimeout(function(){
+      rep.afterClose_bodyOverflow=document.body.style.overflow||'(unset)';
+      document.getElementById('wjdiag').textContent=JSON.stringify(rep,null,2);
+    },350);
+  },450);
+},1200);
 </script>`;
 
 export default function Diag() {
   return html`
     ${unsafeHTML(EARLY)}
     <main style="padding:1rem;font-family:system-ui;max-width:100%">
-      <h1 style="font-size:1.1rem">webjs Tier-2 iOS diagnostic (#730)</h1>
-      <p style="font-size:.85rem;color:#666">Wait about 3 seconds, then copy the whole readout below and send it to me.</p>
-      <pre id="wjdiag" style="white-space:pre-wrap;word-break:break-word;font:12px/1.5 monospace;background:#f4f4f5;color:#111;padding:1rem;border-radius:8px;border:1px solid #ccc">collecting (wait about 3s)...</pre>
-      <div style="margin-top:1.5rem;padding:1rem;border:1px dashed #bbb;border-radius:8px">
-        <p style="font-size:.85rem;margin:0 0 .5rem">Manual check: tap this button. Does a modal dialog appear?</p>
-        <ui-dialog>
-          <ui-dialog-trigger><button class=${buttonClass()}>Open dialog (manual)</button></ui-dialog-trigger>
-          <ui-dialog-content><p style="padding:1rem">If you can read this inside a modal, the dialog works on your device.</p></ui-dialog-content>
-        </ui-dialog>
-      </div>
+      <h1 style="font-size:1.1rem">webjs Tier-2 iOS diagnostic v2 (#730)</h1>
+      <p style="font-size:.85rem;color:#666">Wait about 2 seconds, then copy the whole readout and send it to me. The page stays scrollable (the diagnostic opens then auto-closes the probe dialog).</p>
+      <button onclick="location.reload()" style="margin-bottom:.75rem" class=${buttonClass({ variant: 'outline', size: 'sm' })}>Re-run</button>
+      <pre id="wjdiag" style="white-space:pre-wrap;word-break:break-word;font:12px/1.5 monospace;background:#f4f4f5;color:#111;padding:1rem;border-radius:8px;border:1px solid #ccc">collecting (wait about 2s)...</pre>
+      <div style="height:60vh"></div>
+      <ui-dialog style="position:absolute;width:0;height:0;overflow:hidden">
+        <ui-dialog-content><p style="padding:1rem">probe dialog content</p></ui-dialog-content>
+      </ui-dialog>
     </main>
     ${unsafeHTML(REPORT)}
   `;


### PR DESCRIPTION
Refs #730. v2 of the /diag route. The 'cannot scroll' report revealed the dialog DOES open on iOS (its body-scroll-lock fires) but renders invisibly. v2 measures the open dialog's content-panel visibility (rect/display/on-screen), then closes it so the page is never left scroll-locked.