### PR TITLE
test: cut e2e wall-clock and widen browser coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,8 +216,8 @@ jobs:
           node-version: '24'
           cache: npm
       - run: npm ci
-      - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
+      - name: Install Playwright browsers (Chromium, Firefox, WebKit)
+        run: npx playwright install --with-deps chromium firefox webkit
       - run: npm run test:browser
 
   e2e:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,15 +249,44 @@ jobs:
       # under a Chromium iPhone context (faithful touch events, no real device).
       - name: Run ui touch e2e
         run: npm run test:e2e:touch --workspace=@webjsdev/ui
-      # Cross-runtime e2e (#523): re-run the SAME suite under node --test (its
-      # node:test hook lifecycle does not survive `bun test`) but with the blog
-      # SERVED on Bun (WEBJS_E2E_RUNTIME=bun spawns the blog under the bun binary).
-      # This proves the Bun.serve shell + Drizzle-on-Bun in a real browser. The few
-      # node-only assertions (SSR seeding, #472/#488) and the #528-blocked abort
-      # test skip themselves on Bun.
+
+  # Cross-runtime e2e (#523), split into its OWN job (#774) so it runs in
+  # PARALLEL with the Node-served e2e above instead of as a trailing step
+  # (which serialized the two and ~doubled the e2e critical path). Re-runs the
+  # SAME suite under node --test (its node:test hook lifecycle does not survive
+  # `bun test`) but with the blog SERVED on Bun (WEBJS_E2E_RUNTIME=bun spawns
+  # the blog under the bun binary), proving the Bun.serve shell + Drizzle-on-Bun
+  # in a real browser. The few node-only assertions (SSR seeding, #472/#488) and
+  # the #528-blocked abort test skip themselves on Bun.
+  #
+  # NOTE: the required-status-check gate on `main` is the Node job above
+  # ("E2E (Puppeteer against the blog example)"); this Bun job is an additional
+  # parallel signal. To also gate merges on it, add its name to
+  # branches/main/protection required_status_checks (admin op, see
+  # scripts/protect-main.sh).
+  e2e-bun:
+    name: E2E (blog served on Bun)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+      - run: npm ci
+      - name: Install Chromium for Puppeteer
+        run: npx playwright install --with-deps chromium
+      - name: Resolve the Chromium binary path
+        run: echo "CHROMIUM_PATH=$(node -e "console.log(require('playwright-core').chromium.executablePath())")" >> "$GITHUB_ENV"
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+      - name: Prepare the blog example database
+        working-directory: examples/blog
+        run: |
+          cp .env.example .env
+          npm run db:migrate
+          npm run db:seed
       - name: Run e2e with the blog served on Bun
         env:
           WEBJS_E2E: '1'

--- a/agent-docs/testing.md
+++ b/agent-docs/testing.md
@@ -24,7 +24,7 @@ app work.
 | Kind | Location | What it does | Runner |
 |---|---|---|---|
 | **unit + integration** (node) | `test/<feature>/<name>.test.{js,ts,mjs}` | Imports modules and asserts. No spawned process, no network. Includes both true unit tests and in-process integration. | `node --test` |
