### PR TITLE
refactor(elision): single-source binding sigils and drift-guard the analyser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,12 @@ jobs:
       # Bun.serve. The pure mapping is also unit-tested under the matrix below.
       - name: webjs server timeouts on Bun
         run: bun test/bun/timeouts.mjs
+      # Template binding-prefix dispatch on Bun (#784): the renderers now read
+      # the prefix set from core's single-sourced BINDING_PREFIXES and dispatch
+      # on kind; this asserts @event drops and .prop / ?bool round-trip the same
+      # on the Bun SSR path (buffered and streamed) as on Node.
+      - name: webjs binding-prefix dispatch on Bun
+        run: bun test/bun/binding-prefixes.mjs
       # SQLite busy_timeout on Bun (#673): bun:sqlite (like node:sqlite) defaults
       # busy_timeout to 0, so a contended write throws `database is locked`; the
       # connection tune sets busy_timeout=5000 + WAL. This asserts the bug

--- a/agent-docs/components.md
+++ b/agent-docs/components.md
@@ -244,10 +244,22 @@ patterns, treat the component as interactive.
 
 The detection lists live in `packages/server/src/component-elision.js`
 and are the single source of truth. They are kept in lockstep with the
-lifecycle table above by `packages/server/test/elision/lifecycle-coverage.test.js`,
-which fails if a new `WebComponent` hook is added without teaching the
-analyser about it. If you add an interactivity feature to the framework,
-update that file.
+framework's interactivity surface by two drift guards, which fail the build
+if a new interactivity feature ships without teaching the analyser about it
+(a silent over-elision otherwise). `packages/server/test/elision/lifecycle-coverage.test.js`
+introspects the live `WebComponent` prototype and covers hooks and methods.
+`packages/server/test/elision/sigil-coverage.test.js` covers the two surfaces
+that are not prototype members: template binding sigils and interactivity
+static fields. The renderers' sigil set is single-sourced in core's
+`BINDING_PREFIXES` (`packages/core/src/binding-prefixes.js`); the analyser
+classifies each sigil as a client-behaviour ship signal (`SSR_DROPPED_PREFIXES`,
+`@event`, drops at SSR) or an SSR-safe round-trip (`ROUND_TRIP_PREFIXES`,
+`.prop` / `?bool`, survives into the served HTML). The guard asserts that
+classification partitions `BINDING_PREFIXES` exactly, so a new sigil cannot be
+added without a deliberate ship-or-round-trip decision. Interactivity static
+fields live in the `INTERACTIVITY_STATIC_FIELDS` registry (`shadow`, `refresh`).
+If you add an interactivity feature to the framework, update that file (and add
+a new static convention to both the registry and this lifecycle table).
 
 ## Pages and layouts: keep them carriers, out of the network tab
 

