### PR TITLE
chore: release core 0.7.28, server 0.8.40

### DIFF
--- a/changelog/core/0.7.28.md
+++ b/changelog/core/0.7.28.md
@@ -1,0 +1,26 @@
+---
+package: "@webjsdev/core"
+version: 0.7.28
+date: 2026-06-29T16:09:09.537Z
+commit_count: 3
+---
+## Features
+
+- **webjs:before-cache hook; kit overlays reset on back/forward (#766)** ([#769](https://github.com/webjsdev/webjs/pull/769)) [`4e569110`](https://github.com/webjsdev/webjs/commit/4e569110)
+  The client router keeps a Turbo-style outerHTML snapshot cache for instant
+  back/forward. An overlay that is open when you navigate away is captured open
+  and restored open on Forward (repro: open a hover-card, Back, Forward, still
+  open). Add a webjs:before-cache event the router dispatches on document
+
+## Fixes
+
+- **valid hydration marker so slot components work on iOS (#730)** ([#744](https://github.com/webjsdev/webjs/pull/744)) [`95550fc3`](https://github.com/webjsdev/webjs/commit/95550fc3)
+  MARKER was 'w$' since the first commit. Part-sentinel attribute names are
+  built as data-${MARKER}${i} -> data-w$0, and discoverSlots applies them via
+  the strict setAttribute API. The '$' is not a valid attribute-name character:
+  Chromium and desktop WebKit tolerate it, but iOS WebKit's setAttribute enforces
+- **strip renamed wjm- hydration markers in ssrFixture normalize()** ([#762](https://github.com/webjsdev/webjs/pull/762)) [`4a95966c`](https://github.com/webjsdev/webjs/commit/4a95966c)
+  #744 renamed the hydration marker from w$ to wjm- (a $ is invalid in an
+  XML qualified name, which broke slot components on iOS), but the
+  ssr-fixture browser test's normalize() still stripped only the old w$
+  form. The new <!--wjm-s-->/<!--wjm-0-->/<!--wjm-e--> markers survived into

--- a/changelog/server/0.8.40.md
+++ b/changelog/server/0.8.40.md
@@ -1,0 +1,49 @@
+---
+package: "@webjsdev/server"
+version: 0.8.40
+date: 2026-06-29T16:09:09.584Z
+commit_count: 7
+---
+## Features
+
+- **modulepreload reached npm vendor deps (flatten CDN waterfall)** ([#776](https://github.com/webjsdev/webjs/pull/776)) [`3efb2af8`](https://github.com/webjsdev/webjs/commit/3efb2af8)
+  * feat(server): modulepreload reached npm vendor deps (flatten CDN waterfall)
+  
+  Vendor (bare npm) dependencies previously got an importmap entry plus ONE
+  CDN preconnect, but no modulepreload, so a deep dependency tree was
+
+## Performance
+
+- **cut Bun listener per-request overhead (IP clone + compress bridge)** ([#773](https://github.com/webjsdev/webjs/pull/773)) [`0ab50e83`](https://github.com/webjsdev/webjs/commit/0ab50e83)
+  * perf: cut Bun listener per-request overhead (IP clone + compress bridge)
+  
+  The Bun shell cloned the whole Request on every request just to stamp the
+  remote IP, and bridged every compressed response web -> node -> web even
+
+## Fixes
+
+- **cache() preserves rich types via the RPC serializer, not JSON** ([#759](https://github.com/webjsdev/webjs/pull/759)) [`2272c4a2`](https://github.com/webjsdev/webjs/commit/2272c4a2)
+  * fix: cache() preserves rich types via the RPC serializer, not JSON
+  
+  cache() serialized values with JSON.stringify/parse while the RPC wire
+  uses the rich @webjsdev/core serializer. A cached query returning a Date
+- **sanitize prod server-action errors to a generic message + digest** ([#764](https://github.com/webjsdev/webjs/pull/764)) [`f484b58b`](https://github.com/webjsdev/webjs/commit/f484b58b)
+  * fix: sanitize prod server-action errors to a generic message + digest
+  
+  A thrown server action returned its raw err.message verbatim to the
+  client in prod. DB-driver messages (constraint/column names), ECONNREFUSED
+- **deterministic positional route specificity ordering** ([#765](https://github.com/webjsdev/webjs/pull/765)) [`b122fb51`](https://github.com/webjsdev/webjs/commit/b122fb51)
+  * fix: deterministic positional route specificity ordering
+  
+  Route precedence used a coarse 3-bucket score (static=1/dynamic=2/
+  catch-all=3) and same-bucket ties resolved by filesystem walk order, so
+- **track string-literal dynamic import() in the browser graph** ([#767](https://github.com/webjsdev/webjs/pull/767)) [`5add5d37`](https://github.com/webjsdev/webjs/commit/5add5d37)
+  * fix: track string-literal dynamic import() in the browser graph
+  
+  A dynamic import('./local.ts') of an app module was never discovered by
+  the regex import scanner (it matched only static import/export-from), so
+- **make the revalidateTag index atomic via store set ops** ([#768](https://github.com/webjsdev/webjs/pull/768)) [`9b4f27f8`](https://github.com/webjsdev/webjs/commit/9b4f27f8)
+  * fix: make the revalidateTag index atomic via store set ops
+  
+  The tag -> cacheKey index was a read-modify-write of a JSON array, not
+  atomic across processes: two concurrent mutations appending a key to the

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.27",
+  "version": "0.7.28",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.39",
+  "version": "0.8.40",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Batched release of accumulated debt for two published packages. cli (0.10.29), mcp (0.1.6), ui (0.3.6), and intellisense (0.5.3) have no unreleased user-facing commits, so they are not bumped.

## @webjsdev/core 0.7.27 to 0.7.28 (3 commits)

- feat: `webjs:before-cache` hook; kit overlays reset on back/forward (#769)
- fix: valid hydration marker so slot components work on iOS (#744)
- fix: strip renamed `wjm-` hydration markers in ssrFixture normalize() (#762)

## @webjsdev/server 0.8.39 to 0.8.40 (7 commits)

- feat: modulepreload reached npm vendor deps, flatten the CDN waterfall (#776)
- perf: cut Bun listener per-request overhead, IP clone + compress bridge (#773)
- fix: cache() preserves rich types via the RPC serializer, not JSON (#759)
- fix: sanitize prod server-action errors to a generic message + digest (#764)
- fix: deterministic positional route specificity ordering (#765)
- fix: track string-literal dynamic import() in the browser graph (#767)
- fix: make the revalidateTag index atomic via store set ops (#768)

Patch bumps follow the project convention (a `feat:` rides a patch in the 0.x line, matching prior server releases). The `@webjsdev/server` dep range on core (`^0.7.1`) already covers 0.7.28, so no dependency edit is needed. Changelogs under `changelog/{core,server}/` were auto-generated by the pre-commit hook.

On merge, `.github/workflows/release.yml` publishes both packages to npm and creates the GitHub releases from the new changelog files.
