### PR TITLE
fix: strip renamed wjm- hydration markers in ssrFixture normalize()

### DIFF
--- a/packages/core/src/slot.js
+++ b/packages/core/src/slot.js
@@ -436,7 +436,7 @@ export function attachSlotObservers(host) {
       // Skip records produced by the framework's own renderer. Each
       // top-level TemplateInstance commit (`createInstance`) and each
       // child-part template swap (`applyChildPart`) inserts and removes
-      // its content as a unit bounded by `w$s`/`w$e` comment markers
+      // its content as a unit bounded by `wjm-s`/`wjm-e` comment markers
       // (see render-client.js). When such a record reaches the host's
       // childList observer, treating its addedNodes as authored
       // children pollutes assignedByName with the renderer's own

--- a/packages/core/test/testing/browser/ssr-fixture.test.js
+++ b/packages/core/test/testing/browser/ssr-fixture.test.js
@@ -27,7 +27,13 @@ const assert = {
 function normalize(s) {
   return String(s)
     .replace(/<!--webjs-hydrate-->/g, '')
+    // Strip lit-html-style part markers the live client render leaves in the
+    // DOM but the clean SSR string does not have. The marker name was renamed
+    // from `w$` to `wjm-` in #744 (a `$` is invalid in an XML qualified name,
+    // which broke slot components on iOS); strip both forms so this comparison
+    // stays marker-agnostic. New form: <!--wjm-s-->, <!--wjm-e-->, <!--wjm-N-->.
     .replace(/<!--\/?w\$[^>]*-->/g, '')
+    .replace(/<!--\/?wjm-[^>]*-->/g, '')
     .replace(/\s+data-webjs-prop-[a-z0-9-]+="[^"]*"/g, '')
     .replace(/=""/g, '')
     .replace(/>\s+</g, '><')


### PR DESCRIPTION
Closes #761

The Browser CI gate has been red on `main` since #744 (the `w$` to `wjm-` hydration-marker rename for iOS slot components). The ssr-fixture browser test reconciles the marker-free SSR string against the marker-carrying live DOM by stripping markers in `normalize()`, but that helper still stripped only the old `w$` form, so the new `<!--wjm-s-->`/`<!--wjm-0-->`/`<!--wjm-e-->` markers survived and the passing-case assert failed. Browser tests are not in `npm test`, so it merged red and stayed red, blocking every PR.

## Fix
Strip the `wjm-` marker form too (keep the legacy `w$` strip). Corrected the stale `w$s`/`w$e` comment in `slot.js` (the functional code already uses the `MARKER` constant).

## Verify
`npx wtr packages/core/test/testing/browser/ssr-fixture.test.js`: 4/4 pass. Counterfactual: removing the new regex reproduces 3 passed / 1 failed.

## Bun parity / docs
N/A: test-helper regex + a source comment, no runtime behaviour change.