--- a/agent-docs/components.md
+++ b/agent-docs/components.md
@@ -258,8 +258,9 @@ classifies each sigil as a client-behaviour ship signal (`SSR_DROPPED_PREFIXES`,
 classification partitions `BINDING_PREFIXES` exactly, so a new sigil cannot be
 added without a deliberate ship-or-round-trip decision. Interactivity static
 fields live in the `INTERACTIVITY_STATIC_FIELDS` registry (`shadow`, `refresh`).
-If you add an interactivity feature to the framework, update that file (and add
-a new static convention to both the registry and this lifecycle table).
+If you add an interactivity feature to the framework, update the matching list
+in `component-elision.js` (and add a new static convention to both the
+`INTERACTIVITY_STATIC_FIELDS` registry and this lifecycle table).
 
 ## Pages and layouts: keep them carriers, out of the network tab
 

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -148,24 +148,35 @@ them per app.
    webjs elides display-only component modules from the browser by
    static analysis (`packages/server/src/component-elision.js`). It is a
    conservative denylist of interactivity signals. When you add a new
-   overridable lifecycle hook, reactive primitive, client-only
-   directive, or event-binding syntax to core, add its marker to the
-   matching exported list in `component-elision.js`
-   (`CLIENT_LIFECYCLE_HOOKS`, `CLIENT_METHOD_CALLS`, or
-   `REACTIVE_IMPORTS`). Skipping this lets the analyser wrongly elide a
-   component that now does client work. The guard test
-   (`packages/server/test/elision/lifecycle-coverage.test.js`) fails on
-   any new prototype method until it is classified.
+   overridable lifecycle hook, reactive primitive, or client-only
+   directive to core, add its marker to the matching exported list in
+   `component-elision.js` (`CLIENT_LIFECYCLE_HOOKS`, `CLIENT_METHOD_CALLS`,
+   or `REACTIVE_IMPORTS`). When you add a new template binding SIGIL,
+   register it in core's `BINDING_PREFIXES`
+   (`packages/core/src/binding-prefixes.js`, the single source both
+   renderers read) and classify it in `component-elision.js` as a
+   client-behaviour ship signal (`SSR_DROPPED_PREFIXES`, like `@event`,
+   which drops at SSR) or an SSR-safe round-trip (`ROUND_TRIP_PREFIXES`,
+   like `.prop` / `?bool`, which survives into the served HTML). When you
+   add an interactivity STATIC field, add it to
+   `INTERACTIVITY_STATIC_FIELDS`. Skipping any of these lets the analyser
+   wrongly elide a component that now does client work. Two guard tests
+   fail until the new surface is classified:
+   `packages/server/test/elision/lifecycle-coverage.test.js` (prototype
+   methods and hooks) and `.../sigil-coverage.test.js` (binding sigils and
+   static fields, asserting the classification partitions `BINDING_PREFIXES`
+   exactly).
    Note (#474): an `async render()` is NOT, by itself, a ship signal. A
    bare async leaf (no other client signal, light DOM) is elided like any
    display-only component, since SSR bakes its data into the first paint.
    It ships only on an independent signal (the lists above, an `@event`, a
    non-`state` prop, a `<slot>`, cross-module observation, an interactive
-   child) or one of the two static carve-outs `analyzeComponentSource`
-   checks inline: `static shadow = true` (Declarative Shadow DOM must
-   re-attach on a client-side DOM insertion) and `static refresh = true`
-   (the explicit opt-in to keep the on-load re-fetch). `renderFallback`
-   stays a ship signal via `CLIENT_LIFECYCLE_HOOKS`.
+   child) or one of the two static carve-outs in the
+   `INTERACTIVITY_STATIC_FIELDS` registry: `static shadow = true`
+   (Declarative Shadow DOM must re-attach on a client-side DOM insertion)
+   and `static refresh = true` (the explicit opt-in to keep the on-load
+   re-fetch). `renderFallback` stays a ship signal via
+   `CLIENT_LIFECYCLE_HOOKS`.
 
 7. **`<slot>` works identically in light and shadow DOM.** Light-DOM
    slots get the same `assignedNodes` / `assignedElements` /

--- a/packages/core/src/binding-prefixes.js
+++ b/packages/core/src/binding-prefixes.js
@@ -1,0 +1,42 @@
+/**
+ * The template attribute-binding prefixes the renderers recognise.
+ *
+ * A binding hole whose attribute name starts with one of these is NOT a
+ * plain attribute: `@event` is a client event listener (dropped at SSR,
+ * wired only after hydration), `.prop` is a DOM property, `?bool` a
+ * boolean attribute. This object is the SINGLE source of truth for that
+ * set: both the client renderer (`render-client.js`) and the server
+ * renderer (`render-server.js`, two sites) read it instead of hardcoding
+ * the prefix characters inline.
+ *
+ * It is also the anchor for the elision drift guard. The analyser
+ * (`packages/server/src/component-elision.js`) classifies every prefix as
+ * either a client-behaviour ship signal (it drops at SSR and implies the
+ * component does client work, so a component using it must ship) or an
+ * SSR-safe round-trip (it survives into the served HTML, so it is not a
+ * ship signal). The guard test
+ * (`packages/server/test/elision/sigil-coverage.test.js`) asserts that
+ * classification covers EXACTLY these keys, so a new prefix cannot be
+ * added here without the analyser being taught which kind it is. That
+ * closes the one gap the prototype-introspection guard
+ * (`lifecycle-coverage.test.js`) cannot reach, because a sigil is syntax,
+ * not a prototype method or a named export.
+ *
+ * @type {Readonly<Record<string, 'event' | 'prop' | 'bool'>>}
+ */
+export const BINDING_PREFIXES = Object.freeze({
+  '@': 'event',
+  '.': 'prop',
+  '?': 'bool',
+});
+
+/**
+ * True if `ch` is a recognised binding prefix. A single-character string is
+ * expected (the first char of an attribute name).
+ *
+ * @param {string} ch
+ * @returns {boolean}
+ */
+export function isBindingPrefix(ch) {
+  return Object.prototype.hasOwnProperty.call(BINDING_PREFIXES, ch);
+}

--- a/packages/core/src/render-client.js
+++ b/packages/core/src/render-client.js
@@ -1,4 +1,5 @@
 import { isTemplate, MARKER } from './html.js';
+import { BINDING_PREFIXES, isBindingPrefix } from './binding-prefixes.js';
 import { escapeAttr } from './escape.js';
 import { isRepeat } from './repeat.js';
 import { isUnsafeHTML, isLive, isKeyed, isGuard, isTemplateContent, isRef, isCache, isUntil, isAsyncAppend, isAsyncReplace, isWatch } from './directives.js';
@@ -307,10 +308,10 @@ function compile(tr) {
       } else if (state === 'after-eq') {
         const prefix = attrName[0];
         const name = attrName.slice(1);
-        if (prefix === '@' || prefix === '.' || prefix === '?') {
+        if (isBindingPrefix(prefix)) {
           // Strip the attribute name+"=" from html and add a sentinel attr.
           html = html.slice(0, attrStart);
-          const kind = prefix === '@' ? 'event' : prefix === '.' ? 'prop' : 'bool';
+          const kind = BINDING_PREFIXES[prefix];
           const sentinel = `data-${MARKER}${partIdx}`;
           html += `${sentinel}=""`;
           parts.push({ kind, path: [], name });

--- a/packages/core/src/render-server.js
+++ b/packages/core/src/render-server.js
@@ -1,4 +1,5 @@
 import { html, isTemplate } from './html.js';
+import { BINDING_PREFIXES } from './binding-prefixes.js';
 import { escapeText, escapeAttr } from './escape.js';
 import { lookup, lookupModuleUrl, allTags } from './registry.js';
 import { stylesToString, isCSS } from './css.js';
@@ -256,12 +257,13 @@ async function renderTemplate(tr, ctx) {
       } else if (state === 'after-eq') {
         const prefix = attrName[0];
         const name = attrName.slice(1);
-        if (prefix === '@') {
+        const kind = BINDING_PREFIXES[prefix];
+        if (kind === 'event') {
           // Event listener. Client-only behaviour, drop at SSR.
           out = out.slice(0, attrStart);
           state = 'in-tag';
           attrName = '';
-        } else if (prefix === '.') {
+        } else if (kind === 'prop') {
           // Property binding. Only meaningful on custom elements (which
           // have a hyphen in the tag name and a WebComponent subclass
           // that knows how to apply + strip data-webjs-prop-* on
@@ -315,7 +317,7 @@ async function renderTemplate(tr, ctx) {
           }
           state = 'in-tag';
           attrName = '';
-        } else if (prefix === '?') {
+        } else if (kind === 'bool') {
           out = out.slice(0, attrStart);
           if (val) out += `${name}=""`;
           state = 'in-tag';
@@ -1422,11 +1424,12 @@ async function streamTemplate(tr, ctx, controller) {
       } else if (state === 'after-eq') {
         const prefix = attrName[0];
         const name = attrName.slice(1);
-        if (prefix === '@' || prefix === '.') {
+        const kind = BINDING_PREFIXES[prefix];
+        if (kind === 'event' || kind === 'prop') {
           buf = buf.slice(0, attrStart);
           state = 'in-tag';
           attrName = '';
-        } else if (prefix === '?') {
+        } else if (kind === 'bool') {
           buf = buf.slice(0, attrStart);
           if (val) buf += `${name}=""`;
           state = 'in-tag';

--- a/packages/server/AGENTS.md
+++ b/packages/server/AGENTS.md
@@ -403,8 +403,13 @@ and the reader key set never diverge (a counterfactual unknown key proves
    "display-only" verdict breaks the page, a false "interactive" verdict
    only misses an optimization, so anything ambiguous ships. The signal
    lists in `component-elision.js` are the single source of truth and
-   must grow whenever core adds an interactivity surface (enforced by
-   `test/elision/lifecycle-coverage.test.js`). Only side-effect imports
+   must grow whenever core adds an interactivity surface, enforced by two
+   guard tests: `test/elision/lifecycle-coverage.test.js` (prototype hooks
+   and methods, via prototype introspection) and
+   `test/elision/sigil-coverage.test.js` (template binding sigils, which
+   are single-sourced in core's `BINDING_PREFIXES` and classified here as
+   `SSR_DROPPED_PREFIXES` or `ROUND_TRIP_PREFIXES`, plus the
+   `INTERACTIVITY_STATIC_FIELDS` registry). Only side-effect imports
    are stripped; binding imports are always preserved. Tests live in
    `test/elision/`. Cross-module observation of an elided element's
    registration (a shipping `whenDefined('tag')`, a CSS `tag:defined`

--- a/packages/server/src/component-elision.js
+++ b/packages/server/src/component-elision.js
@@ -127,6 +127,35 @@ export const CLIENT_LIFECYCLE_HOOKS = [
 export const CLIENT_METHOD_CALLS = ['addController', 'removeController', 'requestUpdate'];
 
 /**
+ * Static class fields whose declaration (to a non-`false` value) marks a
+ * component interactive (must ship). Kept as ONE registry so a new
+ * interactivity-relevant static convention is added in a single place; the
+ * per-class analysis loops over it. Unlike prototype methods (guarded by
+ * `lifecycle-coverage.test.js` via prototype introspection), there is no
+ * enumerable runtime source of "all static conventions", so the contract is
+ * a documented one: a new interactivity static field MUST be added here AND
+ * to the lifecycle table in agent-docs/components.md. `sigil-coverage.test.js`
+ * asserts each entry is honoured as a ship signal.
+ *
+ *   - `shadow`: Declarative Shadow DOM attaches ONLY during HTML parsing, so a
+ *     component that arrives via a client DOM insertion (a soft-nav swap, a
+ *     streamed <webjs-suspense> boundary's replaceWith) would never re-attach
+ *     its shadow root if elided. Context-free, so any shadow component ships.
+ *   - `refresh`: `static refresh = true` is the explicit opt-in to ship a bare
+ *     async component so its stale-while-revalidate refresh runs after SSR;
+ *     eliding drops that on-load re-fetch (moot for request-stable data).
+ *
+ * @type {readonly string[]}
+ */
+export const INTERACTIVITY_STATIC_FIELDS = ['shadow', 'refresh'];
+
+/** Why each INTERACTIVITY_STATIC_FIELDS entry forces a ship (analyser reason). */
+const STATIC_FIELD_REASONS = {
+  shadow: 'declares static shadow (DSD must re-attach on a client swap)',
+  refresh: 'declares static refresh = true (keeps the on-load re-fetch)',
+};
+
+/**
  * A bare `async render()` is NOT a standalone ship signal (#474). Its SSR
  * pass bakes the resolved data into the first paint, so a light-DOM async
  * component with no OTHER client signal renders identical HTML with or
@@ -144,8 +173,37 @@ export const CLIENT_METHOD_CALLS = ['addController', 'removeController', 'reques
  * re-fetch that eliding would drop).
  */
 
-/** Match a `@event=${...}` binding inside a template (unquoted per invariant 4). */
-const EVENT_BINDING_RE = /@[A-Za-z][\w-]*\s*=\s*\$\{/;
+/**
+ * Template binding-prefix classification, the anchor for the elision drift
+ * guard. Every prefix core's renderers recognise (core's `BINDING_PREFIXES`)
+ * is one of two kinds:
+ *   - SSR_DROPPED_PREFIXES: a CLIENT-BEHAVIOUR ship signal. The binding drops
+ *     at SSR and is wired only after hydration (`@event`), so a component whose
+ *     only interactivity is such a binding MUST ship.
+ *   - ROUND_TRIP_PREFIXES: an SSR-SAFE binding that survives into the served
+ *     HTML (`.prop` via `data-webjs-prop-*`, `?bool` as a boolean attribute),
+ *     so it is NOT a ship signal on its own and stays elidable.
+ * `sigil-coverage.test.js` asserts these two lists PARTITION `BINDING_PREFIXES`
+ * exactly (union equal, disjoint), so a new sigil cannot be added to the
+ * renderers without being classified here. That closes the one interactivity
+ * surface the prototype-introspection guard (`lifecycle-coverage.test.js`)
+ * cannot see, because a sigil is template syntax, not a method or an export.
+ */
+export const SSR_DROPPED_PREFIXES = ['@'];
+export const ROUND_TRIP_PREFIXES = ['.', '?'];
+
+/** Escape a single char for safe inclusion in a regex character class. */
+const escapeForCharClass = (c) => c.replace(/[\\\]^-]/g, '\\$&');
+
+/**
+ * Match a client-behaviour binding (`@event=${...}`), a ship signal. The
+ * prefix set is DERIVED from SSR_DROPPED_PREFIXES (not hardcoded), so a new
+ * client-behaviour sigil added to core is detected here automatically once it
+ * is classified above. (unquoted per invariant 4)
+ */
+const EVENT_BINDING_RE = new RegExp(
+  `[${SSR_DROPPED_PREFIXES.map(escapeForCharClass).join('')}][A-Za-z][\\w-]*\\s*=\\s*\\$\\{`,
+);
 
 /** Match a `.onclick=${...}` (native event-handler property) binding. */
 const EVENT_PROP_RE = /\.on[a-z]+\s*=\s*\$\{/;
@@ -505,22 +563,13 @@ export function analyzeComponentSource(src) {
   }
 
   for (const { body, factoryArg } of bodies) {
-    // Shadow DOM always ships (#474). Declarative Shadow DOM attaches ONLY
-    // during HTML parsing; an elided component that arrives via a client DOM
-    // insertion (a soft-nav swap, a streamed <webjs-suspense> boundary's
-    // replaceWith) would never re-attach its shadow root, because eliding
-    // drops the module that runs `attachShadow`. The analyser is context-free
-    // (it cannot tell whether a given component will be streamed or
-    // navigated to), so any shadow component is shipped.
-    if (declaresStaticTrue(body, 'shadow')) {
-      return { interactive: true, reason: 'declares static shadow (DSD must re-attach on a client swap)' };
-    }
-    // `static refresh = true` is the explicit opt-in to ship a bare async
-    // component so its stale-while-revalidate refresh runs ~after SSR; eliding
-    // a bare async component drops that on-load re-fetch (moot for request-
-    // stable data, the default), so an author who wants fresh-on-load opts in.
-    if (declaresStaticTrue(body, 'refresh')) {
-      return { interactive: true, reason: 'declares static refresh = true (keeps the on-load re-fetch)' };
+    // Interactivity-signal static conventions (`static shadow` / `static
+    // refresh = true`), driven by the INTERACTIVITY_STATIC_FIELDS registry so a
+    // new convention is added in one place (see its doc for why each ships).
+    for (const field of INTERACTIVITY_STATIC_FIELDS) {
+      if (declaresStaticTrue(body, field)) {
+        return { interactive: true, reason: STATIC_FIELD_REASONS[field] };
+      }
     }
     for (const hook of CLIENT_LIFECYCLE_HOOKS) {
       // A client lifecycle hook as a method (`hook(`) OR as an arrow class

--- a/packages/server/test/elision/sigil-coverage.test.js
+++ b/packages/server/test/elision/sigil-coverage.test.js
@@ -1,0 +1,136 @@
+/**
+ * GUARD TEST for the elision analyser's template-sigil + static-field
+ * coverage, the sibling of lifecycle-coverage.test.js.
+ *
+ * lifecycle-coverage introspects WebComponent.prototype and fails if a new
+ * method ships without the analyser being taught about it. But two
+ * interactivity surfaces are NOT prototype methods or named exports, so that
+ * guard cannot see them:
+ *
+ *   1. Template binding sigils (`@` / `.` / `?`). A new client-behaviour sigil
+ *      added to the renderers without teaching the analyser would let it
+ *      wrongly elide a component whose only interactivity is that sigil, and
+ *      the failure would be silent in production.
+ *   2. Interactivity-signal static fields (`static shadow` / `static refresh`).
+ *
+ * This test makes that drift LOUD. The renderers' sigil set lives in core's
+ * BINDING_PREFIXES (single source of truth); the analyser classifies each as a
+ * ship signal (SSR_DROPPED_PREFIXES) or an SSR-safe round-trip
+ * (ROUND_TRIP_PREFIXES). The partition assertion below fails the moment a sigil
+ * is added to BINDING_PREFIXES without being classified, so the fix is forced:
+ * decide whether the new sigil ships and add it to the matching analyser list.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { BINDING_PREFIXES } from '../../../core/src/binding-prefixes.js';
+import {
+  analyzeComponentSource,
+  SSR_DROPPED_PREFIXES,
+  ROUND_TRIP_PREFIXES,
+  INTERACTIVITY_STATIC_FIELDS,
+} from '../../src/component-elision.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const coreSrc = resolve(here, '../../../core/src');
+
+/**
+ * Pure partition check, reused so the counterfactual can prove it is sensitive:
+ * `dropped` and `roundTrip` must together cover `prefixes` exactly, disjointly.
+ */
+function partitionGaps(prefixes, dropped, roundTrip) {
+  const classified = new Set([...dropped, ...roundTrip]);
+  const unclassified = prefixes.filter((p) => !classified.has(p));
+  const overlap = dropped.filter((p) => roundTrip.includes(p));
+  const stray = [...classified].filter((p) => !prefixes.includes(p));
+  return { unclassified, overlap, stray };
+}
+
+test('every renderer binding sigil is classified by the analyser (partition)', () => {
+  const prefixes = Object.keys(BINDING_PREFIXES);
+  const { unclassified, overlap, stray } = partitionGaps(
+    prefixes, SSR_DROPPED_PREFIXES, ROUND_TRIP_PREFIXES,
+  );
+  assert.deepEqual(unclassified, [],
+    `binding sigil(s) ${JSON.stringify(unclassified)} are in core's BINDING_PREFIXES `
+    + 'but not classified in component-elision.js. Add each to SSR_DROPPED_PREFIXES '
+    + '(it drops at SSR / implies client work, so the component must ship) or '
+    + 'ROUND_TRIP_PREFIXES (it survives into the served HTML, stays elidable).');
+  assert.deepEqual(overlap, [], `sigil(s) ${JSON.stringify(overlap)} are in BOTH lists`);
+  assert.deepEqual(stray, [],
+    `sigil(s) ${JSON.stringify(stray)} are classified but not a renderer prefix`);
+});
+
+test('counterfactual: the partition check fires on an unclassified new sigil', () => {
+  // A hypothetical new client-behaviour sigil `&` added to the renderers but
+  // NOT classified in the analyser is exactly the silent over-elision this
+  // guard exists to catch. Prove the check would red.
+  const drifted = partitionGaps(['@', '.', '?', '&'], SSR_DROPPED_PREFIXES, ROUND_TRIP_PREFIXES);
+  assert.deepEqual(drifted.unclassified, ['&']);
+});
+
+test('an SSR-dropped sigil is honoured as a ship signal', () => {
+  for (const p of SSR_DROPPED_PREFIXES) {
+    // `@event` is the canonical case; build a minimal display-only component
+    // whose ONLY interactivity is a binding with this prefix.
+    const src = `class C extends WebComponent({}) {
+      render() { return html\`<button ${p}click=\${() => {}}>x</button>\`; }
+    }`;
+    const { interactive } = analyzeComponentSource(src);
+    assert.equal(interactive, true,
+      `a component using only the '${p}' binding must ship (it is an SSR-dropped client behaviour)`);
+  }
+});
+
+test('a round-trip sigil alone keeps a component elidable', () => {
+  for (const p of ROUND_TRIP_PREFIXES) {
+    // `.prop` / `?bool` survive into SSR HTML, so a component whose only
+    // non-render content is such a binding stays display-only. Use a custom
+    // element target so `.prop` is the data-webjs-prop round-trip (not a
+    // dropped native prop), and a non-`on` name so it is not EVENT_PROP_RE.
+    const src = `class C extends WebComponent({}) {
+      render() { return html\`<my-badge ${p}label=\${'x'}></my-badge>\`; }
+    }`;
+    const { interactive } = analyzeComponentSource(src);
+    assert.equal(interactive, false,
+      `a component using only the '${p}' (round-trip) binding should stay elidable`);
+  }
+});
+
+test('the renderers route binding recognition through BINDING_PREFIXES (no stray literals)', () => {
+  // Both renderers must consume the shared set, not re-hardcode a prefix. A
+  // future hand-added `prefix === '<sigil>'` branch would bypass the single
+  // source of truth and dodge the partition guard, so forbid it.
+  for (const file of ['render-client.js', 'render-server.js']) {
+    const src = readFileSync(resolve(coreSrc, file), 'utf8');
+    assert.match(src, /binding-prefixes\.js/, `${file} must import the shared BINDING_PREFIXES`);
+    for (const p of Object.keys(BINDING_PREFIXES)) {
+      const stray = new RegExp(`prefix\\s*===\\s*['"\`]\\${p}['"\`]`);
+      assert.ok(!stray.test(src),
+        `${file} hardcodes \`prefix === '${p}'\`; route it through BINDING_PREFIXES instead`);
+    }
+  }
+});
+
+test('every interactivity static field is honoured as a ship signal', () => {
+  for (const field of INTERACTIVITY_STATIC_FIELDS) {
+    const src = `class C extends WebComponent({}) {
+      static ${field} = true;
+      render() { return html\`<div>x</div>\`; }
+    }`;
+    const { interactive } = analyzeComponentSource(src);
+    assert.equal(interactive, true, `static ${field} = true must force the component to ship`);
+  }
+});
+
+test('the interactivity static-field registry is the known set (change-detector)', () => {
+  // A deliberate change-detector: there is no enumerable runtime source for
+  // "all static conventions" (unlike prototype methods), so adding a new
+  // interactivity static field must be a conscious edit here AND in
+  // agent-docs/components.md. If this assertion fails because you added a real
+  // convention, update both, then update this expected set.
+  assert.deepEqual([...INTERACTIVITY_STATIC_FIELDS].sort(), ['refresh', 'shadow']);
+});

--- a/packages/server/test/elision/sigil-coverage.test.js
+++ b/packages/server/test/elision/sigil-coverage.test.js
@@ -85,12 +85,17 @@ test('an SSR-dropped sigil is honoured as a ship signal', () => {
   }
 });
 
-test('a round-trip sigil alone keeps a component elidable', () => {
+test('a round-trip sigil does not force a component to ship', () => {
   for (const p of ROUND_TRIP_PREFIXES) {
-    // `.prop` / `?bool` survive into SSR HTML, so a component whose only
-    // non-render content is such a binding stays display-only. Use a custom
-    // element target so `.prop` is the data-webjs-prop round-trip (not a
-    // dropped native prop), and a non-`on` name so it is not EVENT_PROP_RE.
+    // `.prop` / `?bool` survive into SSR HTML, so they must NOT be ship signals
+    // on their own: a component whose only non-render content is such a binding
+    // stays elidable. This does not by itself prove ROUND_TRIP membership (the
+    // partition test does), but it IS load-bearing against the misclassification
+    // it guards: if `.` or `?` were moved into SSR_DROPPED_PREFIXES, the derived
+    // EVENT_BINDING_RE would match this binding and flip the verdict to ship,
+    // reding this test. Use a custom-element target so `.prop` is the
+    // data-webjs-prop round-trip (not a dropped native prop), and a non-`on`
+    // name so it is not EVENT_PROP_RE.
     const src = `class C extends WebComponent({}) {
       render() { return html\`<my-badge ${p}label=\${'x'}></my-badge>\`; }
     }`;
@@ -108,9 +113,13 @@ test('the renderers route binding recognition through BINDING_PREFIXES (no stray
     const src = readFileSync(resolve(coreSrc, file), 'utf8');
     assert.match(src, /binding-prefixes\.js/, `${file} must import the shared BINDING_PREFIXES`);
     for (const p of Object.keys(BINDING_PREFIXES)) {
-      const stray = new RegExp(`prefix\\s*===\\s*['"\`]\\${p}['"\`]`);
+      const lit = `['"\`]\\${p}['"\`]`;
+      // Forbid an `=== '<sigil>'` compare in EITHER operand order (`prefix ===
+      // '@'` and the Yoda `'@' === prefix`), so a reintroduced hardcoded branch
+      // cannot slip past on operand order.
+      const stray = new RegExp(`(===\\s*${lit})|(${lit}\\s*===)`);
       assert.ok(!stray.test(src),
-        `${file} hardcodes \`prefix === '${p}'\`; route it through BINDING_PREFIXES instead`);
+        `${file} hardcodes an \`=== '${p}'\` compare; route it through BINDING_PREFIXES instead`);
     }
   }
 });

--- a/packages/server/test/elision/sigil-coverage.test.js
+++ b/packages/server/test/elision/sigil-coverage.test.js
@@ -124,14 +124,20 @@ test('the renderers route binding recognition through BINDING_PREFIXES (no stray
   }
 });
 
-test('every interactivity static field is honoured as a ship signal', () => {
+test('every interactivity static field is honoured as a ship signal with a reason', () => {
   for (const field of INTERACTIVITY_STATIC_FIELDS) {
     const src = `class C extends WebComponent({}) {
       static ${field} = true;
       render() { return html\`<div>x</div>\`; }
     }`;
-    const { interactive } = analyzeComponentSource(src);
+    const { interactive, reason } = analyzeComponentSource(src);
     assert.equal(interactive, true, `static ${field} = true must force the component to ship`);
+    // A field added to INTERACTIVITY_STATIC_FIELDS without a matching
+    // STATIC_FIELD_REASONS entry would ship with reason `undefined` (a
+    // diagnostics gap). Require a real reason so the registry and the reasons
+    // map cannot drift apart.
+    assert.equal(typeof reason, 'string', `static ${field} must carry a string reason, got ${reason}`);
+    assert.ok(reason.length > 0, `static ${field} reason must be non-empty`);
   }
 });
 

--- a/test/bun/binding-prefixes.mjs
+++ b/test/bun/binding-prefixes.mjs
@@ -1,0 +1,58 @@
+/**
+ * Cross-runtime proof that the template binding-prefix dispatch (#784) renders
+ * identically under WHICHEVER runtime executes this file. Run it under both:
+ *
+ *   node test/bun/binding-prefixes.mjs
+ *   bun  test/bun/binding-prefixes.mjs
+ *
+ * The renderers (`render-server.js`, buffered + streaming) now read the prefix
+ * set from core's single-sourced `BINDING_PREFIXES` and dispatch on the kind
+ * instead of hardcoded `prefix === '@'|'.'|'?'` chains. That dispatch is on the
+ * SSR hot path, so it is runtime-sensitive: this asserts every branch is
+ * byte-correct on Node AND Bun. A plain assert script (not `*.test.mjs`, so the
+ * node:test runner does not double-run it); it exits non-zero on failure. Run
+ * from the repo root so the bare `@webjsdev/core` specifier resolves to the
+ * workspace package.
+ */
+import assert from 'node:assert/strict';
+import { html } from '@webjsdev/core';
+import { renderToString, renderToStream } from '@webjsdev/core/server';
+
+const runtime = process.versions.bun ? `bun ${process.versions.bun}` : `node ${process.versions.node}`;
+
+/** One template exercising all three prefixes on a custom element. */
+const tpl = () => html`<my-el @click=${() => {}} .label=${'x'} ?open=${true}></my-el>`;
+
+/** Assert the three dispatch outcomes on a rendered string. */
+function assertBindings(out, via) {
+  // `@event` is client-only behaviour: dropped at SSR (no listener attribute).
+  assert.ok(!/@click|\bclick=/.test(out), `${via}: @event must drop at SSR, got ${out}`);
+  // `.prop` on a custom element round-trips as data-webjs-prop-* (rehydrated).
+  assert.match(out, /data-webjs-prop-label="/, `${via}: .prop must round-trip as data-webjs-prop-*, got ${out}`);
+  // `?bool` round-trips as a bare boolean attribute when truthy.
+  assert.match(out, /\bopen=""/, `${via}: ?bool must round-trip as a boolean attribute, got ${out}`);
+}
+
+async function drain(stream) {
+  let out = '';
+  const reader = stream.getReader();
+  const dec = new TextDecoder();
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out += typeof value === 'string' ? value : dec.decode(value);
+  }
+  return out;
+}
+
+const buffered = await renderToString(tpl());
+assertBindings(buffered, 'renderToString');
+
+const streamed = await drain(renderToStream(tpl()));
+assertBindings(streamed, 'renderToStream');
+
+// The two paths must agree (the streaming site groups event+prop as drop; for a
+// synchronous prop value both resolve to the same served HTML).
+assert.equal(streamed, buffered, 'buffered and streamed binding dispatch must match');
+
+console.log(`[binding-prefixes] OK on ${runtime}: @event dropped, .prop + ?bool round-trip (buffered == streamed)`);

--- a/test/bun/binding-prefixes.mjs
+++ b/test/bun/binding-prefixes.mjs
@@ -59,7 +59,11 @@ assert.match(buffered, BOOL, `buffered: ?bool must round-trip as a boolean attri
 const streamed = await drain(renderToStream(tpl(), { ssr: false }));
 assert.match(streamed, /<my-el/, `streamed: the element must render, got ${streamed}`);
 assert.ok(!EVENT.test(streamed), `streamed: @event must drop, got ${streamed}`);
-assert.ok(!PROP.test(streamed), `streamed: .prop is grouped with @event as a drop here, got ${streamed}`);
+// A genuine .prop DROP leaves no `label` token at all. Assert that directly,
+// not the absence of `data-webjs-prop-*` (streamTemplate never emits that form,
+// so a `!PROP` check would pass even if .prop leaked through as a plain
+// `label="x"` attribute). `label` appears nowhere else in this template.
+assert.ok(!/label/.test(streamed), `streamed: .prop must drop (no label token), got ${streamed}`);
 assert.match(streamed, BOOL, `streamed: ?bool must round-trip, got ${streamed}`);
 
 console.log(`[binding-prefixes] OK on ${runtime}: buffered (@event drop, .prop + ?bool round-trip) and streamed (@event + .prop drop, ?bool round-trip) dispatch correctly`);

--- a/test/bun/binding-prefixes.mjs
+++ b/test/bun/binding-prefixes.mjs
@@ -5,14 +5,22 @@
  *   node test/bun/binding-prefixes.mjs
  *   bun  test/bun/binding-prefixes.mjs
  *
- * The renderers (`render-server.js`, buffered + streaming) now read the prefix
- * set from core's single-sourced `BINDING_PREFIXES` and dispatch on the kind
- * instead of hardcoded `prefix === '@'|'.'|'?'` chains. That dispatch is on the
- * SSR hot path, so it is runtime-sensitive: this asserts every branch is
- * byte-correct on Node AND Bun. A plain assert script (not `*.test.mjs`, so the
- * node:test runner does not double-run it); it exits non-zero on failure. Run
- * from the repo root so the bare `@webjsdev/core` specifier resolves to the
- * workspace package.
+ * The renderers now read the prefix set from core's single-sourced
+ * BINDING_PREFIXES and dispatch on the kind instead of hardcoded
+ * `prefix === '@'|'.'|'?'` chains. That dispatch is on the SSR hot path, so it
+ * is runtime-sensitive. There are TWO server dispatch sites with DIFFERENT
+ * rules, and this exercises both:
+ *   - the buffered renderer (`renderToString`): `@event` drops, `.prop` on a
+ *     custom element round-trips as `data-webjs-prop-*`, `?bool` round-trips as
+ *     a boolean attribute.
+ *   - the streaming renderer (`renderToStream({ ssr: false })`, i.e.
+ *     `streamTemplate`): `@event` AND `.prop` BOTH drop (grouped), `?bool`
+ *     round-trips. The `ssr: true` default goes through the buffered renderer,
+ *     so `ssr: false` is required to reach the streaming dispatch.
+ *
+ * A plain assert script (not `*.test.mjs`, so the node:test runner does not
+ * double-run it); it exits non-zero on failure. Run from the repo root so the
+ * bare `@webjsdev/core` specifier resolves to the workspace package.
  */
 import assert from 'node:assert/strict';
 import { html } from '@webjsdev/core';
@@ -23,15 +31,9 @@ const runtime = process.versions.bun ? `bun ${process.versions.bun}` : `node ${p
 /** One template exercising all three prefixes on a custom element. */
 const tpl = () => html`<my-el @click=${() => {}} .label=${'x'} ?open=${true}></my-el>`;
 
-/** Assert the three dispatch outcomes on a rendered string. */
-function assertBindings(out, via) {
-  // `@event` is client-only behaviour: dropped at SSR (no listener attribute).
-  assert.ok(!/@click|\bclick=/.test(out), `${via}: @event must drop at SSR, got ${out}`);
-  // `.prop` on a custom element round-trips as data-webjs-prop-* (rehydrated).
-  assert.match(out, /data-webjs-prop-label="/, `${via}: .prop must round-trip as data-webjs-prop-*, got ${out}`);
-  // `?bool` round-trips as a bare boolean attribute when truthy.
-  assert.match(out, /\bopen=""/, `${via}: ?bool must round-trip as a boolean attribute, got ${out}`);
-}
+const PROP = /data-webjs-prop-label="/;
+const EVENT = /@click|\bclick=/;
+const BOOL = /\bopen=""/;
 
 async function drain(stream) {
   let out = '';
@@ -45,14 +47,19 @@ async function drain(stream) {
   return out;
 }
 
+// Buffered renderer: @event drops, .prop round-trips, ?bool round-trips.
 const buffered = await renderToString(tpl());
-assertBindings(buffered, 'renderToString');
+assert.match(buffered, /<my-el/, `buffered: the element must render, got ${buffered}`);
+assert.ok(!EVENT.test(buffered), `buffered: @event must drop at SSR, got ${buffered}`);
+assert.match(buffered, PROP, `buffered: .prop must round-trip as data-webjs-prop-*, got ${buffered}`);
+assert.match(buffered, BOOL, `buffered: ?bool must round-trip as a boolean attribute, got ${buffered}`);
 
-const streamed = await drain(renderToStream(tpl()));
-assertBindings(streamed, 'renderToStream');
+// Streaming renderer (streamTemplate, the third dispatch site): @event AND
+// .prop BOTH drop (grouped), ?bool round-trips. `ssr: false` is what reaches it.
+const streamed = await drain(renderToStream(tpl(), { ssr: false }));
+assert.match(streamed, /<my-el/, `streamed: the element must render, got ${streamed}`);
+assert.ok(!EVENT.test(streamed), `streamed: @event must drop, got ${streamed}`);
+assert.ok(!PROP.test(streamed), `streamed: .prop is grouped with @event as a drop here, got ${streamed}`);
+assert.match(streamed, BOOL, `streamed: ?bool must round-trip, got ${streamed}`);
 
-// The two paths must agree (the streaming site groups event+prop as drop; for a
-// synchronous prop value both resolve to the same served HTML).
-assert.equal(streamed, buffered, 'buffered and streamed binding dispatch must match');
-
-console.log(`[binding-prefixes] OK on ${runtime}: @event dropped, .prop + ?bool round-trip (buffered == streamed)`);
+console.log(`[binding-prefixes] OK on ${runtime}: buffered (@event drop, .prop + ?bool round-trip) and streamed (@event + .prop drop, ?bool round-trip) dispatch correctly`);

--- a/test/bun/binding-prefixes.test.mjs
+++ b/test/bun/binding-prefixes.test.mjs
@@ -1,0 +1,13 @@
+/**
+ * Run the cross-runtime binding-prefix dispatch proof (#784) under WHICHEVER
+ * runtime executes the suite. Picked up by the root `node --test` runner (so
+ * `npm test` exercises the Node path); CI also runs `bun test/bun/binding-prefixes.mjs`
+ * for the Bun path. The proof is a plain assert script (`binding-prefixes.mjs`,
+ * not `*.test.mjs`, so the runner does not double-run it); importing it runs it
+ * and throws on any failure.
+ */
+import { test } from 'node:test';
+
+test('template binding-prefix dispatch renders identically on this runtime (#784)', async () => {
+  await import('./binding-prefixes.mjs');
+});


### PR DESCRIPTION
Closes #784

The elision analyser is conservative by construction (ship-when-unsure) and already has a mechanical drift guard for the surface it can introspect: `lifecycle-coverage.test.js` walks the live `WebComponent.prototype` and fails the build if a new public method or reactive export lands without being classified. Two interactivity surfaces sit outside that guard because they are neither prototype methods nor named exports: template binding sigils (`@` / `.` / `?`) and interactivity-signal static fields (`static shadow` / `static refresh`). A future client-behavior sigil or static convention added without teaching the analyser would silently over-elide a component that does client work, the exact silent-failure the lifecycle guard exists to prevent.

This single-sources the client-behavior sigil set in core (it was triplicated across the two renderers) and adds a coupling guard test mirroring `lifecycle-coverage`, plus a single registry for the interactivity static fields with a contract comment.

The conservative direction is preserved throughout: `.prop` / `?bool` stay elidable (they round-trip through SSR), the change only ever makes MORE things ship, and existing elision verdicts are unchanged.
