### PR TITLE
fix(ui): dialog opens via querySelector not the iOS-null ref (#730)

### DIFF
--- a/packages/ui/packages/registry/components/alert-dialog.ts
+++ b/packages/ui/packages/registry/components/alert-dialog.ts
@@ -237,9 +237,17 @@ export class UiAlertDialogContent extends WebComponent({
     this.size = 'default';
   }
 
+  // Query the native <dialog> rather than the #dialog ref: the ref's `.value`
+  // came back null on iOS WebKit (the binding did not populate through SSR
+  // hydration), so showModal() never ran (#730). querySelector is robust on
+  // every engine.
+  _native(): HTMLDialogElement | null {
+    return this.querySelector<HTMLDialogElement>('dialog[data-slot="alert-dialog-native"]');
+  }
+
   showModal(): void {
     this._wireLabels();
-    const native = this.#dialog.value;
+    const native = this._native();
     if (native && !native.open) native.showModal();
   }
 
@@ -266,7 +274,7 @@ export class UiAlertDialogContent extends WebComponent({
   }
 
   close(): void {
-    const native = this.#dialog.value;
+    const native = this._native();
     if (native?.open) native.close();
   }
 

--- a/packages/ui/packages/registry/components/dialog.ts
+++ b/packages/ui/packages/registry/components/dialog.ts
@@ -299,14 +299,23 @@ export class UiDialogContent extends WebComponent({
     this.showCloseButton = 'true';
   }
 
+  // Resolve the native <dialog> by query, NOT the #dialog ref: on iOS WebKit
+  // the ref's `.value` came back null (the ref binding did not populate through
+  // SSR hydration), so showModal() was never called and the dialog never opened
+  // (#730). A direct querySelector is robust on every engine, and matches what
+  // the tooltip / popover components already do.
+  _native(): HTMLDialogElement | null {
+    return this.querySelector<HTMLDialogElement>('dialog[data-slot="dialog-native"]');
+  }
+
   showModal(): void {
     wireDialogLabels(this, '[data-slot="dialog-content"]');
-    const native = this.#dialog.value;
+    const native = this._native();
     if (native && !native.open) native.showModal();
   }
 
   close(): void {
-    const native = this.#dialog.value;
+    const native = this._native();
     if (native?.open) native.close();
   }
 

--- a/packages/ui/packages/website/app/diag/page.ts
+++ b/packages/ui/packages/website/app/diag/page.ts
@@ -1,15 +1,12 @@
 /**
  * TEMPORARY on-device diagnostic route for #730 (Tier-2 components on iOS).
- * Not linked from anywhere; removed once the fix is confirmed.
+ * Not linked from anywhere; removed once the fixes are confirmed.
  *
- * v4: confirmed root cause is the 0x0 native <dialog> collapsing its
- * position:fixed content panel on WebKit (now fixed: the host fills the
- * viewport). This version VERIFIES the dialog fix and also probes the two
- * other Tier-2 mechanisms on-device so we know whether they share the bug:
- *   - dialog (showModal top-layer)  -> measure the content panel is visible
- *   - tooltip (Popover API top-layer) -> open + measure the popover is visible
- *   - tabs (no overlay, reactive re-render) -> switch tab + measure the panel
- * Plain inline scripts; opens then closes everything so scroll is never left
+ * v5: verifies the DIALOG fix (ref -> querySelector + viewport host) actually
+ * opens + is visible, and DISSECTS the tabs failure (does a trigger click, a
+ * direct setAttribute('value'), or a direct property set switch the panel?) to
+ * find the exact failing sub-step for the non-overlay components on WebKit.
+ * Plain inline scripts; opens then closes the dialog so scroll is never left
  * locked.
  */
 import { html, unsafeHTML } from '@webjsdev/core';
@@ -31,32 +28,34 @@ addEventListener('unhandledrejection',function(ev){var r=ev.reason;__wjd.e.push(
 </script>`;
 
 const REPORT = `<script>
-function rct(el){if(!el)return 'noEl';var r=el.getBoundingClientRect();var on=(r.width>0&&r.height>0&&r.top<innerHeight&&r.bottom>0&&r.left<innerWidth&&r.right>0);return Math.round(r.width)+'x'+Math.round(r.height)+' @'+Math.round(r.left)+','+Math.round(r.top)+(on?' ON-SCREEN':' off-screen');}
+function rct(el){if(!el)return 'noEl';var r=el.getBoundingClientRect();var on=(r.width>0&&r.height>0&&r.top<innerHeight&&r.bottom>0&&r.left<innerWidth&&r.right>0);return Math.round(r.width)+'x'+Math.round(r.height)+(on?' ON-SCREEN':' off-screen');}
+function ist(el){return el?(el.hasAttribute('inert')?'inert(hidden)':'active(shown)'):'noPanel';}
 setTimeout(function(){
   var rep={ua:navigator.userAgent, ERRORS:__wjd.e.length?__wjd.e:'(none)'};
   var d=document.getElementById('d');
   try{ if(d&&d.show) d.show(); }catch(e){rep.dialogShowErr=e.message;}
   setTimeout(function(){
-    rep.DIALOG={ nativeOpen:((document.querySelector('#d dialog')||{}).open?'Y':'n'), nativeRect:rct(document.querySelector('#d dialog')), panel:rct(document.querySelector('#d [data-slot=\"dialog-content\"]')) };
+    rep.DIALOG={ nativeOpen:((document.querySelector('#d dialog')||{}).open?'Y':'n'), panel:rct(document.querySelector('#d [data-slot=\"dialog-content\"]')) };
     try{ if(d&&d.hide) d.hide(); }catch(e){}
-    var tt=document.getElementById('tt');
-    try{ if(tt&&tt.show) tt.show(); }catch(e){rep.ttShowErr=e.message;}
+    var tb=document.getElementById('tb');
+    function pw(){return tb?tb.querySelector('ui-tabs-content[value=\"password\"]'):null;}
+    rep.TABS={ startAttr: tb?tb.getAttribute('value'):'?', startProp: tb?String(tb.value):'?', panelStart: ist(pw()) };
+    var trig=tb?tb.querySelector('ui-tabs-trigger[value=\"password\"] button'):null;
+    rep.TABS.triggerBtnFound=trig?'Y':'n';
+    try{ if(trig) trig.click(); }catch(e){rep.TABS.clickErr=e.message;}
     setTimeout(function(){
-      var pop=document.querySelector('#tt [popover]');
-      rep.TOOLTIP={ openAttr:(tt&&tt.hasAttribute('open'))?'Y':'n', popoverShown: pop?(pop.matches(':popover-open')?'Y':'n'):'noPop', popoverRect:rct(pop) };
-      try{ if(tt&&tt.hide) tt.hide(); }catch(e){}
-      var tb=document.getElementById('tb');
-      var pBefore=rct(tb?tb.querySelector('ui-tabs-content[value=\"password\"]'):null);
-      var trig=tb?tb.querySelector('ui-tabs-trigger[value=\"password\"]'):null;
-      var clk=trig?(trig.querySelector('button')||trig):null;
-      try{ if(clk) clk.click(); }catch(e){rep.tabsClickErr=e.message;}
+      rep.TABS.afterClick={attr:tb?tb.getAttribute('value'):'?',prop:tb?String(tb.value):'?',panel:ist(pw())};
+      try{ tb.setAttribute('value','password'); }catch(e){rep.TABS.setAttrErr=e.message;}
       setTimeout(function(){
-        var pPanel=tb?tb.querySelector('ui-tabs-content[value=\"password\"]'):null;
-        rep.TABS={ tabsValue: tb?tb.getAttribute('value'):'noTabs', passwordPanel_before:pBefore, passwordPanel_after:rct(pPanel), passwordPanel_inert: pPanel?(pPanel.hasAttribute('inert')?'inert(hidden)':'active(shown)'):'noPanel' };
-        rep.bodyOverflowEnd=document.body.style.overflow||'(unset)';
-        document.getElementById('wjdiag').textContent=JSON.stringify(rep,null,2);
-      },350);
-    },350);
+        rep.TABS.afterSetAttr={panel:ist(pw()),prop:tb?String(tb.value):'?'};
+        try{ tb.value='account'; tb.value='password'; }catch(e){rep.TABS.setPropErr=e.message;}
+        setTimeout(function(){
+          rep.TABS.afterSetProp={panel:ist(pw()),attr:tb?tb.getAttribute('value'):'?'};
+          rep.bodyOverflowEnd=document.body.style.overflow||'(unset)';
+          document.getElementById('wjdiag').textContent=JSON.stringify(rep,null,2);
+        },200);
+      },200);
+    },250);
   },450);
 },1200);
 </script>`;
@@ -65,7 +64,7 @@ export default function Diag() {
   return html`
     ${unsafeHTML(EARLY)}
     <main style="padding:1rem;font-family:system-ui;max-width:100%">
-      <h1 style="font-size:1.1rem">webjs Tier-2 iOS diagnostic v4 (#730)</h1>
+      <h1 style="font-size:1.1rem">webjs Tier-2 iOS diagnostic v5 (#730)</h1>
       <p style="font-size:.85rem;color:#666">Wait about 2s, then copy the whole readout and send it to me. The page stays scrollable.</p>
       <button onclick="location.reload()" style="margin-bottom:.75rem" class=${buttonClass({ variant: 'outline', size: 'sm' })}>Re-run</button>
       <pre id="wjdiag" style="white-space:pre-wrap;word-break:break-word;font:12px/1.5 monospace;background:#f4f4f5;color:#111;padding:1rem;border-radius:8px;border:1px solid #ccc">collecting (wait about 2s)...</pre>
@@ -73,10 +72,6 @@ export default function Diag() {
       <ui-dialog id="d" style="position:absolute;width:0;height:0;overflow:hidden">
         <ui-dialog-content><p style="padding:1rem">dialog probe content</p></ui-dialog-content>
       </ui-dialog>
-      <ui-tooltip id="tt" delay-duration="0" skip-delay-duration="0" style="position:absolute;width:0;height:0;overflow:hidden">
-        <ui-tooltip-trigger><button class=${buttonClass({ size: 'sm' })} aria-label="probe">?</button></ui-tooltip-trigger>
-        <ui-tooltip-content>tooltip probe</ui-tooltip-content>
-      </ui-tooltip>
       <ui-tabs id="tb" value="account" style="position:absolute;width:0;height:0;overflow:hidden">
         <ui-tabs-list>
           <ui-tabs-trigger value="account">Account</ui-tabs-trigger>


### PR DESCRIPTION
Refs #730. The dialog reached its native <dialog> via a ref (this.#dialog.value) that is NULL on iOS WebKit, so showModal() was never called (confirmed on a real iPhone: open=true + scroll locked but nativeOpen=n; a direct showModal worked in v3). Switch to querySelector (the working tooltip pattern). With the prior viewport-host fix the dialog now opens + renders. v5 of /diag verifies this on-device and dissects the separate tabs-switch failure.