### PR TITLE
fix(ui): hover-card tap never navigates on touch (no history pollution) (#745)

### DIFF
--- a/packages/ui/packages/registry/components/hover-card.ts
+++ b/packages/ui/packages/registry/components/hover-card.ts
@@ -123,7 +123,9 @@ export class UiHoverCard extends WebComponent({
     clearTimeout(this._hideTimer);
     this.open = true;
     const onOutside = (ev: Event): void => {
-      if (!this.contains(ev.target as Node)) {
+      // Close on an outside tap; also self-remove if the card was already
+      // closed by other means (a re-tap toggle), so the listener never lingers.
+      if (!this.open || !this.contains(ev.target as Node)) {
         this.open = false;
         document.removeEventListener('pointerdown', onOutside, true);
       }
@@ -215,18 +217,21 @@ export class UiHoverCardTrigger extends WebComponent {
     (this.closest('ui-hover-card') as UiHoverCard | null)?.hide();
   };
 
-  // Touch path. A touch device has no `mouseenter`, so a tap would fall
-  // through to the inner `<a href>` and navigate (the card never opens). On a
-  // no-hover device the FIRST tap opens the card and is prevented from
-  // navigating; once open, a second tap follows the link as usual.
+  // Touch path. A touch device has no `mouseenter`, so a tap would fall through
+  // to the inner `<a href>` and navigate. On a no-hover device the trigger tap
+  // TOGGLES the card and NEVER navigates (the real link is reachable inside the
+  // opened card). It must ALWAYS preventDefault, including while open: the
+  // client router pushState()s on any bubble-phase `<a>` click that is not
+  // defaultPrevented, so a re-tap that fell through would push a history entry
+  // every time and Back would need N presses (#745).
   _onClick = (e: Event): void => {
     if (!window.matchMedia?.('(hover: none)').matches) return;
     const card = this.closest('ui-hover-card') as UiHoverCard | null;
-    if (card && !card.open) {
-      e.preventDefault();
-      e.stopPropagation();
-      card.openByTouch();
-    }
+    if (!card) return;
+    e.preventDefault();
+    e.stopPropagation();
+    if (card.open) card.open = false;
+    else card.openByTouch();
   };
 }
 UiHoverCardTrigger.register('ui-hover-card-trigger');

--- a/packages/ui/test/touch-interactions.test.js
+++ b/packages/ui/test/touch-interactions.test.js
@@ -46,24 +46,34 @@ test('dropdown sub pointerleave schedules close on mouse, not on touch (#745)', 
   assert.equal(scheduled, 1, 'mouse pointerleave still schedules close');
 });
 
-test('hover-card tap opens + blocks nav on a no-hover device; no-op on hover (#745)', () => {
+test('hover-card tap toggles + ALWAYS blocks nav on touch; no-op on hover (#745)', () => {
   const t = new UiHoverCardTrigger();
-  let opened = 0, prevented = 0;
-  const card = { open: false, openByTouch: () => { opened++; } };
+  let opened = 0;
+  const card = { open: false, openByTouch: () => { opened++; card.open = true; } };
   t.closest = () => /** @type {any} */ (card);
-  const mkEvt = () => ({ preventDefault: () => { prevented++; }, stopPropagation() {} });
+  const mkEvt = () => { const e = { p: 0, preventDefault() { e.p++; }, stopPropagation() {} }; return e; };
 
-  // No-hover device (touch): the tap opens the card and is prevented from
-  // navigating the inner link.
   /** @type {any} */ (globalThis).window = { matchMedia: () => ({ matches: true }) };
-  t._onClick(/** @type {any} */ (mkEvt()));
-  assert.equal(opened, 1, 'tap on a no-hover device opens the card');
-  assert.equal(prevented, 1, 'tap on a no-hover device blocks the link navigation');
+
+  // Closed -> first tap opens the card and blocks the link navigation.
+  const e1 = mkEvt();
+  t._onClick(/** @type {any} */ (e1));
+  assert.equal(card.open, true, 'tap opens a closed card');
+  assert.equal(opened, 1);
+  assert.equal(e1.p, 1, 'blocks the link navigation when opening');
+
+  // Open -> a re-tap toggles it closed and STILL preventsDefault, so the inner
+  // <a>'s click never reaches the client router (no pushState, no history
+  // pollution that needs N Back presses) (#745).
+  const e2 = mkEvt();
+  t._onClick(/** @type {any} */ (e2));
+  assert.equal(card.open, false, 'a re-tap toggles the card closed (never navigates)');
+  assert.equal(e2.p, 1, 'still blocks nav while open, so the router never pushState');
 
   // Hover device (desktop): handler is a no-op, the link navigates normally.
-  opened = 0; prevented = 0;
+  card.open = false;
   /** @type {any} */ (globalThis).window = { matchMedia: () => ({ matches: false }) };
-  t._onClick(/** @type {any} */ (mkEvt()));
-  assert.equal(opened, 0, 'on a hover device the tap handler is a no-op');
-  assert.equal(prevented, 0, 'on a hover device the inner link still navigates');
+  const e3 = mkEvt();
+  t._onClick(/** @type {any} */ (e3));
+  assert.equal(e3.p, 0, 'on a hover device the inner link still navigates');
 });


### PR DESCRIPTION
Continues #745. Last hover-card touch issue: tapping the trigger pushed a browser-history entry per tap, so Back needed N presses to leave the page.

**Cause:** the client router intercepts `<a>` clicks on `document` in bubble phase and `pushState`s unless the event is `defaultPrevented` (router-client.js:341). The #758 fix only `preventDefault`'d on the *opening* tap; a re-tap while open fell through, so the inner `<a>`'s click reached the router and pushed history every time.

**Fix:** on a no-hover (touch) device the trigger tap ALWAYS `preventDefault`s and TOGGLES the card (open if closed, close if open). It never navigates, because the real link is reachable inside the opened card. Desktop/hover behaviour unchanged (the link still navigates).

**Verified in a Chromium iPhone context** (this one IS emulatable, unlike the synthetic-event stay-open bug): 4 taps -> history delta 0, no navigation, toggle [open,closed,open,closed]. Unit test updated to assert the re-tap-while-open still preventsDefault.

https://claude.ai/code/session_012hpgX16Gbg8Xhk5JmJmYcV