### PR TITLE
chore: diag v11 - capture createInstance throw (#730) (TEMP)

### DIFF
--- a/packages/core/src/render-client.js
+++ b/packages/core/src/render-client.js
@@ -461,19 +461,33 @@ function assignPaths(root, parts) {
  * @param {Element | DocumentFragment | ShadowRoot} container
  */
 function createInstance(tr, container) {
+  // TEMP #730 diagnostic for the <diag-slot-btn> probe only.
+  const __D = (typeof globalThis !== 'undefined' && /** @type any */ (globalThis).__WEBJS_DIAG && /** @type any */ (container).tagName === 'DIAG-SLOT-BTN') ? /** @type any */ (globalThis).__WEBJS_DIAG : null;
+
   const { templateEl, parts } = compile(tr);
+  if (__D) __D.push('compiled parts=[' + parts.map((p) => p.kind + ':' + JSON.stringify(p.path)).join(' ') + ']');
   const frag = /** @type DocumentFragment */ (templateEl.content.cloneNode(true));
+  if (__D) {
+    const top = Array.from(frag.childNodes).map((n) => n.nodeName).join(',');
+    const c0 = frag.childNodes[0];
+    const kids = c0 ? Array.from(c0.childNodes).map((n) => n.nodeName).join(',') : 'NO-firstChild';
+    __D.push('frag top=[' + top + '] firstChildKids=[' + kids + ']');
+  }
 
   // Bookend markers bound the instance so we can tear it down cleanly.
   const startNode = document.createComment(`${MARKER}s`);
   const endNode = document.createComment(`${MARKER}e`);
 
-  const bound = parts.map((p) => bindPart(p, frag));
+  const bound = parts.map((p) => {
+    try {
+      return bindPart(p, frag);
+    } catch (e) {
+      if (__D) __D.push('bindPart THREW kind=' + p.kind + ' path=' + JSON.stringify(p.path) + ' err=' + (e && /** @type any */ (e).message));
+      throw e;
+    }
+  });
 
-  // TEMP #730 diagnostic for the <diag-slot-btn> probe only.
-  const __D = (typeof globalThis !== 'undefined' && /** @type any */ (globalThis).__WEBJS_DIAG && /** @type any */ (container).tagName === 'DIAG-SLOT-BTN') ? /** @type any */ (globalThis).__WEBJS_DIAG : null;
   if (__D) {
-    __D.push('createInstance parts=[' + parts.map((p) => p.kind).join(',') + ']');
     __D.push('eventBinds=[' + bound.filter((b) => b.kind === 'event').map((b) => (b.el && /** @type any */ (b.el).tagName) + (b.el && /** @type any */ (b.el).isConnected ? ':conn' : ':frag')).join(',') + ']');
   }
 

--- a/packages/ui/packages/website/app/diag/page.ts
+++ b/packages/ui/packages/website/app/diag/page.ts
@@ -57,7 +57,7 @@ export default function Diag() {
   return html`
     ${unsafeHTML(EARLY)}
     <main style="padding:1rem;font-family:system-ui;max-width:100%">
-      <h1 style="font-size:1.1rem">webjs Tier-2 iOS diagnostic v10 (#730)</h1>
+      <h1 style="font-size:1.1rem">webjs Tier-2 iOS diagnostic v11 (#730)</h1>
       <p style="font-size:.85rem;color:#666">Wait about 2s, then copy the whole readout and send it to me. The page stays scrollable.</p>
       <button onclick="location.reload()" style="margin-bottom:.75rem" class=${buttonClass({ variant: 'outline', size: 'sm' })}>Re-run</button>
       <pre id="wjdiag" style="white-space:pre-wrap;word-break:break-word;font:12px/1.5 monospace;background:#f4f4f5;color:#111;padding:1rem;border-radius:8px;border:1px solid #ccc">collecting (wait about 2s)...</pre>


### PR DESCRIPTION
Refs #730. v10 proved createInstance throws before binding on iOS. v11 captures the exact throw (compiled parts+paths, fragment structure, bindPart try/catch). Gated; reverted after diagnosis.