-| **browser** | `test/<feature>/browser/<name>.test.js` | Runs in real Chromium with Playwright. Real DOM, events, `adoptedStyleSheets`, `IntersectionObserver`, shadow / light DOM. | web-test-runner (`wtr`) |
+| **browser** | `test/<feature>/browser/<name>.test.js` | Runs in real Chromium, Firefox, AND WebKit via Playwright (#774). Real DOM, events, `adoptedStyleSheets`, `IntersectionObserver`, shadow / light DOM. WebKit is the engine behind the iOS-only repaint bugs (the #610 class), so it runs in CI now, not just by hand on-device. | web-test-runner (`wtr`) |
 | **e2e** | `test/<feature>/e2e/<name>.test.{ts,mjs}` | Boots a real process (dev server, CLI binary) and drives it through its public interface (HTTP, browser, stdout). Opt in with `WEBJS_E2E=1`. | `node --test` (driver) |
 | **smoke** | `test/<feature>/smoke/<name>.test.{js,ts}` | Fast deploy-time sanity check. A subset of e2e in spirit, kept separate so it runs on every deploy. | `node --test` |
 
@@ -99,8 +99,18 @@ package, it goes in that package's `test/`.
 - `npm run test:browser` → `wtr`: globs
   `packages/*/test/**/browser/**/*.test.js` and
   `test/**/browser/**/*.test.js`. The blog browser e2e is
-  excluded (it needs the blog dev server up first).
-- `npm run test:e2e` → `WEBJS_E2E=1 node --test test/e2e/e2e.test.mjs`.
+  excluded (it needs the blog dev server up first). Runs on Chromium,
+  Firefox, and WebKit concurrently; narrow to one engine for a fast local
+  loop with `WEBJS_BROWSERS=chromium npx wtr` (comma-separate for a subset).
+- `npm run test:e2e` → `WEBJS_E2E=1 node --test test/e2e/e2e.test.mjs`. In CI
+  this runs as two PARALLEL jobs (#774): the Node-served suite (the required
+  merge-gate check) and a Bun-served run (`WEBJS_E2E_RUNTIME=bun`) in a
+  separate `e2e-bun` job, so the cross-runtime e2e no longer serializes behind
+  the Node run.
+- `npm run test:coverage` → `WEBJS_COVERAGE=1 npm test`: the node suite with
+  Node's built-in coverage reporter (#774). Opt-in, kept off the default
+  `npm test` so the common path stays fast; excludes test files and the
+  `scripts/` harness so the numbers reflect shipped source.
 - `npm run test:all` runs node + browser (not e2e).
 
 The root drivers above ONLY discover the framework packages and the root
@@ -195,7 +205,7 @@ ui-website ship no test suite yet, so they are not in the job.
 
 ## Component test helpers (`@webjsdev/core/testing`)
 
-`import { fixture, ssrFixture, waitForUpdate, assertNoA11yViolations, click, shadowQuery, shadowQueryAll } from '@webjsdev/core/testing'`. The mount + hydrate + a11y helpers run in the WTR Chromium session (real DOM), thin wrappers over the browser already running.
+`import { fixture, ssrFixture, waitForUpdate, assertNoA11yViolations, click, shadowQuery, shadowQueryAll } from '@webjsdev/core/testing'`. The mount + hydrate + a11y helpers run in the WTR browser session (real DOM, on each of Chromium / Firefox / WebKit), thin wrappers over the browser already running.
 
 ### `fixture()` vs `ssrFixture()`
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "check:git": "node scripts/git-worktree-safe.mjs --check",
     "dev": "node scripts/dev-all.js",
     "test": "node scripts/run-node-tests.js",
+    "test:coverage": "WEBJS_COVERAGE=1 node scripts/run-node-tests.js",
     "test:browser": "wtr",
     "test:browser:example-blog": "node scripts/run-example-blog-browser-e2e.js",
     "test:e2e": "WEBJS_E2E=1 node --test test/e2e/e2e.test.mjs",

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -184,7 +184,8 @@ organised by feature: `signals/`, `rendering/`, `directives/`,
 `slots/`, `lifecycle/`, `context/`, `task/`, `suspense/`,
 `routing/`, `serializer/`, `styling/`, `registry/`, `nav/`,
 `websocket-client/`, `rich-fetch/`, `seed/`. Each feature folder has a
-`browser/` subfolder when there are real-Chromium tests for it.
+`browser/` subfolder when there are real-browser tests for it (run on
+Chromium, Firefox, and WebKit via web-test-runner).
 
 Cross-package tests that exercise core through the SSR pipeline
 or scaffolds live at the repo root in `test/ssr/`,

--- a/scripts/run-node-tests.js
+++ b/scripts/run-node-tests.js
@@ -67,6 +67,20 @@ if (!files.length) {
   process.exit(0);
 }
 
-const args = ['--test', ...files];
+// Opt-in coverage (#774): `WEBJS_COVERAGE=1 npm test` (or `npm run
+// test:coverage`) turns on Node's built-in coverage reporter. Kept off the
+// default run so the common `npm test` stays fast and its output uncluttered;
+// it is purely an observability lever, no new dependency. Test files and the
+// scripts/ harness are excluded so the numbers reflect shipped source only.
+const coverageArgs = process.env.WEBJS_COVERAGE
+  ? [
+      '--experimental-test-coverage',
+      '--test-coverage-exclude=**/test/**',
+      '--test-coverage-exclude=**/*.test.*',
+      '--test-coverage-exclude=scripts/**',
+    ]
+  : [];
+
+const args = ['--test', ...coverageArgs, ...files];
 const child = spawn(process.execPath, args, { stdio: 'inherit' });
 child.on('exit', (code) => process.exit(code ?? 1));

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -59,9 +59,16 @@ export default {
   ],
   nodeResolve: true,
   plugins: [stripTypesPlugin()],
-  browsers: [
-    playwrightLauncher({ product: 'chromium' }),
-  ],
+  // Run the browser suite on all three engines Playwright ships (#774).
+  // Chromium alone left WebKit-only repaint/layout bugs (the iOS sticky-header
+  // class behind #610) uncaught in CI; webjs avoids browser-specific APIs so the
+  // same tests run on each. WTR runs the browsers concurrently, and an engine
+  // can be narrowed for a fast local loop with WEBJS_BROWSERS, e.g.
+  // `WEBJS_BROWSERS=chromium npx wtr`.
+  browsers: (process.env.WEBJS_BROWSERS
+    ? process.env.WEBJS_BROWSERS.split(',').map((s) => s.trim()).filter(Boolean)
+    : ['chromium', 'firefox', 'webkit']
+  ).map((product) => playwrightLauncher({ product })),
   testFramework: {
     config: {
       ui: 'tdd',


### PR DESCRIPTION
Closes #774

Improves the testing architecture after comparing webjs against the Astro, Next.js, and Lit clones. Two headline goals, both minimal-refactor: cut the e2e critical path, and close the Chromium-only browser gap.

## What landed

- **Parallelize Node vs Bun e2e.** The Bun-served e2e ran as a trailing step after the Node-served run in one job, so it only started once the Node run finished and the e2e critical path was about 2x what it needed to be. Split the Bun run into its own `e2e-bun` job so the two run concurrently. The Node job keeps its EXACT name (`E2E (Puppeteer against the blog example)`), which is the required-status-check gate on `main`, so merges are unaffected. (A matrix would have renamed the gate check dynamically and permanently blocked merges, which is why this is a second job, not a matrix.)
- **Run the browser suite on Firefox and WebKit, not just Chromium.** WebKit is the engine behind the iOS-only repaint bugs we keep hitting by hand (the #610 sticky-header class); it never ran in CI. Lit runs all three engines by default and webjs avoids browser-specific APIs, so the same tests run on each. Narrowable for a fast local loop with `WEBJS_BROWSERS=chromium npx wtr`.
- **Opt-in node:test coverage.** We had no coverage measurement at all. `npm run test:coverage` (or `WEBJS_COVERAGE=1 npm test`) turns on Node's built-in reporter, excluding test files and the scripts harness. Kept off the default `npm test` so the common path stays fast; no new dependency.
- **Docs synced** (`agent-docs/testing.md`, `packages/core/AGENTS.md`).

## Deliberately deferred to #777

The heaviest item from #774, demoting the non-browser assertions out of the 144KB Puppeteer file into a fetch-based integration layer, plus the 45-file shared-assert-module dedup, is a large careful refactor rather than a minimal one. The CI split already roughly halves the e2e critical path on its own, so the demotion is split into its own tracked issue (#777) instead of bloating this PR.

## Test plan

- `npm test`: 2790 pass, 0 fail, 1 skipped (full node suite, blog DB prepared as CI does).
- Browser matrix: verified the rendering and lifecycle browser suites pass on Chromium, Firefox, AND WebKit locally; the full 45-test matrix runs in the CI browser job (which installs all three with system deps).
- Coverage: verified `--experimental-test-coverage` produces a report and the default `npm test` path is byte-identical when `WEBJS_COVERAGE` is unset.
- Dogfood four-app gate: N/A, this PR touches only CI config, the WTR config, the node test-runner script, and docs, nothing that changes what the apps serve or what the browser fetches.
- Bun parity: N/A, no runtime-sensitive source touched.