### PR TITLE
test: catch iOS/touch regression classes on plain CI (#747)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,11 @@ jobs:
         env:
           WEBJS_E2E: '1'
         run: node --test test/e2e/e2e.test.mjs
+      # Touch-emulation e2e for interactive Tier-2 ui components (#745/#747):
+      # boots the ui-website and taps hover-card / dropdown-submenu / sonner
+      # under a Chromium iPhone context (faithful touch events, no real device).
+      - name: Run ui touch e2e
+        run: npm run test:e2e:touch --workspace=@webjsdev/ui
       # Cross-runtime e2e (#523): re-run the SAME suite under node --test (its
       # node:test hook lifecycle does not survive `bun test`) but with the blog
       # SERVED on Bun (WEBJS_E2E_RUNTIME=bun spawns the blog under the bun binary).

--- a/packages/core/test/rendering/strict-setattr-hydration.test.js
+++ b/packages/core/test/rendering/strict-setattr-hydration.test.js
@@ -1,0 +1,84 @@
+/**
+ * Generalized guard for the #730 class (tracked by #747).
+ *
+ * #730: the client renderer built part-sentinel ATTRIBUTE names as
+ * `data-${MARKER}${i}` and applied them via `setAttribute` in discoverSlots.
+ * The old `MARKER = 'w$'` produced `data-w$0`, whose `$` is invalid in an XML
+ * qualified name. iOS WebKit enforces the rule and threw, crashing
+ * createInstance for EVERY slot template; Chromium, desktop WebKit, and linkedom
+ * all TOLERATE it (verified). So no engine in CI catches this, and a browser
+ * test cannot catch what the browser accepts.
+ *
+ * This asserts the invariant directly: patch `setAttribute` to enforce the XML
+ * Name production (as strict iOS WebKit does), then run real templates through
+ * the client render path. If the renderer ever emits an invalid attribute name
+ * again, the strict wrapper throws and this fails, on ordinary CI hardware.
+ */
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseHTML } from 'linkedom';
+
+// XML Name production (ASCII subset), the rule Element.setAttribute() enforces.
+const VALID_XML_NAME = /^[A-Za-z_:][A-Za-z0-9_:.\-]*$/;
+
+let html, render, ElementProto, origSetAttribute;
+
+before(async () => {
+  const { window } = parseHTML('<!doctype html><html><head></head><body></body></html>');
+  globalThis.window = window;
+  globalThis.document = window.document;
+  globalThis.HTMLElement = window.HTMLElement;
+  globalThis.Element = window.Element;
+  globalThis.Node = window.Node;
+  globalThis.DocumentFragment = window.DocumentFragment;
+  globalThis.Comment = window.Comment;
+  globalThis.Text = window.Text;
+  globalThis.customElements = window.customElements;
+  globalThis.NodeFilter = window.NodeFilter;
+  globalThis.MutationObserver = window.MutationObserver;
+
+  // Make setAttribute strict like iOS WebKit: reject names that violate the
+  // XML Name production with an InvalidCharacterError.
+  ElementProto = window.Element.prototype;
+  origSetAttribute = ElementProto.setAttribute;
+  ElementProto.setAttribute = function (name, value) {
+    if (!VALID_XML_NAME.test(String(name))) {
+      const err = new Error(`Invalid qualified name: '${name}'`);
+      err.name = 'InvalidCharacterError';
+      throw err;
+    }
+    return origSetAttribute.call(this, name, value);
+  };
+
+  ({ html, render } = await import('../../index.js'));
+});
+
+after(() => {
+  if (ElementProto && origSetAttribute) ElementProto.setAttribute = origSetAttribute;
+});
+
+test('the strict setAttribute wrapper has teeth (rejects the historic data-w$0) (#747)', () => {
+  const el = document.createElement('div');
+  assert.throws(() => el.setAttribute('data-w$0', ''), /Invalid qualified name/);
+  // ...and accepts a valid name, so it is not rejecting everything.
+  assert.doesNotThrow(() => el.setAttribute('data-wjm-0', ''));
+});
+
+test('the renderer emits only valid attribute names (slot + @click + attrs) (#730/#747)', () => {
+  // The slot sentinel is applied via setAttribute in discoverSlots, the exact
+  // path that crashed iOS. Several representative templates, all with a <slot>.
+  const templates = [
+    () => html`<button type="button" class="x" @click=${() => {}}><slot></slot></button>`,
+    () => html`<div role="dialog" aria-label="x" @pointerenter=${() => {}}><slot></slot><slot name="end"></slot></div>`,
+    () => html`<section .value=${{ a: 1 }} ?hidden=${false}><span>x</span><slot></slot></section>`,
+  ];
+  for (const make of templates) {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    assert.doesNotThrow(
+      () => render(make(), container),
+      'renderer must not emit an attribute name a strict (iOS) setAttribute rejects'
+    );
+    assert.ok(container.querySelector('button, div, section'), 'template rendered');
+  }
+});

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,7 +19,8 @@
     "README.md"
   ],
   "scripts": {
-    "test": "node --test test/*.test.js"
+    "test": "node --test test/*.test.js",
+    "test:e2e:touch": "node test/e2e/touch.e2e.mjs"
   },
   "dependencies": {
     "commander": "^14.0.0",

--- a/packages/ui/test/e2e/touch.e2e.mjs
+++ b/packages/ui/test/e2e/touch.e2e.mjs
@@ -1,0 +1,117 @@
+/**
+ * Touch-emulation e2e for interactive Tier-2 components (#745, tracked by #747).
+ *
+ * hover-card / dropdown-submenu / sonner each broke on iOS touch in ways no
+ * desktop test caught. Touch *events* (`pointerType`, `matchMedia('(hover:none)')`)
+ * emulate faithfully under Playwright's iPhone context (unlike the #730
+ * engine-strictness quirk), so this runs on ordinary CI hardware: it boots the
+ * ui-website and TAPS each component's primary trigger, asserting the open /
+ * render outcome that was broken pre-#746.
+ *
+ * Self-contained: boots the website, runs the checks, tears down. Needs
+ * Playwright + a browser. Run: `node packages/ui/test/e2e/touch.e2e.mjs`
+ * (the runner sets WEBJS_E2E_TOUCH=1). Skips with a clear message if Playwright
+ * or a browser is unavailable.
+ */
+import { spawn } from 'node:child_process';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import process from 'node:process';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const WEBSITE = resolve(HERE, '../../packages/website');
+const PORT = Number(process.env.WEBJS_E2E_PORT || 5181);
+const BASE = `http://localhost:${PORT}`;
+
+function fail(msg) { console.error('FAIL: ' + msg); process.exitCode = 1; }
+
+let pw;
+try {
+  pw = (await import('playwright')).default ?? (await import('playwright'));
+} catch {
+  console.log('SKIP touch e2e: playwright not installed.');
+  process.exit(0);
+}
+
+// Boot the ui-website (copies the registry, then `webjs start`).
+const cli = resolve(WEBSITE, '../../../../node_modules/@webjsdev/cli/bin/webjs.js');
+spawn(process.execPath, [resolve(WEBSITE, 'scripts/copy-registry.js')], { cwd: WEBSITE, stdio: 'ignore' });
+await sleep(800);
+const server = spawn(process.execPath, [cli, 'start', '--port', String(PORT)], {
+  cwd: WEBSITE,
+  stdio: 'ignore',
+  env: { ...process.env, WEBJS_E2E_TOUCH: '1' },
+});
+const teardown = () => { try { server.kill('SIGTERM'); } catch { /* ignore */ } };
+process.on('exit', teardown);
+
+// Wait for readiness.
+let up = false;
+for (let i = 0; i < 40; i++) {
+  try {
+    const r = await fetch(BASE + '/__webjs/ready').catch(() => null);
+    if (r && r.ok) { up = true; break; }
+  } catch { /* retry */ }
+  await sleep(500);
+}
+if (!up) { fail('ui-website did not become ready'); teardown(); process.exit(1); }
+
+// Chromium with the iPhone descriptor activates every touch path the fixes key
+// on (verified: matchMedia('(hover:none)') + '(pointer:coarse)' both match, and
+// page.tap() dispatches pointerType 'touch'), and CI already installs Chromium.
+// The engine-strictness quirk that needed real WebKit (#730) is NOT what these
+// components depend on, so Chromium emulation is a faithful and CI-cheap target.
+let browser;
+try {
+  browser = await pw.chromium.launch({ headless: true });
+} catch (e) {
+  console.log('SKIP touch e2e: could not launch Chromium (' + String(e.message).split('\n')[0] + ').');
+  teardown();
+  process.exit(0);
+}
+
+const ctx = await browser.newContext({ ...pw.devices['iPhone 13'] });
+const page = await ctx.newPage();
+const results = [];
+
+// 1) sonner: tap "Show toast" -> a toast renders.
+await page.goto(BASE + '/docs/components/sonner', { waitUntil: 'domcontentloaded' });
+await page.waitForTimeout(1800);
+const sbtn = await page.evaluateHandle(() =>
+  [...document.querySelectorAll('button')].find((b) => /show toast/i.test(b.textContent || '')));
+await sbtn.asElement()?.tap();
+await page.waitForTimeout(1200);
+const toastNodes = await page.evaluate(() =>
+  [...document.querySelectorAll('ui-sonner')].reduce((n, s) => n + s.querySelectorAll('.pointer-events-auto').length, 0));
+results.push(['sonner toast renders on tap', toastNodes > 0]);
+
+// 2) hover-card: tap trigger -> opens, no navigation.
+await page.goto(BASE + '/docs/components/hover-card', { waitUntil: 'domcontentloaded' });
+await page.waitForTimeout(1800);
+const urlBefore = page.url();
+await (await page.$('ui-hover-card-trigger'))?.tap();
+await page.waitForTimeout(600);
+const hcOpen = await page.evaluate(() => !!document.querySelector('ui-hover-card')?.hasAttribute('open'));
+results.push(['hover-card opens on tap without navigating', hcOpen && page.url() === urlBefore]);
+
+// 3) dropdown submenu: open menu, tap sub-trigger -> opens AND stays (past close delay).
+await page.goto(BASE + '/docs/components/dropdown-menu', { waitUntil: 'domcontentloaded' });
+await page.waitForTimeout(1800);
+await (await page.$('ui-dropdown-menu-trigger button, ui-dropdown-menu-trigger'))?.tap();
+await page.waitForTimeout(400);
+await (await page.$('ui-dropdown-menu-sub-trigger [role="menuitem"], ui-dropdown-menu-sub-trigger'))?.tap();
+await page.waitForTimeout(700); // > SUB_CLOSE_DELAY (200ms): proves it STAYS open
+const subOpen = await page.evaluate(() => !!document.querySelector('ui-dropdown-menu-sub')?.hasAttribute('open'));
+results.push(['dropdown submenu opens and stays open on tap', subOpen]);
+
+await browser.close();
+teardown();
+
+let ok = true;
+for (const [name, pass] of results) {
+  console.log((pass ? 'PASS' : 'FAIL') + ': ' + name);
+  if (!pass) { ok = false; fail(name); }
+}
+if (ok) console.log('touch e2e: all ' + results.length + ' checks passed');
+process.exit(ok ? 0 : 1);


### PR DESCRIPTION
Closes #747. Follow-up to #730 (iOS marker crash) and #745 (touch bugs): prevention tests so the whole class is caught on ordinary CI, not after a multi-day on-device hunt.

## 1. Strict attribute-name guard (the #730 class)
`packages/core/test/rendering/strict-setattr-hydration.test.js` patches `setAttribute` to enforce the XML Name production (as iOS WebKit does), then runs real slot+`@click` templates through the client render path. No engine in CI catches this otherwise (Chromium, desktop WebKit, and linkedom all tolerate `data-w$0`, verified).

**Counterfactual verified:** restoring `MARKER='w$'` makes it fail with the exact on-device error, `Invalid qualified name: 'data-w$1'`. This single node test would have prevented the entire #730 session.

## 2. Touch-emulation e2e (the #745 class)
`packages/ui/test/e2e/touch.e2e.mjs` boots the ui-website and taps hover-card / dropdown-submenu / sonner under a **Chromium iPhone** context (verified: `matchMedia('(hover:none)')` and `pointerType: 'touch'` are both faithful, so no real device is needed and CI already installs Chromium). Wired into the CI `e2e` job and an `@webjsdev/ui` `test:e2e:touch` script.

**Counterfactual verified:** reverting the hover-card touch path makes its check fail (sonner/dropdown still pass).

## Tests
- core rendering node tests 137/137; ui node tests 143/143.
- Both new guards pass on current main; both counterfactuals confirmed.

## Related (separate, not in this PR)
The biggest #730 time-sink was the createInstance throw being silently swallowed (`ERRORS: (none)` on-device). Surfacing hydration/commit errors (dev `console.error` plus the `onError` hook) is noted in #747 to track separately.

https://claude.ai/code/session_012hpgX16Gbg8Xhk5JmJmYcV
