### PR TITLE
chore: diag v10 - instrument core binding path (#730) (TEMP)

### DIFF
--- a/packages/core/src/render-client.js
+++ b/packages/core/src/render-client.js
@@ -89,9 +89,15 @@ export function render(value, container) {
   const host = /** @type any */ (container);
   const prev = host[INSTANCE];
 
+  // TEMP #730 diagnostic: trace the binding path for the <diag-slot-btn>
+  // probe only, gated on globalThis.__WEBJS_DIAG (set by the /diag page).
+  const __D = (typeof globalThis !== 'undefined' && /** @type any */ (globalThis).__WEBJS_DIAG && host && host.tagName === 'DIAG-SLOT-BTN') ? /** @type any */ (globalThis).__WEBJS_DIAG : null;
+
   if (isTemplate(value)) {
     const tr = /** @type {import('./html.js').TemplateResult} */ (value);
+    if (__D) __D.push('render prev=' + (prev ? 'Y' : 'n'));
     if (prev && prev.strings === tr.strings) {
+      if (__D) __D.push('-> updateInstance (no rebind)');
       updateInstance(prev, tr.values);
       return;
     }
@@ -102,6 +108,7 @@ export function render(value, container) {
     // rendering. The content will be replaced with identical output -
     // no visible flash because SSR and client render produce the same HTML.
     const firstChild = container.firstChild;
+    if (__D) __D.push('-> createInstance (firstChild=' + (firstChild ? (firstChild.nodeType === 8 ? 'comment:' + /** @type any */ (firstChild).data : firstChild.nodeName) : 'none') + ')');
     if (firstChild && firstChild.nodeType === 8 && /** @type {Comment} */ (firstChild).data === 'webjs-hydrate') {
       firstChild.remove();
     }
@@ -462,6 +469,14 @@ function createInstance(tr, container) {
   const endNode = document.createComment(`${MARKER}e`);
 
   const bound = parts.map((p) => bindPart(p, frag));
+
+  // TEMP #730 diagnostic for the <diag-slot-btn> probe only.
+  const __D = (typeof globalThis !== 'undefined' && /** @type any */ (globalThis).__WEBJS_DIAG && /** @type any */ (container).tagName === 'DIAG-SLOT-BTN') ? /** @type any */ (globalThis).__WEBJS_DIAG : null;
+  if (__D) {
+    __D.push('createInstance parts=[' + parts.map((p) => p.kind).join(',') + ']');
+    __D.push('eventBinds=[' + bound.filter((b) => b.kind === 'event').map((b) => (b.el && /** @type any */ (b.el).tagName) + (b.el && /** @type any */ (b.el).isConnected ? ':conn' : ':frag')).join(',') + ']');
+  }
+
   const lastValues = [];
   for (let i = 0; i < tr.values.length; i++) {
     applyPart(bound[i], tr.values[i], undefined, tr.values);
@@ -469,6 +484,10 @@ function createInstance(tr, container) {
   }
 
   /** @type any */ (container).replaceChildren(startNode, ...frag.childNodes, endNode);
+  if (__D) {
+    const lb = /** @type any */ (container).querySelector('button');
+    __D.push('afterReplace liveBtn=' + (lb ? 'Y' : 'n') + ' liveBtnIsBoundEl=' + (lb && bound.some((b) => b.kind === 'event' && b.el === lb) ? 'Y' : 'n'));
+  }
 
   // Slot parts have no value-hole to drive applyPart from the loop above.
   // Apply them once now that the fragment is inserted into the live

--- a/packages/ui/packages/website/app/diag/page.ts
+++ b/packages/ui/packages/website/app/diag/page.ts
@@ -32,6 +32,7 @@ DiagSlotBtn.register('diag-slot-btn');
 
 const EARLY = `<script>
 window.__wjd={e:[],probeBClicked:false};
+window.__WEBJS_DIAG=[];
 addEventListener('error',function(ev){__wjd.e.push((ev.message||ev.type)+' @@ '+String(ev.filename||'').split('/').slice(-2).join('/')+':'+(ev.lineno||0))});
 addEventListener('unhandledrejection',function(ev){var r=ev.reason;__wjd.e.push('reject: '+((r&&r.message)||String(r)))});
 </script>`;
@@ -43,6 +44,7 @@ setTimeout(function(){
   __wjd.probeBClicked=false;
   if(bBtn) bBtn.click();
   rep.PROBE_B_minimal_slot_click={ buttonFound:bBtn?'Y':'n', clickFired:__wjd.probeBClicked?'Y':'n' };
+  rep.CORE_TRACE=window.__WEBJS_DIAG;
   var tb=document.getElementById('tb');
   var aBtn=tb?tb.querySelector('ui-tabs-trigger[value=\"password\"] button'):null;
   if(aBtn) aBtn.click();
@@ -55,7 +57,7 @@ export default function Diag() {
   return html`
     ${unsafeHTML(EARLY)}
     <main style="padding:1rem;font-family:system-ui;max-width:100%">
-      <h1 style="font-size:1.1rem">webjs Tier-2 iOS diagnostic v9 (#730)</h1>
+      <h1 style="font-size:1.1rem">webjs Tier-2 iOS diagnostic v10 (#730)</h1>
       <p style="font-size:.85rem;color:#666">Wait about 2s, then copy the whole readout and send it to me. The page stays scrollable.</p>
       <button onclick="location.reload()" style="margin-bottom:.75rem" class=${buttonClass({ variant: 'outline', size: 'sm' })}>Re-run</button>
       <pre id="wjdiag" style="white-space:pre-wrap;word-break:break-word;font:12px/1.5 monospace;background:#f4f4f5;color:#111;padding:1rem;border-radius:8px;border:1px solid #ccc">collecting (wait about 2s)...</pre>


### PR DESCRIPTION
Refs #730. TEMPORARY gated instrumentation in render-client.js to trace the slot+@click binding path on iOS hardware (gated on globalThis.__WEBJS_DIAG, set only by /diag; inert everywhere else). Reverted immediately after the iOS divergence is pinned.