### PR TITLE
chore: diag v8 - tabs-trigger lifecycle timeline (#730)

### DIFF
--- a/packages/ui/packages/website/app/diag/page.ts
+++ b/packages/ui/packages/website/app/diag/page.ts
@@ -2,13 +2,12 @@
  * TEMPORARY on-device diagnostic route for #730 (Tier-2 components on iOS).
  * Not linked from anywhere; removed once the core fix is confirmed.
  *
- * v7: webjs hydration re-renders fresh (createInstance) and bindPart does
- * el.addEventListener('click', dispatcher) on the rendered button, then
- * slot.js re-projects. v6 proved the live button receives clicks but the webjs
- * @click never fires. This instruments addEventListener BEFORE hydration to
- * record every button/div webjs binds a click to, then checks whether the LIVE
- * tab-trigger button is one webjs bound (and whether any bound button ended up
- * DETACHED, meaning the slot re-projection replaced the @click-bound node).
+ * v8: instruments the ui-tabs-trigger LIFECYCLE on the device by wrapping
+ * customElements.define BEFORE the boot module loads. Records how many times
+ * connectedCallback / disconnectedCallback / render fire, in order, plus
+ * whether webjs ever bound a click to the live tab button. This reveals the
+ * WebKit divergence in the hydration / slot-projection-move / first-render
+ * timing that source reading could not pin.
  */
 import { html, unsafeHTML } from '@webjsdev/core';
 import { buttonClass } from '#components/ui/button.ts';
@@ -23,12 +22,21 @@ import '#components/ui/toggle-group.ts';
 import '#components/ui/sonner.ts';
 
 const EARLY = `<script>
-window.__wjd={e:[],clickEls:[]};
+window.__wjd={e:[],log:[],cc:0,dc:0,render:0,clickEls:[]};
+(function(){var O=EventTarget.prototype.addEventListener;EventTarget.prototype.addEventListener=function(t,f,o){try{if(t==='click'&&this&&this.nodeType===1&&(this.tagName==='BUTTON'||this.tagName==='DIV')){__wjd.clickEls.push(this);}}catch(e){}return O.call(this,t,f,o);};})();
 (function(){
-  var O=EventTarget.prototype.addEventListener;
-  EventTarget.prototype.addEventListener=function(t,f,o){
-    try{ if(t==='click' && this && this.nodeType===1 && (this.tagName==='BUTTON'||this.tagName==='DIV')){ __wjd.clickEls.push(this); } }catch(e){}
-    return O.call(this,t,f,o);
+  var D=customElements.define.bind(customElements);
+  customElements.define=function(n,c,o){
+    if(n==='ui-tabs-trigger' && c && c.prototype){
+      var p=c.prototype;
+      var cc=p.connectedCallback;
+      p.connectedCallback=function(){__wjd.cc++;__wjd.log.push('connect#'+__wjd.cc+' conn='+this.isConnected);return cc?cc.apply(this,arguments):undefined;};
+      var dc=p.disconnectedCallback;
+      p.disconnectedCallback=function(){__wjd.dc++;__wjd.log.push('disconnect#'+__wjd.dc);return dc?dc.apply(this,arguments):undefined;};
+      var rr=p.render;
+      if(rr){ p.render=function(){__wjd.render++;__wjd.log.push('render#'+__wjd.render);return rr.apply(this,arguments);}; }
+    }
+    return D(n,c,o);
   };
 })();
 addEventListener('error',function(ev){__wjd.e.push((ev.message||ev.type)+' @@ '+String(ev.filename||'').split('/').slice(-2).join('/')+':'+(ev.lineno||0))});
@@ -39,30 +47,18 @@ const REPORT = `<script>
 setTimeout(function(){
   var rep={ua:navigator.userAgent, ERRORS:__wjd.e.length?__wjd.e:'(none)'};
   var tb=document.getElementById('tb');
-  var trig=tb?tb.querySelector('ui-tabs-trigger[value=\"password\"]'):null;
-  var btn=trig?trig.querySelector('button'):null;
-  var els=__wjd.clickEls;
-  var detachedBound=0,boundButtonsTotal=0;
-  for(var i=0;i<els.length;i++){ if(els[i].tagName==='BUTTON'){ boundButtonsTotal++; if(!els[i].isConnected) detachedBound++; } }
-  rep.TABS={
-    liveButtonFound: btn?'Y':'n',
-    webjsBoundClickToLiveButton: btn?(els.indexOf(btn)>=0?'Y':'n'):'noBtn',
-    totalClickBindingsRecorded: els.length,
-    buttonClickBindingsRecorded: boundButtonsTotal,
-    boundButtonsNowDetached: detachedBound,
-    liveButtonConnected: btn?(btn.isConnected?'Y':'n'):'noBtn'
-  };
-  var th=document.querySelector('theme-toggle button, button[aria-label*=\"theme\" i], button[title*=\"theme\" i]');
-  rep.THEME_CONTROL={ liveBtn: th?'Y':'n', webjsBoundClickToIt: th?(els.indexOf(th)>=0?'Y':'n'):'noBtn' };
+  var btn=tb?tb.querySelector('ui-tabs-trigger[value=\"password\"] button'):null;
+  rep.LIFECYCLE={ connectCallbacks:__wjd.cc, disconnectCallbacks:__wjd.dc, renderCalls:__wjd.render, timeline:__wjd.log.slice(0,16) };
+  rep.CLICK={ liveButton:btn?'Y':'n', webjsBoundClickToLiveButton:btn?(__wjd.clickEls.indexOf(btn)>=0?'Y':'n'):'noBtn', totalButtonBindings:__wjd.clickEls.filter(function(e){return e.tagName==='BUTTON';}).length };
   document.getElementById('wjdiag').textContent=JSON.stringify(rep,null,2);
-},1600);
+},1700);
 </script>`;
 
 export default function Diag() {
   return html`
     ${unsafeHTML(EARLY)}
     <main style="padding:1rem;font-family:system-ui;max-width:100%">
-      <h1 style="font-size:1.1rem">webjs Tier-2 iOS diagnostic v7 (#730)</h1>
+      <h1 style="font-size:1.1rem">webjs Tier-2 iOS diagnostic v8 (#730)</h1>
       <p style="font-size:.85rem;color:#666">Wait about 2s, then copy the whole readout and send it to me. The page stays scrollable.</p>
       <button onclick="location.reload()" style="margin-bottom:.75rem" class=${buttonClass({ variant: 'outline', size: 'sm' })}>Re-run</button>
       <pre id="wjdiag" style="white-space:pre-wrap;word-break:break-word;font:12px/1.5 monospace;background:#f4f4f5;color:#111;padding:1rem;border-radius:8px;border:1px solid #ccc">collecting (wait about 2s)...</pre>


### PR DESCRIPTION
Refs #730. Instruments the ui-tabs-trigger lifecycle (connect/disconnect/render counts + order) to pin the WebKit hydration/projection-move/first-render timing.