### PR TITLE
docs(blog): SEO-optimized blog batch (elision, no-RSC, Bun) + existing-post SEO

### DIFF
--- a/blog/accessible-web-components-by-default.md
+++ b/blog/accessible-web-components-by-default.md
@@ -2,7 +2,7 @@
 title: "Accessible Web Components Out of the Box"
 date: 2026-06-20T10:00:00+05:30
 slug: accessible-web-components-by-default
-description: "How WebJs ships accessible web components by default through @webjsdev/ui. An a11y-by-default component library where keyboard navigation, screen-reader labels, and focus management come wired in, plus accessibility contracts AI agents read so their edits do not silently break your WCAG-aligned UI."
+description: "How @webjsdev/ui ships accessible web components by default, with keyboard navigation, screen-reader labels, and focus management wired in from the start."
 tags: accessibility, a11y, web-components, ui, wcag
 author: Vivek
 ---

--- a/blog/accessible-web-components-by-default.md
+++ b/blog/accessible-web-components-by-default.md
@@ -1,6 +1,6 @@
 ---
 title: "Accessible Web Components Out of the Box"
-date: 2026-06-22T10:00:00+05:30
+date: 2026-06-20T10:00:00+05:30
 slug: accessible-web-components-by-default
 description: "How WebJs ships accessible web components by default through @webjsdev/ui. An a11y-by-default component library where keyboard navigation, screen-reader labels, and focus management come wired in, plus accessibility contracts AI agents read so their edits do not silently break your WCAG-aligned UI."
 tags: accessibility, a11y, web-components, ui, wcag

--- a/blog/accessible-web-components-by-default.md
+++ b/blog/accessible-web-components-by-default.md
@@ -83,9 +83,9 @@ So the accessibility expectations are encoded where the agent reads them. The ti
 There is one more agent-friendly detail. The variant names, sizes, and data-attribute conventions mirror shadcn/ui. An agent's existing knowledge of shadcn maps directly onto these components, so it reaches for the right API on the first try.
 
 
-# A note on what I did not claim
+# What the defaults do and do not cover
 
-I deliberately did not put a WCAG conformance badge on this post. WCAG (the Web Content Accessibility Guidelines, the standard that defines what "accessible" means on the web) has graded levels, and I found no audit in the repo stating the library hits a specific one, so I am not going to invent a number. What I can say, because I read the source, is that the components are keyboard navigable, screen-reader labelled, and focus-managed by default, and the tier-2 elements follow the published ARIA Authoring Practices patterns. Your own app still has to do its part (real content, real labels, sensible color contrast), and you should test with a keyboard and a screen reader like anyone else. The library gives you a floor that is a long way above blank.
+Accessible out of the box is a floor, not a certification. The library does not come with a WCAG conformance grade (WCAG, the Web Content Accessibility Guidelines, is the standard that defines web accessibility, with graded levels A, AA, and AAA), and no component library can earn that grade for you. What the defaults give you is concrete: keyboard navigation, screen-reader labels, and focus management, with the tier-2 elements following the published ARIA Authoring Practices patterns. The rest is still your app's job, meaning real content, meaningful labels, sensible color contrast, and testing with a keyboard and a screen reader. Starting from these defaults means you begin well above blank instead of retrofitting accessibility after the fact.
 
 
 # The takeaway

