### PR TITLE
fix(ui): hover-card stays open on iOS touch (#745)

### DIFF
--- a/packages/ui/packages/registry/components/hover-card.ts
+++ b/packages/ui/packages/registry/components/hover-card.ts
@@ -200,8 +200,20 @@ export class UiHoverCardTrigger extends WebComponent {
     ><slot></slot></div>`;
   }
 
-  _onEnter = (): void => (this.closest('ui-hover-card') as UiHoverCard | null)?.show();
-  _onLeave = (): void => (this.closest('ui-hover-card') as UiHoverCard | null)?.hide();
+  // Hover/focus open + close are MOUSE affordances. On a no-hover (touch)
+  // device, iOS Safari still fires SYNTHETIC mouseenter/mouseleave (and
+  // focusin/focusout from the inner link) around a tap, which would otherwise
+  // immediately re-close a tap-opened card. Gate the hover handlers to pointer
+  // devices so on touch the card is driven only by the tap path (#745).
+  _noHover = (): boolean => !!window.matchMedia?.('(hover: none)').matches;
+  _onEnter = (): void => {
+    if (this._noHover()) return;
+    (this.closest('ui-hover-card') as UiHoverCard | null)?.show();
+  };
+  _onLeave = (): void => {
+    if (this._noHover()) return;
+    (this.closest('ui-hover-card') as UiHoverCard | null)?.hide();
+  };
 
   // Touch path. A touch device has no `mouseenter`, so a tap would fall
   // through to the inner `<a href>` and navigate (the card never opens). On a
@@ -238,7 +250,19 @@ export class UiHoverCardContent extends WebComponent {
     ><slot></slot></div>`;
   }
 
-  _onEnter = (): void => (this.closest('ui-hover-card') as UiHoverCard | null)?.show();
-  _onLeave = (): void => (this.closest('ui-hover-card') as UiHoverCard | null)?.hide();
+  // Hover/focus open + close are MOUSE affordances. On a no-hover (touch)
+  // device, iOS Safari still fires SYNTHETIC mouseenter/mouseleave (and
+  // focusin/focusout from the inner link) around a tap, which would otherwise
+  // immediately re-close a tap-opened card. Gate the hover handlers to pointer
+  // devices so on touch the card is driven only by the tap path (#745).
+  _noHover = (): boolean => !!window.matchMedia?.('(hover: none)').matches;
+  _onEnter = (): void => {
+    if (this._noHover()) return;
+    (this.closest('ui-hover-card') as UiHoverCard | null)?.show();
+  };
+  _onLeave = (): void => {
+    if (this._noHover()) return;
+    (this.closest('ui-hover-card') as UiHoverCard | null)?.hide();
+  };
 }
 UiHoverCardContent.register('ui-hover-card-content');

--- a/packages/ui/packages/website/app/hctest/page.ts
+++ b/packages/ui/packages/website/app/hctest/page.ts
@@ -1,0 +1,39 @@
+// TEMPORARY on-device diagnostic for #745 (hover-card stay-open on iOS).
+// Removed once confirmed. Renders the (fixed) hover-card and logs every trigger
+// event + every open-state change, so a single tap on a real iPhone either
+// confirms the card stays open or shows exactly what closes it.
+import { html, unsafeHTML } from '@webjsdev/core';
+import '#components/ui/hover-card.ts';
+
+const LOG = `<script>
+window.__hc={ev:[],t0:Date.now()};
+setTimeout(function(){
+  var trig=document.querySelector('ui-hover-card-trigger');
+  var card=document.querySelector('ui-hover-card');
+  if(!trig||!card){document.getElementById('log').textContent='no hover-card found';return;}
+  ['pointerdown','pointerup','click','mouseenter','mouseleave','focusin','focusout','touchstart','touchend'].forEach(function(t){
+    trig.addEventListener(t,function(e){__hc.ev.push((Date.now()-__hc.t0)+'ms '+t+(e.pointerType?'('+e.pointerType+')':''));},true);
+  });
+  new MutationObserver(function(){__hc.ev.push((Date.now()-__hc.t0)+'ms OPEN='+card.hasAttribute('open'));}).observe(card,{attributes:true,attributeFilter:['open']});
+  setInterval(function(){document.getElementById('log').textContent=JSON.stringify({ua:navigator.userAgent.slice(0,32),hoverNone:matchMedia('(hover: none)').matches,seq:__hc.ev.slice(-22)},null,1);},400);
+},1000);
+</script>`;
+
+export default function HcTest() {
+  return html`
+    ${unsafeHTML(LOG)}
+    <main style="padding:1rem;font-family:system-ui;max-width:100%">
+      <h1 style="font-size:1.1rem">hover-card iOS test (#745)</h1>
+      <p style="font-size:.85rem;color:#666">Tap the blue link once, wait about 2s, then copy the whole readout and send it. The card should OPEN and STAY open until you tap elsewhere.</p>
+      <div style="height:18vh"></div>
+      <ui-hover-card>
+        <ui-hover-card-trigger><a href="/docs" style="color:#0066ff;text-decoration:underline">@vivek (tap me)</a></ui-hover-card-trigger>
+        <ui-hover-card-content>
+          <div style="padding:0.75rem">This card should stay open after a tap.</div>
+        </ui-hover-card-content>
+      </ui-hover-card>
+      <div style="height:28vh"></div>
+      <pre id="log" style="white-space:pre-wrap;word-break:break-word;font:12px/1.5 monospace;background:#f4f4f5;color:#111;padding:1rem;border-radius:8px;border:1px solid #ccc">tap the link, then wait about 2s</pre>
+    </main>
+  `;
+}


### PR DESCRIPTION
Reopens/continues #745. The #746 hover-card fix opened the card on tap but left the hover/focus handlers active; iOS Safari's synthetic mouse/focus events on tap re-closed it (real-device only; emulation does not fire them). Gate the hover handlers to pointer devices. Temporary /hctest logger included to confirm on-device, removed before ready.

https://claude.ai/code/session_012hpgX16Gbg8Xhk5JmJmYcV