### PR TITLE
fix(ui): hover-card, dropdown submenu, sonner on iOS/touch (#745)

### DIFF
--- a/packages/ui/packages/registry/components/dropdown-menu.ts
+++ b/packages/ui/packages/registry/components/dropdown-menu.ts
@@ -564,7 +564,13 @@ export class UiDropdownMenuSub extends WebComponent({
   }
 
   _cancelCloseHandler = (): void => this._cancelClose();
-  _scheduleCloseHandler = (): void => this._scheduleClose();
+  // Hover-close is a mouse affordance. On touch, lifting the finger fires
+  // pointerleave; without this guard a tap-opened submenu would close itself
+  // ~200ms after the tap. On touch the submenu stays open until tapped again.
+  _scheduleCloseHandler = (e: Event): void => {
+    if ((e as PointerEvent).pointerType === 'touch') return;
+    this._scheduleClose();
+  };
 
   _scheduleClose(): void {
     this._cancelClose();
@@ -635,6 +641,10 @@ export class UiDropdownMenuSubTrigger extends WebComponent({ inset: Boolean }) {
   };
 
   _onPointerEnter = (e: Event): void => {
+    // Hover-open is a mouse affordance. On touch there is no hover: a tap
+    // fires pointerenter on finger-down, which would open the submenu only for
+    // the following click to toggle it shut. On touch, @click is the opener.
+    if ((e as PointerEvent).pointerType === 'touch') return;
     const el = e.currentTarget as HTMLElement;
     if (el.hasAttribute('data-disabled')) return;
     el.focus();

--- a/packages/ui/packages/registry/components/hover-card.ts
+++ b/packages/ui/packages/registry/components/hover-card.ts
@@ -114,6 +114,23 @@ export class UiHoverCard extends WebComponent({
     this._hideTimer = window.setTimeout(() => { this.open = false; }, this.closeDelay);
   }
 
+  // Touch open: there is no hover delay and no mouseleave to close it, so open
+  // immediately and arm a one-shot outside-tap dismiss (a tap anywhere outside
+  // this card closes it). Deferred a tick so the opening tap itself does not
+  // immediately dismiss it.
+  openByTouch(): void {
+    clearTimeout(this._showTimer);
+    clearTimeout(this._hideTimer);
+    this.open = true;
+    const onOutside = (ev: Event): void => {
+      if (!this.contains(ev.target as Node)) {
+        this.open = false;
+        document.removeEventListener('pointerdown', onOutside, true);
+      }
+    };
+    setTimeout(() => document.addEventListener('pointerdown', onOutside, true), 0);
+  }
+
   render() {
     return html`<div
       data-slot="hover-card"
@@ -179,11 +196,26 @@ export class UiHoverCardTrigger extends WebComponent {
       @mouseleave=${this._onLeave}
       @focusin=${this._onEnter}
       @focusout=${this._onLeave}
+      @click=${this._onClick}
     ><slot></slot></div>`;
   }
 
   _onEnter = (): void => (this.closest('ui-hover-card') as UiHoverCard | null)?.show();
   _onLeave = (): void => (this.closest('ui-hover-card') as UiHoverCard | null)?.hide();
+
+  // Touch path. A touch device has no `mouseenter`, so a tap would fall
+  // through to the inner `<a href>` and navigate (the card never opens). On a
+  // no-hover device the FIRST tap opens the card and is prevented from
+  // navigating; once open, a second tap follows the link as usual.
+  _onClick = (e: Event): void => {
+    if (!window.matchMedia?.('(hover: none)').matches) return;
+    const card = this.closest('ui-hover-card') as UiHoverCard | null;
+    if (card && !card.open) {
+      e.preventDefault();
+      e.stopPropagation();
+      card.openByTouch();
+    }
+  };
 }
 UiHoverCardTrigger.register('ui-hover-card-trigger');
 

--- a/packages/ui/packages/registry/components/sonner.ts
+++ b/packages/ui/packages/registry/components/sonner.ts
@@ -61,13 +61,28 @@ interface ToastItem extends ToastOptions {
 }
 
 let nextId = 1;
-const toaster: { add(t: ToastItem): void; remove(id: string | number): void } = {
-  add() {},
-  remove() {},
-};
+
+interface ToastBus {
+  add(t: ToastItem): void;
+  remove(id: string | number): void;
+}
+
+// The toast bus lives on `globalThis`, NOT in module scope, so the global
+// `toast()` still reaches a mounted <ui-sonner> when the module is loaded
+// under two different URLs. The app registers the element from the
+// version-hashed `sonner.ts?v=<hash>` (asset-hash, #243), while a caller may
+// do a bare `import('/components/ui/sonner.ts')`: those are distinct module
+// instances with distinct module-scope state, but they share one `window`.
+// Last-mounted viewport wins (it overwrites `bus().add`), matching the prior
+// singleton semantics. Without this, toasts published from a different module
+// instance silently went to a no-op bus (#745).
+function bus(): ToastBus {
+  const g = globalThis as unknown as { __webjsSonnerBus?: ToastBus };
+  return (g.__webjsSonnerBus ??= { add() {}, remove() {} });
+}
 
 function publish(item: ToastItem): string | number {
-  toaster.add(item);
+  bus().add(item);
   return item.id;
 }
 
@@ -92,7 +107,7 @@ toast.warning = (msg: string, o?: ToastOptions) => makeToast(msg, o, 'warning');
 toast.loading = (msg: string, o?: ToastOptions) => makeToast(msg, o, 'loading');
 toast.dismiss = (id?: string | number) => {
   if (id == null) return;
-  toaster.remove(id);
+  bus().remove(id);
 };
 toast.promise = <T,>(p: Promise<T>, opts: { loading: string; success: string; error: string }) => {
   const id = toast.loading(opts.loading);
@@ -147,16 +162,18 @@ export class UiSonner extends WebComponent({
   // Routing the global toast() function to this viewport. Runs in
   // firstUpdated rather than the constructor because tests can mount
   // multiple <ui-sonner> instances and the most recently mounted wins
-  // (matches the existing semantics).
+  // (matches the existing semantics). The bus lives on globalThis so this
+  // routing is visible to a toast() called from another module instance.
   firstUpdated(): void {
-    toaster.add = (t) => this._add(t);
-    toaster.remove = (id) => this._remove(id);
+    const b = bus();
+    b.add = (t) => this._add(t);
+    b.remove = (id) => this._remove(id);
   }
 
   /**
    * Publish a toast directly to THIS viewport. Use when you have a
-   * specific <ui-sonner> reference and want to bypass the singleton
-   * `toaster.add` routing (which always points to the last-mounted
+   * specific <ui-sonner> reference and want to bypass the global
+   * `bus().add` routing (which always points to the last-mounted
    * viewport). Primary use case: docs demos that mount one viewport
    * per position and want each demo button to fire into its own
    * viewport. App code should normally call the global `toast()` /

--- a/packages/ui/test/sonner-bus.test.js
+++ b/packages/ui/test/sonner-bus.test.js
@@ -1,0 +1,43 @@
+/**
+ * Regression test for #745: the global `toast()` must reach a mounted
+ * <ui-sonner> even when the sonner module is loaded under two different URLs
+ * (the app registers the element from the version-hashed `sonner.ts?v=<hash>`,
+ * while a caller may `import('/components/ui/sonner.ts')` bare). Those are
+ * distinct module instances, so the toast bus MUST live on `globalThis`, not in
+ * module scope. Before the fix the bus was a module-scope const, so a toast()
+ * published from one instance silently went to a no-op bus and never rendered.
+ *
+ * This asserts `toast()` routes through `globalThis.__webjsSonnerBus` (which a
+ * mounted <ui-sonner> writes its `_add` into via firstUpdated). It does not need
+ * a DOM: standing in for the element by writing the bus directly is exactly the
+ * cross-module-instance contract the fix guarantees.
+ */
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { toast } from '../packages/registry/components/sonner.ts';
+
+afterEach(() => {
+  delete /** @type {any} */ (globalThis).__webjsSonnerBus;
+});
+
+test('global toast() routes through the globalThis bus (#745)', () => {
+  const got = [];
+  /** @type {any} */ (globalThis).__webjsSonnerBus = { add: (t) => got.push(t), remove() {} };
+
+  const id = toast.success('hi', { description: 'saved' });
+
+  assert.equal(got.length, 1, 'toast() must route to the globalThis bus, not module scope');
+  assert.equal(got[0].message, 'hi');
+  assert.equal(got[0].type, 'success');
+  assert.equal(got[0].description, 'saved');
+  assert.equal(got[0].id, id);
+});
+
+test('toast.dismiss() routes removal through the same globalThis bus (#745)', () => {
+  const removed = [];
+  /** @type {any} */ (globalThis).__webjsSonnerBus = { add() {}, remove: (id) => removed.push(id) };
+
+  toast.dismiss(42);
+
+  assert.deepEqual(removed, [42]);
+});

--- a/packages/ui/test/touch-interactions.test.js
+++ b/packages/ui/test/touch-interactions.test.js
@@ -1,0 +1,69 @@
+/**
+ * Regression tests for #745: hover-card and dropdown-menu submenu relied on
+ * hover/pointer events that do not exist on touch, so on iOS the hover-card tap
+ * fell through to the inner <a> (navigation) and the submenu only stayed open
+ * while pressed. The fix gates the HOVER handlers on `pointerType !== 'touch'`
+ * (leaving @click as the touch path) and adds a tap-to-open path to hover-card.
+ *
+ * These exercise the handlers directly with mock events, which is exactly the
+ * pointer-type / no-hover branch the fix introduces (a full browser is not
+ * needed to prove the guard; the e2e touch behaviour is verified separately).
+ */
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  UiDropdownMenuSubTrigger,
+  UiDropdownMenuSub,
+} from '../packages/registry/components/dropdown-menu.ts';
+import { UiHoverCardTrigger } from '../packages/registry/components/hover-card.ts';
+
+afterEach(() => {
+  delete /** @type {any} */ (globalThis).window;
+});
+
+test('dropdown sub-trigger pointerenter hover-opens on mouse, not on touch (#745)', () => {
+  const t = new UiDropdownMenuSubTrigger();
+  let shown = 0;
+  t._sub = () => /** @type {any} */ ({ show: () => { shown++; } });
+  const evt = (pointerType) => ({ pointerType, currentTarget: { hasAttribute: () => false, focus() {} } });
+
+  t._onPointerEnter(evt('touch'));
+  assert.equal(shown, 0, 'touch pointerenter must NOT hover-open (the tap click opens it)');
+
+  t._onPointerEnter(evt('mouse'));
+  assert.equal(shown, 1, 'mouse pointerenter still hover-opens');
+});
+
+test('dropdown sub pointerleave schedules close on mouse, not on touch (#745)', () => {
+  const s = new UiDropdownMenuSub();
+  let scheduled = 0;
+  s._scheduleClose = () => { scheduled++; };
+
+  s._scheduleCloseHandler(/** @type {any} */ ({ pointerType: 'touch' }));
+  assert.equal(scheduled, 0, 'touch pointerleave must NOT close a tap-opened submenu');
+
+  s._scheduleCloseHandler(/** @type {any} */ ({ pointerType: 'mouse' }));
+  assert.equal(scheduled, 1, 'mouse pointerleave still schedules close');
+});
+
+test('hover-card tap opens + blocks nav on a no-hover device; no-op on hover (#745)', () => {
+  const t = new UiHoverCardTrigger();
+  let opened = 0, prevented = 0;
+  const card = { open: false, openByTouch: () => { opened++; } };
+  t.closest = () => /** @type {any} */ (card);
+  const mkEvt = () => ({ preventDefault: () => { prevented++; }, stopPropagation() {} });
+
+  // No-hover device (touch): the tap opens the card and is prevented from
+  // navigating the inner link.
+  /** @type {any} */ (globalThis).window = { matchMedia: () => ({ matches: true }) };
+  t._onClick(/** @type {any} */ (mkEvt()));
+  assert.equal(opened, 1, 'tap on a no-hover device opens the card');
+  assert.equal(prevented, 1, 'tap on a no-hover device blocks the link navigation');
+
+  // Hover device (desktop): handler is a no-op, the link navigates normally.
+  opened = 0; prevented = 0;
+  /** @type {any} */ (globalThis).window = { matchMedia: () => ({ matches: false }) };
+  t._onClick(/** @type {any} */ (mkEvt()));
+  assert.equal(opened, 0, 'on a hover device the tap handler is a no-op');
+  assert.equal(prevented, 0, 'on a hover device the inner link still navigates');
+});


### PR DESCRIPTION
Closes #745.

Three Tier-2 bugs found dogfooding on iOS after the #730 marker fix. All three fixed + verified.

- [x] **sonner**: global `toast()` rendered nothing because the toaster bus was module-scope, and the module loads under two URLs (the app uses the version-hashed `sonner.ts?v=<hash>`; a caller does a bare `import('/components/ui/sonner.ts')`). Distinct module instances → duplicated singleton → toasts went to a no-op bus. Moved the bus to `globalThis.__webjsSonnerBus`. (desktop-reproducible; node test)
- [x] **hover-card**: hover-only; an iOS tap fell through to the inner `<a>` → client-router navigation ("refresh"). Added a touch tap-to-open path (first tap opens + blocks the nav, second tap follows the link) with a one-shot outside-tap dismiss; mouse hover unchanged.
- [x] **dropdown submenu**: opened on pointer-enter, closed on pointer-leave, so on touch it was only open while pressed. Gated the hover handlers on `pointerType !== 'touch'`, leaving `@click → toggle` as the touch opener; mouse hover unchanged.

## Verification
- WebKit **iPhone emulation** e2e: sonner toast renders, hover-card opens on tap without navigating, dropdown submenu opens and **stays open** past the 200ms close delay. (Touch *events* are emulatable; the #730 engine quirk was not.)
- Desktop Chromium regression: hover-card and dropdown still open on hover.
- Node tests: sonner bus routing (+counterfactual), the hover/touch pointer-type guards.
- On-device iOS confirmation pending after deploy.

https://claude.ai/code/session_012hpgX16Gbg8Xhk5JmJmYcV