--- a/blog/accessible-web-components-by-default.md
+++ b/blog/accessible-web-components-by-default.md
@@ -1,0 +1,93 @@
+---
+title: "Accessible Web Components Out of the Box"
+date: 2026-06-22T10:00:00+05:30
+slug: accessible-web-components-by-default
+description: "How WebJs ships accessible web components by default through @webjsdev/ui. An a11y-by-default component library where keyboard navigation, screen-reader labels, and focus management come wired in, plus accessibility contracts AI agents read so their edits do not silently break your WCAG-aligned UI."
+tags: accessibility, a11y, web-components, ui, wcag
+author: Vivek
+---
+
+Here is a thing most tutorials skip. A button that only works when you click it with a mouse is broken for a lot of people. Someone navigating with a keyboard cannot reach it. Someone using a screen reader (software that reads the page aloud for blind and low-vision users) hears nothing useful if the button has no label. That whole area of making a site usable by everyone, not just people with a mouse and good eyesight, is called accessibility, or "a11y" for short (the 11 is the number of letters between the a and the y).
+
+The problem is that accessibility almost always gets bolted on late. You build the feature, ship it, and then someone files a bug that says the dropdown cannot be operated with a keyboard. Now you are retrofitting ARIA attributes, focus management, and roving tabindex into code that was written without any of them in mind. Retrofitting is painful because accessibility is not one attribute you sprinkle on at the end. It is a set of relationships (this control names that panel, arrow keys move between these items, focus returns here when the dialog closes) that are far easier to build in from the start than to reverse-engineer later.
+
+So WebJs starts from accessible defaults. That is the whole pitch of this post.
+
+
+# The component library, and how you get it
+
+WebJs ships a component library called `@webjsdev/ui`. You pull components into your app from the CLI:
+
+```sh
+webjs ui init                       # one-time setup in your project
+webjs ui add button card dialog     # copy those components into your repo
+webjs ui list                       # see everything available
+webjs ui view tabs                  # print a component's source before adding it
+```
+
+The components are source-copied into your project, so you own the files. There is no opaque dependency you cannot read or edit. That matters for accessibility specifically, because when you can read the component, you can see exactly what accessible behaviour it already handles.
+
+The library is split into two tiers, and the split is the key to the whole design.
+
+
+# Tier 1, class helpers on real native elements
+
+The first tier is plain functions that return Tailwind class strings. `buttonClass()`, `cardClass()`, `inputClass()`, `labelClass()`, `alertClass()`, and friends. You spread them onto native HTML elements:
+
+```ts
+import { buttonClass } from '#components/ui/button.ts';
+
+html`<button class=${buttonClass({ variant: 'outline' })}>Save</button>`;
+```
+
+That is a real `<button>`, not a wrapper. It participates in form submission, keyboard activation (Enter and Space work because the browser gives you that for a native button), the accessibility tree, and devtools as itself. WebJs components render in light DOM by default (the component's markup goes straight into the page, no shadow root), which is what lets the accessibility tree behave the way the spec assumes. I wrote about that choice in [Light DOM by default](/blog/light-dom-by-default).
+
+Because a class helper returns only classes, the semantic markup is yours to write. So each helper carries an `A11y (required for accessible output)` block in its JSDoc that tells you precisely what to add. The icon-only button JSDoc says it must carry an `aria-label` (a screen reader has no text to read otherwise). The alert helper says to put `role="alert"` for an urgent message or `role="status"` for a polite one. Pagination says to wrap the list in a labelled `<nav>` and set `aria-current="page"` on the active link. Table headers need `scope`, an avatar image needs `alt`. Follow the block and the markup is fully accessible. The contract is written down right where you (or an AI agent) are reading the code.
+
+
+# Tier 2, stateful custom elements that wire their own ARIA
+
+The second tier is for the behaviour the browser still does not give you for free. Hover-with-delay tooltips, roving-focus keyboard navigation for menus and tabs, a toast queue that stacks and dismisses. These ship as custom elements (`<ui-dialog>`, `<ui-tabs>`, `<ui-tooltip>`, `<ui-dropdown-menu>`, `<ui-sonner>`, and more).
+
+These are accessible out of the box. You do not hand-add ARIA to them, they wire their own. Look at what you write versus what you get:
+
+```ts
+// What you author. No aria-* anywhere.
+html`
+  <ui-tabs value="account">
+    <ui-tabs-list>
+      <ui-tabs-trigger value="account">Account</ui-tabs-trigger>
+      <ui-tabs-trigger value="password">Password</ui-tabs-trigger>
+    </ui-tabs-list>
+    <ui-tabs-content value="account">...</ui-tabs-content>
+    <ui-tabs-content value="password">...</ui-tabs-content>
+  </ui-tabs>
+`;
+```
+
+The rendered output carries `role="tablist"`, `role="tab"` with `aria-selected` and `aria-controls`, `role="tabpanel"` with `aria-labelledby`, roving `tabindex`, and Arrow-key navigation, none of which you had to type. I read the actual source rather than trust a README, so here is what is genuinely there.
+
+`<ui-tabs>` follows the WAI-ARIA Authoring Practices tabs pattern (the source links the spec URL directly). The list gets `role="tablist"` with `aria-orientation`, each trigger is a native `<button role="tab">` with `aria-selected` and `aria-controls` pointing at its panel, and each panel gets `role="tabpanel"` with `aria-labelledby` pointing back at its trigger. Focus is roving (the active trigger has `tabindex="0"`, the rest `-1`) and Arrow keys, Home, and End move between tabs. An inactive panel is marked `hidden` and `inert`, so it drops out of the tab order and the accessibility tree entirely.
+
+`<ui-dialog>` is a thin decorator over the native `<dialog>` element's `showModal()`. That means the focus trap, Escape-to-close, the backdrop, and background-inert all come from the platform rather than from hand-rolled JS that tends to have edge-case bugs. On open it names itself from your title and description via `aria-labelledby` and `aria-describedby`, marks the panel `role="dialog"` with `aria-modal="true"`, and gives the auto-injected close button an `aria-label="Close"`.
+
+The rest follow the same discipline. The dropdown menu declares `aria-haspopup="menu"`, uses `role="menu"` and `role="menuitem"` with roving focus and `aria-disabled`. The tooltip wires `aria-describedby` from the trigger to the tip text. The toaster (`<ui-sonner>`) is a live region, so new toasts get announced (`role="alert"` for errors, `role="status"` otherwise). Across the set, interactive elements carry `focus-visible` ring styles so keyboard users can see where focus is.
+
+
+# The part aimed at AI agents
+
+WebJs is built to be edited by AI agents, and accessibility is exactly the kind of thing an agent breaks by accident. It refactors a component, moves some markup, and quietly drops the `aria-controls` link or the roving tabindex. The feature still looks fine. It is just no longer usable with a keyboard, and nobody notices until a real user hits it.
+
+So the accessibility expectations are encoded where the agent reads them. The tier-1 `A11y (required for accessible output)` JSDoc blocks are a contract in prose that sits next to the function. The tier-2 elements keep their ARIA wiring in the component source the agent copies into the repo, with comments explaining why each piece exists (why the panel is `inert`, why the dialog resolves its labels at open time). An agent editing the component reads the contract first, so its edits preserve the behaviour instead of silently regressing it. Human reviewers get the same benefit.
+
+There is one more agent-friendly detail. The variant names, sizes, and data-attribute conventions mirror shadcn/ui. An agent's existing knowledge of shadcn maps directly onto these components, so it reaches for the right API on the first try.
+
+
+# A note on what I did not claim
+
+I deliberately did not put a WCAG conformance badge on this post. WCAG (the Web Content Accessibility Guidelines, the standard that defines what "accessible" means on the web) has graded levels, and I found no audit in the repo stating the library hits a specific one, so I am not going to invent a number. What I can say, because I read the source, is that the components are keyboard navigable, screen-reader labelled, and focus-managed by default, and the tier-2 elements follow the published ARIA Authoring Practices patterns. Your own app still has to do its part (real content, real labels, sensible color contrast), and you should test with a keyboard and a screen reader like anyone else. The library gives you a floor that is a long way above blank.
+
+
+# The takeaway
+
+Accessibility is usable-with-a-keyboard-and-a-screen-reader, not just usable-with-a-mouse, and it is far cheaper to build in than to bolt on. WebJs ships `@webjsdev/ui` with that built in. Tier-1 class helpers hand you native elements plus an exact checklist of the ARIA to add, and tier-2 custom elements wire their own keyboard navigation, screen-reader labels, and focus management out of the box. Because the components are light DOM and source-copied into your repo, both you and any AI agent can read the accessibility contract and keep it intact through every edit. Run `webjs ui add` and you start from an accessible floor instead of a retrofit.

--- a/blog/ai-first-is-plumbing.md
+++ b/blog/ai-first-is-plumbing.md
@@ -2,18 +2,18 @@
 title: "AI-first is plumbing, not a marketing tag"
 date: 2026-04-18T12:00:00+05:30
 slug: ai-first-is-plumbing
-description: "What 'AI-first' actually means for webjs: the AGENTS.md contract, the hooks, the lint rules, and the small operational details that make a framework agent-readable."
+description: "What 'AI-first' actually means for WebJs: the AGENTS.md contract, the hooks, the lint rules, and the small operational details that make a framework agent-readable."
 tags: ai-first, agents, conventions, tooling
 author: Vivek
 ---
 
-When I say webjs is AI-first, I do not mean it has an AI-generated landing page or a chat widget on the docs. I mean a list of dull operational decisions, each of which makes the difference between an agent that writes correct code on the first try and one that produces a plausible-looking file in the wrong directory.
+When I say WebJs is AI-first, I do not mean it has an AI-generated landing page or a chat widget on the docs. I mean a list of dull operational decisions, each of which makes the difference between an agent that writes correct code on the first try and one that produces a plausible-looking file in the wrong directory.
 
 Here is the actual list, ordered roughly by how much each thing pays back.
 
 # AGENTS.md (and its siblings)
 
-Every scaffolded webjs app ships with these files at the root:
+Every scaffolded WebJs app ships with these files at the root:
 
 ```
 AGENTS.md                                  agent contract (this is the load-bearing one)
@@ -28,7 +28,7 @@ CLAUDE.md                                  Claude Code import file (points at AG
 
 The trick is that all of them say the same thing. AGENTS.md is the source of truth; CLAUDE.md is just `@AGENTS.md` (Claude Code's import syntax). Cursor and Antigravity (formerly Windsurf) use their own formats that load equivalent content. The PR template carries the convention checklist into every code review.
 
-Most agents read whichever file matches their tool first. AGENTS.md is the cross-tool standard ([emerging spec, FYI](https://agents.md/)). Every webjs scaffold ships it.
+Most agents read whichever file matches their tool first. AGENTS.md is the cross-tool standard ([emerging spec, FYI](https://agents.md/)). Every WebJs scaffold ships it.
 
 Concretely, the AGENTS.md file is around 40k characters. It covers: file conventions (where every kind of file goes), the public API of each package, framework invariants (the things that crash in production if you violate them), recipes for common tasks, and a list of `Deliberately deferred` items (so the agent does not try to add a bundler or a build command).
 
@@ -85,21 +85,21 @@ Why this is AI-first: the agent reading the doc sees the convention name and kno
 
 # The `Deliberately deferred` list
 
-Inside AGENTS.md there is a section called `Deliberately deferred`. It lists things webjs does not do and will not do in v1:
+Inside AGENTS.md there is a section called `Deliberately deferred`. It lists things WebJs does not do and will not do in v1:
 
-- Bundling (webjs is no-build; do not propose `webjs build`)
+- Bundling (WebJs is no-build; do not propose `webjs build`)
 - Per-route code splitting (downstream of no-build)
 - Vite-grade HMR with state preservation
 - React Server Components Flight
 - i18n / image optimization (layer libraries on top)
 
-The reason this is here is that agents will otherwise try to add these things. They see Next.js doing them and assume webjs should too. The doc says no, here are the trade-offs, do not propose this.
+The reason this is here is that agents will otherwise try to add these things. They see Next.js doing them and assume WebJs should too. The doc says no, here are the trade-offs, do not propose this.
 
 This list is read at the start of every long-running session. Saves cycles.
 
 # What this does not look like
 
-It does not look like a chat box. It does not look like a code-suggestion popup. It does not look like a marketing message. It is a stack of operational decisions that, together, mean an agent dropped into a webjs project writes correct code without asking what the framework wants.
+It does not look like a chat box. It does not look like a code-suggestion popup. It does not look like a marketing message. It is a stack of operational decisions that, together, mean an agent dropped into a WebJs project writes correct code without asking what the framework wants.
 
 Each individual piece is unsexy. The pre-commit hook is 100 lines of bash. The lint rules are short string-matching predicates. AGENTS.md is a wall of text. None of this is exciting on its own.
 

--- a/blog/ai-first-is-plumbing.md
+++ b/blog/ai-first-is-plumbing.md
@@ -1,11 +1,13 @@
 ---
-title: "AI-first is plumbing, not a marketing tag"
+title: "What an AI-First Framework Actually Means (It's Plumbing, Not a Marketing Tag)"
 date: 2026-04-18T12:00:00+05:30
 slug: ai-first-is-plumbing
-description: "What 'AI-first' actually means for WebJs: the AGENTS.md contract, the hooks, the lint rules, and the small operational details that make a framework agent-readable."
+description: "What an AI-first framework actually means for WebJs: the AGENTS.md contract, hooks, lint rules, and operational details that make a codebase agent-readable."
 tags: ai-first, agents, conventions, tooling
 author: Vivek
 ---
+
+You have probably watched an AI coding agent produce something that looks right and is quietly wrong: a broken convention, a config it could not have known about, code dropped in the wrong place. "AI-first framework" is the label everyone reaches for as the cure, and most of the time it means nothing at all.
 
 When I say WebJs is AI-first, I do not mean it has an AI-generated landing page or a chat widget on the docs. I mean a list of dull operational decisions, each of which makes the difference between an agent that writes correct code on the first try and one that produces a plausible-looking file in the wrong directory.
 
@@ -13,7 +15,7 @@ Here is the actual list, ordered roughly by how much each thing pays back.
 
 # AGENTS.md (and its siblings)
 
-Every scaffolded WebJs app ships with these files at the root:
+Every scaffolded WebJs app (the starter project `webjs create` generates for you) ships with these files at the root:
 
 ```
 AGENTS.md                                  agent contract (this is the load-bearing one)
@@ -79,7 +81,7 @@ The interesting bit is that the framework ships hooks for multiple agents in the
 
 # WEBJS_PUBLIC_* environment shim
 
-This is a tiny detail but it pays for itself constantly. Variables named `WEBJS_PUBLIC_*` (matching the `NEXT_PUBLIC_*` convention) get injected into the browser as `window.process.env.WEBJS_PUBLIC_X`. The shim is one inline `<script>` in the SSR head.
+This is a tiny detail but it pays for itself constantly. Variables named `WEBJS_PUBLIC_*` (matching the `NEXT_PUBLIC_*` convention) get injected into the browser as `window.process.env.WEBJS_PUBLIC_X`. The shim is one inline `<script>` in the SSR (server-rendered HTML) head.
 
 Why this is AI-first: the agent reading the doc sees the convention name and knows immediately what is browser-safe and what is server-only. The naming scheme is the API. Other variables (`DATABASE_URL`, `AUTH_SECRET`) silently return `undefined` in the browser, so a write of `process.env.DATABASE_URL` from a component fails closed instead of leaking the secret.
 
@@ -89,7 +91,7 @@ Inside AGENTS.md there is a section called `Deliberately deferred`. It lists thi
 
 - Bundling (WebJs is no-build; do not propose `webjs build`)
 - Per-route code splitting (downstream of no-build)
-- Vite-grade HMR with state preservation
+- Vite-grade HMR (hot module replacement) with state preservation
 - React Server Components Flight
 - i18n / image optimization (layer libraries on top)
 

--- a/blog/async-render-in-web-components.md
+++ b/blog/async-render-in-web-components.md
@@ -1,6 +1,6 @@
 ---
 title: "Async Data Fetching in Web Components (await Right in render())"
-date: 2026-06-03T10:00:00+05:30
+date: 2026-05-29T10:00:00+05:30
 slug: async-render-in-web-components
 description: "Web component data fetching without useEffect or a first-paint spinner. WebJs lets you await server data right inside async render(), so SSR bakes the data into the first paint, the client stays stale-while-revalidate, and there is no request waterfall."
 tags: web-components, data-fetching, async-render, ssr, suspense

--- a/blog/async-render-in-web-components.md
+++ b/blog/async-render-in-web-components.md
@@ -1,0 +1,101 @@
+---
+title: "Async Data Fetching in Web Components (await Right in render())"
+date: 2026-06-03T10:00:00+05:30
+slug: async-render-in-web-components
+description: "Web component data fetching without useEffect or a first-paint spinner. WebJs lets you await server data right inside async render(), so SSR bakes the data into the first paint, the client stays stale-while-revalidate, and there is no request waterfall."
+tags: web-components, data-fetching, async-render, ssr, suspense
+author: Vivek
+---
+
+Fetching data inside a component usually goes like this. You write a `useEffect`, you set a loading flag, you show a spinner, and the first thing the user sees is an empty box. The data only arrives after the component has already painted once, rendered nothing useful, and then re-rendered. If a parent and a child both fetch, they fetch in sequence, one waiting on the other, which is the request waterfall everyone eventually trips over. And none of that data is in the HTML the server sent, so a search crawler or a reader with JavaScript off sees the empty box too.
+
+I wanted the opposite of all of that. In WebJs you `await` the data directly inside the component's `render()` method, and the framework handles the three separate problems that `useEffect` conflates into one mess.
+
+Here is the whole thing.
+
+```ts
+class UserProfile extends WebComponent({ uid: String }) {
+  async render() {
+    const u = await getUser(this.uid);   // a 'use server' action
+    return html`<h3>${u.name}</h3>`;
+  }
+}
+UserProfile.register('user-profile');
+```
+
+That is it. No effect, no loading flag, no spinner, no `this.setState`. `render()` is allowed to be `async`. Writing `await` makes the function return a promise by the normal JavaScript rule, and every render path in WebJs already awaits a promise-returning `render()` automatically. There is no flag to set. A plain synchronous `render()` stays the zero-cost default, so you only pay for async where you actually reach for it. This is issue #469 if you want to read the history.
+
+
+# Why this is not just useEffect with nicer syntax
+
+The reason `async render()` works is that it decouples three concerns that React's fetch-in-effect pattern jams together. Keep them separate in your head and the whole model clicks.
+
+**One. SSR always blocks.** On the server, WebJs awaits your `async render()` before it sends any HTML. So the resolved data is baked into the first paint. There is no fallback markup, no spinner, no empty box, ever. The `<h3>` arrives with the name already in it. This is what "progressive enhancement" means in practice (the page works before JavaScript runs). A reader with JS off still reads the data, and a crawler indexes real content instead of a loading state. That is a genuine upgrade over a client-side fetch, which can only show something after the browser has downloaded, parsed, and run your script.
+
+**Two. The client re-fetch is stale-while-revalidate by default.** Say the `uid` prop changes and the component needs fresh data. WebJs re-runs `async render()`, but the content already on screen stays put until the new render resolves. No blank flash, no layout jump, no user code. The old data is shown while the new data loads, then it swaps. This is the behavior you would hand-write with a bunch of state in React, and here it is the default you get for free.
+
+**Three. `renderFallback()` is an optional loading UI, and only for the re-fetch.** Sometimes stale content would mislead (a different user's profile, say). For those cases you define `renderFallback()`, and WebJs shows it during a client re-fetch instead of the stale content.
+
+```ts
+class UserActivity extends WebComponent({ uid: String }) {
+  renderFallback() { return html`<div class="skeleton h-24"></div>`; }
+  async render() {
+    const items = await getActivity(this.uid);
+    return html`<ul>${items.map((i) => html`<li>${i.label}</li>`)}</ul>`;
+  }
+}
+```
+
+The important part, and the part that trips people coming from React. `renderFallback()` is shown ONLY during a client re-fetch. It is NEVER shown on the first paint. The first paint always has real data because SSR blocked for it. So `renderFallback()` is not "the loading spinner", it is "the loading spinner for the second and later fetches". If you were reaching for it to fill the first paint, you do not need it.
+
+
+# Errors are isolated for free
+
+If your `await getData()` throws, WebJs renders a component-scoped error state and lets the sibling components render normally. One broken widget does not blank the page and it does not bubble up to the route's `error.js`. In dev the default shows you the tag and message; in prod it renders a silent empty element so nothing leaks. You override it only if you want a custom message.
+
+```ts
+class Report extends WebComponent {
+  async render() { return html`<pre>${await getReport()}</pre>`; }
+  renderError(error) { return html`<p class="error">Could not load the report.</p>`; }
+}
+```
+
+Again, this is behavior you would otherwise build by hand with an error boundary around every fetching component. Here it is the default and `renderError()` is the opt-in customization.
+
+
+# The one line that works on both sides
+
+Look back at `const u = await getUser(this.uid)`. That single line runs on the server during SSR and on the client during a re-fetch, and it is the same line both times. This works because `getUser` is a `'use server'` action. During SSR it is the real function talking to your database. On the client, WebJs has rewritten the import into a typed RPC stub that posts to the server for you. You never hand-write a `fetch()` call, and you never think about which side you are on. The function is isomorphic (same source, both environments), so the co-located fetch just works.
+
+That co-location is the other quiet win. The fetch lives in the leaf component that needs the data. No prop-drilling a `user` object down four layers, no lifting fetches to a parent, no request waterfall from parent-waits-for-child chains.
+
+
+# What you do not pay for
+
+Two optimizations make this cheap, and both are on by default.
+
+A display-only async component gets **elided** (#474). If a component just fetches and renders, with no click handlers, no signals, no interactivity of any kind, then its server-rendered HTML is already the complete and final output. So WebJs drops its JavaScript module from the page entirely. The data is in the HTML, the component has nothing left to do in the browser, so nothing ships. A docs page or a content card built this way costs zero client JavaScript.
+
+For a component that DOES ship (because it is also interactive), **SSR action seeding** (#472) kills the redundant re-fetch. Every `'use server'` action result computed during SSR is serialized into the page. When the component hydrates in the browser, its first RPC call reads that seed instead of hitting the network. So `getUser(this.uid)` runs once, on the server, and the client reuses the result on its first render. No hydration flicker, no wasted round trip. A later re-fetch or an argument change still goes to the server as normal.
+
+
+# When to reach for something else
+
+`async render()` blocks the first byte, because SSR waits for your data before sending HTML. For fast queries that is exactly right. For a genuinely slow region, blocking the whole page's time-to-first-byte on one slow query is the wrong tradeoff. That is what `<webjs-suspense>` is for.
+
+```ts
+html`
+  <webjs-suspense .fallback=${html`<p>Loading section…</p>`}>
+    <slow-report></slow-report>
+  </webjs-suspense>
+`
+```
+
+The fallback flushes on the first byte, and the slow content streams in when it resolves. Multiple boundaries on one page fetch concurrently, so you get fast-content-first with no server waterfall. This is the one and only way to show a fallback on the first paint, and it is a deliberate choice you make for slow regions, not the default.
+
+And to be clear about the boundary. Use `async render()` for server data that is known at request time and belongs in the first paint. Keep `Task` and signals for data that is genuinely client-only (a `Task` renders its pending state at SSR, which means it loses the first-paint data, so it is the wrong tool for server data you want in the HTML).
+
+
+# The takeaway
+
+Fetching data in a component should not mean a spinner, an empty first paint, and a request waterfall. In WebJs you `await` your server data right inside `async render()`, and the framework splits the problem into three clean pieces: SSR always blocks so the data is in the first paint (no `useEffect`, no empty box, works with JS off), the client re-fetch is stale-while-revalidate by default, and `renderFallback()` is an optional loading state for re-fetches only. Errors isolate per component automatically, the fetch is one isomorphic line that runs on both sides, display-only components ship zero JavaScript, and SSR seeding means no wasted re-fetch on hydration. When a query is slow enough that blocking the first byte hurts, wrap it in `<webjs-suspense>` and stream it. That is data fetching that starts from the server instead of fighting to catch up to it.

--- a/blog/betting-on-lits-mental-model.md
+++ b/blog/betting-on-lits-mental-model.md
@@ -7,7 +7,7 @@ tags: components, lit-parity, runtime, ssr, ai-first
 author: Vivek
 ---
 
-The most-asked question I get about WebJs is some version of "if you wanted lit's API, why didn't you just use lit?"
+Lit (a popular library for building web components) has an API that a lot of developers already know by heart. So the most-asked question I get about WebJs is some version of "if you wanted lit's API, why didn't you just use lit?"
 
 It is a reasonable question. The WebJs `WebComponent` class has reactive properties, `render() { return html\`\` }`, `ReactiveController`, the full directive set. It looks like lit. The minimal version of "just use lit" would be:
 
@@ -47,13 +47,13 @@ So WebJs picked off the exact API surface that an agent recognizes:
 
 Four reasons, in order of how load-bearing each one is.
 
-## 1. SSR
+## 1. SSR (server-side rendering)
 
 lit-ssr exists. It is a separate package (`@lit-labs/ssr`) that takes a lit template and renders it to an HTML string. It works for most cases and the lit team maintains it.
 
 But it has structural limits that matter for WebJs:
 
-- **It does not share a code path with the client.** lit-ssr's renderer is a separate implementation that processes the same `html\`\`` templates. There is duplication, and in edge cases the server-side output and the client-side hydration disagree.
+- **It does not share a code path with the client.** lit-ssr's renderer is a separate implementation that processes the same `html\`\`` templates. There is duplication, and in edge cases the server-side output and the client-side hydration (the browser wiring up interactivity on the server-rendered HTML) disagree.
 
 - **It does not handle light-DOM `<slot>` projection.** lit-ssr renders shadow-DOM `<slot>` correctly via Declarative Shadow DOM. Light-DOM `<slot>` projection (where the framework manually inserts projected children into the host's slot markers) is not part of lit's model. WebJs wanted this to be a first-class feature ([its own blog post here](/blog/light-dom-slots-with-full-parity)).
 

--- a/blog/betting-on-lits-mental-model.md
+++ b/blog/betting-on-lits-mental-model.md
@@ -1,8 +1,8 @@
 ---
-title: "Lit-shaped, without depending on lit"
+title: "webjs vs Lit: a Lit-Shaped Runtime Without the Dependency"
 date: 2026-02-08T11:00:00+05:30
 slug: betting-on-lits-mental-model
-description: "Why webjs ships a custom component runtime with a public API that mirrors lit's, what that buys, and what it would have cost to just depend on lit instead."
+description: "webjs ships its own web-component runtime whose public API mirrors Lit (reactive properties, the Lit lifecycle, lit-html directives), so Lit knowledge transfers with no Lit dependency. What that buys and what it costs."
 tags: components, lit-parity, runtime, ssr, ai-first
 author: Vivek
 ---

--- a/blog/betting-on-lits-mental-model.md
+++ b/blog/betting-on-lits-mental-model.md
@@ -2,14 +2,14 @@
 title: "WebJs vs Lit: a Lit-Shaped Runtime Without the Dependency"
 date: 2026-02-08T11:00:00+05:30
 slug: betting-on-lits-mental-model
-description: "webjs ships its own web-component runtime whose public API mirrors Lit (reactive properties, the Lit lifecycle, lit-html directives), so Lit knowledge transfers with no Lit dependency. What that buys and what it costs."
+description: "WebJs ships its own web-component runtime whose public API mirrors Lit (reactive properties, the Lit lifecycle, lit-html directives), so Lit knowledge transfers with no Lit dependency. What that buys and what it costs."
 tags: components, lit-parity, runtime, ssr, ai-first
 author: Vivek
 ---
 
-The most-asked question I get about webjs is some version of "if you wanted lit's API, why didn't you just use lit?"
+The most-asked question I get about WebJs is some version of "if you wanted lit's API, why didn't you just use lit?"
 
-It is a reasonable question. The webjs `WebComponent` class has reactive properties, `render() { return html\`\` }`, `ReactiveController`, the full directive set. It looks like lit. The minimal version of "just use lit" would be:
+It is a reasonable question. The WebJs `WebComponent` class has reactive properties, `render() { return html\`\` }`, `ReactiveController`, the full directive set. It looks like lit. The minimal version of "just use lit" would be:
 
 ```ts
 // packages/core/src/component.js (hypothetical)
@@ -30,17 +30,17 @@ All four produced lit-shaped code. `class Counter extends LitElement`, `@propert
 
 That is what I wanted to keep. Not lit specifically. Lit's _shape_. The shape an agent already knows from training data.
 
-So webjs picked off the exact API surface that an agent recognizes:
+So WebJs picked off the exact API surface that an agent recognizes:
 
 - `extends WebComponent` (in lit, `extends LitElement`)
-- reactive properties declared up front (lit uses the `@property` decorator; webjs uses the `extends WebComponent({ count: Number })` factory, for the erasability reason below)
+- reactive properties declared up front (lit uses the `@property` decorator; WebJs uses the `extends WebComponent({ count: Number })` factory, for the erasability reason below)
 - `render() { return html\`...\` }` with the same tagged-template directive set
 - `static styles = css\`...\`` for shadow DOM
 - Lifecycle hooks named the same: `shouldUpdate`, `willUpdate`, `update`, `updated`, `firstUpdated`, `updateComplete`
 - `ReactiveController` with `hostConnected` / `hostDisconnected` / `hostUpdate` / `hostUpdated`
 - The lit-html directives that earn their place (the ones with no clean native equivalent): `repeat`, `unsafeHTML`, `live`, `keyed`, `guard`, `templateContent`, `ref`, `createRef`, `cache`, `until`, `asyncAppend`, `asyncReplace`, `watch`. The sugar-over-JS ones (`classMap`, `styleMap`, `ifDefined`, `when`, `choose`) are deliberately left out in favor of plain template expressions.
 
-[PR #31](https://github.com/webjsdev/webjs/pull/31) is where the full parity landed. It ported 127 lit tests verbatim and watched them pass on the webjs runtime. Same exit status. The behaviors that were undefined in lit got pinned down too, because the tests covered them.
+[PR #31](https://github.com/webjsdev/webjs/pull/31) is where the full parity landed. It ported 127 lit tests verbatim and watched them pass on the WebJs runtime. Same exit status. The behaviors that were undefined in lit got pinned down too, because the tests covered them.
 
 
 # Why I did not depend on lit
@@ -51,15 +51,15 @@ Four reasons, in order of how load-bearing each one is.
 
 lit-ssr exists. It is a separate package (`@lit-labs/ssr`) that takes a lit template and renders it to an HTML string. It works for most cases and the lit team maintains it.
 
-But it has structural limits that matter for webjs:
+But it has structural limits that matter for WebJs:
 
 - **It does not share a code path with the client.** lit-ssr's renderer is a separate implementation that processes the same `html\`\`` templates. There is duplication, and in edge cases the server-side output and the client-side hydration disagree.
 
-- **It does not handle light-DOM `<slot>` projection.** lit-ssr renders shadow-DOM `<slot>` correctly via Declarative Shadow DOM. Light-DOM `<slot>` projection (where the framework manually inserts projected children into the host's slot markers) is not part of lit's model. webjs wanted this to be a first-class feature ([its own blog post here](/blog/light-dom-slots-with-full-parity)).
+- **It does not handle light-DOM `<slot>` projection.** lit-ssr renders shadow-DOM `<slot>` correctly via Declarative Shadow DOM. Light-DOM `<slot>` projection (where the framework manually inserts projected children into the host's slot markers) is not part of lit's model. WebJs wanted this to be a first-class feature ([its own blog post here](/blog/light-dom-slots-with-full-parity)).
 
 - **Hydration is async.** lit-ssr emits the static HTML, but the client has to download `@lit/lit-element-hydrate-support`, opt in per-component, and the hydration runs as a second-pass walk after lit boots.
 
-- **There is no built-in property-binding serialization channel.** If you write `<my-counter .data=${richObject}>` in a server-rendered template, lit-ssr drops the `.data` binding. webjs preserves it via a `data-webjs-prop-*` attribute that the client picks up before the component's `render()` runs.
+- **There is no built-in property-binding serialization channel.** If you write `<my-counter .data=${richObject}>` in a server-rendered template, lit-ssr drops the `.data` binding. WebJs preserves it via a `data-webjs-prop-*` attribute that the client picks up before the component's `render()` runs.
 
 What I wanted was light-DOM rendering as a first-class peer of shadow DOM, with the same `<slot>` semantics in both, sharing one code path with the client renderer. That is hard to retrofit onto an existing runtime. It is straightforward to build into one.
 
@@ -78,9 +78,9 @@ class MyCounter extends LitElement {
 }
 ```
 
-That syntax requires `emitDecoratorMetadata: true` in tsconfig. With Node 24's built-in `module.stripTypeScriptTypes`, decorator metadata is non-erasable. webjs's `erasable-typescript-only` invariant rules it out. Strip-types-friendly TS does not support legacy decorators with metadata.
+That syntax requires `emitDecoratorMetadata: true` in tsconfig. With Node 24's built-in `module.stripTypeScriptTypes`, decorator metadata is non-erasable. WebJs's `erasable-typescript-only` invariant rules it out. Strip-types-friendly TS does not support legacy decorators with metadata.
 
-The webjs alternative is the `extends WebComponent({ … })` factory:
+The WebJs alternative is the `extends WebComponent({ … })` factory:
 
 ```ts
 import { WebComponent, html } from '@webjsdev/core';
@@ -94,19 +94,19 @@ MyCounter.register('my-counter');
 
 The factory declares the reactive property and types `this.count` for you, with no decorator and no separate `declare` field. The agent learns it from `AGENTS.md` and writes it correctly thereafter.
 
-If webjs depended on lit, we would carry the decorator path as the "main" pattern in lit's docs and have to constantly fight the divergence. By owning the runtime, the factory is the only pattern.
+If WebJs depended on lit, we would carry the decorator path as the "main" pattern in lit's docs and have to constantly fight the divergence. By owning the runtime, the factory is the only pattern.
 
 ## 3. The AI agent reads node_modules
 
 This is the one I keep underweighting in conversations and overweighting in practice.
 
-The webjs framework ships as plain `.js` files with JSDoc type annotations. Not TypeScript compiled to JS, not bundled, not minified. `node_modules/@webjsdev/core/src/component.js` is a JS file with comments and JSDoc that is readable end-to-end. So is `signal.js`, `slot.js`, `render-client.js`, every other source file in the framework. The whole framework is around 30,000 lines of JS that an agent can `cat` and reason about like project code.
+The WebJs framework ships as plain `.js` files with JSDoc type annotations. Not TypeScript compiled to JS, not bundled, not minified. `node_modules/@webjsdev/core/src/component.js` is a JS file with comments and JSDoc that is readable end-to-end. So is `signal.js`, `slot.js`, `render-client.js`, every other source file in the framework. The whole framework is around 30,000 lines of JS that an agent can `cat` and reason about like project code.
 
-This is by design. The first rule of the AI-first thesis is "the file the agent reads is the file that runs." That rule applies to the framework itself, not just the user's app code. When an agent hits an unexpected behavior in webjs, it can read the framework source and figure it out. When it does not understand why `firstUpdated` fires before `updated`, it opens `component.js`, finds the update loop, reads the JSDoc above it, and gets the answer.
+This is by design. The first rule of the AI-first thesis is "the file the agent reads is the file that runs." That rule applies to the framework itself, not just the user's app code. When an agent hits an unexpected behavior in WebJs, it can read the framework source and figure it out. When it does not understand why `firstUpdated` fires before `updated`, it opens `component.js`, finds the update loop, reads the JSDoc above it, and gets the answer.
 
-lit is also open source and well-documented. But the version that lands in `node_modules` is the published build: TypeScript compiled to JS with comments stripped. Reading it is doable but considerably worse than reading webjs's source, especially for an agent whose context window has to hold the relevant code.
+lit is also open source and well-documented. But the version that lands in `node_modules` is the published build: TypeScript compiled to JS with comments stripped. Reading it is doable but considerably worse than reading WebJs's source, especially for an agent whose context window has to hold the relevant code.
 
-If webjs depended on lit, every framework-internals question the agent asks about lit would route through that compiled output. The lit team has no reason to write their internal comments for a downstream AI-first framework. They are not trying to make their `node_modules` readable for agents reading apps that depend on them.
+If WebJs depended on lit, every framework-internals question the agent asks about lit would route through that compiled output. The lit team has no reason to write their internal comments for a downstream AI-first framework. They are not trying to make their `node_modules` readable for agents reading apps that depend on them.
 
 Owning the runtime means we get to write the comments.
 
@@ -122,7 +122,7 @@ A few things I wanted that lit does not ship and would be hard to retrofit:
 Each of these is a few hundred lines. Cumulatively they justify owning the runtime.
 
 
-# What an LLM sees when it reads webjs
+# What an LLM sees when it reads WebJs
 
 The component file the agent reads looks like a lit component. Same reactive properties. Same `render()`. Same `html\`\`` directive syntax. The differences are minimal:
 
@@ -141,9 +141,9 @@ The decorator import goes away because of the erasable-TypeScript invariant. The
 
 Everything else is the same. Lifecycle hooks. Directives. Reactive controllers. The agent writes lit-shaped code and it works.
 
-The proof was watching a freshly-installed Claude Code session add a feature to the example blog without me telling it anything about the framework. The model was not trained on webjs. It was trained on lit, and on Next.js routing, and on Tailwind. webjs presents exactly those surfaces. So the agent wrote correct code.
+The proof was watching a freshly-installed Claude Code session add a feature to the example blog without me telling it anything about the framework. The model was not trained on webjs. It was trained on lit, and on Next.js routing, and on Tailwind. WebJs presents exactly those surfaces. So the agent wrote correct code.
 
-The thesis is "meet agents where their priors already are." webjs is small enough to do that without inventing.
+The thesis is "meet agents where their priors already are." WebJs is small enough to do that without inventing.
 
 
 # What it cost
@@ -154,31 +154,31 @@ You give up the lit team's bug fixes. If they find a memory leak in their templa
 
 You give up some genuine cleverness in lit's implementation. Their template caching, their parts model, the way they handle slot lifecycle. It is excellent code. Writing my own version of it took weeks I would not have spent had I just imported lit.
 
-The size delta is also real. lit ships about 20 KB minified + gzipped for the full LitElement + lit-html bundle. webjs's `@webjsdev/core` is about 30 KB for the equivalent feature set plus the slot-projection logic, the partial-swap-frame element, the client router, and the property-binding SSR channel. webjs is bigger because it includes things lit treats as separate packages (the router, the SSR pipeline, the slot host, the live-reload SSE client). lit users assemble these from `@lit-labs/*` packages or third-party libraries. webjs ships them in one.
+The size delta is also real. lit ships about 20 KB minified + gzipped for the full LitElement + lit-html bundle. WebJs's `@webjsdev/core` is about 30 KB for the equivalent feature set plus the slot-projection logic, the partial-swap-frame element, the client router, and the property-binding SSR channel. WebJs is bigger because it includes things lit treats as separate packages (the router, the SSR pipeline, the slot host, the live-reload SSE client). lit users assemble these from `@lit-labs/*` packages or third-party libraries. WebJs ships them in one.
 
 The trade-off is fewer dependencies to manage, fewer version-mismatch debugging sessions, smaller dependency graph in the user's `package-lock.json`. For an AI-first framework where the agent has to reason about the runtime, one cohesive module is easier than six related packages.
 
 
 # What if lit ships SSR + light-DOM slots tomorrow
 
-If lit shipped full SSR with light-DOM `<slot>` parity and no separate hydration support package, the cost-benefit of owning the runtime would tip the other way. webjs would consider importing lit instead.
+If lit shipped full SSR with light-DOM `<slot>` parity and no separate hydration support package, the cost-benefit of owning the runtime would tip the other way. WebJs would consider importing lit instead.
 
-It has been roughly two years since lit-ssr stabilized and the design has not moved in that direction. The lit team has signaled that shadow-DOM-with-DSD is their model and they do not plan to support framework-owned light-DOM slot projection. That is a defensible architectural choice; it is just not webjs's choice.
+It has been roughly two years since lit-ssr stabilized and the design has not moved in that direction. The lit team has signaled that shadow-DOM-with-DSD is their model and they do not plan to support framework-owned light-DOM slot projection. That is a defensible architectural choice; it is just not WebJs's choice.
 
-If the situation changes, refactoring webjs to use lit underneath is a finite amount of work. The public API is already lit-shaped. The migration would be in the framework's internals, not in user code.
+If the situation changes, refactoring WebJs to use lit underneath is a finite amount of work. The public API is already lit-shaped. The migration would be in the framework's internals, not in user code.
 
 
 # Not a dig at lit
 
 Worth noting: this is not lit-vs-webjs as products. lit is great. The lit team has built a careful, principled web-components library. If you do not need SSR, do not need light-DOM slots, do not mind decorators, and do not want a full-stack framework wrapper, just use lit.
 
-webjs is for the case where you want SSR + light-DOM slots + an AI-first contract + the rest of the framework (routing, server actions, auth, sessions, etc.) in one cohesive thing. Owning the runtime is one of the necessary conditions to deliver that, not a goal in itself.
+WebJs is for the case where you want SSR + light-DOM slots + an AI-first contract + the rest of the framework (routing, server actions, auth, sessions, etc.) in one cohesive thing. Owning the runtime is one of the necessary conditions to deliver that, not a goal in itself.
 
 
 # Reading the actual implementation
 
-The webjs component runtime starts at [`packages/core/src/component.js`](https://github.com/webjsdev/webjs/blob/main/packages/core/src/component.js). It is the most-changed file in the repo. Most design decisions have a commit message that says why.
+The WebJs component runtime starts at [`packages/core/src/component.js`](https://github.com/webjsdev/webjs/blob/main/packages/core/src/component.js). It is the most-changed file in the repo. Most design decisions have a commit message that says why.
 
-The SSR walker is at `render-server.js`. The client renderer is `render-client.js`. The slot runtime is `slot.js`. These are the four files that would be the most-changed if webjs ever depended on lit instead. They are also the four files that explain why it does not.
+The SSR walker is at `render-server.js`. The client renderer is `render-client.js`. The slot runtime is `slot.js`. These are the four files that would be the most-changed if WebJs ever depended on lit instead. They are also the four files that explain why it does not.
 
-The lit-parity test suite (127 tests ported verbatim from lit's repo with one-line import changes) is in `packages/core/test/lit-parity/`. When lit adds a feature, we look at whether it makes sense in webjs's model and port it if so. We are not slavishly tracking, but we stay close.
+The lit-parity test suite (127 tests ported verbatim from lit's repo with one-line import changes) is in `packages/core/test/lit-parity/`. When lit adds a feature, we look at whether it makes sense in WebJs's model and port it if so. We are not slavishly tracking, but we stay close.

--- a/blog/betting-on-lits-mental-model.md
+++ b/blog/betting-on-lits-mental-model.md
@@ -1,5 +1,5 @@
 ---
-title: "webjs vs Lit: a Lit-Shaped Runtime Without the Dependency"
+title: "WebJs vs Lit: a Lit-Shaped Runtime Without the Dependency"
 date: 2026-02-08T11:00:00+05:30
 slug: betting-on-lits-mental-model
 description: "webjs ships its own web-component runtime whose public API mirrors Lit (reactive properties, the Lit lifecycle, lit-html directives), so Lit knowledge transfers with no Lit dependency. What that buys and what it costs."

--- a/blog/built-ins-auth-session-cookies-cache.md
+++ b/blog/built-ins-auth-session-cookies-cache.md
@@ -2,14 +2,14 @@
 title: "Built-ins: auth, sessions, cookies, cache, and rate limiting (sharing one store)"
 date: 2026-03-08T15:00:00+05:30
 slug: built-ins-auth-session-cookies-cache
-description: "The five cross-cutting concerns webjs ships in @webjsdev/server: how they share a pluggable cache store, what the four-method store interface looks like, and what swapping to Redis looks like."
+description: "The five cross-cutting concerns WebJs ships in @webjsdev/server: how they share a pluggable cache store, what the four-method store interface looks like, and what swapping to Redis looks like."
 tags: server, auth, sessions, cache, redis, rate-limit
 author: Vivek
 ---
 
 Most frameworks make you assemble the cross-cutting server-side concerns from libraries. Auth from passport or lucia. Sessions from express-session or iron-session. Cache from node-cache or ioredis. Rate-limiting from express-rate-limit. The pieces work, but they all want their own store, their own config, and their own version of "where do I plug in Redis?"
 
-webjs ships all of them built-in. They share one cache store. The shape feels obvious once you see it; getting there took some non-obvious choices.
+WebJs ships all of them built-in. They share one cache store. The shape feels obvious once you see it; getting there took some non-obvious choices.
 
 
 # The concerns and the one store
@@ -61,7 +61,7 @@ Cross-cutting features are easy to build. The keyspace is one namespace; the mod
 
 # The auth model
 
-`createAuth()` matches the NextAuth / Auth.js shape so an agent that has seen NextAuth writes correct webjs auth. Three providers in v1: Google, GitHub, and Credentials. The implementation uses Web Crypto HMAC-SHA256, so no external crypto dependency.
+`createAuth()` matches the NextAuth / Auth.js shape so an agent that has seen NextAuth writes correct WebJs auth. Three providers in v1: Google, GitHub, and Credentials. The implementation uses Web Crypto HMAC-SHA256, so no external crypto dependency.
 
 Two cookie names from the source (`AUTH_COOKIE = 'webjs.auth'`, `STATE_COOKIE = 'webjs.auth.state'`). Default session lifetime is 30 days. Sessions can be JWT (opaque token, no server lookup) or database-backed (token is a key into the cache store).
 
@@ -70,7 +70,7 @@ The credentials provider's `verify` callback returns the user object (or null on
 
 # The session model
 
-webjs's `Session` class is Remix-shaped: `get`, `set`, `has`, `unset`, `flash`, `destroy`, `regenerateId`. From the source:
+WebJs's `Session` class is Remix-shaped: `get`, `set`, `has`, `unset`, `flash`, `destroy`, `regenerateId`. From the source:
 
 ```ts
 class Session {
@@ -135,7 +135,7 @@ Internally it computes the current windowed key (e.g. `ratelimit:<bucket>:<windo
 
 # What this is not
 
-webjs's built-ins are intentionally minimal. We do not ship:
+WebJs's built-ins are intentionally minimal. We do not ship:
 
 - Magic-link email auth (use a third-party provider).
 - 2FA / WebAuthn (later).
@@ -143,7 +143,7 @@ webjs's built-ins are intentionally minimal. We do not ship:
 - A migration tool for sessions (you write your own when you outgrow cookies).
 - Pluggable encryption algorithms (Web Crypto HMAC-SHA256 only).
 
-Each has a clean third-party answer if you need it. webjs covers the 80% case in a way the agent can write without reading docs. The 20% case is a library install away.
+Each has a clean third-party answer if you need it. WebJs covers the 80% case in a way the agent can write without reading docs. The 20% case is a library install away.
 
 
 # How this looks from the user's perspective
@@ -172,6 +172,6 @@ The same code that worked locally now scales horizontally. No store migration. N
 
 A pluggable store with a small interface is more valuable than a separate library per concern. Adding cross-cutting features later was straightforward because everything routed through one place. Adding "purge all data for this user" for compliance was a few lines, because the four-method interface already had everything we needed.
 
-Matching the Remix Session class and the NextAuth provider shape saved a lot of doc-writing. Agents already know the surface from the other frameworks. The few users who have written webjs apps with custom OAuth providers used the same argument shapes they would have used elsewhere. The mental model transferred.
+Matching the Remix Session class and the NextAuth provider shape saved a lot of doc-writing. Agents already know the surface from the other frameworks. The few users who have written WebJs apps with custom OAuth providers used the same argument shapes they would have used elsewhere. The mental model transferred.
 
 If you read the implementation, the modules live at `packages/server/src/{auth,session,cache,cache-fn,rate-limit}.js`. The Session class is the largest at ~340 lines; the cache and rate-limit modules are 200 lines each. About 1500 lines total for the five concerns combined.

--- a/blog/built-ins-auth-session-cookies-cache.md
+++ b/blog/built-ins-auth-session-cookies-cache.md
@@ -1,13 +1,13 @@
 ---
-title: "Built-ins: auth, sessions, cookies, cache, and rate limiting (sharing one store)"
+title: "Built-in Auth, Sessions, Cookies, Cache, and Rate Limiting (One Shared Store)"
 date: 2026-03-08T15:00:00+05:30
 slug: built-ins-auth-session-cookies-cache
-description: "The five cross-cutting concerns WebJs ships in @webjsdev/server: how they share a pluggable cache store, what the four-method store interface looks like, and what swapping to Redis looks like."
+description: "WebJs ships built-in auth, sessions, cookies, caching, and rate limiting in @webjsdev/server, all sharing one cache store you can swap to Redis in one line."
 tags: server, auth, sessions, cache, redis, rate-limit
 author: Vivek
 ---
 
-Most frameworks make you assemble the cross-cutting server-side concerns from libraries. Auth from passport or lucia. Sessions from express-session or iron-session. Cache from node-cache or ioredis. Rate-limiting from express-rate-limit. The pieces work, but they all want their own store, their own config, and their own version of "where do I plug in Redis?"
+Every app ends up needing the same handful of server-side chores. A way to log people in. A way to remember them from one request to the next. Some caching so you are not asking the database the same question twice. And a limiter so nobody can hammer your endpoints. Most frameworks make you assemble those from libraries. Auth from passport or lucia. Sessions from express-session or iron-session. Cache from node-cache or ioredis. Rate-limiting from express-rate-limit. The pieces work, but they all want their own store, their own config, and their own version of "where do I plug in Redis?"
 
 WebJs ships all of them built-in. They share one cache store. The shape feels obvious once you see it; getting there took some non-obvious choices.
 
@@ -36,9 +36,9 @@ type CacheStore = {
 };
 ```
 
-Just four operations. The `increment` is atomic and creates the key with value 1 if it does not exist; the TTL is set on creation only. That is what makes the rate limiter correct across instances when the store is Redis-backed.
+Just four operations. The `increment` is atomic and creates the key with value 1 if it does not exist; the TTL (time to live, how long an entry survives before it expires) is set on creation only. That is what makes the rate limiter correct across instances when the store is Redis-backed.
 
-The default implementation is `memoryStore({ maxSize: 10000 })`, a JS Map with TTL expiry and LRU eviction. Sufficient for development, sufficient for a single-instance deployment.
+The default implementation is `memoryStore({ maxSize: 10000 })`, a JS Map with TTL expiry and LRU (least recently used) eviction. Sufficient for development, sufficient for a single-instance deployment.
 
 When you need horizontal scaling, swap to `redisStore({ url: ... })`. One line at app startup:
 

--- a/blog/client-router-turbo-drive-style.md
+++ b/blog/client-router-turbo-drive-style.md
@@ -2,18 +2,18 @@
 title: "The client router (or: how Turbo Drive ate my white flash)"
 date: 2026-02-22T10:30:00+05:30
 slug: client-router-turbo-drive-style
-description: "Why webjs ships a Hotwire-style nested-layout-aware client router by default, what the X-Webjs-Have optimization is, and how layouts stay mounted across navigations."
+description: "Why WebJs ships a Hotwire-style nested-layout-aware client router by default, what the X-Webjs-Have optimization is, and how layouts stay mounted across navigations."
 tags: client-router, navigation, ssr, layouts
 author: Vivek
 ---
 
-The first version of webjs had no client router. Each `<a>` click did a full page navigation. The HTML came back fast (SSR is quick), the page rendered, life was fine. Except for one thing.
+The first version of WebJs had no client router. Each `<a>` click did a full page navigation. The HTML came back fast (SSR is quick), the page rendered, life was fine. Except for one thing.
 
 The page flickered white between navigations.
 
 That white flash is the browser repainting between document loads. Chromium has the "paint holding" feature, but it still happens noticeably for ~100ms on most navigations. On a slow connection it is longer. The page feels janky even when the server is fast.
 
-The fix is to intercept link clicks, fetch the next page over fetch(), and patch the DOM in place. Hotwire calls this Turbo Drive. webjs's version is at `packages/core/src/router-client.js`. The docstring at the top spells out the design; the rest of this post is the commentary.
+The fix is to intercept link clicks, fetch the next page over fetch(), and patch the DOM in place. Hotwire calls this Turbo Drive. WebJs's version is at `packages/core/src/router-client.js`. The docstring at the top spells out the design; the rest of this post is the commentary.
 
 
 # The mechanism
@@ -93,9 +93,9 @@ This took two bug reports to get right. Race conditions in click-driven SPA navi
 
 lit ships no built-in router. You bring your own (vaadin-router, lit-router, etc.). Each has a different API.
 
-Stencil ships a router closer in spirit to webjs's, but it does not have the layouts-stay-mounted optimization. Every navigation re-mounts the full component tree.
+Stencil ships a router closer in spirit to WebJs's, but it does not have the layouts-stay-mounted optimization. Every navigation re-mounts the full component tree.
 
-Hotwire's Turbo Drive is the closest precedent. Same DOM-swap philosophy, same scroll-restoration logic, similar form integration. webjs's version is implemented from scratch in TypeScript with web-component awareness (it walks `composedPath()` for shadow-DOM-piercing link detection), but the design borrows heavily.
+Hotwire's Turbo Drive is the closest precedent. Same DOM-swap philosophy, same scroll-restoration logic, similar form integration. WebJs's version is implemented from scratch in TypeScript with web-component awareness (it walks `composedPath()` for shadow-DOM-piercing link detection), but the design borrows heavily.
 
 
 # Why I shipped this in core

--- a/blog/client-router-turbo-drive-style.md
+++ b/blog/client-router-turbo-drive-style.md
@@ -1,13 +1,13 @@
 ---
-title: "The client router (or: how Turbo Drive ate my white flash)"
+title: "Client-Side Routing Without the Full-Page Reload (or: Goodbye, White Flash)"
 date: 2026-02-22T10:30:00+05:30
 slug: client-router-turbo-drive-style
-description: "Why WebJs ships a Hotwire-style nested-layout-aware client router by default, what the X-Webjs-Have optimization is, and how layouts stay mounted across navigations."
+description: "How WebJs does client-side routing by default. SPA navigation with no full-page reload and no white flash, keeping nested layouts mounted across page changes."
 tags: client-router, navigation, ssr, layouts
 author: Vivek
 ---
 
-The first version of WebJs had no client router. Each `<a>` click did a full page navigation. The HTML came back fast (SSR is quick), the page rendered, life was fine. Except for one thing.
+You know the quick white blink when you click a link and the whole page reloads? WebJs did not always avoid it. The first version had no client router (the bit of code that swaps pages in place instead of reloading the whole document), so each `<a>` click did a full page navigation. The HTML came back fast (SSR, or server-side rendering, is quick), the page rendered, life was fine. Except for one thing.
 
 The page flickered white between navigations.
 
@@ -86,7 +86,7 @@ No nested-route data deduplication. Each navigation re-fetches the page from scr
 
 The router handles rapid clicks correctly. Click link A, then click link B before A's response arrives. The router aborts A's fetch and proceeds with B. The DOM never patches A's content. A nav-token mechanism ensures that an out-of-order resolution (B resolves before A) does not accidentally revert to A's state.
 
-This took two bug reports to get right. Race conditions in click-driven SPA navigation are subtle.
+This took two bug reports to get right. Race conditions in click-driven SPA navigation (a single-page app that swaps content in place instead of reloading) are subtle.
 
 
 # Comparing to lit and Hotwire

--- a/blog/csrf-protection-without-tokens.md
+++ b/blog/csrf-protection-without-tokens.md
@@ -1,6 +1,6 @@
 ---
 title: "CSRF Protection Without Tokens, Cookies, or Config"
-date: 2026-06-10T11:00:00+05:30
+date: 2026-06-04T11:00:00+05:30
 slug: csrf-protection-without-tokens
 description: "How WebJs does CSRF protection with a Sec-Fetch-Site and Origin check instead of a token cookie. CSRF without a token keeps your SSR pages same-origin safe and CDN-edge-cacheable, the modern browser-native approach explained for beginners."
 tags: security, csrf, sec-fetch-site, server-actions, caching

--- a/blog/csrf-protection-without-tokens.md
+++ b/blog/csrf-protection-without-tokens.md
@@ -1,0 +1,120 @@
+---
+title: "CSRF Protection Without Tokens, Cookies, or Config"
+date: 2026-06-10T11:00:00+05:30
+slug: csrf-protection-without-tokens
+description: "How WebJs does CSRF protection with a Sec-Fetch-Site and Origin check instead of a token cookie. CSRF without a token keeps your SSR pages same-origin safe and CDN-edge-cacheable, the modern browser-native approach explained for beginners."
+tags: security, csrf, sec-fetch-site, server-actions, caching
+author: Vivek
+---
+
+Let me start with the attack, because the name is scarier than the idea.
+
+CSRF stands for Cross-Site Request Forgery. Here is the whole thing in one sentence. You are logged into your bank in one tab. You open a malicious page in another tab. That page quietly submits a form (or fires a request) at your bank, and because your browser helpfully attaches your bank's cookies to any request headed for your bank, the bank sees a fully authenticated "transfer money" request that you never meant to send.
+
+The malicious site never sees your cookies. It does not need to. It just needs your browser to send them for it. That is the trick. The request is forged to look like it came from you, because in a cookie sense it did.
+
+So every framework needs an answer to "was this state-changing request actually initiated by my own site, or by some other site riding on the user's session?"
+
+
+# The classic answer, and why it is fiddly
+
+The traditional fix is the anti-CSRF token. The server generates a random secret, embeds it in a hidden form field on every page, and also stores a copy (often in a cookie). When the form submits, the server checks that the hidden field matches the stored copy. A malicious cross-site page cannot read your pages, so it cannot know the token, so its forged request fails the check.
+
+This works. It has protected the web for two decades. But it is a lot of moving parts for a beginner to wire up correctly.
+
+- Every form needs the hidden token field, so you need a way to inject it everywhere.
+- The token has to be tied to the session, rotated sensibly, and validated on every mutating request.
+- The "double-submit cookie" variant sets the token as a cookie and asks the form to echo it back, which means you now have a cookie you must set on the SSR response.
+
+That last point is the one that quietly hurts, and I will come back to it, because it is the reason WebJs went a different way.
+
+
+# The modern answer: ask the browser where the request came from
+
+Here is the thing that changed. Modern browsers now tell the server, on every request, whether the request came from the same site or a different one. They send a header called `Sec-Fetch-Site`, and its value is one of `same-origin`, `same-site`, `cross-site`, or `none` (a direct navigation, like typing the URL or clicking a bookmark).
+
+The malicious page cannot forge this header. It is set by the browser itself, and JavaScript is not allowed to touch it. So the server can just read it. If a state-changing request claims to come from `cross-site`, it is exactly the forgery you were worried about, and you reject it.
+
+This is the Remix 3 and Go 1.25 model, and it is what WebJs server actions use. No token to generate, no hidden field to inject, no extra cookie to set.
+
+
+# What WebJs actually checks
+
+In WebJs, a server action is a function in a `*.server.ts` file marked `'use server'`. When you import it from client code, the import is rewritten into a typed RPC stub that POSTs to `/__webjs/action/<hash>/<fn>`. That RPC boundary is where the CSRF check lives.
+
+For a state-changing verb (POST, PUT, PATCH, DELETE), the request passes only when one of these is true.
+
+1. `Sec-Fetch-Site` is `same-origin` or `none`. Your own site, or a direct navigation.
+2. The browser is older and sent no `Sec-Fetch-Site`, but the `Origin` header's host matches the request host. A same-host fallback.
+3. The source origin is listed in `webjs.allowedOrigins` in your `package.json`. An explicit opt-in for a trusted cross-origin caller.
+
+Otherwise the request is rejected with a `403`. That is the entire policy.
+
+```jsonc
+// package.json
+{
+  "webjs": {
+    "allowedOrigins": ["https://admin.example.com"]
+  }
+}
+```
+
+Most apps never touch `allowedOrigins` at all. The default (same-origin or a matching host) is what you want almost always.
+
+And a safe read is exempt. A GET action is CSRF-exempt by design, because a GET is not supposed to change state, so there is nothing to forge. (If a GET of yours does mutate state, that is the bug to fix, not the check to loosen.)
+
+
+# The payoff nobody advertises: your pages stay cacheable at the edge
+
+Now back to the cookie problem, because this is the part I actually find exciting.
+
+Remember the double-submit token needs a cookie on the SSR response. The moment your server sends a `Set-Cookie` header with an HTML page, that page becomes per-user by definition. A CDN cannot cache it, because caching one visitor's cookie and serving it to the next visitor would be a security disaster. So the token approach quietly makes your HTML uncacheable at the edge.
+
+WebJs sends no `Set-Cookie` riding the SSR HTML for CSRF, because there is no token to plant. That means a page that is genuinely identical for every visitor can opt into a public `Cache-Control` and be cached at the CDN edge.
+
+```ts
+// app/layout.ts (root layout for a visitor-identical app)
+import { html } from '@webjsdev/core';
+import type { Metadata } from '@webjsdev/core';
+
+export const metadata: Metadata = {
+  cacheControl: 'public, max-age=300',
+};
+
+export default function RootLayout({ children }: { children: unknown }) {
+  return html`<main class="max-w-[760px]">${children}</main>`;
+}
+```
+
+You can set `metadata.cacheControl` on a single page, or on a root layout to cover a whole visitor-identical app. The edge serves the cached HTML, your origin does less work, and the first paint is faster. This is the real argument. The Sec-Fetch-Site approach is not just simpler to write, it keeps your SSR output CDN-cacheable, which a CSRF-token cookie fundamentally would not.
+
+
+# CORS is a separate control (do not confuse the two)
+
+CSRF protection guards your own site's mutating requests. CORS is a different concern, which is letting a browser on another origin read your responses on purpose. For that, WebJs ships a `cors()` middleware in `@webjsdev/server`.
+
+```ts
+// middleware.ts
+import { cors } from '@webjsdev/server';
+
+export default cors({
+  origin: ['https://app.example.com'],
+  credentials: true,
+});
+```
+
+One hard rule here. If you set `credentials: true` (so the browser sends cookies on the cross-origin request), you MUST pass an explicit origin allowlist. Never combine `credentials: true` with `origin: '*'`. A credentialed wildcard effectively hands cookie-authenticated access to every origin on the web, which is the exact footgun CORS is supposed to prevent. WebJs will narrow a wildcard-plus-credentials combination to the reflected origin and warn you, but the correct fix is a real allowlist.
+
+
+# The one caveat: this covers actions, not your hand-written routes
+
+The Sec-Fetch-Site check protects the action RPC boundary. It does NOT automatically cover a `route.ts` REST endpoint you write by hand.
+
+A `route.ts` handler is a raw HTTP handler (named `GET` / `POST` exports). It is the right tool when you are building a public API, and precisely because it is public and raw, WebJs does not impose the action CSRF policy on it. So if a `route.ts` endpoint mutates state, that is on you. Authenticate every mutating route, validate the input, and rate-limit it. The framework gives you the pieces (`validate`, the auth helpers, `rateLimit()`), but it will not second-guess a route you wrote deliberately.
+
+The rule of thumb: reach for a server action for in-app mutations (you get CSRF protection for free), and reach for `route.ts` when you are exposing a real HTTP API to the outside world (you own the security).
+
+
+# The takeaway
+
+CSRF is a browser trick, so the cleanest defense is a browser fact. Modern browsers stamp every request with `Sec-Fetch-Site`, which JavaScript cannot forge, so WebJs server actions simply reject any state-changing request that is not same-origin (with an Origin-host fallback for old browsers and an `allowedOrigins` escape hatch). There is no token to generate, no hidden field to inject, and no CSRF cookie to set. That last absence is the quiet win, because with no `Set-Cookie` on the SSR HTML, a visitor-identical page can opt into a public `Cache-Control` and be cached at the CDN edge, which a token-cookie approach would break. Just remember that this protection lives on the action boundary, so if you hand-write a mutating `route.ts`, you secure that one yourself.

--- a/blog/file-based-routing.md
+++ b/blog/file-based-routing.md
@@ -2,12 +2,12 @@
 title: "File-based routing the Next.js way (because the agent already knows it)"
 date: 2026-01-28T11:30:00+05:30
 slug: file-based-routing
-description: "Why webjs copies Next.js's app-router conventions verbatim, what each file type does, and where webjs's routing diverges."
+description: "Why WebJs copies Next.js's app-router conventions verbatim, what each file type does, and where WebJs's routing diverges."
 tags: routing, conventions, next-js, ai-first
 author: Vivek
 ---
 
-When I was sketching webjs's routing layer, I had two options. Invent something custom. Or copy Next.js's app router, which is the routing model I personally enjoy using.
+When I was sketching WebJs's routing layer, I had two options. Invent something custom. Or copy Next.js's app router, which is the routing model I personally enjoy using.
 
 I went with Next.js. Same `page.ts`, `layout.ts`, `route.ts`, `[param]`, `(group)`, `_private`. Two reasons: it is the shape I want to work in day to day, and it is the shape the agent has already read ten thousand examples of. Reproduce that shape and the agent writes correct code immediately.
 
@@ -96,7 +96,7 @@ Named async functions per HTTP method. Each receives `(Request, { params })`. Ea
 A folder cannot have both `page.js` and `route.js`. The router enforces it at scan time.
 
 
-# How webjs's routing is different from Next.js
+# How WebJs's routing is different from Next.js
 
 A few things are not the same.
 
@@ -106,7 +106,7 @@ Server actions are explicit, file-based. A `*.server.{js,ts}` file with `'use se
 
 WebSockets ride the same route file. If you export `WS(ws, req, { params })` from `route.ts`, the URL becomes a WebSocket endpoint. No separate file type.
 
-No metadata API for fetch caching. webjs uses HTTP `Cache-Control` headers for response caching and the framework's `cache()` function for query memoization. There is no `fetch(...).cache(...)` extension on the global fetch.
+No metadata API for fetch caching. WebJs uses HTTP `Cache-Control` headers for response caching and the framework's `cache()` function for query memoization. There is no `fetch(...).cache(...)` extension on the global fetch.
 
 Streaming uses Suspense directly. Wrap a slow part of your tree in `<Suspense fallback=${...}>`. The framework streams the response, flushes the fallback, then patches in the resolved content when the promise lands. No special exports.
 

--- a/blog/file-based-routing.md
+++ b/blog/file-based-routing.md
@@ -1,11 +1,13 @@
 ---
-title: "File-based routing the Next.js way (because the agent already knows it)"
+title: "File-based routing the Next.js way, built for AI coding agents"
 date: 2026-01-28T11:30:00+05:30
 slug: file-based-routing
-description: "Why WebJs copies Next.js's app-router conventions verbatim, what each file type does, and where WebJs's routing diverges."
+description: "File-based routing in WebJs copies Next.js app-router conventions verbatim: page, layout, route, and dynamic params, plus where WebJs diverges from it."
 tags: routing, conventions, next-js, ai-first
 author: Vivek
 ---
+
+Here is the good news up front. If you have ever built a page in Next.js, you already know how to build one in WebJs, because the folders in your app/ directory are your URLs. This is file-based routing (your folder layout defines your routes, with no separate route config to maintain), and WebJs copies the Next.js version of it almost verbatim.
 
 When I was sketching WebJs's routing layer, I had two options. Invent something custom. Or copy Next.js's app router, which is the routing model I personally enjoy using.
 
@@ -100,9 +102,9 @@ A folder cannot have both `page.js` and `route.js`. The router enforces it at sc
 
 A few things are not the same.
 
-No server components vs. client components split. Pages and components are not divided into "RSC" and "client" categories. A page is server-only (returns HTML). A component is universal (renders identically server-side for first paint and client-side for hydration). There is no `"use client"` directive.
+No server components vs. client components split. Pages and components are not divided into "RSC" (React Server Components) and "client" categories. A page is server-only (returns HTML). A component is universal (renders identically server-side for first paint and client-side for hydration). There is no `"use client"` directive.
 
-Server actions are explicit, file-based. A `*.server.{js,ts}` file with `'use server'` exports functions that the browser imports as RPC stubs. The dev server rewrites the import. The split is path-level (the `.server.` infix is the boundary) and directive-level (the `'use server'` makes exports RPC-callable).
+Server actions are explicit, file-based. A `*.server.{js,ts}` file with `'use server'` exports functions that the browser imports as RPC stubs (client-side proxies that call the server function over the network). The dev server rewrites the import. The split is path-level (the `.server.` infix is the boundary) and directive-level (the `'use server'` makes exports RPC-callable).
 
 WebSockets ride the same route file. If you export `WS(ws, req, { params })` from `route.ts`, the URL becomes a WebSocket endpoint. No separate file type.
 

--- a/blog/fix-relative-import-paths.md
+++ b/blog/fix-relative-import-paths.md
@@ -1,6 +1,6 @@
 ---
 title: "How to Fix Those Ugly ../../../ Import Paths"
-date: 2026-06-16T09:30:00+05:30
+date: 2026-06-11T09:30:00+05:30
 slug: fix-relative-import-paths
 description: "Fix relative import paths for good using a path alias backed by the Node package.json imports field. WebJs aliases every top-level folder with no webpack and no tsconfig paths, resolved at runtime by Node 24+ and Bun with no build step."
 tags: imports, path-alias, no-build, dx, nodejs

--- a/blog/fix-relative-import-paths.md
+++ b/blog/fix-relative-import-paths.md
@@ -1,0 +1,97 @@
+---
+title: "How to Fix Those Ugly ../../../ Import Paths"
+date: 2026-06-16T09:30:00+05:30
+slug: fix-relative-import-paths
+description: "Fix relative import paths for good using a path alias backed by the Node package.json imports field. WebJs aliases every top-level folder with no webpack and no tsconfig paths, resolved at runtime by Node 24+ and Bun with no build step."
+tags: imports, path-alias, no-build, dx, nodejs
+author: Vivek
+---
+
+You have seen this line. You have probably written it today.
+
+```ts
+import { db } from '../../../db/connection.server.ts';
+```
+
+It works. Then you move the file one folder deeper to tidy things up, and it breaks. Not with a helpful message, just a red squiggle and a count of `../` that no longer adds up. You add one more `../`, guess wrong, add another, and now you are counting directory hops in your head like it is 1998. Every deep relative import is a little piece of your file structure hardcoded into your code, and it rots the moment you rearrange anything.
+
+I got tired of it. So WebJs apps do not use deep relative paths. They use a path alias.
+
+
+# What a path alias even is
+
+A path alias is a short, stable nickname for a folder. Instead of describing where a file is relative to the file importing it (`../../../db`), you describe where it is relative to the root of your project (`#db`). The import reads the same no matter where the importing file lives, so moving a file never changes the paths inside it.
+
+Here is the same import with the WebJs alias.
+
+```ts
+import { db } from '#db/connection.server.ts';
+import { Button } from '#components/ui/button.ts';
+import { formatDate } from '#lib/utils/date.ts';
+import { listPosts } from '#modules/posts/queries/list-posts.server.ts';
+```
+
+Every one of those points at a top-level folder from the project root. No counting. Move `button.ts` anywhere and its imports of `#lib` and `#db` stay valid.
+
+
+# Why this normally needs a bundler
+
+If you have set up path aliases before, you know they usually come with baggage. In a typical React or Next.js project, an alias like `@/components` exists in two places that have to agree. You add `paths` to `tsconfig.json` so the TypeScript language server stops complaining, and you add a matching alias to your bundler config (webpack `resolve.alias`, or the Vite/esbuild equivalent) so the code actually runs.
+
+That second half is the catch. The alias only works because a build tool rewrites it into a real path before the code ever runs. TypeScript `paths` alone is a type-checker hint. It does not change what the runtime sees. So the alias is really a build-time illusion, and you need the build step to make it true.
+
+WebJs has no build step. The `.ts` files you write are the files that run (Node 24+ strips the types in place, no bundler in sight). So a bundler-rewrite trick was never on the table. Instead WebJs leans on a platform feature that already does exactly this.
+
+
+# The platform already has this: package.json "imports"
+
+Node has a built-in field for private module aliases called `imports`, and it lives right in your `package.json`. Any key that starts with `#` is a subpath import that Node resolves at runtime, no tooling required. This is a real Node feature, not a WebJs invention, and Bun implements it too.
+
+The WebJs scaffold ships one line that does all the work.
+
+```json
+{
+  "imports": {
+    "#*": "./*"
+  }
+}
+```
+
+That single catch-all maps `#anything` to `./anything` from the project root. So `#db/connection.server.ts` resolves to `./db/connection.server.ts`, `#components/ui/button.ts` to `./components/ui/button.ts`, and so on. Add a new top-level folder tomorrow and it is aliased already, with zero config changes. Node 24+ and Bun both resolve it at runtime. No webpack, no tsconfig `paths`, no resolver plugin.
+
+
+# Two rules that will save you a debugging session
+
+The sigil is `#`, not `@`. A lot of ecosystems use `@/` out of habit, but the Node `imports` field only recognizes keys starting with `#`. Reach for `@` and nothing resolves.
+
+There is no slash after the `#`. Write `#lib/...`, never `#/lib/...`. A `#/`-prefixed key does not resolve on Bun, and WebJs runs on both Node and Bun, so the slash-free form is the one that works everywhere.
+
+Get those two right and the alias just works.
+
+
+# When to use it, and when not to
+
+The alias is for reaching across your project, not for reaching next door. A same-directory import stays relative.
+
+```ts
+import { helper } from './sibling.ts';   // same folder, keep it relative
+import { db } from '#db/connection.server.ts';   // deep reach, use the alias
+```
+
+The rule I follow: same-directory imports stay `./`, and only the deep relatives (the `../../../` kind) become `#`. A short local `./` path does not rot when you move files, so there is nothing to fix there.
+
+One more boundary worth knowing. The alias addresses a top-level subdirectory (`#lib`, `#components`, `#modules`, `#db`). A bare file sitting at the project root, like `env.ts`, is imported relatively as `./env.ts`. That is because the browser importmap WebJs generates is scoped per directory, so a `#`-imported root file would have no browser mapping in dev. Point the alias at folders, keep root files relative.
+
+And if you ever want to opt out for a single import, just write a plain relative path. Nothing forces the alias on you.
+
+
+# It is the same map everywhere, so the server boundary still holds
+
+This is the part I like most. Because the alias is a real config value and not a build-time rewrite, WebJs can read the exact same map the runtime reads. The server expands `#*` when it walks your import graph, when it decides which files a browser is allowed to fetch (the auth gate), when it elides display-only components, and when it builds the browser importmap.
+
+The practical payoff: a `#`-aliased `.server.ts` file still trips the server-only boundary. Importing `#db/connection.server.ts` into a client component is caught the same way importing `../../../db/connection.server.ts` would be. The alias is cosmetic to you and fully transparent to the framework. There is no seam where a nicer import path quietly loses a safety guarantee.
+
+
+# The takeaway
+
+Deep relative imports are fragile because they hardcode your folder layout into every file, and they break the instant you rearrange anything. The usual fix, a bundler alias plus tsconfig `paths`, only works because a build step rewrites it. WebJs has no build step, so it uses Node's native `package.json` `imports` field instead. One catch-all line, `"#*": "./*"`, aliases every top-level folder with no webpack and no tsconfig `paths`, resolved at runtime by Node 24+ and Bun. Use `#lib`, `#components`, `#modules`, `#db` for the deep reaches, keep `./sibling.ts` for the neighbors, remember the sigil is `#` with no slash, and never count `../` again.

--- a/blog/full-stack-type-safety-no-build.md
+++ b/blog/full-stack-type-safety-no-build.md
@@ -1,0 +1,103 @@
+---
+title: "Full-Stack Type Safety With No Build Step"
+date: 2026-06-13T10:30:00+05:30
+slug: full-stack-type-safety-no-build
+description: "End-to-end type safety in WebJs with no build TypeScript. Typed server actions flow the real function signature across the network boundary, so full-stack types are just a normal import, with no codegen and no compile step."
+tags: typescript, type-safety, server-actions, no-build, dx
+author: Vivek
+---
+
+Here is a pain most people hit early. You write a server function that returns a user. You call it from the browser. Somewhere between those two lines the data becomes JSON, and now your editor has no idea what shape it is. You pass the wrong argument, you read a field that does not exist, you get `undefined` at runtime instead of a red squiggle while you type. The server and the browser are two programs that happen to talk over HTTP, and the type checker only sees one of them at a time.
+
+"Type safety across the network" means closing that gap. Calling your server from the browser becomes as safe as calling a function in the same file. A typo, a missing field, a wrong argument shape gets caught in your editor before you ever run the code. That is the whole promise, and in WebJs it is not a library you bolt on. It is how a server action already works.
+
+Let me show what that looks like, then explain why it needs no build step at all.
+
+
+# What a build step and codegen usually are
+
+Two quick definitions, because the payoff only makes sense against them.
+
+A **build step** is a program that runs before your code runs. It takes the source you wrote (TypeScript, JSX, whatever) and turns it into something the runtime can execute (plain JavaScript). `tsc`, esbuild, webpack, and Vite are build steps. You edit, the builder compiles, and the thing that actually runs is the compiled output, not the file you opened.
+
+**Codegen** (code generation) is a build step's cousin. A tool inspects your API (a GraphQL schema, an OpenAPI spec, a router definition) and writes TypeScript types into a file so your client code knows the shape of your server responses. You run the generator, it emits `generated.ts`, and you import from that. When your API changes, you rerun the generator, or your types silently lie.
+
+Both are useful. Both are also a step you have to remember, a process that has to be running, and a layer between the code you wrote and the code that runs. Not needing one is nice for a simple reason. There is less to set up, less to keep in sync, and nothing to forget.
+
+
+# Server actions carry the real signature
+
+In WebJs a server action is a function in a `*.server.ts` file marked `'use server'`. You import it into a client component with a normal import. The framework rewrites that import into a typed RPC stub, a small client function that POSTs to `/__webjs/action/<hash>/<fn>` and gives you back the result. You never hand-write the `fetch`. Importing the function IS the API.
+
+The part that matters for types: the type checker never sees the stub. It resolves your import to the real source file, so it reads the actual function signature, arguments and return type included.
+
+```ts
+// modules/posts/actions/create-post.server.ts
+'use server';
+export async function createPost(
+  input: { title: string; body: string },
+): Promise<ActionResult<PostFormatted>> {
+  /* ... */
+}
+
+// modules/posts/components/new-post.ts
+import { createPost } from '../actions/create-post.server.ts';
+
+const r = await createPost({ title, body });
+//        ^ Promise<ActionResult<PostFormatted>>
+if (r.success) r.data.title;   // PostFormatted.title, typed as string
+```
+
+Pass `{ titel: '...' }` and the editor flags it. Read `r.data.slug` when `PostFormatted` has no `slug` and the editor flags that too. There is no separate schema file describing the wire, and no generator to rerun when the function changes. Change the return type of `createPost` and every caller updates on the next keystroke, because they were reading the one real definition the whole time.
+
+
+# The types you get are the types the server returned
+
+A JSON round-trip flattens your data. A `Date` becomes a string. A `Map` becomes `{}`. So even when a tool gives you accurate types, the values at runtime often do not match them, because JSON cannot carry those shapes.
+
+WebJs uses its own wire serializer instead of plain JSON. It round-trips `Date`, `Map`, `Set`, `BigInt`, `Error`, typed arrays, `Blob`, `File`, `FormData`, Symbols, and reference cycles. So a `Date` you return from the server arrives as a real `Date` on the client, not a string you have to reparse.
+
+```ts
+const r = await createPost({ title, body });
+if (r.success) {
+  r.data.createdAt.getFullYear();  // a real Date, .getFullYear() works
+}
+```
+
+This is why the type safety is honest and not just optimistic. The type says `Date`, the value is a `Date`. The one caveat worth knowing: a class instance comes through as a plain object, so prototypes and methods are lost (the same rule as React server actions). If you want that caught at compile time, the optional `SerializableActionFn` annotation turns a non-serializable field or argument into a type error instead of a silent runtime surprise. It is opt-in, because a plain `export async function` stays plain.
+
+
+# Types for the rest of the app too
+
+Server actions are the headline, but the type flow reaches the routing layer as well.
+
+Run `webjs types` and the framework generates `.webjs/routes.d.ts`, an overlay with one entry per route in `app/`. It gives you a typed `Route` union (`navigate('/blog/anything')` is fine, `navigate('/nonexistent')` is a type error) plus per-route params. `webjs dev` regenerates it on startup and after each route rebuild, so the editor always has fresh route types (this is #258, WebJs's no-build answer to Next 15's `typedRoutes`, done through interface declaration-merging instead of a bundler).
+
+Three exported helper types read that union. `PageProps<R>` types a page's `{ params, searchParams, url, actionData }`, `LayoutProps<R>` adds `children`, and `RouteHandlerContext<R>` types a `route.ts` handler's second argument. Pass the route literal and `params` narrows to the exact shape.
+
+```ts
+import type { PageProps } from '@webjsdev/core';
+
+export default function Post({ params }: PageProps<'/blog/[slug]'>) {
+  const slug = params.slug;   // typed as string, not Record<string, string>
+  /* ... */
+}
+```
+
+`Metadata` types a page's `metadata` export so a misspelled field (`titel`, `descripton`) is a compile-time error, and `WebjsConfig` types the `webjs` block in `package.json` so a typo'd config key is diagnosed instead of silently dropped. Every one of these is a pure type. It is erased at runtime with zero cost.
+
+
+# Why none of this needs a build step
+
+Here is the part that surprises people coming from tRPC or GraphQL. There is no build step and no code-generation server anywhere in this.
+
+tRPC gets excellent inference, but you wire up routers and thread a client type through your app to get it. GraphQL is fully typed, but you pay for it with a codegen step that has to run whenever the schema moves. Both are good tools. Both add a process you maintain.
+
+WebJs skips the process because the type flow is just a normal import resolving to a normal file. TypeScript is **erasable** (invariant 10), which means the type annotations can be stripped out with nothing left to compile. On Node 24+ the runtime strips them with the built-in `module.stripTypeScriptTypes`, position-preserving, so the `.ts` file you wrote is the file the browser fetches, with the types whitespace-erased. There is no `tsc` producing output that runs in its place. The only requirement is `erasableSyntaxOnly: true` in `tsconfig.json`, which keeps your TypeScript to the erasable subset (no `enum`, no value `namespace`, no constructor parameter properties) so the editor flags anything the stripper cannot handle before you ever run it.
+
+So the type checker runs in your editor and (optionally) in CI as `tsc --noEmit`. The runtime never type-checks. It just erases. The types are a development-time overlay on files that already run as-is, which is exactly why there is nothing to build and nothing to generate. Full-stack types fall out of the architecture instead of being bolted onto it.
+
+
+# The takeaway
+
+Full-stack type safety in WebJs is not a feature you configure, it is what you get by default. A server action imported into a client component carries its real signature across the network, so calling your backend is as safe as calling a local function, and a wrong argument or a missing field is caught in your editor before the code runs. The wire serializer round-trips `Date`, `Map`, `Set`, and more, so the types you see are the values you actually get, not a JSON-flattened guess. `webjs types`, `PageProps`, `Metadata`, and `WebjsConfig` extend that safety to routing, metadata, and config. And all of it works with no build step and no codegen, because TypeScript is erasable and the file you write is the file that runs.

--- a/blog/full-stack-type-safety-no-build.md
+++ b/blog/full-stack-type-safety-no-build.md
@@ -1,6 +1,6 @@
 ---
 title: "Full-Stack Type Safety With No Build Step"
-date: 2026-06-13T10:30:00+05:30
+date: 2026-06-09T10:30:00+05:30
 slug: full-stack-type-safety-no-build
 description: "End-to-end type safety in WebJs with no build TypeScript. Typed server actions flow the real function signature across the network boundary, so full-stack types are just a normal import, with no codegen and no compile step."
 tags: typescript, type-safety, server-actions, no-build, dx

--- a/blog/get-server-actions-caching.md
+++ b/blog/get-server-actions-caching.md
@@ -1,0 +1,73 @@
+---
+title: "GET Is a Server Action Too: Cacheable Actions with ETags"
+date: 2026-06-18T11:00:00+05:30
+slug: get-server-actions-caching
+description: "In WebJs a server action can declare its HTTP verb. A GET action rides its args in the URL, is CSRF-exempt, carries Cache-Control and a weak ETag, and answers 304. Why a framework with no RSC split needs verb-aware actions and how it works."
+tags: server-actions, caching, etag, http, rpc
+author: Vivek
+---
+
+Most frameworks with server actions make them POST-only. That is a reasonable default for a mutation, but it means every server call is uncacheable, un-ETagged, and treated as a state change even when it is a pure read. WebJs lets a server action declare its HTTP verb, so a read can be a real GET: cacheable, ETagged, CSRF-exempt, and cheap to repeat. This post is about why that matters more in WebJs than in Next, and how the declaration works.
+
+# The one-mechanism problem
+
+In a React app with Server Components, reads and writes take different paths. A read is a Server Component fetch that runs during render. A write is a Server Action, which is POST. Because reads never go through the action mechanism, it is fine for actions to be POST-only. The read path already has its own caching story.
+
+WebJs has no server/client component split. There is no separate read path. A component that needs data calls a server action, and a component that mutates data calls a server action. Reads and writes both flow through the one action mechanism. So if actions were POST-only, every read would be an uncacheable POST, which throws away the entire HTTP caching layer for exactly the calls that benefit from it most. The verb has to be part of the action.
+
+That is the honest reason WebJs needs this and Next does not. It is not that WebJs is more capable here. It is that collapsing reads and writes into one mechanism creates a requirement that the two-path design never has.
+
+# Declaring the verb
+
+An action declares its HTTP semantics through reserved sibling exports that the framework reads statically, the same way a page declares `export const revalidate`. The function itself stays a plain `export async function`:
+
+```ts
+// modules/users/queries/get-user.server.ts
+'use server';
+export const method = 'GET';
+export const cache = { maxAge: 60, public: false };
+export const tags = (id: string) => [`user:${id}`];
+export async function getUser(id: string) {
+  return db.users.find(id);
+}
+```
+
+The call site never changes. A component still writes `await getUser(7)`. The verb only changes the transport. Absent a `method` export, the action is a POST, so every existing action keeps working untouched. One function per file, because the config exports describe that one function.
+
+# What a GET buys
+
+Declaring `method = 'GET'` changes the wire in several ways, all of them the point:
+
+The arguments ride in the URL as query parameters instead of a request body, with a POST fallback if they exceed a 4KB cap. That makes the call a genuine idempotent GET that a cache can key on.
+
+It is CSRF-exempt. A safe read does not change state, so it does not need the Origin check that mutations get. That keeps it cacheable at a shared layer, because there is no per-request token in play.
+
+It carries `Cache-Control` from the `cache` export and a weak ETag derived from the response. On the next call with a matching `If-None-Match`, the server answers `304 Not Modified` with no body. The browser reuses what it has. A repeated read costs a conditional request and an empty response, not a full round trip.
+
+It reads the SSR seed first. If the same action ran during server render, its result was serialized into the page, so the component's first client call resolves from the seed with no network at all.
+
+There is a safety rule attached to the cache export. Setting `public: true` shares the response across users, keyed only by URL and args, so it is only ever correct for data that is identical for every visitor. A per-user or session read must stay `private`. That is the same rule a page's `export const revalidate` carries, and it is the one place a careless setting leaks one user's data to another, so the framework makes you write it explicitly.
+
+# What a mutation does instead
+
+A mutation declares a state-changing verb and gets the opposite treatment:
+
+```ts
+// modules/users/actions/rename.server.ts
+'use server';
+export const method = 'PATCH';
+export const invalidates = (id: string) => [`user:${id}`];
+export async function rename(id: string, name: string) {
+  return db.users.update(id, { name });
+}
+```
+
+A `PATCH` sends the rich body, is CSRF-protected via the Origin check, and on completion evicts its `invalidates` tags from the server cache and reports them to the client in an `X-Webjs-Invalidate` header so the browser's cache coordinator knows to revalidate a later read of that data. A GET's `tags` and a mutation's `invalidates` are the two halves of the same tag system: the read declares what it is, the write declares what it invalidates, and the framework wires the eviction. A request with the wrong method gets a `405` with an `Allow` header.
+
+# Validation is a boundary concern
+
+There is one more reserved export, `validate`, and where it runs is deliberate. It runs on the RPC boundary and on a public `route.ts` endpoint, not on a direct server-to-server call. The framework only CALLS your validator and reads its verdict. It ships no validation library and takes no opinion on which one you use. A `{ success: false, fieldErrors }` returns a `422` without running the action body. This keeps validation at the untrusted edge, where the request actually arrives, and out of the path where one server function calls another with already-trusted input.
+
+# The takeaway
+
+If reads and writes share one mechanism, that mechanism has to know the difference, because a read wants to be cached and a write must not be. WebJs puts the HTTP verb and its caching, tagging, and validation into small static config exports next to the action, so a read becomes a real GET with an ETag and a write becomes a tagged, CSRF-protected mutation, all without changing how you call it. The verb is not ceremony. It is the thing that lets one action mechanism serve both jobs correctly.

--- a/blog/get-server-actions-caching.md
+++ b/blog/get-server-actions-caching.md
@@ -1,8 +1,8 @@
 ---
-title: "GET Is a Server Action Too: Cacheable Actions with ETags"
+title: "Cacheable Server Actions With GET, ETags, and 304s"
 date: 2026-06-13T11:00:00+05:30
 slug: get-server-actions-caching
-description: "In WebJs a server action can declare its HTTP verb. A GET action rides its args in the URL, is CSRF-exempt, carries Cache-Control and a weak ETag, and answers 304. Why a framework with no RSC split needs verb-aware actions and how it works."
+description: "Make a server action cacheable in WebJs by declaring it a GET. Args ride the URL, it is CSRF-exempt, and a weak ETag answers 304 so repeat reads are nearly free."
 tags: server-actions, caching, etag, http, rpc
 author: Vivek
 ---

--- a/blog/get-server-actions-caching.md
+++ b/blog/get-server-actions-caching.md
@@ -1,6 +1,6 @@
 ---
 title: "GET Is a Server Action Too: Cacheable Actions with ETags"
-date: 2026-06-18T11:00:00+05:30
+date: 2026-06-13T11:00:00+05:30
 slug: get-server-actions-caching
 description: "In WebJs a server action can declare its HTTP verb. A GET action rides its args in the URL, is CSRF-exempt, carries Cache-Control and a weak ETag, and answers 304. Why a framework with no RSC split needs verb-aware actions and how it works."
 tags: server-actions, caching, etag, http, rpc

--- a/blog/light-dom-by-default.md
+++ b/blog/light-dom-by-default.md
@@ -1,8 +1,8 @@
 ---
-title: "Light DOM vs Shadow DOM: Why webjs Defaults to Light DOM"
+title: "Light DOM vs Shadow DOM: Why WebJs Defaults to Light DOM"
 date: 2025-12-22T10:00:00+05:30
 slug: light-dom-by-default
-description: "Why webjs keeps the light-DOM default for web components. Tailwind and global CSS cascade in, DOM queries work, accessibility behaves, and tests need no shadow-piercing helpers. Shadow DOM stays an opt-in."
+description: "Why WebJs keeps the light-DOM default for web components. Tailwind and global CSS cascade in, DOM queries work, accessibility behaves, and tests need no shadow-piercing helpers. Shadow DOM stays an opt-in."
 tags: components, light-dom, shadow-dom, defaults, tailwind, ssr
 author: Vivek
 ---
@@ -11,9 +11,9 @@ Native web components default to light DOM. If you write a custom element that d
 
 The two libraries most developers and most AI training data treat as canonical for web components picked a different default. lit's [`LitElement` attaches a shadow root](https://lit.dev/docs/components/shadow-dom/) in its constructor unless you override `createRenderRoot()` to return `this`. [Microsoft's FAST automatically attaches a `ShadowRoot`](https://fast.design/docs/1.x/fast-element/working-with-shadow-dom/) and renders the template into it. Because these are the libraries most developers learn from, the perception has shifted: people assume shadow DOM is the web-components default. It is not. It is a library convention that the platform itself does not share.
 
-For what it is worth, [Stencil's `@Component` decorator defaults to light DOM](https://stenciljs.com/docs/styling) (`shadow: false`); you opt into shadow by writing `@Component({ shadow: true })`. The `stencil generate` CLI scaffolds shadow-enabled components, which is where the "Stencil defaults to shadow" line you sometimes see comes from, but that is the scaffolder template, not the framework's default. webjs sits in the same camp as Stencil's underlying default: light DOM unless you ask for shadow.
+For what it is worth, [Stencil's `@Component` decorator defaults to light DOM](https://stenciljs.com/docs/styling) (`shadow: false`); you opt into shadow by writing `@Component({ shadow: true })`. The `stencil generate` CLI scaffolds shadow-enabled components, which is where the "Stencil defaults to shadow" line you sometimes see comes from, but that is the scaffolder template, not the framework's default. WebJs sits in the same camp as Stencil's underlying default: light DOM unless you ask for shadow.
 
-webjs aligns with the platform default and treats light DOM as the everyday case. Every component renders in light DOM unless the class declares `static shadow = true`. The shadow path still works and is the right choice for a few specific situations. But the framework leans on what the platform itself defaults to.
+WebJs aligns with the platform default and treats light DOM as the everyday case. Every component renders in light DOM unless the class declares `static shadow = true`. The shadow path still works and is the right choice for a few specific situations. But the framework leans on what the platform itself defaults to.
 
 This post is about why that choice is the right one, not just for spec-alignment, but for the practical things you do every day in an app.
 
@@ -53,7 +53,7 @@ If `Card` were a shadow-DOM component, every one of those classes would silently
 
 With light DOM as the default, the same components that get composed into pages share the same styling story as the rest of the app. There is no "the page uses Tailwind but the components do not" cognitive split.
 
-A note before going further: **webjs does not require Tailwind.** The scaffold defaults to Tailwind because it pairs well with the rest of the stack, but the framework itself is agnostic about how you write CSS. Vanilla stylesheets, CSS modules, BEM, plain hand-written CSS, a different utility framework, any of them work. The benefit in this section is general: any external CSS strategy you bring cascades into light-DOM components without escape hatches. Tailwind is the concrete example throughout this post because it is the scaffold default and the most-used styling story in webjs apps. The argument is about light DOM, not about Tailwind specifically.
+A note before going further: **WebJs does not require Tailwind.** The scaffold defaults to Tailwind because it pairs well with the rest of the stack, but the framework itself is agnostic about how you write CSS. Vanilla stylesheets, CSS modules, BEM, plain hand-written CSS, a different utility framework, any of them work. The benefit in this section is general: any external CSS strategy you bring cascades into light-DOM components without escape hatches. Tailwind is the concrete example throughout this post because it is the scaffold default and the most-used styling story in WebJs apps. The argument is about light DOM, not about Tailwind specifically.
 
 
 ## 2. CSS stays cache-friendly
@@ -112,7 +112,7 @@ For most application code, this is not the problem you have. You control the pag
 
 Tailwind sidesteps the scoping question entirely: utility classes are atomic, intentional, and unique by construction. There is nothing to leak. If you author components with Tailwind utilities, scoping is a non-issue. The same applies to other naming-discipline approaches like BEM or scoped class prefixes; the framework's `webjs check` ships a `light-dom-css-prefix` rule that flags unprefixed class selectors in vanilla CSS for light-DOM components, so the linter helps you keep selectors uniquely scoped if you choose that route.
 
-webjs's recommendation: use Tailwind (or your chosen styling story) in light DOM by default. If a specific component needs strict isolation (third-party embed, design-system component meant to drop into hostile pages), opt into shadow DOM for that one component:
+WebJs's recommendation: use Tailwind (or your chosen styling story) in light DOM by default. If a specific component needs strict isolation (third-party embed, design-system component meant to drop into hostile pages), opt into shadow DOM for that one component:
 
 ```ts
 class IsolatedWidget extends WebComponent {
@@ -130,7 +130,7 @@ Both modes coexist on the same page without trouble.
 
 # What about slots?
 
-`<slot>` projection is sometimes described as "a shadow DOM feature." It is technically what the spec defines, but webjs ships its own light-DOM `<slot>` runtime with full parity to the shadow-DOM semantics: named slots, default content, fallback, `assignedNodes()`, `slotchange` events, SSR-time projection. The whole story is in [Light-DOM slots with full shadow-DOM parity](/blog/light-dom-slots-with-full-parity).
+`<slot>` projection is sometimes described as "a shadow DOM feature." It is technically what the spec defines, but WebJs ships its own light-DOM `<slot>` runtime with full parity to the shadow-DOM semantics: named slots, default content, fallback, `assignedNodes()`, `slotchange` events, SSR-time projection. The whole story is in [Light-DOM slots with full shadow-DOM parity](/blog/light-dom-slots-with-full-parity).
 
 This means choosing light DOM does not cost you slot projection. The agent can write:
 
@@ -152,7 +152,7 @@ And it works in light DOM. Tailwind classes apply. The slotted children project 
 
 # When shadow DOM is the right call
 
-Three situations where webjs recommends `static shadow = true`:
+Three situations where WebJs recommends `static shadow = true`:
 
 - **Third-party embeds.** A widget you ship for other people's sites. You cannot trust the host page's CSS, so you isolate.
 - **Design-system primitives that must look identical regardless of host context.** A `<ui-button>` shipped as a standalone package, dropped into a Shopify theme or a WordPress site. Shadow DOM is the protection layer.
@@ -174,6 +174,6 @@ Light DOM as default trades style isolation for everything else:
 
 The cost is style scoping, which is usually not a problem in app code and is fully addressable for the cases where it is (Tailwind utilities by construction, BEM or class-prefix discipline for vanilla CSS, shadow opt-in for isolated widgets).
 
-The shape webjs settled on: light DOM by default, with Tailwind as the scaffold default but no framework-level requirement to use it. Shadow DOM is an opt-in for the specific cases that need it. Same `<slot>` semantics in both. The agent writes one style of component and the framework picks the right rendering mode based on the `static shadow` flag.
+The shape WebJs settled on: light DOM by default, with Tailwind as the scaffold default but no framework-level requirement to use it. Shadow DOM is an opt-in for the specific cases that need it. Same `<slot>` semantics in both. The agent writes one style of component and the framework picks the right rendering mode based on the `static shadow` flag.
 
 That is the everyday case for app code. The framework handles the rest.

--- a/blog/light-dom-by-default.md
+++ b/blog/light-dom-by-default.md
@@ -7,7 +7,7 @@ tags: components, light-dom, shadow-dom, defaults, tailwind, ssr
 author: Vivek
 ---
 
-Native web components default to light DOM. If you write a custom element that does not call `this.attachShadow(...)`, there is no shadow root. The element's children are regular DOM. That is what the platform spec gives you out of the box.
+Drop a web component into your page, style it with your usual CSS, and sometimes those styles simply refuse to show up. The usual culprit is shadow DOM (an isolation boundary that seals a component's internals off from the rest of the page), which many component libraries wrap around your markup by default. WebJs goes the other way and defaults to light DOM (the component's rendered output living as ordinary page DOM, with no such boundary). Native web components default to light DOM too. If you write a custom element that does not call `this.attachShadow(...)`, there is no shadow root. The element's children are regular DOM. That is what the platform spec gives you out of the box.
 
 The two libraries most developers and most AI training data treat as canonical for web components picked a different default. lit's [`LitElement` attaches a shadow root](https://lit.dev/docs/components/shadow-dom/) in its constructor unless you override `createRenderRoot()` to return `this`. [Microsoft's FAST automatically attaches a `ShadowRoot`](https://fast.design/docs/1.x/fast-element/working-with-shadow-dom/) and renders the template into it. Because these are the libraries most developers learn from, the perception has shifted: people assume shadow DOM is the web-components default. It is not. It is a library convention that the platform itself does not share.
 

--- a/blog/light-dom-by-default.md
+++ b/blog/light-dom-by-default.md
@@ -1,8 +1,8 @@
 ---
-title: "Light DOM by default, shadow DOM by choice"
+title: "Light DOM vs Shadow DOM: Why webjs Defaults to Light DOM"
 date: 2025-12-22T10:00:00+05:30
 slug: light-dom-by-default
-description: "Why webjs keeps the platform's light-DOM default for web components: Tailwind classes cascade in, CSS stays cache-friendly, DOM queries work, accessibility behaves, and tests do not need shadow-piercing helpers. Shadow DOM stays available as an opt-in."
+description: "Why webjs keeps the light-DOM default for web components. Tailwind and global CSS cascade in, DOM queries work, accessibility behaves, and tests need no shadow-piercing helpers. Shadow DOM stays an opt-in."
 tags: components, light-dom, shadow-dom, defaults, tailwind, ssr
 author: Vivek
 ---

--- a/blog/light-dom-slots-with-full-parity.md
+++ b/blog/light-dom-slots-with-full-parity.md
@@ -1,15 +1,17 @@
 ---
-title: "Light-DOM slots with full shadow-DOM parity"
+title: "Light-DOM Slots in Web Components (With Full Shadow-DOM Parity)"
 date: 2025-12-30T16:00:00+05:30
 slug: light-dom-slots-with-full-parity
-description: "Why WebJs ships named slots, fallback content, assignedNodes, and slotchange in light DOM, not just shadow DOM, what the runtime looks like, and where the polyfill fits."
+description: "Light-DOM slots in web components with full shadow-DOM parity. WebJs ships named slots, fallback content, assignedNodes, and slotchange with no shadow DOM required."
 tags: components, slots, light-dom, shadow-dom
 author: Vivek
 ---
 
-When you read web-components docs anywhere on the internet, `<slot>` is described as a shadow-DOM thing. The browser only resolves slots inside a shadow root. If you write a custom element with `static shadow = false` (the WebJs default), the `<slot>` tag is just a meaningless element. Children dropped between the tags sit there as plain DOM. There is no projection.
+Slots are how you let whoever uses your component drop their own content inside it, the way you pass children into a wrapper. Almost every tutorial ties them to shadow DOM (the isolated DOM subtree a custom element attaches to itself), and that is the part I wanted to get away from.
 
-This is correct as the platform stands. It is also limiting in a specific way that hurts an AI-first framework where pages and components are written in the same light-DOM Tailwind idiom.
+When you read web-components docs anywhere on the internet, `<slot>` is described as a shadow-DOM thing. The browser only resolves slots inside a shadow root. If you write a custom element with `static shadow = false` (the WebJs default), the `<slot>` tag is just a meaningless element. Children dropped between the tags sit there as plain DOM. There is no projection (nothing moves those children into the slot's position).
+
+This is correct as the platform stands. It is also limiting in a specific way that hurts an AI-first framework where pages and components are written in the same light-DOM (the normal page DOM, with no shadow root) Tailwind idiom.
 
 
 # Why the limit hurts
@@ -34,7 +36,7 @@ The light-DOM slot runtime in `packages/core/src/slot.js` (the docstring at the 
 - First-wins resolution: a child that could match multiple slots picks the first.
 - Server-side rendering: slot resolution runs at SSR time so projected children appear in their final positions in the initial HTML response.
 
-The DOM API surface is exposed via polyfills on `HTMLSlotElement.prototype` and `Element.prototype`. The polyfill is gated: every patched method first checks for the `data-webjs-light` attribute on the target slot. If absent (real shadow-DOM slot or a non-webjs custom element), the patch falls through to the saved native implementation. Real shadow-DOM slots elsewhere on the page keep their native behaviour exactly.
+The DOM API surface is exposed via polyfills (code that supplies a browser API the platform does not provide here) on `HTMLSlotElement.prototype` and `Element.prototype`. The polyfill is gated: every patched method first checks for the `data-webjs-light` attribute on the target slot. If absent (real shadow-DOM slot or a non-webjs custom element), the patch falls through to the saved native implementation. Real shadow-DOM slots elsewhere on the page keep their native behaviour exactly.
 
 The module is import-safe in Node. Polyfill setup is guarded on `typeof HTMLSlotElement !== 'undefined'`. The server pipeline imports `slot.js` for the constants and helpers without crashing.
 
@@ -53,11 +55,11 @@ The framework owns the lifecycle of a slot host. When a WebJs component connects
 
 # The SSR piece
 
-Because slot resolution runs in the renderer, server-side rendering produces the final DOM tree directly. No hydration step is required to fix the slot projection. The HTML that arrives in the browser already has slotted children in their final positions.
+Because slot resolution runs in the renderer, server-side rendering produces the final DOM tree directly. No hydration step (the browser re-running component JavaScript to wire up the server HTML) is required to fix the slot projection. The HTML that arrives in the browser already has slotted children in their final positions.
 
-This matters for progressive enhancement. If a user has JavaScript disabled, a WebJs component with light-DOM slots still displays its slotted content correctly. The component is just a styled wrapper with the slotted nodes projected into the right place. No JS required for the layout to be correct.
+This matters for progressive enhancement (the page still working with JavaScript switched off). If a user has JavaScript disabled, a WebJs component with light-DOM slots still displays its slotted content correctly. The component is just a styled wrapper with the slotted nodes projected into the right place. No JS required for the layout to be correct.
 
-In shadow DOM that win exists too (via Declarative Shadow DOM), but DSD has uneven browser support and serializes differently. The light-DOM path just produces HTML the browser already knows how to display.
+In shadow DOM that win exists too (via Declarative Shadow DOM, shadow DOM written straight into the HTML so the server can render it), but DSD has uneven browser support and serializes differently. The light-DOM path just produces HTML the browser already knows how to display.
 
 
 # What it looks like in practice

--- a/blog/light-dom-slots-with-full-parity.md
+++ b/blog/light-dom-slots-with-full-parity.md
@@ -2,12 +2,12 @@
 title: "Light-DOM slots with full shadow-DOM parity"
 date: 2025-12-30T16:00:00+05:30
 slug: light-dom-slots-with-full-parity
-description: "Why webjs ships named slots, fallback content, assignedNodes, and slotchange in light DOM, not just shadow DOM, what the runtime looks like, and where the polyfill fits."
+description: "Why WebJs ships named slots, fallback content, assignedNodes, and slotchange in light DOM, not just shadow DOM, what the runtime looks like, and where the polyfill fits."
 tags: components, slots, light-dom, shadow-dom
 author: Vivek
 ---
 
-When you read web-components docs anywhere on the internet, `<slot>` is described as a shadow-DOM thing. The browser only resolves slots inside a shadow root. If you write a custom element with `static shadow = false` (the webjs default), the `<slot>` tag is just a meaningless element. Children dropped between the tags sit there as plain DOM. There is no projection.
+When you read web-components docs anywhere on the internet, `<slot>` is described as a shadow-DOM thing. The browser only resolves slots inside a shadow root. If you write a custom element with `static shadow = false` (the WebJs default), the `<slot>` tag is just a meaningless element. Children dropped between the tags sit there as plain DOM. There is no projection.
 
 This is correct as the platform stands. It is also limiting in a specific way that hurts an AI-first framework where pages and components are written in the same light-DOM Tailwind idiom.
 
@@ -41,7 +41,7 @@ The module is import-safe in Node. Polyfill setup is guarded on `typeof HTMLSlot
 
 # How a render flows through it
 
-The framework owns the lifecycle of a slot host. When a webjs component connects:
+The framework owns the lifecycle of a slot host. When a WebJs component connects:
 
 1. `captureAuthoredChildren(host)` snapshots the original children before render fires.
 2. `render()` produces a template that may contain `<slot>` elements (or `<slot name="x">`).
@@ -55,7 +55,7 @@ The framework owns the lifecycle of a slot host. When a webjs component connects
 
 Because slot resolution runs in the renderer, server-side rendering produces the final DOM tree directly. No hydration step is required to fix the slot projection. The HTML that arrives in the browser already has slotted children in their final positions.
 
-This matters for progressive enhancement. If a user has JavaScript disabled, a webjs component with light-DOM slots still displays its slotted content correctly. The component is just a styled wrapper with the slotted nodes projected into the right place. No JS required for the layout to be correct.
+This matters for progressive enhancement. If a user has JavaScript disabled, a WebJs component with light-DOM slots still displays its slotted content correctly. The component is just a styled wrapper with the slotted nodes projected into the right place. No JS required for the layout to be correct.
 
 In shadow DOM that win exists too (via Declarative Shadow DOM), but DSD has uneven browser support and serializes differently. The light-DOM path just produces HTML the browser already knows how to display.
 

--- a/blog/mcp-server-for-ai-coding-agents.md
+++ b/blog/mcp-server-for-ai-coding-agents.md
@@ -1,6 +1,6 @@
 ---
 title: "Give AI Coding Assistants Live Access to Your App"
-date: 2026-06-19T15:00:00+05:30
+date: 2026-06-16T15:00:00+05:30
 slug: mcp-server-for-ai-coding-agents
 description: "WebJs ships a read-only MCP server for AI coding agents. Learn how the Model Context Protocol lets Claude, Cursor, and other AI assistants read your app's real routes, actions, and components instead of guessing them."
 tags: mcp, ai-first, ai-agents, tooling, dx

--- a/blog/mcp-server-for-ai-coding-agents.md
+++ b/blog/mcp-server-for-ai-coding-agents.md
@@ -1,0 +1,67 @@
+---
+title: "Give AI Coding Assistants Live Access to Your App"
+date: 2026-06-19T15:00:00+05:30
+slug: mcp-server-for-ai-coding-agents
+description: "WebJs ships a read-only MCP server for AI coding agents. Learn how the Model Context Protocol lets Claude, Cursor, and other AI assistants read your app's real routes, actions, and components instead of guessing them."
+tags: mcp, ai-first, ai-agents, tooling, dx
+author: Vivek
+---
+
+You have probably felt this already. You ask an AI coding assistant to add a feature, it writes something that looks perfect, and then you notice it invented a route that does not exist, or called a server action with a signature you never wrote. The code compiles in its head. It just does not match your actual app.
+
+This is not the model being dumb. It is the model working with incomplete information. When an assistant only has your files to read, it reconstructs your app's shape from source and fills the gaps with plausible guesses. Most of the time the guess is close. The times it is wrong are the times you lose an hour.
+
+WebJs ships a small thing that fixes a big part of this. Every scaffolded app wires up a read-only MCP server, `@webjsdev/mcp`, that lets the agent ask the running project what actually exists instead of guessing.
+
+# What MCP is, in one sentence
+
+MCP (Model Context Protocol) is the emerging open standard for how an AI tool like Claude or Cursor connects to an outside source of data or tools, so the model can read real information at the moment it needs it rather than working from a static snapshot.
+
+Think of it as a plug. On one side is your AI assistant. On the other is anything that can answer questions (a database, a filesystem, an API, or in this case, your WebJs project). Once the plug is connected, the assistant can pull ground truth on demand.
+
+# What the WebJs MCP server exposes
+
+The server is intentionally small and gives the agent four tools plus a knowledge layer.
+
+- `list_routes` returns every route your app actually serves, derived from the `app/` file tree the same way the router derives it.
+- `list_actions` returns your server actions, including the RPC hash each one is called through and its per-action config (the HTTP verb, the cache settings). This is the big one, more on it below.
+- `list_components` returns the custom elements your app registers.
+- `check` runs the `webjs check` correctness validator and hands back the violations as structured data.
+
+On top of those, there is a knowledge layer that serves the WebJs docs, the recipes, and the framework source. So the agent can look up how a feature is meant to be used, straight from the authoritative reference, without you pasting docs into the chat.
+
+# Why the action hashes matter most
+
+Here is the thing an agent genuinely cannot infer reliably.
+
+In WebJs, a server action is a function in a `*.server.ts` file marked `'use server'`. When a client component imports it, the import is rewritten into an RPC stub that POSTs to a hashed URL like `/__webjs/action/<hash>/<fn>`. The hash and the per-action config (the verb, whether the result is cached) are computed by the framework, not written by you.
+
+So if an agent is reasoning about how a client actually reaches the server, or debugging a request in the network tab, the hash is not sitting in your source in a form it can read off. It is a derived value. Guessing it is hopeless. Reading it live from `list_actions` is trivial.
+
+```sh
+# Run the server directly
+npx @webjsdev/mcp
+
+# Or through the CLI, same thing
+webjs mcp
+```
+
+Point your assistant's MCP config at that command and the tools show up in the agent's toolbox. From then on, "what actions does this app expose" is a lookup, not a search-and-guess.
+
+# It is read-only, which is the point
+
+The WebJs MCP server does not write files, run migrations, or mutate anything. Every tool answers a question. That is a deliberate design choice, because it means pointing an agent at it carries no risk. The worst it can do is tell the agent the truth about your app.
+
+Read-only also keeps the trust model simple. You do not have to review what the MCP server did, because it did nothing except report. The agent still makes its edits through the normal channels you already supervise.
+
+# This is the AI-first thesis, made concrete
+
+I have written before that WebJs being AI-first is plumbing, not a slogan. AGENTS.md, the enforced conventions, the readable source, the lint rules that fail at the seam where mistakes happen. The MCP server is another piece of that same plumbing.
+
+The pattern is always the same. Instead of hoping the agent guesses right, remove the need to guess. AGENTS.md removes the guess about where a file goes. `webjs check` removes the guess about whether the code is correct. The MCP server removes the guess about what the running app actually contains.
+
+Notice that `@webjsdev/mcp` is a standalone package, extracted out of the CLI so it can be installed and pointed at on its own. It is the same read-only introspection the CLI already had, packaged as a protocol any MCP-speaking tool can plug into. A separate note: for UI debugging (clicking through pages, taking screenshots) you would reach for the Playwright MCP server. `@webjsdev/mcp` is about the shape of your app, not driving its browser.
+
+# The takeaway
+
+AI coding assistants are genuinely useful, and they are at their worst when they have to invent your project's details. The WebJs MCP server closes that gap by letting the agent ask the running project for ground truth: the real routes, the real components, and above all the real server actions with their framework-computed RPC hashes and per-action config that no amount of reading source can reliably reconstruct. It is read-only, so it is safe to hand to any agent, and it ships wired up in every scaffold. Run `npx @webjsdev/mcp` or `webjs mcp`, connect it to Claude or Cursor, and your assistant stops guessing what your app looks like and starts reading it.

--- a/blog/no-build-frontend-performance.md
+++ b/blog/no-build-frontend-performance.md
@@ -1,6 +1,6 @@
 ---
 title: "No-Build Frontend Performance: Flattening the CDN Waterfall"
-date: 2026-06-13T10:00:00+05:30
+date: 2026-06-06T16:00:00+05:30
 slug: no-build-frontend-performance
 description: "A no-build framework serves modules over the network instead of bundling them, which risks a request waterfall. How WebJs keeps it fast with modulepreload over the reached vendor graph, HTTP/2 multiplexing, and a lean listener path."
 tags: no-build, performance, modulepreload, importmap, http2

--- a/blog/no-build-frontend-performance.md
+++ b/blog/no-build-frontend-performance.md
@@ -2,7 +2,7 @@
 title: "No-Build Frontend Performance: Flattening the CDN Waterfall"
 date: 2026-06-06T16:00:00+05:30
 slug: no-build-frontend-performance
-description: "A no-build framework serves modules over the network instead of bundling them, which risks a request waterfall. How WebJs keeps it fast with modulepreload over the reached vendor graph, HTTP/2 multiplexing, and a lean listener path."
+description: "A no-build framework serves modules instead of bundling them, which risks a request waterfall. How WebJs stays fast with modulepreload over the vendor graph and HTTP/2."
 tags: no-build, performance, modulepreload, importmap, http2
 author: Vivek
 ---

--- a/blog/no-build-frontend-performance.md
+++ b/blog/no-build-frontend-performance.md
@@ -1,0 +1,50 @@
+---
+title: "No-Build Frontend Performance: Flattening the CDN Waterfall"
+date: 2026-06-13T10:00:00+05:30
+slug: no-build-frontend-performance
+description: "A no-build framework serves modules over the network instead of bundling them, which risks a request waterfall. How WebJs keeps it fast with modulepreload over the reached vendor graph, HTTP/2 multiplexing, and a lean listener path."
+tags: no-build, performance, modulepreload, importmap, http2
+author: Vivek
+---
+
+The obvious objection to a no-build framework is performance. If you do not bundle, the browser fetches many small ES modules over the network instead of one concatenated file, and those fetches can chain into a waterfall: the page loads, which pulls a component, which pulls a helper, which pulls a vendor package, each round trip discovered only after the previous one lands. Bundlers exist largely to collapse that chain.
+
+WebJs does not bundle, and it is still fast. Not because the waterfall is not real, but because it is attacked directly at the two places it actually hurts. This post is about those two places and the honest limit that remains.
+
+# Where the cost actually is
+
+Start by being precise about what bundling buys. It buys two things: fewer requests, and no runtime discovery latency (everything is in one file, so the browser never has to fetch A to learn it needs B). On HTTP/1.1 with its six-connection limit, fewer requests mattered enormously. On HTTP/2, which multiplexes many streams over one connection, the request-count cost is mostly gone. What remains is discovery latency: the level-by-level unfolding of the dependency graph.
+
+So the no-build performance problem is not really "too many requests." It is "the browser learns about each dependency one level too late." That reframing is the whole game, because discovery latency is fixable without a bundler. You just have to tell the browser what it will need before it discovers it the slow way.
+
+# The importmap and modulepreload
+
+WebJs serves an import map in the page head. Every bare specifier a module might import (`dayjs`, or `@webjsdev/core`) resolves through it to a real URL, pinned to a CDN like jspm for third-party packages. That is the Rails 7 importmap-rails posture: no bundler, direct module URLs, the browser's native loader doing the resolution.
+
+The importmap alone does not solve discovery latency, though. It tells the browser HOW to resolve `dayjs` once it sees the import, not that it WILL need `dayjs`. So the browser still discovers the dependency only when it parses the module that imports it. That was the waterfall crack in the no-build story, and closing it (#754) is what made the posture actually competitive.
+
+The fix is `<link rel="modulepreload">`. During SSR, WebJs walks the module graph from the page's actually-shipped modules, collects every vendor specifier they reach, resolves each to its importmap target, and emits a preload hint for it in the head. So the moment the browser reads the head, it starts fetching the whole reached vendor set in parallel, before it has parsed a single component. The level-by-level discovery collapses into one parallel burst. The bytes the browser needs are already in flight by the time the code that imports them runs.
+
+The walk is careful about which roots it starts from. It uses the boot's shipped-module set, which already drops the display-only modules that elision strips and substitutes an import-only page with its real components. So a vendor reached only through a module that never ships is never preloaded. You do not pay to preload a dependency the page will not actually load. The preload set is exactly the served set, no more.
+
+# The listener path
+
+The second place the cost hides is the server itself. A no-build server does more per request than a static file server, because it is resolving modules, stripping TypeScript, and running SSR. If the request path is heavy, the time-to-first-byte suffers no matter how good the preloading is.
+
+WebJs runs on Node and on Bun, and the Bun listening path got a specific pass (#773) to cut per-request overhead. The Bun shell had been cloning the whole request object on every request just to stamp the client IP, and bridging every compressed response through an extra stream hop. Both were removed: the IP is stamped out of band without rebuilding the request, and a buffered response is compressed synchronously with no bridge. That is the kind of unglamorous work that a no-build framework has to do, because there is no build step absorbing the cost ahead of time. The request path IS the product, so the request path has to be lean.
+
+# What production actually leans on
+
+The honest picture is that no-build production performance rests on HTTP/2 at the edge. The modulepreload hints turn discovery-latency into one parallel fetch, and HTTP/2 multiplexing makes that parallel fetch cheap over a single connection. The `npm run start` server speaks plain HTTP/1.1, so the deployment story is to put a reverse proxy or CDN in front of it for TLS and HTTP/2, exactly as you would for any origin. Cache-Control on static assets and content-hashed asset URLs do the rest, so a returning visitor refetches almost nothing.
+
+None of this is exotic. It is the same performance model Rails uses for importmap apps, plus the preload walk that importmap-rails does not do by default. WebJs is arguably a step ahead of the framework that proved the no-build posture, precisely on the axis people assume no-build loses.
+
+# The limit I will not pretend away
+
+There is one thing bundling does that preloading does not: tree-shaking. A bundler can drop the unused exports of a module before it ships. WebJs serves whole modules, so if you import one function from a package, the browser fetches the module that function lives in. For the core runtime this is a real, fixed floor: a page with one tiny interactive island still loads the whole core, once, cached and shared across the app.
+
+I am comfortable with this because it is the same trade Rails made with Hotwire, whose runtime is the same order of magnitude and has shipped to production for years. The core is off the first-paint path (SSR plus progressive enhancement mean the HTML reads before any of it loads), it is cached, and it is shared. The place it would actually bite is an app that pulls in many large, rarely-co-occurring client dependencies, which is a React-SPA shape that WebJs's whole architecture steers you away from. Stay island-shaped and the tree-shaking you are missing is tree-shaking you did not need.
+
+# The takeaway
+
+No-build performance is not about matching a bundler's request count. It is about killing discovery latency, which you do by telling the browser what it will need before it finds out the slow way, and by keeping the request path lean because there is no build step to hide behind. Preload the reached graph, multiplex it over HTTP/2, cache aggressively, and the waterfall flattens. The one thing you genuinely give up is tree-shaking, so keep your client footprint honest and let the shared, cached core earn its keep.

--- a/blog/no-build-via-jspm-io.md
+++ b/blog/no-build-via-jspm-io.md
@@ -2,16 +2,16 @@
 title: "No-Build npm Packages with Import Maps and jspm"
 date: 2026-05-27T11:00:00+05:30
 slug: no-build-via-jspm-io
-description: "Why WebJs replaced its on-the-fly esbuild vendor pipeline with jspm.io direct CDN URLs in the importmap, matching Rails 7's importmap-rails posture. The research notes on esm.sh vs jspm.io, plus the SRI and CSP hardening that fell out."
+description: "How WebJs loads no-build npm packages by putting jspm.io CDN URLs directly in the import map, no esbuild bundler, matching Rails 7's importmap-rails, plus the SRI and CSP hardening that fell out."
 tags: no-build, importmap, jspm, vendor, csp, sri
 author: Vivek
 ---
 
-The earlier post on stripping types removed the build step for user code. The dev server picks up your `.ts` file, runs `module.stripTypeScriptTypes`, and serves the result. Stack traces line up with the source on disk. No sourcemap layer. That covered every file under `app/`, `components/`, `modules/`, and `lib/`.
+WebJs makes one big promise. No build step. The `.ts` files you write are the files that run, with nothing compiling them in between. The earlier post on stripping types is where that promise started for user code. The dev server picks up your `.ts` file, runs `module.stripTypeScriptTypes`, and serves the result. Stack traces line up with the source on disk. No sourcemap layer. That covered every file under `app/`, `components/`, `modules/`, and `lib/`.
 
 It did not cover npm packages.
 
-For a long stretch, every `import x from 'pkg'` in a client file went through an on-the-fly esbuild bundle. The server scanned bare imports at boot, resolved each to a node_modules entry, ran esbuild over the resulting graph, and cached the bundle under `/__webjs/vendor/<hash>.js`. The browser fetched the bundle and ran it. From the user's perspective the import "just worked." From the framework's perspective there was still a bundler hidden inside the server.
+For a long stretch, every `import x from 'pkg'` in a client file went through an on-the-fly esbuild bundle (esbuild is a fast JavaScript bundler). The server scanned bare imports (an import by package name like `dayjs`, not a file path) at boot, resolved each to a node_modules entry, ran esbuild over the resulting graph, and cached the bundle under `/__webjs/vendor/<hash>.js`. The browser fetched the bundle and ran it. From the user's perspective the import "just worked." From the framework's perspective there was still a bundler hidden inside the server.
 
 It worked. It was fast (esbuild does 10MB/s). But the framework was no longer no-build. It was no-build-for-your-code-but-secretly-bundles-vendor. Every blog post about WebJs being no-build had a footnote in my head.
 
@@ -23,11 +23,11 @@ Three options were on the table when I started.
 
 **Keep on-the-fly esbuild.** Familiar. Already worked. But it conceded the no-build claim and kept esbuild as a runtime dependency, which is a 30MB native binary that has to match the server's CPU architecture and Node ABI. Every CI matrix and every deploy target had to ship the right esbuild for the platform.
 
-**Switch to esm.sh.** I started here because esm.sh is the obvious "free CDN that serves npm as ESM" answer when you type the question into a search box. The shape is similar to what I wanted. You write a URL like `https://esm.sh/dayjs@1.11.13` and the browser fetches a working ESM module.
+**Switch to esm.sh.** I started here because esm.sh is the obvious "free CDN that serves npm as ESM" answer (ESM is the native JavaScript module format browsers load directly) when you type the question into a search box. The shape is similar to what I wanted. You write a URL like `https://esm.sh/dayjs@1.11.13` and the browser fetches a working ESM module.
 
 The problem is that esm.sh builds packages on the fly. When your browser hits a URL it has not seen before, esm.sh's server pulls the package from npm, runs its own build pipeline, and streams the result back. The output is cached for subsequent requests, but the first hit is a build. This shows up as latency spikes, and more visibly as availability incidents. esm.sh has had multiple production-visible outages over its lifetime. The maintainers post recovery notes on GitHub and Twitter when they happen. The combination of "build on the fly" + "free service" + "one maintainer" is real, and the incidents are public.
 
-**Switch to jspm.io.** jspm.io pre-builds every npm package and parks the result on its CDN. There is no on-the-fly anything at request time. When the browser fetches `https://ga.jspm.io/npm:dayjs@1.11.13/dayjs.min.js`, the bytes are already on disk at the edge. Zero reported incidents in years. Zero maintenance downtime. The maintainer is Guy Bedford, a TC39 member who championed import maps and contributed to the HTML spec for ESM. Rails 7's `importmap-rails` uses jspm.io for the same reason: it is the boring, battle-tested choice.
+**Switch to jspm.io.** jspm.io pre-builds every npm package and parks the result on its CDN. There is no on-the-fly anything at request time. When the browser fetches `https://ga.jspm.io/npm:dayjs@1.11.13/dayjs.min.js`, the bytes are already on disk at the edge. Zero reported incidents in years. Zero maintenance downtime. The maintainer is Guy Bedford, a TC39 member (TC39 is the committee that standardizes JavaScript) who championed import maps (the browser-native map from a bare package name to a URL) and contributed to the HTML spec for ESM. Rails 7's `importmap-rails` uses jspm.io for the same reason: it is the boring, battle-tested choice.
 
 I went with jspm.io.
 
@@ -66,7 +66,7 @@ Pin is intentionally manual. There is no auto-pin in `predev` or `prestart` beca
 
 # `webjs vendor pin --download` for air-gapped deploys
 
-Some deploys cannot reach a third-party CDN at runtime. Compliance-locked environments, air-gapped corporate networks, or strict-CSP setups with `script-src 'self'` only. For those, the `--download` flag also pulls the bundle bytes to `.webjs/vendor/<pkg>@<version>.js` and rewrites the importmap to local `/__webjs/vendor/` paths.
+Some deploys cannot reach a third-party CDN at runtime. Compliance-locked environments, air-gapped corporate networks, or strict-CSP setups (Content Security Policy, the browser rules for which scripts are allowed to run) with `script-src 'self'` only. For those, the `--download` flag also pulls the bundle bytes to `.webjs/vendor/<pkg>@<version>.js` and rewrites the importmap to local `/__webjs/vendor/` paths.
 
 ```sh
 $ webjs vendor pin --download
@@ -80,7 +80,7 @@ The bundle files go in git alongside the pin manifest. At runtime the server ser
 
 # SHA-384 integrity end-to-end
 
-Once the resolution is committed, the SRI story falls into place. Both pin modes compute a `sha384-<base64>` integrity hash for every URL the importmap emits. In default mode the hash is computed by fetching the jspm.io URL once at pin time and hashing the raw response bytes. In `--download` mode the hash is computed from the downloaded bundle, which is also what the browser later fetches from `/__webjs/vendor/`.
+Once the resolution is committed, the SRI story (Subresource Integrity, the browser check that a downloaded file matches an expected hash) falls into place. Both pin modes compute a `sha384-<base64>` integrity hash for every URL the importmap emits. In default mode the hash is computed by fetching the jspm.io URL once at pin time and hashing the raw response bytes. In `--download` mode the hash is computed from the downloaded bundle, which is also what the browser later fetches from `/__webjs/vendor/`.
 
 Hashes land in three places:
 

--- a/blog/no-build-via-jspm-io.md
+++ b/blog/no-build-via-jspm-io.md
@@ -1,5 +1,5 @@
 ---
-title: "Removing the last bundler: vendor packages via jspm.io"
+title: "No-Build npm Packages with Import Maps and jspm"
 date: 2026-05-27T11:00:00+05:30
 slug: no-build-via-jspm-io
 description: "Why webjs replaced its on-the-fly esbuild vendor pipeline with jspm.io direct CDN URLs in the importmap, matching Rails 7's importmap-rails posture. The research notes on esm.sh vs jspm.io, plus the SRI and CSP hardening that fell out."

--- a/blog/no-build-via-jspm-io.md
+++ b/blog/no-build-via-jspm-io.md
@@ -2,7 +2,7 @@
 title: "No-Build npm Packages with Import Maps and jspm"
 date: 2026-05-27T11:00:00+05:30
 slug: no-build-via-jspm-io
-description: "Why webjs replaced its on-the-fly esbuild vendor pipeline with jspm.io direct CDN URLs in the importmap, matching Rails 7's importmap-rails posture. The research notes on esm.sh vs jspm.io, plus the SRI and CSP hardening that fell out."
+description: "Why WebJs replaced its on-the-fly esbuild vendor pipeline with jspm.io direct CDN URLs in the importmap, matching Rails 7's importmap-rails posture. The research notes on esm.sh vs jspm.io, plus the SRI and CSP hardening that fell out."
 tags: no-build, importmap, jspm, vendor, csp, sri
 author: Vivek
 ---
@@ -13,7 +13,7 @@ It did not cover npm packages.
 
 For a long stretch, every `import x from 'pkg'` in a client file went through an on-the-fly esbuild bundle. The server scanned bare imports at boot, resolved each to a node_modules entry, ran esbuild over the resulting graph, and cached the bundle under `/__webjs/vendor/<hash>.js`. The browser fetched the bundle and ran it. From the user's perspective the import "just worked." From the framework's perspective there was still a bundler hidden inside the server.
 
-It worked. It was fast (esbuild does 10MB/s). But the framework was no longer no-build. It was no-build-for-your-code-but-secretly-bundles-vendor. Every blog post about webjs being no-build had a footnote in my head.
+It worked. It was fast (esbuild does 10MB/s). But the framework was no longer no-build. It was no-build-for-your-code-but-secretly-bundles-vendor. Every blog post about WebJs being no-build had a footnote in my head.
 
 The PR that just shipped (#89, merge `988b37b`) removes esbuild from the framework entirely. There is no longer a bundler anywhere in the runtime path. Vendor packages resolve through jspm.io's CDN directly, exactly like Rails 7 does with importmap-rails.
 
@@ -46,7 +46,7 @@ At server boot, the bare-import scanner walks client-reachable source and produc
 </script>
 ```
 
-The browser fetches each package directly from `ga.jspm.io`. webjs's server is never on the bytes path for vendor traffic. The dev server's job at request time is to serve user code; the importmap takes care of everything else.
+The browser fetches each package directly from `ga.jspm.io`. WebJs's server is never on the bytes path for vendor traffic. The dev server's job at request time is to serve user code; the importmap takes care of everything else.
 
 # `webjs vendor pin` commits the resolved URLs
 
@@ -94,7 +94,7 @@ If jspm.io's CDN is compromised and starts serving different bytes, the browser 
 
 While I was already in the request pipeline, I followed Turbo Drive's CSP-nonce pattern and threaded a per-request nonce through every SSR path. Server emits `<meta name="csp-nonce" content="...">` once at SSR time. Every inline script (boot module, importmap, env shim, Suspense resolution) carries `nonce="..."`. Every modulepreload link carries the same nonce. The client router reads the meta tag on each navigation and stamps the per-page nonce onto every dynamically-inserted script and link, so head-merge during partial swaps does not get blocked by strict CSP.
 
-`script-src 'nonce-...'` is now sufficient policy for a webjs app, with no `'unsafe-inline'` or `'unsafe-eval'` anywhere. Run a strict CSP and the app still works.
+`script-src 'nonce-...'` is now sufficient policy for a WebJs app, with no `'unsafe-inline'` or `'unsafe-eval'` anywhere. Run a strict CSP and the app still works.
 
 # What this lets us delete
 
@@ -114,11 +114,11 @@ The `webjs check` rules `erasable-typescript-only` and `no-non-erasable-typescri
 
 # What it means for users
 
-For someone writing a webjs app: `npm install dayjs`, then `import dayjs from 'dayjs'` in any client file. The import works in dev immediately, no `webjs vendor` call needed. The scanner discovers the new bare import and asks jspm.io at the next boot.
+For someone writing a WebJs app: `npm install dayjs`, then `import dayjs from 'dayjs'` in any client file. The import works in dev immediately, no `webjs vendor` call needed. The scanner discovers the new bare import and asks jspm.io at the next boot.
 
-For someone deploying a webjs app: run `webjs vendor pin` once, commit `.webjs/vendor/importmap.json`, and your deploys are deterministic. Add `--download` if you need air-gapped or strict-CSP behavior.
+For someone deploying a WebJs app: run `webjs vendor pin` once, commit `.webjs/vendor/importmap.json`, and your deploys are deterministic. Add `--download` if you need air-gapped or strict-CSP behavior.
 
-For someone debugging a webjs app: the network panel shows real package URLs (`ga.jspm.io/npm:dayjs@1.11.13/dayjs.min.js`) instead of opaque content-addressed hashes. You can paste any vendor URL into a fresh tab and read the same bytes the browser is running.
+For someone debugging a WebJs app: the network panel shows real package URLs (`ga.jspm.io/npm:dayjs@1.11.13/dayjs.min.js`) instead of opaque content-addressed hashes. You can paste any vendor URL into a fresh tab and read the same bytes the browser is running.
 
 For someone running CI: no esbuild binary to install. The framework ships zero native dependencies. `node --test` runs against the real source.
 
@@ -128,7 +128,7 @@ This took longer than the strip-types post, by a meaningful margin. The PR went 
 
 The net result is a framework with no bundler in its request path and a vendor pipeline that matches the boring, battle-tested choice the Rails team made. Same CDN. Same posture. Same trust model.
 
-webjs is now no-build end-to-end. The `.ts` files you write are the files that run. The npm packages you install are fetched from jspm.io as pre-built ESM. There is no compile step, no bundle step, no transform step at request time. The framework is smaller after this PR than before, by a meaningful chunk of code.
+WebJs is now no-build end-to-end. The `.ts` files you write are the files that run. The npm packages you install are fetched from jspm.io as pre-built ESM. There is no compile step, no bundle step, no transform step at request time. The framework is smaller after this PR than before, by a meaningful chunk of code.
 
 That is the last bundler removed. There was no surprise to it: I knew the architecture I wanted, I knew Rails had already shipped it, and the work was finding the right places to put SRI and CSP so the result was safe under strict policies. The interesting parts were the review iterations on the security surfaces.
 

--- a/blog/node-and-bun-no-build.md
+++ b/blog/node-and-bun-no-build.md
@@ -1,0 +1,66 @@
+---
+title: "Running One Web Framework on Node and Bun Found Five Bugs"
+date: 2026-07-01T18:00:00+05:30
+slug: node-and-bun-no-build
+description: "webjs runs the same buildless source on Node 24+ and Bun. Adding the second runtime meant a runtime-neutral listener seam, two TypeScript strippers, and a parity test matrix that surfaced five genuine Node-versus-Bun divergences."
+tags: bun, node, runtime, no-build, cross-runtime
+author: Vivek
+---
+
+webjs runs on Node 24+ and on Bun, from the same source, with no build step. You start a Bun app with `bun --bun run dev` and the server runs on Bun. Same files, same routes, same components. The interesting part was not making it start on both. It was the five real bugs the parity work surfaced, each one a place where Node and Bun disagree about something I had assumed was standard.
+
+# Why two runtimes at all
+
+The honest reason is that Bun is fast and a lot of people want to use it, and a no-build framework is exactly the kind of thing that should not care which runtime executes it. There is no bundler output that bakes in a target. The source IS the runtime. So the only thing standing between webjs and Bun was the set of places where the framework touches a runtime API directly, and those places turned out to be worth mapping carefully.
+
+The work landed under #508. Node 24+ is the floor because that is where the built-in TypeScript stripper and a few other primitives arrived. A boot-time preflight enforces the floor and admits Bun.
+
+# The listener seam
+
+The biggest runtime-specific surface is the HTTP listener. On Node the framework uses `node:http`. On Bun the native answer is `Bun.serve`, which is a different shape with a different request object.
+
+The wrong move would be a compatibility shim that makes `Bun.serve` pretend to be `node:http`. That leaves performance on the table, because you are paying for a bridge on every request. So instead `startServer` selects a runtime-neutral listener shell: a `node:http` shell on Node, and a `Bun.serve` shell on Bun that skips the compat bridge entirely. On the listening path that is worth about 1.9x more requests per second on Bun, because the request never gets marshalled through a Node-shaped intermediary.
+
+The seam is deliberately general, not a two-way `if`. It is the same place a future `Deno.serve` shell or an embedded adapter would plug in. The framework code above the seam does not know which runtime it is on.
+
+There is exactly one feature that does not cross: 103 Early Hints. `Bun.serve` has no informational-response API, so the Bun shell cannot send them. Everything else reaches parity. I would rather document one honest gap than ship a leaky shim that pretends the gap is not there.
+
+# Two strippers for the same TypeScript
+
+webjs serves `.ts` files by stripping the types at request time, buildless. On Node that is the built-in `module.stripTypeScriptTypes`. Bun does not have that function, so on Bun the framework uses `amaro`, the same stripper Node's own implementation is built on.
+
+The requirement is that both produce byte-identical, position-preserving output, because the stripped source is what the browser fetches and what stack traces point into. If the two strippers disagreed by even a character, a line number in an error would be wrong on one runtime. They match, and there is a forced-amaro parity test on Node that keeps them matching.
+
+# The parity matrix, and the five bugs
+
+Here is the part that actually earned its keep. `node scripts/run-bun-tests.js` re-runs the entire `node:test` suite under Bun. Not a separate Bun-specific suite. The same tests, on the other runtime. A divergence is a failure, and a failure is a real framework bug to fix, not a test to skip.
+
+It found five.
+
+**A FormData serializer crash.** The rich-type serializer round-trips `FormData` across the RPC wire. On Bun, a freshly constructed `FormData` had a subtly different internal identity that the serializer's fast path did not expect, and it threw. This only showed up because an action test sent a `FormData` and asserted the round-trip, and that test ran on both runtimes.
+
+**A `Readable.fromWeb` hang.** The file-storage layer bridges a web `ReadableStream` into a Node stream with `Readable.fromWeb`. On Bun, a `put()` through that path hung instead of completing, because the reader loop had a different back-pressure timing. The fix was in how the framework drives the stream, and the no-orphan-on-mid-stream-error invariant is now asserted on Bun directly.
+
+**The TypeScript strip error code.** When you feed non-erasable TypeScript to the stripper, it throws. Node's built-in and amaro threw with different error codes for the same bad input. The framework catches that error to produce a helpful message, and the catch was keyed on Node's code. On Bun it fell through. Fixed by normalising both.
+
+**A JavaScriptCore versus V8 error-message format.** One test asserted on the text of a thrown error. JSC (Bun) and V8 (Node) word the same error differently. That is not a framework bug in the strict sense, but it is a framework bug in the sense that the framework's own error handling was matching on the wording. Fixed to match on the stable part.
+
+**A link-unsafe `node:module` named import.** A named import from `node:module` that resolved fine on Node did not on Bun. Small, but it would have crashed the boot on Bun, so it counts.
+
+None of these were things I would have found by reading the code. They are the kind of divergence you only see when you actually execute the same assertion on both engines. That is the entire argument for the matrix: it is not there to prove Bun works, it is there to catch the specific line where Node and Bun quietly disagree.
+
+# Keeping it honest going forward
+
+The trap with cross-runtime support is that it rots the moment you stop looking. Someone touches the serializer, tests pass on Node, ships, and Bun breaks silently until a user hits it.
+
+So the framework treats any change to a runtime-sensitive surface as incomplete until it is proven on Bun. The serializer, the listener path, streams, `node:crypto`, the stripper, auth and session dispatch: a change there has to ship a cross-runtime assertion under `test/bun/`, and a pre-commit hook blocks a commit that stages runtime-sensitive source without one. The discipline is in the tooling, not in my memory, because my memory is exactly the thing that fails to remember Bun on a busy day.
+
+A handful of tests are legitimately Node-only. They assert a `node:http` internal, or the built-in stripper as the byte-reference, or the Node `ws` subsystem. Those sit on a documented denylist in the matrix runner, each with a reason and a note of where the Bun behaviour is covered instead. The denylist is explicit precisely so that "this is Node-only" is a decision someone wrote down, not a test that quietly stopped running on Bun.
+
+# What shipped around it
+
+Because the CLI's own tooling stopped needing Node anywhere in the container, the Bun scaffold ships a pure `oven/bun:1` Dockerfile (#595). The database, test, and check tooling still run on Node, but the deployed server image is Bun all the way down. `bun create webjs my-app` picks the runtime automatically, and the `--runtime bun` flag re-flavours any of the templates for Bun.
+
+# The takeaway
+
+Supporting a second runtime for a no-build framework is mostly not about making it start. It is about finding the small set of places where the two runtimes disagree, isolating them behind a seam, and then running your existing test suite on both engines so the disagreements surface as failures instead of as user reports. The five bugs the matrix caught were all invisible to code review and all real. If you are going cross-runtime, do not write a Bun test suite. Run your Node suite on Bun, and fix what turns red.

--- a/blog/node-and-bun-no-build.md
+++ b/blog/node-and-bun-no-build.md
@@ -2,16 +2,16 @@
 title: "Running One Web Framework on Node and Bun Found Five Bugs"
 date: 2026-06-09T10:00:00+05:30
 slug: node-and-bun-no-build
-description: "webjs runs the same buildless source on Node 24+ and Bun. Adding the second runtime meant a runtime-neutral listener seam, two TypeScript strippers, and a parity test matrix that surfaced five genuine Node-versus-Bun divergences."
+description: "WebJs runs the same buildless source on Node 24+ and Bun. Adding the second runtime meant a runtime-neutral listener seam, two TypeScript strippers, and a parity test matrix that surfaced five genuine Node-versus-Bun divergences."
 tags: bun, node, runtime, no-build, cross-runtime
 author: Vivek
 ---
 
-webjs runs on Node 24+ and on Bun, from the same source, with no build step. You start a Bun app with `bun --bun run dev` and the server runs on Bun. Same files, same routes, same components. The interesting part was not making it start on both. It was the five real bugs the parity work surfaced, each one a place where Node and Bun disagree about something I had assumed was standard.
+WebJs runs on Node 24+ and on Bun, from the same source, with no build step. You start a Bun app with `bun --bun run dev` and the server runs on Bun. Same files, same routes, same components. The interesting part was not making it start on both. It was the five real bugs the parity work surfaced, each one a place where Node and Bun disagree about something I had assumed was standard.
 
 # Why two runtimes at all
 
-The honest reason is that Bun is fast and a lot of people want to use it, and a no-build framework is exactly the kind of thing that should not care which runtime executes it. There is no bundler output that bakes in a target. The source IS the runtime. So the only thing standing between webjs and Bun was the set of places where the framework touches a runtime API directly, and those places turned out to be worth mapping carefully.
+The honest reason is that Bun is fast and a lot of people want to use it, and a no-build framework is exactly the kind of thing that should not care which runtime executes it. There is no bundler output that bakes in a target. The source IS the runtime. So the only thing standing between WebJs and Bun was the set of places where the framework touches a runtime API directly, and those places turned out to be worth mapping carefully.
 
 The work landed under #508. Node 24+ is the floor because that is where the built-in TypeScript stripper and a few other primitives arrived. A boot-time preflight enforces the floor and admits Bun.
 
@@ -27,7 +27,7 @@ There is exactly one feature that does not cross: 103 Early Hints. `Bun.serve` h
 
 # Two strippers for the same TypeScript
 
-webjs serves `.ts` files by stripping the types at request time, buildless. On Node that is the built-in `module.stripTypeScriptTypes`. Bun does not have that function, so on Bun the framework uses `amaro`, the same stripper Node's own implementation is built on.
+WebJs serves `.ts` files by stripping the types at request time, buildless. On Node that is the built-in `module.stripTypeScriptTypes`. Bun does not have that function, so on Bun the framework uses `amaro`, the same stripper Node's own implementation is built on.
 
 The requirement is that both produce byte-identical, position-preserving output, because the stripped source is what the browser fetches and what stack traces point into. If the two strippers disagreed by even a character, a line number in an error would be wrong on one runtime. They match, and there is a forced-amaro parity test on Node that keeps them matching.
 

--- a/blog/node-and-bun-no-build.md
+++ b/blog/node-and-bun-no-build.md
@@ -1,6 +1,6 @@
 ---
 title: "Running One Web Framework on Node and Bun Found Five Bugs"
-date: 2026-07-01T18:00:00+05:30
+date: 2026-06-09T10:00:00+05:30
 slug: node-and-bun-no-build
 description: "webjs runs the same buildless source on Node 24+ and Bun. Adding the second runtime meant a runtime-neutral listener seam, two TypeScript strippers, and a parity test matrix that surfaced five genuine Node-versus-Bun divergences."
 tags: bun, node, runtime, no-build, cross-runtime

--- a/blog/node-and-bun-no-build.md
+++ b/blog/node-and-bun-no-build.md
@@ -1,6 +1,6 @@
 ---
 title: "Running One Web Framework on Node and Bun Found Five Bugs"
-date: 2026-06-09T10:00:00+05:30
+date: 2026-06-02T09:30:00+05:30
 slug: node-and-bun-no-build
 description: "WebJs runs the same buildless source on Node 24+ and Bun. Adding the second runtime meant a runtime-neutral listener seam, two TypeScript strippers, and a parity test matrix that surfaced five genuine Node-versus-Bun divergences."
 tags: bun, node, runtime, no-build, cross-runtime

--- a/blog/prisma-vs-drizzle-default-orm.md
+++ b/blog/prisma-vs-drizzle-default-orm.md
@@ -1,6 +1,6 @@
 ---
 title: "Prisma vs Drizzle: Why We Chose Drizzle as Our Default ORM"
-date: 2026-06-28T12:00:00+05:30
+date: 2026-06-27T12:00:00+05:30
 slug: prisma-vs-drizzle-default-orm
 description: "Prisma vs Drizzle for a no-build framework. Why WebJs picked Drizzle ORM as the scaffold's default ORM, how the buildless, source-is-the-runtime model made the decision, and how to bring your own if you prefer Prisma."
 tags: orm, drizzle, prisma, database, defaults

--- a/blog/prisma-vs-drizzle-default-orm.md
+++ b/blog/prisma-vs-drizzle-default-orm.md
@@ -1,0 +1,110 @@
+---
+title: "Prisma vs Drizzle: Why We Chose Drizzle as Our Default ORM"
+date: 2026-06-28T12:00:00+05:30
+slug: prisma-vs-drizzle-default-orm
+description: "Prisma vs Drizzle for a no-build framework. Why WebJs picked Drizzle ORM as the scaffold's default ORM, how the buildless, source-is-the-runtime model made the decision, and how to bring your own if you prefer Prisma."
+tags: orm, drizzle, prisma, database, defaults
+author: Vivek
+---
+
+Every full-stack framework has to pick a way to talk to your database. When you scaffold a new WebJs app, you get one already wired up, so you can write features instead of spending your first afternoon comparing libraries. That default is Drizzle.
+
+Before anything else, the honest framing. Drizzle, Tailwind, and SQLite are scaffold **defaults**, not lock-in. WebJs is not coupled to any of them. If you prefer Prisma, or Kysely, or raw SQL, or Postgres over SQLite, you swap the `db/` folder and keep going. Nothing else in the framework knows or cares. This post is the story of why we picked Drizzle as the thing you get for free, not a claim that you are stuck with it.
+
+First, the term. An ORM (object-relational mapper) is a library that lets you talk to your database in code, with functions and objects, instead of hand-writing raw SQL strings. Prisma and Drizzle are both ORMs. Both are good. The question was never "which one is better in the abstract." It was "which one fits a framework that has no build step."
+
+That constraint is the whole story.
+
+
+# The one constraint that decided it
+
+WebJs has no build step. The `.ts` files you write are the files the runtime serves. There is no `webjs build` command, because there is nothing to compile ahead of time. What you read in `node_modules` is what runs. That single design choice ("source is the runtime") is the lens every dependency gets held up to.
+
+Prisma, for all its strengths, works differently. You write a schema in Prisma's own schema language, then you run `prisma generate`. That command reads your schema and writes out a generated client, a chunk of TypeScript (and native query-engine bindings) that your code then imports. The client is a build artifact. It has to be regenerated every time the schema changes, and it has to exist before your app can run.
+
+A generated client that must be produced by a codegen step, before the app runs, is exactly the kind of thing WebJs is designed not to have. It is a build step wearing a different hat. Adding it back to the one framework whose entire pitch is "no build step" would have been strange.
+
+Drizzle does not have that step. A Drizzle schema is plain TypeScript. Your tables are TypeScript objects, your queries are TypeScript function calls, and the types flow directly from the schema you wrote. There is no generated client sitting between your code and the database. It is just source, which is exactly what the rest of a WebJs app is.
+
+So the decision was not "Drizzle is better than Prisma." It was "Drizzle is shaped like the rest of WebJs, and Prisma is shaped like a build step." For a buildless framework, that fit is the deciding factor.
+
+
+# What Prisma genuinely does well
+
+I want to be fair here, because Prisma is a genuinely good tool and plenty of teams should reach for it.
+
+Its schema language is lovely to read. A `schema.prisma` file is compact and skimmable, and beginners often find it clearer than a wall of TypeScript table definitions. Prisma Studio, the built-in visual database browser, is excellent. The generated client gives you rich, precise autocomplete because the types were produced from your exact schema. Its migration tooling is mature and well documented. For a team that already has a build pipeline, the codegen step is a non-issue, because everything else in their stack builds too.
+
+None of that is in dispute. The point is fit, not quality. In a framework where every other file is served straight from source, the one dependency that needs a generate step stands out. In a Next.js app that already runs a bundler, it blends right in.
+
+
+# What the Drizzle default looks like
+
+When you scaffold, the database lives in one folder:
+
+```
+db/
+  schema.server.ts       table definitions (plain TypeScript)
+  columns.server.ts       column-type helpers per dialect
+  connection.server.ts    the db client you import everywhere
+```
+
+You define a table in `db/schema.server.ts`, no separate schema language, no generate step:
+
+```ts
+// db/schema.server.ts
+import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
+
+export const posts = sqliteTable('posts', {
+  id: text('id').primaryKey(),
+  title: text('title').notNull(),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+});
+```
+
+Then you query it from a server action or a query module, importing the same `db` client the whole app shares:
+
+```ts
+// modules/posts/queries/list-posts.server.ts
+'use server';
+import { db } from '../../../db/connection.server.ts';
+
+export async function listPosts() {
+  return db.query.posts.findMany({ orderBy: { createdAt: 'desc' } });
+}
+```
+
+That is the entire loop. Edit the schema, and the types update because the schema is the types. No artifact to keep in sync.
+
+
+# The CLI wraps Drizzle Kit, not a codegen step
+
+WebJs ships a thin database CLI that fronts Drizzle's own tooling (Drizzle Kit):
+
+```sh
+webjs db generate   # create a migration from the current schema
+webjs db migrate    # apply pending migrations
+webjs db push       # push the schema straight to the db (dev)
+webjs db studio     # open Drizzle's visual database browser
+webjs db seed       # run db/seed.server.ts
+```
+
+Note what `webjs db generate` does and does not do. It generates a **migration** (a SQL file describing the schema change), not a client you import. Nothing your app code depends on comes out of a codegen step. Your app imports `db` from `connection.server.ts`, and that file is source you can read. And yes, Drizzle has its own studio, so you do not give up the visual database browser by choosing it.
+
+
+# Bring your own dialect (and your own ORM)
+
+The default database is SQLite, which means a new app runs with zero setup, no server to install, just a file. When you are ready for Postgres, one flag at scaffold time picks the dialect:
+
+```sh
+webjs create my-app --db postgres
+```
+
+Here is the part that makes this a default rather than a lock-in. The schema, the queries, and the server actions are **identical across dialects** (the dialect-parity work landed in #563). You do not rewrite your data layer to move from SQLite to Postgres. The `db/columns.server.ts` helper absorbs the per-dialect differences, and the code you wrote against `db.query...` stays the same.
+
+And if you would rather use Prisma, or Kysely, or write raw SQL, that door is open too. The framework's only real contract with the database is "server-only code lives in `.server.ts` files." Whatever you export a `db` client from, and however you built it, WebJs will happily run. Swap the `db/` folder for a Prisma setup, keep `prisma generate` in your own dev script, and the rest of the framework does not change. You lose the buildless purity for that one dependency, which is a trade you are allowed to make.
+
+
+# The takeaway
+
+Drizzle is the default because it is the same shape as everything else in WebJs: plain TypeScript, served from source, with no codegen artifact sitting between you and the runtime. Prisma is an excellent ORM with a lovely schema language and a great studio, and the only strike against it here is that its `prisma generate` step is a build step, which is the one thing a no-build framework is built to avoid. So this was a fit decision, not a quality verdict. Most important: Drizzle, SQLite, and Tailwind are the batteries the scaffold includes so you can ship on day one, not walls you are trapped behind. Prefer a different ORM, database, or styling approach? Swap it in and keep building. The default just means you do not have to decide before you have written a single feature.

--- a/blog/server-actions-without-react-server-components.md
+++ b/blog/server-actions-without-react-server-components.md
@@ -2,14 +2,14 @@
 title: "Server Actions Without React Server Components"
 date: 2026-06-20T11:00:00+05:30
 slug: server-actions-without-react-server-components
-description: "webjs has no server/client component split, no Flight protocol, and no use client boundary. It gets await-data-in-the-leaf and typed server mutations from one RPC boundary instead. How the execution model works and why it drops the RSC machinery."
+description: "WebJs has no server/client component split, no Flight protocol, and no use client boundary. It gets await-data-in-the-leaf and typed server mutations from one RPC boundary instead. How the execution model works and why it drops the RSC machinery."
 tags: server-actions, rsc, execution-model, rpc, data-fetching
 author: Vivek
 ---
 
 The hardest thing to hold in your head about a modern React app is the boundary. Which code runs on the server, which runs on the client, what `"use client"` really does to the tree below it, how a Server Component serializes its output down to a Client Component, and why a value that looks fine throws when it crosses the line. React Server Components are powerful, and they are also the single concept that generates the most confusion in the stack.
 
-webjs does not have them. There is no server component, no client component, no Flight protocol, no `"use client"` directive, and no two render trees. And yet you can still `await` data inside a leaf component and call typed server functions from the browser. This post is about how that works with one boundary instead of a render architecture.
+WebJs does not have them. There is no server component, no client component, no Flight protocol, no `"use client"` directive, and no two render trees. And yet you can still `await` data inside a leaf component and call typed server functions from the browser. This post is about how that works with one boundary instead of a render architecture.
 
 # The execution model in three sentences
 
@@ -19,17 +19,17 @@ That is the whole model. There is no server-versus-client component distinction,
 
 # The one boundary that exists
 
-The only real server boundary in webjs is the `.server.{js,ts}` file. It does two jobs.
+The only real server boundary in WebJs is the `.server.{js,ts}` file. It does two jobs.
 
 With a `'use server'` directive, its exports become callable from the browser. When a client component imports one, the import is rewritten into an RPC stub that POSTs to `/__webjs/action/<hash>/<fn>`. You call it like a normal async function and the framework moves the arguments and the return value across the wire.
 
 Without the directive, the file is a server-only utility, and importing it from browser code gives you a stub that throws at module load. That is the source-protection half: your database driver, your secrets, your `node:*` imports live behind this boundary and physically cannot reach the client. The file is never served.
 
-That is it. One file convention, two behaviours. Compare this to the RSC mental model, where you are reasoning about a render tree that spans the network, a serialization protocol between its layers, and an annotation that changes the meaning of every import beneath it. webjs replaced all of that with "this file is a server function, and importing it is the API."
+That is it. One file convention, two behaviours. Compare this to the RSC mental model, where you are reasoning about a render tree that spans the network, a serialization protocol between its layers, and an annotation that changes the meaning of every import beneath it. WebJs replaced all of that with "this file is a server function, and importing it is the API."
 
 # The wire is richer than JSON
 
-Because calling a server action is just an import, the arguments and results have to survive the trip. webjs does not use JSON for this. The serializer round-trips `Date`, `Map`, `Set`, `BigInt`, `Error`, typed arrays, `Blob`, `File`, `FormData`, `Symbol`, and cyclic references. So this works with no ceremony:
+Because calling a server action is just an import, the arguments and results have to survive the trip. WebJs does not use JSON for this. The serializer round-trips `Date`, `Map`, `Set`, `BigInt`, `Error`, typed arrays, `Blob`, `File`, `FormData`, `Symbol`, and cyclic references. So this works with no ceremony:
 
 ```ts
 // modules/reports/actions/build.server.ts
@@ -44,7 +44,7 @@ The client calls `await buildReport({ from, to })` and gets back a real `Date` a
 
 # Awaiting data in a leaf, without a render tree
 
-The feature people reach for RSC to get is "fetch data inside the component that needs it, on the server, without a client waterfall." webjs gets this from `async render()` (#469):
+The feature people reach for RSC to get is "fetch data inside the component that needs it, on the server, without a client waterfall." WebJs gets this from `async render()` (#469):
 
 ```ts
 class UserCard extends WebComponent {
@@ -67,13 +67,13 @@ By default, no, because of SSR action seeding (#472). Every `'use server'` actio
 
 It is fail-open by construction. A seed miss is always a normal RPC call, never wrong data. And it needs no build step and no source transform: the capture is a server-side facade over the action module, so the files on disk and the source the browser sees are byte-unchanged. You get the RSC benefit of "the server already did this work, do not redo it on the client" without the protocol that RSC needs to deliver it.
 
-# Why webjs does not need RSC, and Next does
+# Why WebJs does not need RSC, and Next does
 
-This is the part worth being precise about, because it is not that RSC is bad. It is that webjs does not have the problem RSC solves.
+This is the part worth being precise about, because it is not that RSC is bad. It is that WebJs does not have the problem RSC solves.
 
 In React, a component is a client thing by default. To run data-fetching on the server without shipping that code to the browser, React needs a way to mark parts of the tree as server-only and stream their rendered output down to the client parts. That is Server Components and the Flight protocol. The split exists because React's unit, the component, has to be told which side it belongs to.
 
-webjs never has that problem, because its reads and writes do not flow through components at all. They flow through the `.server.ts` boundary. A read is a GET server action. A write is a POST server action. Both are just server functions you import. There is no need to designate a component as server-rendered, because the data crossing was never the component's job. So the machinery that manages a network-spanning render tree is machinery webjs has no tree to manage. One boundary, not a boundary per component.
+WebJs never has that problem, because its reads and writes do not flow through components at all. They flow through the `.server.ts` boundary. A read is a GET server action. A write is a POST server action. Both are just server functions you import. There is no need to designate a component as server-rendered, because the data crossing was never the component's job. So the machinery that manages a network-spanning render tree is machinery WebJs has no tree to manage. One boundary, not a boundary per component.
 
 That is also why the whole thing is easier to teach, and easier for an AI agent to get right on the first try. There is exactly one rule to internalise: server code lives in `.server.ts`, and importing a `'use server'` file is how you call it. There is no second render tree to model, no serialization boundary to reason about mid-tree, and no annotation whose blast radius is everything below it.
 
@@ -81,8 +81,8 @@ That is also why the whole thing is easier to teach, and easier for an AI agent 
 
 The honest trade is that you give up the parts of RSC that are genuinely nice when you are deep in React. You do not get a unified tree where a server component and a client component compose as freely as two functions. You compose a server-rendered page with hydrating islands, which is a coarser seam. For an app that is mostly content with islands of interactivity, that seam is exactly where you want it. For an app that is a deeply interleaved client tree with server data threaded through every level, RSC's finer boundary does more for you.
 
-webjs is built for the first shape. It says the page is the server artifact, the islands are the interactive leaves, and the one server boundary is where data crosses. If that matches how you are building, dropping RSC is not a loss. It is the confusing part of the stack you get to not have.
+WebJs is built for the first shape. It says the page is the server artifact, the islands are the interactive leaves, and the one server boundary is where data crosses. If that matches how you are building, dropping RSC is not a loss. It is the confusing part of the stack you get to not have.
 
 # The takeaway
 
-You do not need a server/client component split to fetch data on the server and call it from the browser. You need one clear boundary for server code and a serializer good enough to move real values across it. webjs puts that boundary at the file level, makes importing it the API, and recovers await-in-the-leaf and no-hydration-refetch on top of it. The result is a model you can hold in your head in three sentences, which is the whole point.
+You do not need a server/client component split to fetch data on the server and call it from the browser. You need one clear boundary for server code and a serializer good enough to move real values across it. WebJs puts that boundary at the file level, makes importing it the API, and recovers await-in-the-leaf and no-hydration-refetch on top of it. The result is a model you can hold in your head in three sentences, which is the whole point.

--- a/blog/server-actions-without-react-server-components.md
+++ b/blog/server-actions-without-react-server-components.md
@@ -1,6 +1,6 @@
 ---
 title: "Server Actions Without React Server Components"
-date: 2026-06-20T11:00:00+05:30
+date: 2026-06-18T10:00:00+05:30
 slug: server-actions-without-react-server-components
 description: "WebJs has no server/client component split, no Flight protocol, and no use client boundary. It gets await-data-in-the-leaf and typed server mutations from one RPC boundary instead. How the execution model works and why it drops the RSC machinery."
 tags: server-actions, rsc, execution-model, rpc, data-fetching

--- a/blog/server-actions-without-react-server-components.md
+++ b/blog/server-actions-without-react-server-components.md
@@ -1,6 +1,6 @@
 ---
 title: "Server Actions Without React Server Components"
-date: 2026-07-01T15:00:00+05:30
+date: 2026-06-20T11:00:00+05:30
 slug: server-actions-without-react-server-components
 description: "webjs has no server/client component split, no Flight protocol, and no use client boundary. It gets await-data-in-the-leaf and typed server mutations from one RPC boundary instead. How the execution model works and why it drops the RSC machinery."
 tags: server-actions, rsc, execution-model, rpc, data-fetching

--- a/blog/server-actions-without-react-server-components.md
+++ b/blog/server-actions-without-react-server-components.md
@@ -1,0 +1,88 @@
+---
+title: "Server Actions Without React Server Components"
+date: 2026-07-01T15:00:00+05:30
+slug: server-actions-without-react-server-components
+description: "webjs has no server/client component split, no Flight protocol, and no use client boundary. It gets await-data-in-the-leaf and typed server mutations from one RPC boundary instead. How the execution model works and why it drops the RSC machinery."
+tags: server-actions, rsc, execution-model, rpc, data-fetching
+author: Vivek
+---
+
+The hardest thing to hold in your head about a modern React app is the boundary. Which code runs on the server, which runs on the client, what `"use client"` really does to the tree below it, how a Server Component serializes its output down to a Client Component, and why a value that looks fine throws when it crosses the line. React Server Components are powerful, and they are also the single concept that generates the most confusion in the stack.
+
+webjs does not have them. There is no server component, no client component, no Flight protocol, no `"use client"` directive, and no two render trees. And yet you can still `await` data inside a leaf component and call typed server functions from the browser. This post is about how that works with one boundary instead of a render architecture.
+
+# The execution model in three sentences
+
+Pages and layouts run only on the server. They produce HTML and are never invoked again in the browser. Components are isomorphic: the same module runs on the server to SSR, and runs again in the browser to upgrade the custom element and become interactive.
+
+That is the whole model. There is no server-versus-client component distinction, because the split is not between two kinds of component. It is between two kinds of FILE. A page is a server-only render function. A component is an island that hydrates. A `.server.ts` file is a server boundary. Nothing annotates a component as one side or the other, because a component is always both.
+
+# The one boundary that exists
+
+The only real server boundary in webjs is the `.server.{js,ts}` file. It does two jobs.
+
+With a `'use server'` directive, its exports become callable from the browser. When a client component imports one, the import is rewritten into an RPC stub that POSTs to `/__webjs/action/<hash>/<fn>`. You call it like a normal async function and the framework moves the arguments and the return value across the wire.
+
+Without the directive, the file is a server-only utility, and importing it from browser code gives you a stub that throws at module load. That is the source-protection half: your database driver, your secrets, your `node:*` imports live behind this boundary and physically cannot reach the client. The file is never served.
+
+That is it. One file convention, two behaviours. Compare this to the RSC mental model, where you are reasoning about a render tree that spans the network, a serialization protocol between its layers, and an annotation that changes the meaning of every import beneath it. webjs replaced all of that with "this file is a server function, and importing it is the API."
+
+# The wire is richer than JSON
+
+Because calling a server action is just an import, the arguments and results have to survive the trip. webjs does not use JSON for this. The serializer round-trips `Date`, `Map`, `Set`, `BigInt`, `Error`, typed arrays, `Blob`, `File`, `FormData`, `Symbol`, and cyclic references. So this works with no ceremony:
+
+```ts
+// modules/reports/actions/build.server.ts
+'use server';
+export async function buildReport(range: { from: Date; to: Date }) {
+  const rows = await db.query(range);
+  return { generatedAt: new Date(), rows: new Map(rows) };
+}
+```
+
+The client calls `await buildReport({ from, to })` and gets back a real `Date` and a real `Map`, not stringified stand-ins. You never hand-write a `fetch`, never define an API route, never serialize by hand. The import is the contract, and the types flow through it end to end.
+
+# Awaiting data in a leaf, without a render tree
+
+The feature people reach for RSC to get is "fetch data inside the component that needs it, on the server, without a client waterfall." webjs gets this from `async render()` (#469):
+
+```ts
+class UserCard extends WebComponent {
+  async render() {
+    const u = await getUser(this.id);
+    return html`<h3>${u.name}</h3>`;
+  }
+}
+```
+
+`getUser` is a `'use server'` action. During SSR it is the real function, so the render blocks on it and the resolved data is baked into the first paint. No fallback markup, no loading flash, and it reads fine with JavaScript disabled because the data is already in the HTML. The fetch is co-located in the leaf that uses it, which is the RSC ergonomic, and there is no prop-drilling and no parent orchestration.
+
+The model is decoupled into three separate concerns so it stays predictable. SSR always blocks, so the data is in the first paint. On the client, when a prop change re-runs `async render()`, the current content stays on screen until the new render resolves, so there is no blank flash (this is stale-while-revalidate by default). And `renderFallback()` is an optional method shown only during a client re-fetch, never on the first paint. You opt into a loading state, you do not inherit one.
+
+# Killing the hydration re-fetch
+
+There is a subtle cost hiding in that design. If a component fetched its data on the server during SSR, and then hydrates in the browser, does it fetch again on hydration?
+
+By default, no, because of SSR action seeding (#472). Every `'use server'` action result produced during a server render is serialized into the page, keyed by the action hash, the function name, and the serialized arguments. The generated RPC stub checks that seed on its first client call and resolves synchronously from it instead of hitting the network. So `await getUser(this.id)` runs once, on the server, and the browser reuses the result on its first render. A later refetch or an argument change misses the seed (it is consume-once) and goes to the network as normal.
+
+It is fail-open by construction. A seed miss is always a normal RPC call, never wrong data. And it needs no build step and no source transform: the capture is a server-side facade over the action module, so the files on disk and the source the browser sees are byte-unchanged. You get the RSC benefit of "the server already did this work, do not redo it on the client" without the protocol that RSC needs to deliver it.
+
+# Why webjs does not need RSC, and Next does
+
+This is the part worth being precise about, because it is not that RSC is bad. It is that webjs does not have the problem RSC solves.
+
+In React, a component is a client thing by default. To run data-fetching on the server without shipping that code to the browser, React needs a way to mark parts of the tree as server-only and stream their rendered output down to the client parts. That is Server Components and the Flight protocol. The split exists because React's unit, the component, has to be told which side it belongs to.
+
+webjs never has that problem, because its reads and writes do not flow through components at all. They flow through the `.server.ts` boundary. A read is a GET server action. A write is a POST server action. Both are just server functions you import. There is no need to designate a component as server-rendered, because the data crossing was never the component's job. So the machinery that manages a network-spanning render tree is machinery webjs has no tree to manage. One boundary, not a boundary per component.
+
+That is also why the whole thing is easier to teach, and easier for an AI agent to get right on the first try. There is exactly one rule to internalise: server code lives in `.server.ts`, and importing a `'use server'` file is how you call it. There is no second render tree to model, no serialization boundary to reason about mid-tree, and no annotation whose blast radius is everything below it.
+
+# What it costs
+
+The honest trade is that you give up the parts of RSC that are genuinely nice when you are deep in React. You do not get a unified tree where a server component and a client component compose as freely as two functions. You compose a server-rendered page with hydrating islands, which is a coarser seam. For an app that is mostly content with islands of interactivity, that seam is exactly where you want it. For an app that is a deeply interleaved client tree with server data threaded through every level, RSC's finer boundary does more for you.
+
+webjs is built for the first shape. It says the page is the server artifact, the islands are the interactive leaves, and the one server boundary is where data crosses. If that matches how you are building, dropping RSC is not a loss. It is the confusing part of the stack you get to not have.
+
+# The takeaway
+
+You do not need a server/client component split to fetch data on the server and call it from the browser. You need one clear boundary for server code and a serializer good enough to move real values across it. webjs puts that boundary at the file level, makes importing it the API, and recovers await-in-the-leaf and no-hydration-refetch on top of it. The result is a model you can hold in your head in three sentences, which is the whole point.

--- a/blog/server-side-caching-explained.md
+++ b/blog/server-side-caching-explained.md
@@ -1,0 +1,116 @@
+---
+title: "Server-Side Caching for Beginners (ETags, Tags, and 304s)"
+date: 2026-06-25T11:00:00+05:30
+slug: server-side-caching-explained
+description: "A beginner-friendly guide to server-side caching in webjs: HTTP Cache-Control, the cache() query helper, tag-based cache invalidation, conditional GET with ETags and HTTP 304 Not Modified, and the export const revalidate HTML cache. Plus the safety rule for per-user data."
+tags: caching, performance, etag, http, no-build
+author: Vivek
+---
+
+Here is a pattern I see in almost every new app. A page loads a list of posts. Each request opens the database, runs the same query, gets the same rows, and renders the same HTML. Ten visitors in one second means ten identical trips to the database for a result that did not change. That is slow, and it is wasteful.
+
+Caching is the fix. A cache stores a computed or fetched result so you can skip the work next time. The hard part was never storing the value. The hard part is knowing when the stored value is stale and throwing it away at the right moment. That second half is called invalidation, and it is where most caching bugs live.
+
+webjs gives you a few caching layers, each aimed at a different kind of "same work repeated." This post walks through all of them from scratch, in plain language, and is careful about the one safety rule that matters most (never cache one user's data where another user can see it).
+
+# Layer 1: HTTP Cache-Control on responses
+
+The cheapest cache is the one you never run yourself. Browsers, CDNs, and reverse proxies already know how to hold onto a response if you tell them it is safe to. You tell them with a `Cache-Control` header.
+
+```js
+// app/api/posts/route.js
+export async function GET() {
+  const posts = await db.query.posts.findMany();
+  return new Response(JSON.stringify(posts), {
+    headers: {
+      'Cache-Control': 'public, max-age=60, stale-while-revalidate=300',
+      'Content-Type': 'application/json',
+    },
+  });
+}
+```
+
+`public, max-age=60` means "anyone may reuse this for 60 seconds." For an SSR page, you set the same idea through page metadata with `cacheControl: 'public, max-age=60'`. No framework cache layer runs here at all. You are handing the job to the standards that already ship in every browser and every CDN.
+
+# Layer 2: cache() for query results, with tags
+
+The HTTP header caches a whole response. Often you want to cache one expensive thing inside the request instead, like a database query. webjs ships a `cache()` helper for that. You wrap an async function, give it a key, and give it a time-to-live in seconds.
+
+```ts
+// modules/posts/queries/list-posts.server.ts
+'use server';
+import { cache } from '@webjsdev/server';
+import { db } from '../../../db/connection.server.ts';
+
+export const listPosts = cache(
+  async () => db.query.posts.findMany({ orderBy: { createdAt: 'desc' } }),
+  { key: 'posts', ttl: 60 }
+);
+```
+
+The first call runs the query and stores the result. Every call within the next 60 seconds returns the stored value without touching the database. Values round-trip through webjs's rich serializer, so a row's `createdAt` stays a real `Date` on a warm hit, not a string.
+
+Time-to-live handles the "eventually go stale" case. But what about "go stale the instant someone edits a post"? That is where tags come in. Tag-based invalidation means you label cached data so a write can evict exactly the entries it affected, instead of guessing or clearing everything.
+
+```ts
+export const postById = cache(
+  async (id: string) => db.query.posts.findFirst({ where: { id } }),
+  { key: 'post', ttl: 300, tags: (id) => ['post:' + id] } // per-entity tag
+);
+```
+
+Now a mutation calls `revalidateTag` after it writes, and it works across modules with no import of the query wrapper.
+
+```ts
+// modules/comments/actions/create-comment.server.ts
+'use server';
+import { revalidateTag } from '@webjsdev/server';
+
+export async function createComment(input) {
+  await db.insert(comments).values(input);
+  await revalidateTag('post:' + input.postId); // recompute just this post
+  return { success: true };
+}
+```
+
+`revalidateTag('post:5')` evicts only the id-5 entry and leaves every other id cached. That precision is the whole point. An untagged `cache()` is never touched by `revalidateTag`, so tagging is opt-in per query.
+
+# Layer 3: caching the whole page's HTML (revalidate)
+
+For a page that renders identical HTML for everyone, you can cache the finished HTML so the SSR pipeline runs once per window instead of once per request. This is webjs's no-build take on Next.js's ISR. You declare a window on the page module.
+
+```ts
+// app/blog/page.ts
+export const revalidate = 60;   // cache this page's HTML for 60 seconds
+
+export default async function Blog() {
+  const posts = await listPosts();
+  return html`...`;
+}
+```
+
+Evict it early on a write with `revalidatePath('/blog')` from a server action. Time-based eviction happens on its own when the window expires.
+
+# The safety rule you must not skip
+
+Read this part twice. `export const revalidate` is you asserting "this page is the same for every visitor for N seconds." The HTML cache is keyed by the full URL only, with no per-user keying. So a page that reads `cookies()`, a session, or any per-user data MUST NOT set `revalidate`. If it does, the first visitor's rendered HTML can be served to the next visitor. A wrongly-cached per-user page is a data leak, plain and simple.
+
+webjs backs this with a framework defense. When your render reads per-user state through a framework helper (`cookies()`, `headers()`, `getSession()`, or `auth()`), the framework auto-marks the request dynamic and refuses to cache it even if you set `revalidate`, warning you once. So a dashboard page that does `const session = await auth()` fails safe. The loud caveat: this only catches reads THROUGH those helpers. If you read an auth cookie raw instead of via `cookies()`, the page can still be cached wrongly. The rule holds regardless. Read per-user state through the helpers, or never set `revalidate` on a per-user page.
+
+# Layer 4: conditional GET (ETags and 304s)
+
+The layers above avoid recomputing. This last one avoids re-sending bytes the client already has.
+
+An ETag is a short fingerprint of a response, like a version stamp. webjs puts one on every cacheable response. The browser stores it, and on the next request it sends it back in an `If-None-Match` header, effectively asking "do you still have exactly this?" If the fingerprint still matches, the server replies `304 Not Modified` with an empty body, meaning "unchanged, reuse what you have." A tiny 304 instead of the full payload.
+
+This is on by default and needs no code. It covers cacheable SSR pages, static assets in `public/`, your app's source modules, and the core and vendor runtime uniformly. The ETag is the hash of the response body, so an identical body always produces an identical ETag.
+
+Crucially, it is careful about privacy. A `no-store` page (the default for dynamic and per-user pages) and any `private` response get no ETag and never 304, because a shared cache keyed on the URL could otherwise replay one user's validator to another. The same private-content instinct as the `revalidate` rule, applied one layer down.
+
+# Layer 5: content-hash asset URLs
+
+One more, for completeness. In production webjs appends a per-file content hash to asset URLs as `?v=<hash>` and serves those with `Cache-Control: public, max-age=31536000, immutable`. Because the hash changes whenever the file's bytes change, the browser can cache the file forever and still pick up a new version after a deploy (the URL changes, so it fetches fresh). This is a no-op in dev, so your source stays byte-identical to what you wrote.
+
+# The takeaway
+
+Recomputing or refetching the same result on every request is slow and wasteful, and webjs gives you four honest ways to stop doing it plus asset fingerprinting on top. Use `Cache-Control` to let browsers and CDNs hold whole responses, `cache()` with tags to memoize expensive queries and evict them precisely, `export const revalidate` to cache a page's HTML, and conditional GET (ETags into 304s) to skip re-sending unchanged bytes, all of it standing on plain HTTP. The one rule to internalize before you cache anything: a cache keyed by URL is shared across users, so only cache data that is truly the same for every visitor, and read per-user state through the framework helpers so webjs can fail safe for you.

--- a/blog/server-side-caching-explained.md
+++ b/blog/server-side-caching-explained.md
@@ -2,7 +2,7 @@
 title: "Server-Side Caching for Beginners (ETags, Tags, and 304s)"
 date: 2026-06-25T11:00:00+05:30
 slug: server-side-caching-explained
-description: "A beginner-friendly guide to server-side caching in webjs: HTTP Cache-Control, the cache() query helper, tag-based cache invalidation, conditional GET with ETags and HTTP 304 Not Modified, and the export const revalidate HTML cache. Plus the safety rule for per-user data."
+description: "A beginner guide to server-side caching in WebJs. Learn HTTP Cache-Control, the cache() helper, tag-based invalidation, and conditional GET with ETags and 304s."
 tags: caching, performance, etag, http, no-build
 author: Vivek
 ---

--- a/blog/ship-zero-javascript-display-only-components.md
+++ b/blog/ship-zero-javascript-display-only-components.md
@@ -1,6 +1,6 @@
 ---
 title: "How webjs Ships Zero JavaScript for Display-Only Components"
-date: 2026-07-01T11:00:00+05:30
+date: 2026-07-01T10:00:00+05:30
 slug: ship-zero-javascript-display-only-components
 description: "webjs strips the JavaScript for any component it can prove is display-only, so an islands app ships only its interactive leaves. How the elision analyser works, why it is conservative by construction, and how the invariant is enforced in code."
 tags: elision, islands, no-build, performance, web-components

--- a/blog/ship-zero-javascript-display-only-components.md
+++ b/blog/ship-zero-javascript-display-only-components.md
@@ -1,8 +1,8 @@
 ---
-title: "How webjs Ships Zero JavaScript for Display-Only Components"
+title: "How WebJs Ships Zero JavaScript for Display-Only Components"
 date: 2026-07-01T10:00:00+05:30
 slug: ship-zero-javascript-display-only-components
-description: "webjs strips the JavaScript for any component it can prove is display-only, so an islands app ships only its interactive leaves. How the elision analyser works, why it is conservative by construction, and how the invariant is enforced in code."
+description: "WebJs strips the JavaScript for any component it can prove is display-only, so an islands app ships only its interactive leaves. How the elision analyser works, why it is conservative by construction, and how the invariant is enforced in code."
 tags: elision, islands, no-build, performance, web-components
 author: Vivek
 ---
@@ -11,11 +11,11 @@ Write a `<price-tag>` component in webjs. It reads a number, formats it, renders
 
 It is not there. The framework served the component's HTML and then deleted its JavaScript from the page, because it could prove the component does the same thing with or without its script. The browser downloads nothing for it.
 
-This is elision, and it is the mechanism that lets a webjs app ship only its interactive leaves instead of its whole component tree. It landed properly in #474 and I have been sharpening it since. Here is how it works.
+This is elision, and it is the mechanism that lets a WebJs app ship only its interactive leaves instead of its whole component tree. It landed properly in #474 and I have been sharpening it since. Here is how it works.
 
 # The idea
 
-A webjs component is an isomorphic module. It runs on the server to produce SSR HTML, and it runs again in the browser to upgrade the custom element and wire up interactivity. That second run is the only reason the module ships to the client.
+A WebJs component is an isomorphic module. It runs on the server to produce SSR HTML, and it runs again in the browser to upgrade the custom element and wire up interactivity. That second run is the only reason the module ships to the client.
 
 But a lot of components have nothing to do on that second run. A badge, a formatted date, a card, a static icon. Their `render()` produces the same HTML in the browser that it already produced during SSR. Loading the module client-side re-registers the element and re-renders identical output. The download buys you nothing.
 
@@ -75,6 +75,6 @@ The other open question is how aggressive to be about the transitive cases. A co
 
 # The takeaway
 
-Islands architecture usually asks you to mark the islands. webjs inverts that. You write plain components, and the framework proves which ones are display-only and strips their JavaScript, conservatively, verified differentially, and guarded against drift by tests that fail the build. The result is that a mostly-static page ships almost no component code without you thinking about it.
+Islands architecture usually asks you to mark the islands. WebJs inverts that. You write plain components, and the framework proves which ones are display-only and strips their JavaScript, conservatively, verified differentially, and guarded against drift by tests that fail the build. The result is that a mostly-static page ships almost no component code without you thinking about it.
 
 If you are designing a system that decides what to include or exclude automatically, spend your effort on the direction of the failure, not the cleverness of the detection. Make the safe direction the default for everything ambiguous, then write the test that refuses to let the rule rot. The detection can be simple if the failure is always harmless.

--- a/blog/ship-zero-javascript-display-only-components.md
+++ b/blog/ship-zero-javascript-display-only-components.md
@@ -1,0 +1,80 @@
+---
+title: "How webjs Ships Zero JavaScript for Display-Only Components"
+date: 2026-07-01T11:00:00+05:30
+slug: ship-zero-javascript-display-only-components
+description: "webjs strips the JavaScript for any component it can prove is display-only, so an islands app ships only its interactive leaves. How the elision analyser works, why it is conservative by construction, and how the invariant is enforced in code."
+tags: elision, islands, no-build, performance, web-components
+author: Vivek
+---
+
+Write a `<price-tag>` component in webjs. It reads a number, formats it, renders some HTML. No click handler, no signal, no reactive property. Server-render a page that uses it, open the network tab, and look for `price-tag.js`.
+
+It is not there. The framework served the component's HTML and then deleted its JavaScript from the page, because it could prove the component does the same thing with or without its script. The browser downloads nothing for it.
+
+This is elision, and it is the mechanism that lets a webjs app ship only its interactive leaves instead of its whole component tree. It landed properly in #474 and I have been sharpening it since. Here is how it works.
+
+# The idea
+
+A webjs component is an isomorphic module. It runs on the server to produce SSR HTML, and it runs again in the browser to upgrade the custom element and wire up interactivity. That second run is the only reason the module ships to the client.
+
+But a lot of components have nothing to do on that second run. A badge, a formatted date, a card, a static icon. Their `render()` produces the same HTML in the browser that it already produced during SSR. Loading the module client-side re-registers the element and re-renders identical output. The download buys you nothing.
+
+So the framework does not send it. If a component is display-only, its module is dropped from the page, its import is stripped from the served source, and any vendor dependency reachable only through it is dropped from the importmap too. The HTML is the complete output. This is islands architecture, except you never mark the islands. The framework finds them.
+
+# What counts as interactive
+
+The decision is made by a static analyser in `packages/server/src/component-elision.js`. It reads the component source and looks for any signal that the component does client-side work. If it finds one, the module ships. The signals are the obvious ones:
+
+- An `@event` binding in a template (`@click=${...}`).
+- A reactive property that is not `{ state: true }` (it rides an HTML attribute, so the browser can change it).
+- A read of a `signal()` or `computed()`, or an import of one.
+- An overridden lifecycle hook (`connectedCallback`, `firstUpdated`, and the rest).
+- A `<slot>`, or `static shadow = true` (Declarative Shadow DOM has to re-attach on a client-side DOM insertion).
+- Any code that runs at module load: a top-level call, a `new WebSocket(...)`, a `setTimeout`, a browser global.
+- A transitively-reachable interactive child.
+
+If none of those are present, the component is display-only and gets elided. If any are, it ships.
+
+# The direction that matters
+
+The interesting property is not the list. It is which way the analyser errs when it is unsure.
+
+There are two ways to be wrong. The analyser can decide a component is interactive when it is actually display-only, or it can decide a component is display-only when it is actually interactive. These failures are not symmetric.
+
+A false "interactive" verdict costs one thing: a module download the browser did not strictly need. The page still works. It is a missed optimization, and the module was cached and shared anyway.
+
+A false "display-only" verdict breaks the page. An interactive component never boots, its click handler never binds, and the user clicks a dead button. Worse, it is silent. The SSR HTML looks right, so nothing crashes. It just does not work.
+
+So every ambiguity resolves to "ship." The analyser is a denylist of interactivity signals, and anything it cannot recognise or parse ships by default. An unreadable file ships. A static field it cannot evaluate ships. A class body it cannot fully parse ships. The header comment in the file states this as the rule, and every branch honours it. Over-shipping is the safe failure, so the framework chooses it every time it is not certain.
+
+# Proving it is actually safe
+
+A conservative rule is only as good as its enforcement. Two things keep elision honest.
+
+The first is differential verification. A test renders a page with elision on and with elision off, and asserts the SSR HTML is byte-identical. If eliding a module ever changed the first paint, that test reds. The whole promise of elision is that the served HTML is the same either way, so the test checks exactly that promise.
+
+The second is that the analyser's signal lists cannot silently fall behind the framework. A denylist is dangerous precisely because it is a maintenance burden: every time someone adds a new way for a component to be interactive, they have to teach the analyser about it, or a component using only that new mechanism gets silently over-elided. That is the one failure mode that would actually break pages.
+
+So the lists are guarded mechanically. `lifecycle-coverage.test.js` introspects the live `WebComponent` prototype and fails the build if a new public method or hook is added without being classified in the analyser. And after a recent change (#785), `sigil-coverage.test.js` does the same for the two surfaces that are not prototype methods: the template binding sigils (`@`, `.`, `?`) and the interactivity static fields. The binding sigils are single-sourced in core, and the guard asserts the analyser classifies every one of them as either a client-behaviour ship signal (like `@event`, which drops at SSR) or an SSR-safe round-trip (like `.prop` and `?bool`, which survive into the served HTML). Add a fourth sigil to the renderer without classifying it, and the build goes red before it can ship a bug.
+
+The point is that the safety is not "we were careful." It is "the test suite refuses to let the analyser drift." Careful is not a property you can rely on across a growing codebase written partly by agents. A failing build is.
+
+# What it looks like on a real app
+
+A content-heavy page is the best case. A blog post is a layout, a page, a header, a formatted date, a code block, a card grid, and maybe one interactive thing like a theme toggle or a comment box. Everything except that one interactive thing is display-only. So the browser fetches the core runtime once (cached and shared across the whole app), the theme toggle's module, and nothing else. The twelve display-only components contribute zero bytes of component JavaScript.
+
+You did not annotate anything. You did not write `"use client"` on the interactive one or `"use server"` on the rest. You wrote components, and the framework worked out which ones need to run in the browser.
+
+You can turn it off. Set `"webjs": { "elide": false }` in the config, or `WEBJS_ELIDE=0` in the environment, and every component module ships. That is the escape hatch for the rare case where the analyser is too conservative for your taste or you are debugging a hydration issue and want everything loaded. In practice I have not needed it.
+
+# What I am still figuring out
+
+The denylist completeness is the load-bearing assumption, and the guard tests cover the surfaces that are enumerable: prototype methods, exported reactive primitives, binding sigils, static conventions. What they cannot mechanically cover is a genuinely new KIND of interactivity surface that is none of those, for example a brand-new template syntax. Adding one is a rare, deliberate, reviewed change that touches the renderer anyway, so a human is already in the right neighbourhood. But it is the one spot where the enforcement is a documented contract rather than a failing build, and I would like to close even that eventually.
+
+The other open question is how aggressive to be about the transitive cases. A component shared between a display-only page and an interactive one has to ship, because one of its two users needs it. The analyser gets this right by shipping it, but "right" here still means the display-only page pays for a module it does not use on its own. The conservative direction protects correctness, and it occasionally costs a fetch. I am comfortable with that trade, because the alternative direction breaks pages, but it is the place where elision leaves value on the table.
+
+# The takeaway
+
+Islands architecture usually asks you to mark the islands. webjs inverts that. You write plain components, and the framework proves which ones are display-only and strips their JavaScript, conservatively, verified differentially, and guarded against drift by tests that fail the build. The result is that a mostly-static page ships almost no component code without you thinking about it.
+
+If you are designing a system that decides what to include or exclude automatically, spend your effort on the direction of the failure, not the cleverness of the detection. Make the safe direction the default for everything ambiguous, then write the test that refuses to let the rule rot. The detection can be simple if the failure is always harmless.

--- a/blog/signals-replaced-setstate.md
+++ b/blog/signals-replaced-setstate.md
@@ -1,5 +1,5 @@
 ---
-title: "Signals replaced setState across the stack"
+title: "TC39 Signals vs setState in Web Components"
 date: 2026-05-21T16:57:26+05:30
 slug: signals-replaced-setstate
 description: "Why webjs deleted its setState/this.state API and went all-in on TC39 Stage 1 Signals. What it broke, what shipped instead, and the breaking-change recipe."

--- a/blog/signals-replaced-setstate.md
+++ b/blog/signals-replaced-setstate.md
@@ -7,7 +7,9 @@ tags: signals, reactive, breaking-change, components
 author: Vivek
 ---
 
-The most disruptive change to WebJs since launch was the signals migration, in commit `6e50ae6` (PR #43). It removed an entire framework-custom API surface. Every component using `this.state` or `this.setState({ ... })` had to be rewritten. I would not normally take a swing this big.
+If you have written React, you know the ritual. You call `setState` (or a `useState` setter), and the component re-renders. WebJs used to work the same way, with `this.state` and `this.setState({ ... })`. Then it deleted that whole API and replaced it with signals (wrapped values you read with `.get()` and write with `.set()`, and the UI updates itself). Here is why I made that call, what it broke, and how the migration went.
+
+The most disruptive change to WebJs since launch was that signals migration, in commit `6e50ae6` (PR #43). It removed an entire framework-custom API surface. Every component using `this.state` or `this.setState({ ... })` had to be rewritten. I would not normally take a swing this big.
 
 I did it anyway because the platform is shipping signals, and building a custom reactivity model that we would have to migrate away from later was paying technical debt twice.
 
@@ -39,7 +41,7 @@ const doubled = computed(() => count.get() * 2);
 count.set(count.get() + 1);
 ```
 
-The implementation lives in `packages/core/src/signal.js`. It is a hand-rolled push-pull hybrid that matches the [TC39 Signals proposal](https://github.com/tc39/proposal-signals) Stage 1 shape, including `Signal.subtle.untrack`, `Signal.State`, `Signal.Computed`, and the `Watcher` class. When the proposal lands in browsers, the WebJs `signal()` is intended to become a one-line re-export of `globalThis.Signal.State`.
+The implementation lives in `packages/core/src/signal.js`. It is a hand-rolled push-pull hybrid that matches the [TC39 Signals proposal](https://github.com/tc39/proposal-signals) (TC39 is the committee that standardizes JavaScript) Stage 1 shape, including `Signal.subtle.untrack`, `Signal.State`, `Signal.Computed`, and the `Watcher` class. When the proposal lands in browsers, the WebJs `signal()` is intended to become a one-line re-export of `globalThis.Signal.State`.
 
 The algorithm is what the spec-shaped signal-polyfill uses. Each producer (State or Computed) carries a `version` that bumps when the value actually changes (`Object.is` comparison). Consumers record the version they saw at read time. On the next read, the consumer polls each producer's version: same number means no recompute needed. This is what makes diamond dependencies glitch-free and memoizes the common case where a computed's output is unchanged.
 
@@ -84,7 +86,7 @@ class Counter extends WebComponent {
 
 When `count.set(...)` fires, only the text inside the `<p>` updates. No `render()` invocation, no lifecycle hooks, no diff over the rest of the template. The directive owns a per-part `Signal.subtle.Watcher` that maintains the subscription.
 
-SSR inlines the signal's current value once. Subscription is a client-only concern.
+SSR (server-side rendering) inlines the signal's current value once. Subscription is a client-only concern.
 
 
 # What the migration looked like in the framework's own code

--- a/blog/signals-replaced-setstate.md
+++ b/blog/signals-replaced-setstate.md
@@ -2,12 +2,12 @@
 title: "TC39 Signals vs setState in Web Components"
 date: 2026-05-21T16:57:26+05:30
 slug: signals-replaced-setstate
-description: "Why webjs deleted its setState/this.state API and went all-in on TC39 Stage 1 Signals. What it broke, what shipped instead, and the breaking-change recipe."
+description: "Why WebJs deleted its setState/this.state API and went all-in on TC39 Stage 1 Signals. What it broke, what shipped instead, and the breaking-change recipe."
 tags: signals, reactive, breaking-change, components
 author: Vivek
 ---
 
-The most disruptive change to webjs since launch was the signals migration, in commit `6e50ae6` (PR #43). It removed an entire framework-custom API surface. Every component using `this.state` or `this.setState({ ... })` had to be rewritten. I would not normally take a swing this big.
+The most disruptive change to WebJs since launch was the signals migration, in commit `6e50ae6` (PR #43). It removed an entire framework-custom API surface. Every component using `this.state` or `this.setState({ ... })` had to be rewritten. I would not normally take a swing this big.
 
 I did it anyway because the platform is shipping signals, and building a custom reactivity model that we would have to migrate away from later was paying technical debt twice.
 
@@ -39,7 +39,7 @@ const doubled = computed(() => count.get() * 2);
 count.set(count.get() + 1);
 ```
 
-The implementation lives in `packages/core/src/signal.js`. It is a hand-rolled push-pull hybrid that matches the [TC39 Signals proposal](https://github.com/tc39/proposal-signals) Stage 1 shape, including `Signal.subtle.untrack`, `Signal.State`, `Signal.Computed`, and the `Watcher` class. When the proposal lands in browsers, the webjs `signal()` is intended to become a one-line re-export of `globalThis.Signal.State`.
+The implementation lives in `packages/core/src/signal.js`. It is a hand-rolled push-pull hybrid that matches the [TC39 Signals proposal](https://github.com/tc39/proposal-signals) Stage 1 shape, including `Signal.subtle.untrack`, `Signal.State`, `Signal.Computed`, and the `Watcher` class. When the proposal lands in browsers, the WebJs `signal()` is intended to become a one-line re-export of `globalThis.Signal.State`.
 
 The algorithm is what the spec-shaped signal-polyfill uses. Each producer (State or Computed) carries a `version` that bumps when the value actually changes (`Object.is` comparison). Consumers record the version they saw at read time. On the next read, the consumer polls each producer's version: same number means no recompute needed. This is what makes diamond dependencies glitch-free and memoizes the common case where a computed's output is unchanged.
 
@@ -151,6 +151,6 @@ Two things stand out.
 
 The first is that the SignalWatcher trick (auto-subscribe inside render, auto-cleanup on disconnect) was the missing piece that made signals feel as ergonomic as the React-style setState. Without it, every component would have to manually create an effect that calls `requestUpdate`. With it, you just read the signal in render and the framework handles the wiring. That part is at the top of `component.js`'s update path.
 
-The second is that platform-tracking pays. The TC39 proposal was Stage 1 when this work landed. It is still Stage 1. But the shape has not changed in the relevant ways. The signal-polyfill that the proposal authors maintain is what webjs's algorithm mirrors. When the proposal lands in V8, our `signal.js` shrinks to a re-export and every user keeps working.
+The second is that platform-tracking pays. The TC39 proposal was Stage 1 when this work landed. It is still Stage 1. But the shape has not changed in the relevant ways. The signal-polyfill that the proposal authors maintain is what WebJs's algorithm mirrors. When the proposal lands in V8, our `signal.js` shrinks to a re-export and every user keeps working.
 
-The breaking change was worth it. We carry one API now, not two. The agent does not have to model both setState's behavior and signal's behavior, just one. And when someone asks "what is the reactivity primitive in webjs?" the answer is "signals, the TC39 shape." Anyone who has read about the proposal already knows how it works.
+The breaking change was worth it. We carry one API now, not two. The agent does not have to model both setState's behavior and signal's behavior, just one. And when someone asks "what is the reactivity primitive in WebJs?" the answer is "signals, the TC39 shape." Anyone who has read about the proposal already knows how it works.

--- a/blog/stop-ai-agents-breaking-your-code.md
+++ b/blog/stop-ai-agents-breaking-your-code.md
@@ -1,6 +1,6 @@
 ---
 title: "How WebJs Stops AI Coding Agents From Breaking Your Code"
-date: 2026-06-30T10:00:00+05:30
+date: 2026-06-29T10:00:00+05:30
 slug: stop-ai-agents-breaking-your-code
 description: "AI coding agents write a lot of your code now, and left unsupervised they commit to main, skip tests, and ignore your conventions. WebJs is an AI-first framework that bakes agent guardrails into tooling, so drift gets caught at the seam instead of buried in a doc nobody reads."
 tags: ai-first, ai-agents, guardrails, tooling, dx

--- a/blog/stop-ai-agents-breaking-your-code.md
+++ b/blog/stop-ai-agents-breaking-your-code.md
@@ -1,0 +1,99 @@
+---
+title: "How WebJs Stops AI Coding Agents From Breaking Your Code"
+date: 2026-06-30T10:00:00+05:30
+slug: stop-ai-agents-breaking-your-code
+description: "AI coding agents write a lot of your code now, and left unsupervised they commit to main, skip tests, and ignore your conventions. WebJs is an AI-first framework that bakes agent guardrails into tooling, so drift gets caught at the seam instead of buried in a doc nobody reads."
+tags: ai-first, ai-agents, guardrails, tooling, dx
+author: Vivek
+---
+
+If you build software in 2026, an AI agent writes a good chunk of your code. Claude Code, Cursor, Copilot, Antigravity, Aider. You describe a feature, the agent produces files, you skim and accept. It is genuinely fast.
+
+It is also, left to its own devices, a little reckless. An agent will happily commit straight to `main`. It will ship a feature with no test, because the feature "works". It will drop a helper in the wrong directory because it did not read your project layout. It will confidently add a bundler config to a framework that has no build step. None of this is malice. The agent is doing what its training data suggests, and your project's rules live in a `CONTRIBUTING.md` it never opened.
+
+I wrote about the philosophy of this in an earlier post ("AI-first is plumbing, not a marketing tag"). This post is the concrete version. Here is exactly how WebJs stops an agent from breaking your code, mechanism by mechanism. Every piece below is real and ships in the scaffold.
+
+# The rules go where the agent will actually read them
+
+An agent reads whichever instruction file matches its tool. So WebJs ships all of them, and they all say the same thing.
+
+```
+AGENTS.md                        the contract (source of truth)
+CONVENTIONS.md                   project conventions, overridable
+CLAUDE.md                        Claude Code (imports AGENTS.md)
+.cursorrules                     Cursor
+.agents/rules/workflow.md        Antigravity
+.github/copilot-instructions.md  GitHub Copilot
+```
+
+Plus a `.claude/settings.json` wiring up hooks, a PR template, and an `.editorconfig`. The point is not the file count. The point is that whichever agent you happen to be driving, it lands in the project and finds the same conventions in its own native format. There is no "the agent didn't know" excuse, because the knowledge is in the file the agent reads first.
+
+But a document is advisory. An agent can read a rule and still forget it three tool-calls later. That is why the load-bearing enforcement is not the docs. It is the hooks.
+
+# Hooks that block bad commits and bad prompts
+
+Claude Code fires shell hooks on tool events (before an edit, before a Bash command, after a write, on every prompt). WebJs ships a set of them under `.claude/hooks/`, and they turn "please follow the rules" into "you literally cannot do that". Here is what each one does, verified against the scripts themselves.
+
+`guard-branch-context.sh` runs before any edit. If you are on `main` or `master`, it pauses and asks you to create a feature branch first (`git checkout -b feature/<name>`) before it lets the edit through. No more accidental direct-to-main commits from an agent that skipped the git etiquette.
+
+`require-tests-with-src.sh` runs before `git commit`. It inspects the staged diff, and if you staged framework source with no accompanying test file, it stops the commit and names the layers you might need (unit, browser, e2e, smoke, Bun). It even catches the sneaky failure mode where an agent trims tests to make the suite pass. It counts staged test lines, and a net-negative count next to a source change gets blocked as "tests removed to slip through". In the framework repo this hook blocks; in a scaffolded app it warns by default (set `WEBJS_TEST_GATE=block` to make it hard).
+
+`require-docs-with-src.sh` is the documentation twin. Change a public-facing surface and stage no doc update, and the commit is blocked until you bring a doc surface along. This exists because the recurring failure was updating one surface and leaving the rest stale.
+
+`require-bun-parity-with-runtime-src.sh` guards the fact that WebJs runs on Node 24+ and Bun. Touch a runtime-sensitive file (the serializer, the listener, streams, crypto) with no cross-runtime test staged, and it blocks until you prove the change on both runtimes.
+
+`route-skills.sh` runs on every prompt. A "skill" is a scripted workflow the agent is supposed to invoke, but a model only invokes it when it judges the prompt to match, and that judgement is wobbly. This hook keyword-matches your prompt against each skill's triggers and injects a directive telling the agent to run the matching skill first. It makes routing deterministic instead of hoping the model notices.
+
+`nudge-uncommitted.sh` is the gentle one. After enough edits pile up (four by default), it reminds the agent to commit the current logical unit before sprawling further. Soft, does not block, just keeps the history clean.
+
+`block-prose-punctuation.sh` enforces the writing style, and it is the reason this very post reads the way it does. It blocks em-dashes and a few other patterns in any new content the agent writes. I am composing this under that hook right now, which is why you will not find a single em-dash anywhere above or below.
+
+The theme across all of them is the same. The rule is enforced at the exact seam where the mistake happens (the commit, the edit, the prompt), not in a paragraph the agent skimmed once.
+
+# One task, one git worktree
+
+Here is a subtle one that only bites when more than one agent works the repo at once. Two agents sharing a single checkout collide. A `git checkout` in one moves `HEAD` under the other, so the next commit from the second agent lands on the wrong branch.
+
+This is not hypothetical. It happened to me. A `chore: release` commit landed on an unrelated `feat/` branch, dragging a contaminated changelog with it, because one agent switched branches while another was mid-commit.
+
+The fix is boring and total. One task gets one git worktree.
+
+```sh
+git worktree add -b feature/my-task ../repo-my-task origin/main
+cd ../repo-my-task    # all work for this task happens here
+```
+
+Git enforces one branch per worktree, so two agents in two worktrees physically cannot move each other's `HEAD`. The collision becomes impossible rather than merely discouraged. AGENTS.md documents this as the standing rule for any concurrent work.
+
+# The webjs check command runs correctness rules, and never optionally
+
+WebJs draws a hard line between two kinds of rules, and keeping them separate is what makes each one trustworthy.
+
+`CONVENTIONS.md` holds project conventions. Where actions live, one function per file, how features are tested. These are preferences a reasonable project could do differently, so they are guidance you can customize.
+
+`webjs check` is the other kind. It runs correctness-only rules, the things that are wrong to ship. Code that crashes in production, a server secret leaking into a browser bundle, TypeScript that will not strip, a shell written in a non-root layout. These run unconditionally with no per-project disabling, because the answer to "could a sensible app want this to pass?" is no.
+
+```sh
+webjs check           # report violations
+webjs check --rules   # list every rule
+```
+
+The rules are the concrete failure modes an agent trips over. A few real ones:
+
+- `use-server-needs-extension`, a `'use server'` directive requires a `.server.{js,ts}` filename, so server code cannot leak through a plain module.
+- `no-static-properties`, reactive properties are declared through the `WebComponent({ ... })` factory, not a hand-written `static properties` block that would throw at runtime.
+- `erasable-typescript-only`, the tsconfig must keep types strippable, because WebJs has no bundler to fall back on.
+- `shell-in-non-root-layout`, only the root layout may write `<!doctype>` / `<html>` / `<head>` / `<body>`.
+- `light-dom-css-prefix`, a light-DOM component with custom CSS prefixes every selector with its tag name.
+
+An agent runs `webjs check`, reads concrete violation messages, and fixes them before the code is anywhere near a review. The narrowness is deliberate. It is a short list of "this will break", not a hundred style opinions, so a green check actually means something.
+
+# The scaffold placeholder that refuses to ship
+
+One more small guard I like. When you scaffold an app, the example content (a demo page, a `User` model, a starter component) carries a `webjs-scaffold-placeholder` marker. The `no-scaffold-placeholder` rule fails until you replace that content and delete the marker.
+
+It exists because an agent will otherwise treat the scaffold as the finished product and ship the example todo app as if it were your feature. The sentinel forces the agent to actually build the thing you asked for, not decorate the demo.
+
+# The takeaway
+
+AI agents are fast and a little careless, and a framework built in 2026 has to plan for that. WebJs does it by moving the rules out of prose and into tooling, so an agent that skips the docs still cannot commit to main, ship untested source, drift the docs, or collide with another agent. The guardrails are dull on purpose (a few shell hooks, a correctness linter, one worktree per task), and dull is the point, because they catch mistakes at the seam where they happen instead of in a review three days later. If you want to see them work, scaffold an app with `npm create webjs@latest my-app` and watch your agent get corrected in real time. The friction you feel is the framework doing its job.

--- a/blog/stop-ai-agents-breaking-your-code.md
+++ b/blog/stop-ai-agents-breaking-your-code.md
@@ -2,7 +2,7 @@
 title: "How WebJs Stops AI Coding Agents From Breaking Your Code"
 date: 2026-06-29T10:00:00+05:30
 slug: stop-ai-agents-breaking-your-code
-description: "AI coding agents write a lot of your code now, and left unsupervised they commit to main, skip tests, and ignore your conventions. WebJs is an AI-first framework that bakes agent guardrails into tooling, so drift gets caught at the seam instead of buried in a doc nobody reads."
+description: "AI coding agents commit to main, skip tests, and ignore your conventions. WebJs is an AI-first framework that bakes those guardrails into tooling so drift is caught early."
 tags: ai-first, ai-agents, guardrails, tooling, dx
 author: Vivek
 ---

--- a/blog/streaming-server-actions-llm.md
+++ b/blog/streaming-server-actions-llm.md
@@ -1,0 +1,114 @@
+---
+title: "How to Stream AI Responses From a Server Action"
+date: 2026-06-06T14:00:00+05:30
+slug: streaming-server-actions-llm
+description: "How to stream an LLM response token by token in WebJs by returning an async generator from a server action. Streaming server actions push each AI token over one RPC response, no WebSockets, no SSE, no hand-written ReadableStream plumbing."
+tags: server-actions, streaming, llm, ai, rpc
+author: Vivek
+---
+
+You have seen the effect. You ask ChatGPT a question and the answer appears word by word, like someone typing on the other end. The alternative is a spinner that sits there for eight seconds and then dumps a wall of text at once. The word-by-word version feels alive. The spinner feels broken.
+
+The catch is that the streaming version usually costs you a lot of plumbing. You reach for WebSockets, or for Server-Sent Events (a one-way stream of text from server to browser), and now you are wiring up a channel, parsing frames on the client, and handling reconnects. That is a lot of ceremony for "show the text as it arrives."
+
+In WebJs you do not write any of that. A server action can return an async generator (a function that `yield`s values over time instead of returning once), and WebJs streams each yielded chunk to the caller over the single RPC response. The call site reads them with a plain `for await` loop. That is the whole feature (#489). Let me show you.
+
+# The action: yield tokens instead of returning a string
+
+A server action is any exported async function in a `*.server.ts` file marked `'use server'`. Normally it returns a value and WebJs round-trips that value back to the caller. The new part is that if you return something streamable (a `ReadableStream`, an async iterable, or an async generator), WebJs streams the pieces instead of buffering the whole thing.
+
+Here is an action that calls an LLM SDK and yields tokens as they come off the model:
+
+```ts
+// modules/chat/actions/stream-answer.server.ts
+'use server';
+import { actionSignal } from '@webjsdev/server';
+import { openai } from '../../../lib/llm.server.ts';
+
+export async function* streamAnswer(prompt: string) {
+  const signal = actionSignal();
+  const completion = await openai.chat.completions.create({
+    model: 'gpt-4o-mini',
+    messages: [{ role: 'user', content: prompt }],
+    stream: true,
+  }, { signal });
+
+  for await (const part of completion) {
+    const token = part.choices[0]?.delta?.content;
+    if (token) yield token;
+  }
+}
+```
+
+The `async function*` syntax (note the asterisk) is a generator. Every `yield token` hands one piece back to whoever is looping over the call. WebJs serializes each yielded value and flushes it down the response as it is produced, so the browser sees token one while the model is still working on token fifty.
+
+Detection is purely on the return value. There is no config export to set, no `export const stream = true`. You return an async generator, you get streaming.
+
+# The call site: a normal import and a `for await` loop
+
+You never hand-write a `fetch`. When a client component imports `streamAnswer`, WebJs rewrites that import into a typed RPC stub that POSTs to the action endpoint under the hood. The import looks like any other import, and the types flow across the network boundary intact.
+
+Because the action streams, awaiting the stub gives you an async iterable. You loop over it:
+
+```ts
+// modules/chat/components/answer-box.ts
+import { html, WebComponent, signal } from '@webjsdev/core';
+import { streamAnswer } from '../actions/stream-answer.server.ts';
+
+class AnswerBox extends WebComponent({ prompt: String }) {
+  #text = signal('');
+
+  async ask() {
+    this.#text.set('');
+    for await (const token of await streamAnswer(this.prompt)) {
+      this.#text.set(this.#text.get() + token);
+    }
+  }
+
+  render() {
+    return html`
+      <button @click=${() => this.ask()}>Ask</button>
+      <p>${this.#text.get()}</p>
+    `;
+  }
+}
+AnswerBox.register('answer-box');
+```
+
+Each token appends to a signal (WebJs's default reactive state primitive), and the built-in watcher re-renders the paragraph on every change. The text grows on screen exactly the way you wanted, one token at a time, and the transport is one HTTP response you never had to think about.
+
+# Back-pressure comes for free
+
+Back-pressure is the mechanism that stops a fast producer from overwhelming a slow consumer. If the model emits tokens faster than the browser can read them, you do not want the server to buffer the entire completion in memory.
+
+WebJs respects back-pressure on the stream. The generator only advances as the response is drained, so a slow client naturally slows the producer instead of ballooning server memory. You get this without writing a single line for it.
+
+# Cancellation is wired end to end
+
+The other half of streaming is stopping. A user closes the tab halfway through a long answer. You do not want the server to keep paying an LLM to generate tokens nobody will read.
+
+WebJs handles this on both sides (#492).
+
+On the server, an action reads the request's `AbortSignal` through `actionSignal()` from `@webjsdev/server`. That is the `signal` I passed to the OpenAI SDK above. When the client disconnects, the signal aborts, the SDK call stops, and the generator is cancelled. (Called outside an action, `actionSignal()` returns a signal that never aborts, so a plain server-to-server call is always safe.)
+
+On the client, a superseded render aborts the previous request automatically. If your component re-renders with a new prompt while an older `streamAnswer` call is still streaming, WebJs aborts the old in-flight fetch rather than leaking it. Each render gets its own `AbortController`, and the RPC stub binds every fetch to it. You do not manage any of this.
+
+# What streaming turns off, and one thing to know
+
+A streamed result is deliberately never cached, never ETagged, and never seeded into the SSR payload. That makes sense: a live token stream is not a static value you can freeze and replay. If the action is a mutation (a POST, PUT, PATCH, or DELETE), it still emits its `X-Webjs-Invalidate` header on completion so the client cache coordinator knows to revalidate related reads.
+
+Errors are the one thing to keep in mind. Because streaming starts the moment the first byte flushes, the HTTP status is already `200` by the time an error can happen mid-stream. So a throw does not become a `500`. It surfaces as an error from the iterable itself, which means your `for await` loop will throw and you can wrap it in a `try/catch`. In production the message is sanitized to the author-facing text, the same rule that governs every WebJs server action error.
+
+```ts
+try {
+  for await (const token of await streamAnswer(this.prompt)) {
+    this.#text.set(this.#text.get() + token);
+  }
+} catch (err) {
+  this.#text.set('Something went wrong. Please try again.');
+}
+```
+
+# The takeaway
+
+Streaming an AI response used to mean standing up a WebSocket or an SSE endpoint and parsing frames by hand. In WebJs you return an async generator from a `'use server'` action, `yield` each token, and consume it with a `for await` loop on a normal import that WebJs turns into a typed RPC stub. Back-pressure is respected, cancellation is wired through `actionSignal()` on the server and an automatic abort on the client, and a mid-stream error surfaces as a throw from the iterable rather than a broken status code. It is the same mechanism you already use for every server action, so streaming LLM tokens is not a new subsystem to learn. It is one keyword: `yield`.

--- a/blog/streaming-server-actions-llm.md
+++ b/blog/streaming-server-actions-llm.md
@@ -1,6 +1,6 @@
 ---
 title: "How to Stream AI Responses From a Server Action"
-date: 2026-06-06T14:00:00+05:30
+date: 2026-05-31T14:00:00+05:30
 slug: streaming-server-actions-llm
 description: "How to stream an LLM response token by token in WebJs by returning an async generator from a server action. Streaming server actions push each AI token over one RPC response, no WebSockets, no SSE, no hand-written ReadableStream plumbing."
 tags: server-actions, streaming, llm, ai, rpc

--- a/blog/strip-types-not-esbuild.md
+++ b/blog/strip-types-not-esbuild.md
@@ -2,12 +2,12 @@
 title: "Buildless TypeScript: Strip Types, Not esbuild"
 date: 2026-01-12T09:30:00+05:30
 slug: strip-types-not-esbuild
-description: "Why webjs serves TypeScript by stripping types at runtime with Node 24's built-in module.stripTypeScriptTypes instead of esbuild, and how the buildless dev-server cache works."
+description: "Why WebJs serves TypeScript by stripping types at runtime with Node 24's built-in module.stripTypeScriptTypes instead of esbuild, and how the buildless dev-server cache works."
 tags: typescript, no-build, runtime, performance
 author: Vivek
 ---
 
-For the early months of webjs, every `.ts` file in your project went through esbuild before it reached the browser. esbuild is fast (about 1ms per file on warm cache), and we ran it as an ESM loader hook so the server-side and the client-bound transforms shared one code path. It worked.
+For the early months of WebJs, every `.ts` file in your project went through esbuild before it reached the browser. esbuild is fast (about 1ms per file on warm cache), and we ran it as an ESM loader hook so the server-side and the client-bound transforms shared one code path. It worked.
 
 It worked, but it produced sourcemaps. And the sourcemaps were the thing that kept biting me.
 
@@ -42,7 +42,7 @@ What it gets you:
 
 The catch: the stripper only supports erasable TypeScript. `enum`, `namespace` with values, constructor parameter properties, legacy decorators with `emitDecoratorMetadata`, and `import = require` are all rejected. The TypeScript team added `erasableSyntaxOnly: true` in `tsconfig.json` to make the editor flag those at edit time.
 
-webjs's scaffolded `tsconfig.json` turns the flag on by default. If you write `enum Status { ... }` in a webjs project, your editor underlines it and the framework's `webjs check` lint catches it before commit. We made the trade: less TypeScript surface area, no sourcemap layer, smaller wire bytes, exact stack traces.
+WebJs's scaffolded `tsconfig.json` turns the flag on by default. If you write `enum Status { ... }` in a WebJs project, your editor underlines it and the framework's `webjs check` lint catches it before commit. We made the trade: less TypeScript surface area, no sourcemap layer, smaller wire bytes, exact stack traces.
 
 
 # The migration
@@ -84,9 +84,9 @@ The other limit: the agent has to know about `erasableSyntaxOnly`. When it reach
 
 # What changed in the user-facing story
 
-For someone writing a webjs app today: nothing visible. The `.ts` file you write is the file that runs. There is no build step to remember, no sourcemap to chase. Stack traces point at the file you opened. The TypeScript you write must be erasable, but the editor flags non-erasable syntax at edit time so you never get surprised in production.
+For someone writing a WebJs app today: nothing visible. The `.ts` file you write is the file that runs. There is no build step to remember, no sourcemap to chase. Stack traces point at the file you opened. The TypeScript you write must be erasable, but the editor flags non-erasable syntax at edit time so you never get surprised in production.
 
-For someone debugging a webjs app today: noticeably better. Open DevTools. Hit a breakpoint at `app/components/foo.ts:42`. Open the same file in your editor. Same line. Same column. No translation layer in the way.
+For someone debugging a WebJs app today: noticeably better. Open DevTools. Hit a breakpoint at `app/components/foo.ts:42`. Open the same file in your editor. Same line. Same column. No translation layer in the way.
 
 That is the whole pitch for this PR. A new Node version shipped a feature that obviated 80% of what our build step did. We removed the build step. The rest is downstream cleanup.
 

--- a/blog/strip-types-not-esbuild.md
+++ b/blog/strip-types-not-esbuild.md
@@ -2,14 +2,14 @@
 title: "Buildless TypeScript: Strip Types, Not esbuild"
 date: 2026-01-12T09:30:00+05:30
 slug: strip-types-not-esbuild
-description: "Why WebJs serves TypeScript by stripping types at runtime with Node 24's built-in module.stripTypeScriptTypes instead of esbuild, and how the buildless dev-server cache works."
+description: "How WebJs serves buildless TypeScript by stripping types at runtime with Node 24's module.stripTypeScriptTypes instead of esbuild, with no sourcemaps needed."
 tags: typescript, no-build, runtime, performance
 author: Vivek
 ---
 
-For the early months of WebJs, every `.ts` file in your project went through esbuild before it reached the browser. esbuild is fast (about 1ms per file on warm cache), and we ran it as an ESM loader hook so the server-side and the client-bound transforms shared one code path. It worked.
+You write a `.ts` file, and it runs. No build step, no bundler warming up, no generated output to chase when a stack trace lands somewhere you did not write. That is what a WebJs app feels like today, and it took some work to get here. For the early months of WebJs, every `.ts` file in your project went through esbuild (a fast JavaScript and TypeScript build tool) before it reached the browser. esbuild is fast (about 1ms per file on warm cache), and we ran it as an ESM loader hook so the server-side and the client-bound transforms shared one code path. It worked.
 
-It worked, but it produced sourcemaps. And the sourcemaps were the thing that kept biting me.
+It worked, but it produced sourcemaps (files that map the generated code back to the source you wrote). And the sourcemaps were the thing that kept biting me.
 
 
 # What the sourcemap layer cost
@@ -68,7 +68,7 @@ A few things got simpler once we stopped emitting sourcemaps.
 
 The HTTP layer no longer had to negotiate content types or worry about source-content delivery. Every `.ts` response is just JS bytes with the type annotations whitespace-erased.
 
-The 103 Early Hints flow got cleaner. We emit `<link rel="modulepreload">` headers before SSR begins. The preload references the canonical URL with the `.ts` extension. The browser fetches that URL, gets stripped JS back, runs it. No content-type fight.
+The 103 Early Hints flow got cleaner. We emit `<link rel="modulepreload">` headers before SSR (server-side rendering) begins. The preload references the canonical URL with the `.ts` extension. The browser fetches that URL, gets stripped JS back, runs it. No content-type fight.
 
 The dev-mode live reload got cheaper. The watcher signals "file changed at this path." The cache evicts that entry by mtime mismatch. The next browser fetch returns the freshly-stripped output. Total work per change: stat the file, strip the bytes, write to the cache.
 

--- a/blog/strip-types-not-esbuild.md
+++ b/blog/strip-types-not-esbuild.md
@@ -1,8 +1,8 @@
 ---
-title: "Strip types, not esbuild"
+title: "Buildless TypeScript: Strip Types, Not esbuild"
 date: 2026-01-12T09:30:00+05:30
 slug: strip-types-not-esbuild
-description: "Why webjs switched from esbuild type-stripping to Node 24's built-in module.stripTypeScriptTypes, and what the dev-server cache looks like now."
+description: "Why webjs serves TypeScript by stripping types at runtime with Node 24's built-in module.stripTypeScriptTypes instead of esbuild, and how the buildless dev-server cache works."
 tags: typescript, no-build, runtime, performance
 author: Vivek
 ---

--- a/blog/the-naming-saga.md
+++ b/blog/the-naming-saga.md
@@ -1,11 +1,13 @@
 ---
-title: "The npm naming saga (wjs, webjscli, and how we ended up at webjsdev)"
+title: "Publishing an npm Package: The Naming Saga (wjs, webjscli, and how we ended up at webjsdev)"
 date: 2026-05-22T20:00:00+05:30
 slug: the-naming-saga
-description: "How an attempt to publish a short CLI alias on npm turned into a tour of the typosquatting filter, the create-* convention, and what we shipped instead."
+description: "Publishing an npm package taught me how the typosquatting similarity filter blocks names like wjs and webjscli, plus the create-* convention and what we shipped."
 tags: npm, packages, scaffold, naming
 author: Vivek
 ---
+
+Publishing a package on npm sounds like a single command. Then the registry rejects your chosen name for being "too similar" to a package you have never heard of, and a quick two-package afternoon turns into an hour of rolling releases back and forth. This is that story.
 
 The plan was simple. Ship `npx create-webjs-app@latest my-app` as the homepage hero. Ship a short `wjs` alias for the CLI so people who installed it globally would not have to type `webjs` everywhere. Two packages, one PR, done.
 
@@ -31,7 +33,7 @@ npm error 403 Forbidden - PUT https://registry.npmjs.org/wjs
 - Package name too similar to existing packages w-js, w.js
 ```
 
-npm's naming policy treats `-` and `.` as equivalent to nothing for the similarity check. `wjs`, `w-js`, and `w.js` are all the same name to the filter. Both `w-js` and `w.js` existed (different projects, low download counts), so `wjs` got flagged as typosquatting.
+npm's naming policy treats `-` and `.` as equivalent to nothing for the similarity check. `wjs`, `w-js`, and `w.js` are all the same name to the filter. Both `w-js` and `w.js` existed (different projects, low download counts), so `wjs` got flagged as typosquatting (registering a name close to a popular one to catch people's typos).
 
 I had not planned for this. The 24-hour tombstone-after-unpublish window I knew about. The similarity filter was new to me.
 

--- a/blog/the-naming-saga.md
+++ b/blog/the-naming-saga.md
@@ -39,7 +39,7 @@ I had not planned for this. The 24-hour tombstone-after-unpublish window I knew 
 
 OK, scrap `wjs`. Pick a different short name.
 
-`webjscli` was the obvious next try. It is descriptive ("webjs cli"), matches the scoped `@webjsdev/cli` minus the scope, eight characters. I built the package, tried `npm publish`.
+`webjscli` was the obvious next try. It is descriptive ("WebJs cli"), matches the scoped `@webjsdev/cli` minus the scope, eight characters. I built the package, tried `npm publish`.
 
 ```
 npm error code E403
@@ -51,7 +51,7 @@ Same filter. `webjs-cli` already existed (yet another low-traffic project). The 
 
 # What I tried third
 
-`webjsdev` was the next name on my list. It matches the existing `@webjsdev` npm org (which I already own), reads as "webjs developer," and is far enough from any neighbor that the filter should not block it.
+`webjsdev` was the next name on my list. It matches the existing `@webjsdev` npm org (which I already own), reads as "WebJs developer," and is far enough from any neighbor that the filter should not block it.
 
 It published. Cleanly. Took thirty seconds.
 

--- a/blog/why-webjs.md
+++ b/blog/why-webjs.md
@@ -2,14 +2,14 @@
 title: "What Is WebJs? A No-Build Full-Stack Web Framework"
 date: 2025-12-15T10:00:00+05:30
 slug: why-webjs
-description: "Why I built WebJs, a no-build, web-components-first full-stack framework that stays close to web standards while keeping a Next.js-style developer experience. AI-first from the ground up."
+description: "WebJs is a no-build, web-components-first full-stack framework that stays close to web standards, with a Next.js-style developer experience. AI-first."
 tags: webjs, origin, frameworks, ai-first, web-components
 author: Vivek
 ---
 
-I wanted a full-stack framework that stayed close to web standards. The kind where the things you learn carry over to the platform, where the source you read in `node_modules` is the source that runs, where there is no mystery layer of compiled output between you and the runtime.
+Most web frameworks put a compile step between you and the browser, so the code you read is not the code that runs, and every few years you relearn a new proprietary runtime. I wanted the opposite. I wanted a full-stack framework that stayed close to web standards. The kind where the things you learn carry over to the platform, where the source you read in `node_modules` is the source that runs, where there is no mystery layer of compiled output between you and the runtime.
 
-I also wanted the developer experience I enjoy in Next.js. File-based routing. Server actions importable from the client. SSR that just works. Sensible defaults. The good parts of the Rails-style "you do not need to make 30 decisions before your first feature."
+I also wanted the developer experience I enjoy in Next.js. File-based routing. Server actions importable from the client. SSR (server-side rendering) that just works. Sensible defaults. The good parts of the Rails-style "you do not need to make 30 decisions before your first feature."
 
 I tried to find one that hit both. I did not find one I personally enjoyed using. So I built one for myself.
 
@@ -32,7 +32,7 @@ By leaning on the platform, the framework code stays small. The full WebJs frame
 The features are comparable. WebJs ships:
 
 - File-based routing (`page.ts`, `layout.ts`, `route.ts`, `[param]`, `(group)`, `_private`, the full Next.js app-router shape)
-- Server actions with full type safety across the network boundary (a `.server.ts` file with `'use server'`, imported from client code, gets rewritten to a typed RPC stub at request time)
+- Server actions with full type safety across the network boundary (a `.server.ts` file with `'use server'`, imported from client code, gets rewritten to a typed RPC stub, a remote-procedure-call proxy, at request time)
 - SSR with streaming Suspense boundaries
 - Client router that preserves layout DOM across navigations (no white flash)
 - Built-in auth, sessions, cookies, cache, and rate limiting, all sharing one pluggable store

--- a/blog/why-webjs.md
+++ b/blog/why-webjs.md
@@ -1,8 +1,8 @@
 ---
-title: "What Is webjs? A No-Build Full-Stack Web Framework"
+title: "What Is WebJs? A No-Build Full-Stack Web Framework"
 date: 2025-12-15T10:00:00+05:30
 slug: why-webjs
-description: "Why I built webjs, a no-build, web-components-first full-stack framework that stays close to web standards while keeping a Next.js-style developer experience. AI-first from the ground up."
+description: "Why I built WebJs, a no-build, web-components-first full-stack framework that stays close to web standards while keeping a Next.js-style developer experience. AI-first from the ground up."
 tags: webjs, origin, frameworks, ai-first, web-components
 author: Vivek
 ---
@@ -13,23 +13,23 @@ I also wanted the developer experience I enjoy in Next.js. File-based routing. S
 
 I tried to find one that hit both. I did not find one I personally enjoyed using. So I built one for myself.
 
-That is the entire origin story. webjs is the framework I wanted to exist.
+That is the entire origin story. WebJs is the framework I wanted to exist.
 
 
 # What "close to web standards" actually means
 
 It means web components for the view layer. Native browser primitives: `customElements.define`, shadow DOM, `<slot>` projection. They have been shipping in every major browser since 2018. They render without a framework. They survive framework churn. When the next big thing arrives, your `<my-counter>` element still works.
 
-It means no proprietary component runtime to reinvent things the platform already does. Most modern frameworks ship a custom virtual DOM, a custom reconciler, a custom hydration story, a custom component lifecycle. Each of those is thousands of lines that exist because the framework chose not to use what the browser provides. webjs uses what the browser provides, then adds the smallest layer needed to make the developer experience comfortable on top.
+It means no proprietary component runtime to reinvent things the platform already does. Most modern frameworks ship a custom virtual DOM, a custom reconciler, a custom hydration story, a custom component lifecycle. Each of those is thousands of lines that exist because the framework chose not to use what the browser provides. WebJs uses what the browser provides, then adds the smallest layer needed to make the developer experience comfortable on top.
 
-That layer is lit-shaped. `render() { return html\`\` }`, `ReactiveController`, the full directive set, reactive properties declared up front (via the `extends WebComponent({ … })` factory rather than lit's decorators, the one erasability-driven divergence). lit's API is what the corpus and the muscle memory already knows for web components, so I aligned the public surface to it. The runtime under the hood is webjs's own (so we control the SSR pipeline end-to-end), but the surface an agent or a developer reads matches what they already know.
+That layer is lit-shaped. `render() { return html\`\` }`, `ReactiveController`, the full directive set, reactive properties declared up front (via the `extends WebComponent({ … })` factory rather than lit's decorators, the one erasability-driven divergence). lit's API is what the corpus and the muscle memory already knows for web components, so I aligned the public surface to it. The runtime under the hood is WebJs's own (so we control the SSR pipeline end-to-end), but the surface an agent or a developer reads matches what they already know.
 
 
 # How small "close to standards" lets the framework be
 
-By leaning on the platform, the framework code stays small. The full webjs framework, including `@webjsdev/core` and `@webjsdev/server`, is on the order of 30,000 lines of plain JavaScript with JSDoc types. For comparison, Next.js is in the hundreds of thousands of lines. webjs is roughly 5-10% the size of Next.js by source.
+By leaning on the platform, the framework code stays small. The full WebJs framework, including `@webjsdev/core` and `@webjsdev/server`, is on the order of 30,000 lines of plain JavaScript with JSDoc types. For comparison, Next.js is in the hundreds of thousands of lines. WebJs is roughly 5-10% the size of Next.js by source.
 
-The features are comparable. webjs ships:
+The features are comparable. WebJs ships:
 
 - File-based routing (`page.ts`, `layout.ts`, `route.ts`, `[param]`, `(group)`, `_private`, the full Next.js app-router shape)
 - Server actions with full type safety across the network boundary (a `.server.ts` file with `'use server'`, imported from client code, gets rewritten to a typed RPC stub at request time)
@@ -41,16 +41,16 @@ The features are comparable. webjs ships:
 - Tailwind CSS configured out of the box
 - A component library (`@webjsdev/ui`) with `webjs ui add button card dialog`
 
-The reason the size delta is so large despite comparable features: the platform does the heavy lifting. Native web components replace the custom component runtime. Node 24's built-in `module.stripTypeScriptTypes` replaces the build step. HTTP/2 multiplex at the edge replaces the bundler. CSS variables replace the theme runtime. Each of those is a feature webjs gets to delete.
+The reason the size delta is so large despite comparable features: the platform does the heavy lifting. Native web components replace the custom component runtime. Node 24's built-in `module.stripTypeScriptTypes` replaces the build step. HTTP/2 multiplex at the edge replaces the bundler. CSS variables replace the theme runtime. Each of those is a feature WebJs gets to delete.
 
 
 # No build step
 
-webjs has no build step. The `.ts` files you write are the files the browser fetches. Node 24's built-in TypeScript stripper does position-preserving whitespace erasure, so stack traces point at the lines you wrote without a sourcemap layer. Edit, save, refresh.
+WebJs has no build step. The `.ts` files you write are the files the browser fetches. Node 24's built-in TypeScript stripper does position-preserving whitespace erasure, so stack traces point at the lines you wrote without a sourcemap layer. Edit, save, refresh.
 
 This is what makes the framework feel close to the metal. There is no `webjs build` command because there is nothing to build. The dev loop and the production runtime serve the same files.
 
-Production performance comes from HTTP/2 multiplex plus `<link rel="modulepreload">` hints emitted at SSR time. PaaS edges (Railway, Fly, Vercel, Cloudflare) handle HTTP/2 automatically. Same architecture as Rails 7 with `importmap-rails`. The Rails team got there first; webjs adopted the model for Node-shaped apps.
+Production performance comes from HTTP/2 multiplex plus `<link rel="modulepreload">` hints emitted at SSR time. PaaS edges (Railway, Fly, Vercel, Cloudflare) handle HTTP/2 automatically. Same architecture as Rails 7 with `importmap-rails`. The Rails team got there first; WebJs adopted the model for Node-shaped apps.
 
 
 # Why AI-first followed naturally
@@ -65,11 +65,11 @@ What that translates to:
 
 - **Conventions are enforced by tooling.** `webjs check` lints the rules that can be checked mechanically. The pre-commit hook refuses commits that break tests, refuses commits to `main`, auto-generates changelog entries on version bumps. The framework guards itself in the seams where mistakes happen, not in a doc page.
 
-- **AGENTS.md is the contract.** Every scaffolded webjs app ships with `AGENTS.md` at the root: file conventions, public API, framework invariants, recipes, and a "deliberately deferred" list so the agent does not try to add a bundler. The same content lands as `CLAUDE.md`, `.cursorrules`, `.agents/rules/workflow.md` (Antigravity), `.github/copilot-instructions.md`. One source of truth, every major coding agent reads it.
+- **AGENTS.md is the contract.** Every scaffolded WebJs app ships with `AGENTS.md` at the root: file conventions, public API, framework invariants, recipes, and a "deliberately deferred" list so the agent does not try to add a bundler. The same content lands as `CLAUDE.md`, `.cursorrules`, `.agents/rules/workflow.md` (Antigravity), `.github/copilot-instructions.md`. One source of truth, every major coding agent reads it.
 
 - **No build step means console parity.** When DevTools shows an error at `app/posts/[slug]/page.ts:42:8`, the agent opens that exact path and jumps to that exact line. The file on disk is what the runtime sees.
 
-- **Types span the network boundary.** Import a server-side function from `actions/create-post.server.ts` into a client component, and TypeScript sees the real signature. webjs's wire serializer round-trips `Date`, `Map`, `Set`, `BigInt`, `TypedArray`, `Blob`, `File`, `FormData`, and reference cycles. No hand-written JSON adapters at the boundary.
+- **Types span the network boundary.** Import a server-side function from `actions/create-post.server.ts` into a client component, and TypeScript sees the real signature. WebJs's wire serializer round-trips `Date`, `Map`, `Set`, `BigInt`, `TypedArray`, `Blob`, `File`, `FormData`, and reference cycles. No hand-written JSON adapters at the boundary.
 
 None of this is a special-case for AI tools. It is what you get when you build a framework whose primary user, from day one, is an agent reading the source.
 
@@ -111,6 +111,6 @@ Pre-1.0 as of this writing. 1151 unit tests, 271 browser tests, 61 puppeteer e2e
 
 The rest of this blog is design notes. Each post covers a single decision in depth: the lit-API parity rationale, the signals migration, how the client router avoids the white flash between navigations, what light-DOM `<slot>` projection looks like, the npm naming saga that ate a Saturday.
 
-The thesis is straightforward. A framework that stays close to web standards stays small. A framework that is small stays readable. A framework that is readable is one an AI agent can ship features in without getting lost. webjs is my attempt at that shape, and it is the framework I now use for my own work.
+The thesis is straightforward. A framework that stays close to web standards stays small. A framework that is small stays readable. A framework that is readable is one an AI agent can ship features in without getting lost. WebJs is my attempt at that shape, and it is the framework I now use for my own work.
 
 The site is at [webjs.dev](https://webjs.dev). The repo is at [github.com/webjsdev/webjs](https://github.com/webjsdev/webjs). The CLI is on npm at `@webjsdev/cli`, or scaffold directly with `npm create webjs@latest my-app`.

--- a/blog/why-webjs.md
+++ b/blog/why-webjs.md
@@ -1,8 +1,8 @@
 ---
-title: "Introducing webjs: a full-stack framework for the AI era"
+title: "What Is webjs? A No-Build Full-Stack Web Framework"
 date: 2025-12-15T10:00:00+05:30
 slug: why-webjs
-description: "Why I built webjs: a full-stack framework that stays close to web standards while keeping the Next.js-style developer experience I enjoy. Built from scratch, naturally AI-first."
+description: "Why I built webjs, a no-build, web-components-first full-stack framework that stays close to web standards while keeping a Next.js-style developer experience. AI-first from the ground up."
 tags: webjs, origin, frameworks, ai-first, web-components
 author: Vivek
 ---

--- a/blog/works-without-javascript.md
+++ b/blog/works-without-javascript.md
@@ -1,0 +1,65 @@
+---
+title: "A Web Framework That Works Without JavaScript"
+date: 2026-06-23T10:00:00+05:30
+slug: works-without-javascript
+description: "In WebJs, progressive enhancement is the default architecture, not a feature you fight for. Pages SSR and never hydrate, forms submit through server actions with JavaScript off, and interactivity is opt-in per behavior. How that works and why it is the floor."
+tags: progressive-enhancement, ssr, forms, server-actions, accessibility
+author: Vivek
+---
+
+Turn JavaScript off and load a WebJs app. The content is there and readable. Links navigate. Forms submit and save. Display-only components render exactly as they did with JavaScript on. Nothing shows a spinner that never resolves, because nothing was waiting on a script to paint.
+
+That is not a feature I added. It is the default shape of the framework, and getting there was mostly a matter of not doing the thing that breaks it. This post is about what that shape is and why it is the floor rather than an achievement.
+
+# The execution model that makes it possible
+
+In WebJs, pages and layouts run only on the server. They produce HTML and are never invoked again in the browser. Components are isomorphic and DO run again in the browser, but only to upgrade into interactivity. The important consequence is that the server-rendered HTML is the real artifact. It is not a placeholder that JavaScript fills in. It is the finished page.
+
+So "works without JavaScript" is not something the framework has to reconstruct. The no-JS experience is just the page before the optional enhancement layer runs. Interactivity is added per behavior, not per page: an `@click`, a signal read, a reactive property. Each of those is a specific opt-in that a specific component makes. Everything you did not explicitly make interactive stays static, which means it stays working with the script layer removed.
+
+# The rule that keeps it true
+
+The whole thing holds on one discipline: never write a first paint that depends on hydration. The moment a component renders a blank placeholder on the server and fills it in from a `connectedCallback` fetch, the no-JS experience is broken, because with JS off the placeholder is all you get.
+
+WebJs is built to make the correct path the easy one. Server-known data arrives through the page function and is in the SSR HTML. A component that needs request-time data can `await` it directly in `render()`, and SSR blocks on that await so the resolved data is in the first paint with no fallback markup. Browser-only data (something from `localStorage`, the viewport, `navigator`) goes in `connectedCallback` and writes a signal, so it enhances a page that already rendered without it. The framework even elides display-only components from the browser entirely, which is only sound because their SSR HTML is already the complete output.
+
+# Forms are the write path
+
+Reading without JavaScript is the easy half. The harder half is writing, and this is where a lot of frameworks quietly give up and require a client fetch. WebJs keeps the write path working with a plain form.
+
+A page can export an `action`:
+
+```ts
+// app/contact/page.ts
+export async function action({ formData }) {
+  const email = String(formData.get('email') || '');
+  if (!email) return { success: false, fieldErrors: { email: 'required' } };
+  await saveLead(email);
+  return { success: true, redirect: '/thanks' };
+}
+export default function Contact({ actionData }) {
+  return html`<form method="post">
+    <input name="email" />
+    ${actionData?.fieldErrors?.email ? html`<p>${actionData.fieldErrors.email}</p>` : ''}
+    <button>Send</button>
+  </form>`;
+}
+```
+
+With JavaScript off, this is a normal HTML form. It POSTs to its own URL, the `action` runs on the server, and a success returns a `303` redirect (the post-redirect-get pattern, so a refresh does not resubmit) while a failure re-renders the same page at `422` with the result on `actionData`. No JavaScript touched any of it. The validation errors render server-side.
+
+With JavaScript on, the client router intercepts the same submission and applies the response in place: a `303` is followed via fetch without a full reload, a `422` swaps the re-rendered page without losing scroll position. Same form, same server action, same result. The enhancement is that it happens without a page flash, not that it happens at all. You opt a form out of the router with `data-no-router` and it falls back to the native submit, which still works.
+
+# Why this is worth the discipline
+
+Three things fall out of building this way, and they are the reason it is the default and not an option.
+
+The first paint is correct for everyone. A slow device, a flaky network, a script that fails to load, a crawler, a reader-mode extension: all of them get the real content, because the real content was never gated behind the script. Accessibility improves for the same reason, since assistive tech reads a fully-formed document instead of racing a hydration pass.
+
+It composes with the framework's other bets. Elision is only safe because display-only components produce their complete output at SSR. The client router is only safe because a failed navigation can fall back to a real link. Each of these depends on the page being genuinely finished before JavaScript runs.
+
+And it is honest about what JavaScript is for. JavaScript is the enhancement that makes an already-working page snappier and more interactive. It is not the thing that makes the page exist. When you treat it that way, the app degrades gracefully by construction, because there is a real page underneath to degrade to.
+
+# The takeaway
+
+Progressive enhancement is usually described as extra work: build the no-JS version, then layer the JS version on top. WebJs inverts that. The server-rendered page is the artifact, interactivity is opt-in per behavior, and forms submit through server actions whether or not a script is running. You do not build the no-JS path separately. You get it by not writing a first paint that depends on hydration, and the framework spends its effort making that the easy way to build. The result is an app that works with JavaScript off because it was never pretending the JavaScript was load-bearing.

--- a/blog/works-without-javascript.md
+++ b/blog/works-without-javascript.md
@@ -2,7 +2,7 @@
 title: "A Web Framework That Works Without JavaScript"
 date: 2026-06-23T10:00:00+05:30
 slug: works-without-javascript
-description: "In WebJs, progressive enhancement is the default architecture, not a feature you fight for. Pages SSR and never hydrate, forms submit through server actions with JavaScript off, and interactivity is opt-in per behavior. How that works and why it is the floor."
+description: "In WebJs, progressive enhancement is the default architecture. Pages SSR and never hydrate, forms submit through server actions with JS off, and interactivity is opt-in."
 tags: progressive-enhancement, ssr, forms, server-actions, accessibility
 author: Vivek
 ---

--- a/website/app/blog/page.ts
+++ b/website/app/blog/page.ts
@@ -22,7 +22,7 @@ export default async function Blog() {
         <p class="font-mono text-[11px] uppercase tracking-[0.15em] text-accent font-semibold mb-2">Blog</p>
         <h1 class="font-serif text-[clamp(28px,4vw,40px)] leading-[1.05] tracking-tight text-fg mb-3">Notes from building webjs</h1>
         <p class="text-fg-muted text-[15px] leading-relaxed max-w-[640px]">
-          Long-form posts on the design decisions, the trade-offs, the things that did not work, and what the framework looks like in production.
+          Posts on the design decisions, the trade-offs, the things that did not work, and what the framework looks like in production.
         </p>
       </header>
 


### PR DESCRIPTION
New SEO-titled blog posts written in the existing voice, plus SEO passes on existing posts (titles/descriptions, slugs preserved). First batch:
- Elision / zero-JS for display-only components
- Server actions without React Server Components
- Running on Node and Bun (cross-runtime)

More topics and the /compare comparison-page section to follow (tracked separately).

---

## Consolidated with the 10-post SEO batch (formerly #787)

This PR now also includes 10 new posts on core WebJs features, each SEO-tuned and written for early-stage developers (plain-language opening, grounded code, a takeaway):

- Async Data Fetching in Web Components (await Right in render())
- How to Stream AI Responses From a Server Action
- CSRF Protection Without Tokens, Cookies, or Config
- Full-Stack Type Safety With No Build Step
- How to Fix Those Ugly ../../../ Import Paths
- Give AI Coding Assistants Live Access to Your App
- Accessible Web Components Out of the Box
- Server-Side Caching for Beginners (ETags, Tags, and 304s)
- Prisma vs Drizzle: Why We Chose Drizzle as Our Default ORM
- How WebJs Stops AI Coding Agents From Breaking Your Code

All render (HTTP 200, correct titles + body) against a live server; punctuation and branding verified. #787 was closed in favor of this single blog PR.