### PR TITLE
feat: webjs:before-cache hook; kit overlays reset on back/forward (#766)

### DIFF
--- a/agent-docs/advanced.md
+++ b/agent-docs/advanced.md
@@ -642,6 +642,28 @@ document.addEventListener('webjs:prefetch', (e) => {
 });
 ```
 
+### `webjs:before-cache` (strip transient state before a back/forward snapshot)
+
+The router keeps a URL-keyed snapshot cache (Turbo's SnapshotCache pattern) so
+Back/Forward restores instantly. Because a snapshot is a raw `outerHTML` clone of
+the live page, anything OPEN at navigate-away time (a hover-card, a dropdown, a
+toast) is captured open and **restored open** on Forward. To prevent that, the
+router dispatches `webjs:before-cache` on `document` **synchronously, on the page
+being cached, immediately before the `outerHTML` read** (detail `{ url }`). A
+handler's DOM mutations are captured in the snapshot; the live edits are
+invisible because the page is being navigated away from (Turbo's
+`turbo:before-cache` contract). Reset transient state here:
+
+```ts
+document.addEventListener('webjs:before-cache', () => {
+  document.querySelectorAll('[data-transient]').forEach((el) => el.remove());
+  // close open menus, clear in-progress toasts, reset a wizard step, ...
+});
+```
+
+The kit's overlays (hover-card, tooltip, dropdown-menu, dialog, alert-dialog,
+sonner) already listen and reset their open state, so they come back closed.
+
 ### View Transitions (opt-in, all three swap paths)
 
 The router can wrap a client navigation's DOM mutation in the native

--- a/docs/app/docs/client-router/page.ts
+++ b/docs/app/docs/client-router/page.ts
@@ -97,6 +97,13 @@ const result = await optimistic(liked, true, () =&gt; likePost(postId));
   showToast(\`Could not load \${e.detail.url} (status \${e.detail.status})\`);
 });</pre>
 
+    <h2>Strip transient state before back/forward (<code>webjs:before-cache</code>)</h2>
+    <p>Back/Forward restores from a URL-keyed snapshot cache (Turbo's SnapshotCache pattern) for instant navigation. Because a snapshot is a raw <code>outerHTML</code> clone of the live page, anything <em>open</em> when you navigate away (a hover-card, a dropdown, a toast) is captured open and <strong>restored open</strong> on Forward. The router dispatches <code>webjs:before-cache</code> on <code>document</code> synchronously, on the page being cached, right before the snapshot is read, so a handler can reset that state and edits land in the snapshot. The kit's overlays already do this, so they come back closed.</p>
+    <pre>document.addEventListener('webjs:before-cache', () =&gt; {
+  document.querySelectorAll('[data-transient]').forEach((el) =&gt; el.remove());
+  // close open menus, clear in-progress toasts, reset a wizard step, ...
+});</pre>
+
     <h2><code>&lt;webjs-frame&gt;</code>: escape hatch for non-layout regions</h2>
     <p><code>&lt;webjs-frame&gt;</code> is webjs's take on <strong>Turbo Frames</strong> (from Hotwire Turbo), so if you know <code>&lt;turbo-frame&gt;</code> the model transfers directly: a lazy, URL-addressable region that swaps on its own, driven by a link or form that targets its id. See <a href="/docs/data-fetching">Data fetching</a> for when to reach for a frame versus async render, <code>&lt;webjs-suspense&gt;</code>, or <code>&lt;webjs-stream&gt;</code>, and for combining a lazy frame with streamed content inside it.</p>
     <p>The marker mechanism scopes swaps to the deepest shared <strong>layout</strong>. When you need a swap region <em>smaller</em> than the deepest layout (typically a widget inside a page that should swap independently of the rest of the page) wrap it in <code>&lt;webjs-frame id="..."&gt;</code>.</p>

--- a/packages/core/src/router-client.js
+++ b/packages/core/src/router-client.js
@@ -765,6 +765,14 @@ const snapshotCache = new Map();
  */
 function snapshotCurrent(url) {
   const key = cacheKey(url);
+  // Let components and app code strip transient state (open overlays, toasts,
+  // in-progress wizard steps) from the page BEFORE it is serialized into the
+  // back/forward cache, so a later popstate restore shows a clean page rather
+  // than, say, a hover-card frozen open (#766, Turbo's `before-cache` contract).
+  // Fires SYNCHRONOUSLY on the live DOM right before the outerHTML read, so a
+  // handler's mutations are captured; the live edits are invisible because the
+  // page is being navigated away from.
+  document.dispatchEvent(new CustomEvent('webjs:before-cache', { detail: { url } }));
   // Move-to-front for LRU.
   if (snapshotCache.has(key)) snapshotCache.delete(key);
   /** @type {Snapshot} */

--- a/packages/ui/packages/registry/components/alert-dialog.ts
+++ b/packages/ui/packages/registry/components/alert-dialog.ts
@@ -65,7 +65,7 @@
  */
 import { WebComponent, html, prop } from '@webjsdev/core';
 import { ref, createRef } from '@webjsdev/core/directives';
-import { ensureId } from '../lib/utils.ts';
+import { ensureId, onBeforeCache } from '../lib/utils.ts';
 import { buttonClass, type ButtonVariant, type ButtonSize } from './button.ts';
 
 export const alertDialogContentClass = (): string =>
@@ -143,16 +143,22 @@ export class UiAlertDialog extends WebComponent({
     this.open = false;
   }
 
+  _disposeBeforeCache?: () => void;
+
   connectedCallback(): void {
     installStyles();
     // Legacy <ui-alert-dialog-overlay> isn't supported anymore; the native
     // ::backdrop pseudo replaces it. Strip it if a stale doc uses it.
     this.querySelector<HTMLElement>(':scope > ui-alert-dialog-overlay')?.remove();
     super.connectedCallback?.();
+    // Close before a back/forward snapshot: a modal restored half-open (the
+    // `open` attr without the native showModal top-layer state) is broken (#766).
+    this._disposeBeforeCache = onBeforeCache(() => { this.open = false; });
   }
 
   disconnectedCallback(): void {
     if (this.open) this._teardown();
+    this._disposeBeforeCache?.();
     super.disconnectedCallback?.();
   }
 

--- a/packages/ui/packages/registry/components/dialog.ts
+++ b/packages/ui/packages/registry/components/dialog.ts
@@ -65,7 +65,7 @@
  */
 import { WebComponent, html, unsafeHTML, prop } from '@webjsdev/core';
 import { ref, createRef } from '@webjsdev/core/directives';
-import { ensureId } from '../lib/utils.ts';
+import { ensureId, onBeforeCache } from '../lib/utils.ts';
 import { buttonClass } from './button.ts';
 
 // Wires a dialog panel's accessible name + description to its title /
@@ -197,16 +197,22 @@ export class UiDialog extends WebComponent({
     this.open = false;
   }
 
+  _disposeBeforeCache?: () => void;
+
   connectedCallback(): void {
     installStyles();
     // Legacy <ui-dialog-overlay> isn't supported anymore; the native
     // ::backdrop pseudo replaces it. Strip it if a stale doc uses it.
     this.querySelector<HTMLElement>(':scope > ui-dialog-overlay')?.remove();
     super.connectedCallback?.();
+    // Close before a back/forward snapshot: a modal restored half-open (the
+    // `open` attr without the native showModal top-layer state) is broken (#766).
+    this._disposeBeforeCache = onBeforeCache(() => { this.open = false; });
   }
 
   disconnectedCallback(): void {
     if (this.open) this._teardown();
+    this._disposeBeforeCache?.();
     super.disconnectedCallback?.();
   }
 

--- a/packages/ui/packages/registry/components/dropdown-menu.ts
+++ b/packages/ui/packages/registry/components/dropdown-menu.ts
@@ -78,7 +78,7 @@
  * --accent-foreground, --destructive, --muted-foreground, --border.
  */
 import { WebComponent, html, unsafeHTML, signal, prop } from '@webjsdev/core';
-import { ensureId } from '../lib/utils.ts';
+import { ensureId, onBeforeCache } from '../lib/utils.ts';
 import { positionFloating, type PopoverSide, type PopoverAlign } from './popover.ts';
 
 // --------------------------------------------------------------------------
@@ -135,8 +135,11 @@ export class UiDropdownMenu extends WebComponent({
     this.open = false;
   }
 
+  _disposeBeforeCache?: () => void;
+
   disconnectedCallback(): void {
     if (this.open) this._teardown();
+    this._disposeBeforeCache?.();
     super.disconnectedCallback?.();
   }
 
@@ -165,6 +168,9 @@ export class UiDropdownMenu extends WebComponent({
     if (typeof requestAnimationFrame === 'function') {
       requestAnimationFrame(() => this._wireAria());
     }
+    // Close (and tear down) before a back/forward snapshot so the menu does not
+    // restore open (#766). Closing the root also hides any open submenu.
+    this._disposeBeforeCache = onBeforeCache(() => { this.open = false; });
   }
 
   _afterRender(): void {

--- a/packages/ui/packages/registry/components/hover-card.ts
+++ b/packages/ui/packages/registry/components/hover-card.ts
@@ -39,7 +39,7 @@
  * Design tokens used: --popover, --popover-foreground, --border.
  */
 import { WebComponent, html, prop } from '@webjsdev/core';
-import { ensureId } from '../lib/utils.ts';
+import { ensureId, onBeforeCache } from '../lib/utils.ts';
 import { positionFloating, type PopoverSide, type PopoverAlign } from './popover.ts';
 
 // `fixed m-0` opts out of the UA `[popover]` auto-centering margin so
@@ -70,6 +70,8 @@ export class UiHoverCard extends WebComponent({
     this.closeDelay = 300;
   }
 
+  _disposeBeforeCache?: () => void;
+
   connectedCallback(): void {
     super.connectedCallback?.();
     // webjs projects slotted light-DOM children after the first render, so
@@ -78,6 +80,14 @@ export class UiHoverCard extends WebComponent({
     if (typeof requestAnimationFrame === 'function') {
       requestAnimationFrame(() => this._wireAria());
     }
+    // Close before the page is cached for back/forward so a restored snapshot
+    // does not come back frozen open (#766).
+    this._disposeBeforeCache = onBeforeCache(() => { this.open = false; });
+  }
+
+  disconnectedCallback(): void {
+    this._disposeBeforeCache?.();
+    super.disconnectedCallback?.();
   }
 
   // The trigger also opens on focus (see the @focusin handler), so it is

--- a/packages/ui/packages/registry/components/sonner.ts
+++ b/packages/ui/packages/registry/components/sonner.ts
@@ -44,6 +44,7 @@
  * Design tokens used: --popover, --popover-foreground, --border, --radius.
  */
 import { WebComponent, html, repeat, unsafeHTML, signal, prop } from '@webjsdev/core';
+import { onBeforeCache } from '../lib/utils.ts';
 
 type ToastType = 'default' | 'success' | 'error' | 'info' | 'warning' | 'loading';
 
@@ -154,9 +155,23 @@ export class UiSonner extends WebComponent({
 }) {
   items = signal<ToastItem[]>([]);
 
+  _disposeBeforeCache?: () => void;
+
   constructor() {
     super();
     this.position = 'bottom-right';
+  }
+
+  connectedCallback(): void {
+    super.connectedCallback?.();
+    // Clear pending toasts before a back/forward snapshot so a restored page
+    // does not show stale toasts that should have auto-dismissed (#766).
+    this._disposeBeforeCache = onBeforeCache(() => this.items.set([]));
+  }
+
+  disconnectedCallback(): void {
+    this._disposeBeforeCache?.();
+    super.disconnectedCallback?.();
   }
 
   // Routing the global toast() function to this viewport. Runs in

--- a/packages/ui/packages/registry/components/tooltip.ts
+++ b/packages/ui/packages/registry/components/tooltip.ts
@@ -41,7 +41,7 @@
  * Design tokens used: --foreground, --background.
  */
 import { WebComponent, html, prop } from '@webjsdev/core';
-import { ensureId } from '../lib/utils.ts';
+import { ensureId, onBeforeCache } from '../lib/utils.ts';
 import { positionFloating, type PopoverSide, type PopoverAlign } from './popover.ts';
 
 // UA `[popover]` defaults paint a bordered, padded panel centered with
@@ -79,6 +79,8 @@ export class UiTooltip extends WebComponent({
     this.skipDelayDuration = 300;
   }
 
+  _disposeBeforeCache?: () => void;
+
   connectedCallback(): void {
     super.connectedCallback?.();
     // webjs projects slotted light-DOM children in a pass after the first
@@ -88,6 +90,13 @@ export class UiTooltip extends WebComponent({
     if (typeof requestAnimationFrame === 'function') {
       requestAnimationFrame(() => this._wireAria());
     }
+    // Close before a back/forward snapshot so it does not restore open (#766).
+    this._disposeBeforeCache = onBeforeCache(() => { this.open = false; });
+  }
+
+  disconnectedCallback(): void {
+    this._disposeBeforeCache?.();
+    super.disconnectedCallback?.();
   }
 
   // APG tooltip wiring: the focusable trigger references the tip via

--- a/packages/ui/packages/registry/lib/utils.ts
+++ b/packages/ui/packages/registry/lib/utils.ts
@@ -266,3 +266,19 @@ export const helpClass = () => 'text-xs text-muted-foreground';
 
 /** Validation error text: replaces hint when the field is invalid. */
 export const errorClass = () => 'text-sm font-medium text-destructive';
+
+/**
+ * Run `reset` just before the webjs client router snapshots the page into its
+ * back/forward cache (the `webjs:before-cache` event). Transient overlays use
+ * this to close themselves so a restored snapshot is clean rather than, say, a
+ * hover-card frozen open after Back then Forward (#766). Wire it in
+ * `connectedCallback` and call the returned disposer in `disconnectedCallback`
+ * so the listener never leaks across soft navigations.
+ *
+ * SSR-safe: a no-op when there is no `document` (server / no client router).
+ */
+export function onBeforeCache(reset: () => void): () => void {
+  if (typeof document === 'undefined') return () => {};
+  document.addEventListener('webjs:before-cache', reset);
+  return () => document.removeEventListener('webjs:before-cache', reset);
+}

--- a/packages/ui/test/before-cache.test.js
+++ b/packages/ui/test/before-cache.test.js
@@ -1,0 +1,56 @@
+/**
+ * #766: transient overlays reset before the client router snapshots the page
+ * for back/forward (the `webjs:before-cache` event), so a restored snapshot is
+ * clean (e.g. a hover-card does not come back frozen open).
+ *
+ * This covers the shared `onBeforeCache` helper the overlays use: it runs the
+ * reset on the event, the disposer removes the listener (no leak across soft
+ * navigations), and it is a safe no-op with no document (SSR).
+ */
+import { test, before, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseHTML } from 'linkedom';
+
+let onBeforeCache;
+
+before(async () => {
+  const { window } = parseHTML('<!doctype html><html><body></body></html>');
+  globalThis.document = window.document;
+  globalThis.CustomEvent = window.CustomEvent;
+  ({ onBeforeCache } = await import('../packages/registry/lib/utils.ts'));
+});
+
+afterEach(() => {
+  // Restore document in case a test deleted it.
+  if (!globalThis.document) {
+    const { window } = parseHTML('<!doctype html><html><body></body></html>');
+    globalThis.document = window.document;
+    globalThis.CustomEvent = window.CustomEvent;
+  }
+});
+
+test('onBeforeCache runs the reset on webjs:before-cache; disposer removes it (#766)', () => {
+  let n = 0;
+  const dispose = onBeforeCache(() => { n += 1; });
+
+  document.dispatchEvent(new CustomEvent('webjs:before-cache'));
+  assert.equal(n, 1, 'reset runs when the event fires');
+
+  document.dispatchEvent(new CustomEvent('webjs:before-cache'));
+  assert.equal(n, 2, 'runs again on a second cache');
+
+  dispose();
+  document.dispatchEvent(new CustomEvent('webjs:before-cache'));
+  assert.equal(n, 2, 'the disposer removes the listener (no leak across soft navs)');
+});
+
+test('onBeforeCache is SSR-safe: a no-op disposer when there is no document (#766)', () => {
+  const saved = globalThis.document;
+  delete globalThis.document;
+  let ran = false;
+  const dispose = onBeforeCache(() => { ran = true; });
+  assert.equal(typeof dispose, 'function', 'returns a disposer even with no document');
+  assert.doesNotThrow(() => dispose());
+  assert.equal(ran, false);
+  globalThis.document = saved;
+});

--- a/packages/ui/test/e2e/touch.e2e.mjs
+++ b/packages/ui/test/e2e/touch.e2e.mjs
@@ -105,6 +105,44 @@ await page.waitForTimeout(700); // > SUB_CLOSE_DELAY (200ms): proves it STAYS op
 const subOpen = await page.evaluate(() => !!document.querySelector('ui-dropdown-menu-sub')?.hasAttribute('open'));
 results.push(['dropdown submenu opens and stays open on tap', subOpen]);
 
+// 4) before-cache (#766): open a hover-card, then fire the event the router
+// fires when it snapshots the page for back/forward. The card must close.
+await page.goto(BASE + '/docs/components/hover-card', { waitUntil: 'domcontentloaded' });
+await page.waitForTimeout(1500);
+await (await page.$('ui-hover-card-trigger'))?.tap();
+await page.waitForTimeout(500);
+const openedBC = await page.evaluate(() => !!document.querySelector('ui-hover-card')?.hasAttribute('open'));
+await page.evaluate(() => document.dispatchEvent(new CustomEvent('webjs:before-cache')));
+await page.waitForTimeout(200);
+const closedBC = await page.evaluate(() => !document.querySelector('ui-hover-card')?.hasAttribute('open'));
+results.push(['hover-card closes on webjs:before-cache', openedBC && closedBC]);
+
+// 5) real round-trip: open a hover-card, soft-nav away via an internal link,
+// then Back. The restored snapshot must show the card closed (the router fired
+// before-cache when it snapshotted the page being left).
+await page.goto(BASE + '/docs/components/hover-card', { waitUntil: 'domcontentloaded' });
+await page.waitForTimeout(1500);
+await (await page.$('ui-hover-card-trigger'))?.tap();
+await page.waitForTimeout(400);
+const navHref = await page.evaluate(() => {
+  const a = [...document.querySelectorAll('a[href^="/docs/components/"]')]
+    .find((x) => x.getAttribute('href') !== location.pathname);
+  if (a) { a.click(); return a.getAttribute('href'); }
+  return null;
+});
+if (navHref) {
+  await page.waitForTimeout(900);
+  await page.goBack();
+  await page.waitForTimeout(900);
+  const closedAfterBack = await page.evaluate(() => {
+    const c = document.querySelector('ui-hover-card');
+    return !c || !c.hasAttribute('open');
+  });
+  results.push(['hover-card closed after soft-nav + Back (clean snapshot)', closedAfterBack]);
+} else {
+  console.log('NOTE: no internal link found for the back/forward round-trip check');
+}
+
 await browser.close();
 teardown();
 


### PR DESCRIPTION
Closes #766.

The client router keeps a Turbo-style URL-keyed `outerHTML` snapshot cache for instant Back/Forward. Because the snapshot is a raw clone of the live page, an overlay that is open when you navigate away is captured open and **restored open** on Forward (repro found dogfooding on iOS, follow-up to #745: open a hover-card, Back, Forward, still open).

## What it adds
- **`webjs:before-cache`**: a new router event dispatched on `document` **synchronously inside `snapshotCurrent()`, right before the `outerHTML` read** (detail `{ url }`), so a handler's DOM edits land in the cached snapshot. Same contract as Turbo's `turbo:before-cache`. App authors can listen to strip their own transient state.
- **Kit overlays adopt it** via a shared `onBeforeCache()` helper (`registry/lib/utils.ts`): `hover-card`, `tooltip`, `dropdown-menu`, `dialog`, `alert-dialog` reset `open = false`; `sonner` clears its toasts. The listener is removed on `disconnectedCallback` (no leak across soft navs).

## Tests
- `onBeforeCache` unit test (runs reset, disposer removes the listener, SSR-safe no-op), node, passing.
- Touch e2e gains two checks, **verified in a real Chromium browser**: hover-card closes on `webjs:before-cache`, and **open, soft-nav away, Back, the restored snapshot shows the card closed** (full integration: router dispatch + kit reset).
- core routing 162/162, ui 145/145 green.

## Docs
- `agent-docs/advanced.md` (client-router events) plus the docs-site `/docs/client-router` page.

Not in this PR (noted on #766 for later): optional base-class sugar (`beforeCache()` / `static resetOnCache`). The event stays the primitive.

https://claude.ai/code/session_012hpgX16Gbg8Xhk5JmJmYcV
