### PR TITLE
docs(blog): 10 SEO blog posts on core WebJs features

### DIFF
--- a/blog/accessible-web-components-by-default.md
+++ b/blog/accessible-web-components-by-default.md
@@ -1,0 +1,93 @@
+---
+title: "Accessible Web Components Out of the Box"
+date: 2026-06-22T10:00:00+05:30
+slug: accessible-web-components-by-default
+description: "How WebJs ships accessible web components by default through @webjsdev/ui. An a11y-by-default component library where keyboard navigation, screen-reader labels, and focus management come wired in, plus accessibility contracts AI agents read so their edits do not silently break your WCAG-aligned UI."
+tags: accessibility, a11y, web-components, ui, wcag
+author: Vivek
+---
+
+Here is a thing most tutorials skip. A button that only works when you click it with a mouse is broken for a lot of people. Someone navigating with a keyboard cannot reach it. Someone using a screen reader (software that reads the page aloud for blind and low-vision users) hears nothing useful if the button has no label. That whole area of making a site usable by everyone, not just people with a mouse and good eyesight, is called accessibility, or "a11y" for short (the 11 is the number of letters between the a and the y).
+
+The problem is that accessibility almost always gets bolted on late. You build the feature, ship it, and then someone files a bug that says the dropdown cannot be operated with a keyboard. Now you are retrofitting ARIA attributes, focus management, and roving tabindex into code that was written without any of them in mind. Retrofitting is painful because accessibility is not one attribute you sprinkle on at the end. It is a set of relationships (this control names that panel, arrow keys move between these items, focus returns here when the dialog closes) that are far easier to build in from the start than to reverse-engineer later.
+
+So WebJs starts from accessible defaults. That is the whole pitch of this post.
+
+
+# The component library, and how you get it
+
+WebJs ships a component library called `@webjsdev/ui`. You pull components into your app from the CLI:
+
+```sh
+webjs ui init                       # one-time setup in your project
+webjs ui add button card dialog     # copy those components into your repo
+webjs ui list                       # see everything available
+webjs ui view tabs                  # print a component's source before adding it
+```
+
+The components are source-copied into your project, so you own the files. There is no opaque dependency you cannot read or edit. That matters for accessibility specifically, because when you can read the component, you can see exactly what accessible behaviour it already handles.
+
+The library is split into two tiers, and the split is the key to the whole design.
+
+
+# Tier 1, class helpers on real native elements
+
+The first tier is plain functions that return Tailwind class strings. `buttonClass()`, `cardClass()`, `inputClass()`, `labelClass()`, `alertClass()`, and friends. You spread them onto native HTML elements:
+
+```ts
+import { buttonClass } from '#components/ui/button.ts';
+
+html`<button class=${buttonClass({ variant: 'outline' })}>Save</button>`;
+```
+
+That is a real `<button>`, not a wrapper. It participates in form submission, keyboard activation (Enter and Space work because the browser gives you that for a native button), the accessibility tree, and devtools as itself. WebJs components render in light DOM by default (the component's markup goes straight into the page, no shadow root), which is what lets the accessibility tree behave the way the spec assumes. I wrote about that choice in [Light DOM by default](/blog/light-dom-by-default).
+
+Because a class helper returns only classes, the semantic markup is yours to write. So each helper carries an `A11y (required for accessible output)` block in its JSDoc that tells you precisely what to add. The icon-only button JSDoc says it must carry an `aria-label` (a screen reader has no text to read otherwise). The alert helper says to put `role="alert"` for an urgent message or `role="status"` for a polite one. Pagination says to wrap the list in a labelled `<nav>` and set `aria-current="page"` on the active link. Table headers need `scope`, an avatar image needs `alt`. Follow the block and the markup is fully accessible. The contract is written down right where you (or an AI agent) are reading the code.
+
+
+# Tier 2, stateful custom elements that wire their own ARIA
+
+The second tier is for the behaviour the browser still does not give you for free. Hover-with-delay tooltips, roving-focus keyboard navigation for menus and tabs, a toast queue that stacks and dismisses. These ship as custom elements (`<ui-dialog>`, `<ui-tabs>`, `<ui-tooltip>`, `<ui-dropdown-menu>`, `<ui-sonner>`, and more).
+
+These are accessible out of the box. You do not hand-add ARIA to them, they wire their own. Look at what you write versus what you get:
+
+```ts
+// What you author. No aria-* anywhere.
+html`
+  <ui-tabs value="account">
+    <ui-tabs-list>
+      <ui-tabs-trigger value="account">Account</ui-tabs-trigger>
+      <ui-tabs-trigger value="password">Password</ui-tabs-trigger>
+    </ui-tabs-list>
+    <ui-tabs-content value="account">...</ui-tabs-content>
+    <ui-tabs-content value="password">...</ui-tabs-content>
+  </ui-tabs>
+`;
+```
+
+The rendered output carries `role="tablist"`, `role="tab"` with `aria-selected` and `aria-controls`, `role="tabpanel"` with `aria-labelledby`, roving `tabindex`, and Arrow-key navigation, none of which you had to type. I read the actual source rather than trust a README, so here is what is genuinely there.
+
+`<ui-tabs>` follows the WAI-ARIA Authoring Practices tabs pattern (the source links the spec URL directly). The list gets `role="tablist"` with `aria-orientation`, each trigger is a native `<button role="tab">` with `aria-selected` and `aria-controls` pointing at its panel, and each panel gets `role="tabpanel"` with `aria-labelledby` pointing back at its trigger. Focus is roving (the active trigger has `tabindex="0"`, the rest `-1`) and Arrow keys, Home, and End move between tabs. An inactive panel is marked `hidden` and `inert`, so it drops out of the tab order and the accessibility tree entirely.
+
+`<ui-dialog>` is a thin decorator over the native `<dialog>` element's `showModal()`. That means the focus trap, Escape-to-close, the backdrop, and background-inert all come from the platform rather than from hand-rolled JS that tends to have edge-case bugs. On open it names itself from your title and description via `aria-labelledby` and `aria-describedby`, marks the panel `role="dialog"` with `aria-modal="true"`, and gives the auto-injected close button an `aria-label="Close"`.
+
+The rest follow the same discipline. The dropdown menu declares `aria-haspopup="menu"`, uses `role="menu"` and `role="menuitem"` with roving focus and `aria-disabled`. The tooltip wires `aria-describedby` from the trigger to the tip text. The toaster (`<ui-sonner>`) is a live region, so new toasts get announced (`role="alert"` for errors, `role="status"` otherwise). Across the set, interactive elements carry `focus-visible` ring styles so keyboard users can see where focus is.
+
+
+# The part aimed at AI agents
+
+WebJs is built to be edited by AI agents, and accessibility is exactly the kind of thing an agent breaks by accident. It refactors a component, moves some markup, and quietly drops the `aria-controls` link or the roving tabindex. The feature still looks fine. It is just no longer usable with a keyboard, and nobody notices until a real user hits it.
+
+So the accessibility expectations are encoded where the agent reads them. The tier-1 `A11y (required for accessible output)` JSDoc blocks are a contract in prose that sits next to the function. The tier-2 elements keep their ARIA wiring in the component source the agent copies into the repo, with comments explaining why each piece exists (why the panel is `inert`, why the dialog resolves its labels at open time). An agent editing the component reads the contract first, so its edits preserve the behaviour instead of silently regressing it. Human reviewers get the same benefit.
+
+There is one more agent-friendly detail. The variant names, sizes, and data-attribute conventions mirror shadcn/ui. An agent's existing knowledge of shadcn maps directly onto these components, so it reaches for the right API on the first try.
+
+
+# A note on what I did not claim
+
+I deliberately did not put a WCAG conformance badge on this post. WCAG (the Web Content Accessibility Guidelines, the standard that defines what "accessible" means on the web) has graded levels, and I found no audit in the repo stating the library hits a specific one, so I am not going to invent a number. What I can say, because I read the source, is that the components are keyboard navigable, screen-reader labelled, and focus-managed by default, and the tier-2 elements follow the published ARIA Authoring Practices patterns. Your own app still has to do its part (real content, real labels, sensible color contrast), and you should test with a keyboard and a screen reader like anyone else. The library gives you a floor that is a long way above blank.
+
+
+# The takeaway
+
+Accessibility is usable-with-a-keyboard-and-a-screen-reader, not just usable-with-a-mouse, and it is far cheaper to build in than to bolt on. WebJs ships `@webjsdev/ui` with that built in. Tier-1 class helpers hand you native elements plus an exact checklist of the ARIA to add, and tier-2 custom elements wire their own keyboard navigation, screen-reader labels, and focus management out of the box. Because the components are light DOM and source-copied into your repo, both you and any AI agent can read the accessibility contract and keep it intact through every edit. Run `webjs ui add` and you start from an accessible floor instead of a retrofit.

--- a/blog/async-render-in-web-components.md
+++ b/blog/async-render-in-web-components.md
@@ -1,0 +1,101 @@
+---
+title: "Async Data Fetching in Web Components (await Right in render())"
+date: 2026-06-03T10:00:00+05:30
+slug: async-render-in-web-components
+description: "Web component data fetching without useEffect or a first-paint spinner. WebJs lets you await server data right inside async render(), so SSR bakes the data into the first paint, the client stays stale-while-revalidate, and there is no request waterfall."
+tags: web-components, data-fetching, async-render, ssr, suspense
+author: Vivek
+---
+
+Fetching data inside a component usually goes like this. You write a `useEffect`, you set a loading flag, you show a spinner, and the first thing the user sees is an empty box. The data only arrives after the component has already painted once, rendered nothing useful, and then re-rendered. If a parent and a child both fetch, they fetch in sequence, one waiting on the other, which is the request waterfall everyone eventually trips over. And none of that data is in the HTML the server sent, so a search crawler or a reader with JavaScript off sees the empty box too.
+
+I wanted the opposite of all of that. In WebJs you `await` the data directly inside the component's `render()` method, and the framework handles the three separate problems that `useEffect` conflates into one mess.
+
+Here is the whole thing.
+
+```ts
+class UserProfile extends WebComponent({ uid: String }) {
+  async render() {
+    const u = await getUser(this.uid);   // a 'use server' action
+    return html`<h3>${u.name}</h3>`;
+  }
+}
+UserProfile.register('user-profile');
+```
+
+That is it. No effect, no loading flag, no spinner, no `this.setState`. `render()` is allowed to be `async`. Writing `await` makes the function return a promise by the normal JavaScript rule, and every render path in WebJs already awaits a promise-returning `render()` automatically. There is no flag to set. A plain synchronous `render()` stays the zero-cost default, so you only pay for async where you actually reach for it. This is issue #469 if you want to read the history.
+
+
+# Why this is not just useEffect with nicer syntax
+
+The reason `async render()` works is that it decouples three concerns that React's fetch-in-effect pattern jams together. Keep them separate in your head and the whole model clicks.
+
+**One. SSR always blocks.** On the server, WebJs awaits your `async render()` before it sends any HTML. So the resolved data is baked into the first paint. There is no fallback markup, no spinner, no empty box, ever. The `<h3>` arrives with the name already in it. This is what "progressive enhancement" means in practice (the page works before JavaScript runs). A reader with JS off still reads the data, and a crawler indexes real content instead of a loading state. That is a genuine upgrade over a client-side fetch, which can only show something after the browser has downloaded, parsed, and run your script.
+
+**Two. The client re-fetch is stale-while-revalidate by default.** Say the `uid` prop changes and the component needs fresh data. WebJs re-runs `async render()`, but the content already on screen stays put until the new render resolves. No blank flash, no layout jump, no user code. The old data is shown while the new data loads, then it swaps. This is the behavior you would hand-write with a bunch of state in React, and here it is the default you get for free.
+
+**Three. `renderFallback()` is an optional loading UI, and only for the re-fetch.** Sometimes stale content would mislead (a different user's profile, say). For those cases you define `renderFallback()`, and WebJs shows it during a client re-fetch instead of the stale content.
+
+```ts
+class UserActivity extends WebComponent({ uid: String }) {
+  renderFallback() { return html`<div class="skeleton h-24"></div>`; }
+  async render() {
+    const items = await getActivity(this.uid);
+    return html`<ul>${items.map((i) => html`<li>${i.label}</li>`)}</ul>`;
+  }
+}
+```
+
+The important part, and the part that trips people coming from React. `renderFallback()` is shown ONLY during a client re-fetch. It is NEVER shown on the first paint. The first paint always has real data because SSR blocked for it. So `renderFallback()` is not "the loading spinner", it is "the loading spinner for the second and later fetches". If you were reaching for it to fill the first paint, you do not need it.
+
+
+# Errors are isolated for free
+
+If your `await getData()` throws, WebJs renders a component-scoped error state and lets the sibling components render normally. One broken widget does not blank the page and it does not bubble up to the route's `error.js`. In dev the default shows you the tag and message; in prod it renders a silent empty element so nothing leaks. You override it only if you want a custom message.
+
+```ts
+class Report extends WebComponent {
+  async render() { return html`<pre>${await getReport()}</pre>`; }
+  renderError(error) { return html`<p class="error">Could not load the report.</p>`; }
+}
+```
+
+Again, this is behavior you would otherwise build by hand with an error boundary around every fetching component. Here it is the default and `renderError()` is the opt-in customization.
+
+
+# The one line that works on both sides
+
+Look back at `const u = await getUser(this.uid)`. That single line runs on the server during SSR and on the client during a re-fetch, and it is the same line both times. This works because `getUser` is a `'use server'` action. During SSR it is the real function talking to your database. On the client, WebJs has rewritten the import into a typed RPC stub that posts to the server for you. You never hand-write a `fetch()` call, and you never think about which side you are on. The function is isomorphic (same source, both environments), so the co-located fetch just works.
+
+That co-location is the other quiet win. The fetch lives in the leaf component that needs the data. No prop-drilling a `user` object down four layers, no lifting fetches to a parent, no request waterfall from parent-waits-for-child chains.
+
+
+# What you do not pay for
+
+Two optimizations make this cheap, and both are on by default.
+
+A display-only async component gets **elided** (#474). If a component just fetches and renders, with no click handlers, no signals, no interactivity of any kind, then its server-rendered HTML is already the complete and final output. So WebJs drops its JavaScript module from the page entirely. The data is in the HTML, the component has nothing left to do in the browser, so nothing ships. A docs page or a content card built this way costs zero client JavaScript.
+
+For a component that DOES ship (because it is also interactive), **SSR action seeding** (#472) kills the redundant re-fetch. Every `'use server'` action result computed during SSR is serialized into the page. When the component hydrates in the browser, its first RPC call reads that seed instead of hitting the network. So `getUser(this.uid)` runs once, on the server, and the client reuses the result on its first render. No hydration flicker, no wasted round trip. A later re-fetch or an argument change still goes to the server as normal.
+
+
+# When to reach for something else
+
+`async render()` blocks the first byte, because SSR waits for your data before sending HTML. For fast queries that is exactly right. For a genuinely slow region, blocking the whole page's time-to-first-byte on one slow query is the wrong tradeoff. That is what `<webjs-suspense>` is for.
+
+```ts
+html`
+  <webjs-suspense .fallback=${html`<p>Loading section…</p>`}>
+    <slow-report></slow-report>
+  </webjs-suspense>
+`
+```
+
+The fallback flushes on the first byte, and the slow content streams in when it resolves. Multiple boundaries on one page fetch concurrently, so you get fast-content-first with no server waterfall. This is the one and only way to show a fallback on the first paint, and it is a deliberate choice you make for slow regions, not the default.
+
+And to be clear about the boundary. Use `async render()` for server data that is known at request time and belongs in the first paint. Keep `Task` and signals for data that is genuinely client-only (a `Task` renders its pending state at SSR, which means it loses the first-paint data, so it is the wrong tool for server data you want in the HTML).
+
+
+# The takeaway
+
+Fetching data in a component should not mean a spinner, an empty first paint, and a request waterfall. In WebJs you `await` your server data right inside `async render()`, and the framework splits the problem into three clean pieces: SSR always blocks so the data is in the first paint (no `useEffect`, no empty box, works with JS off), the client re-fetch is stale-while-revalidate by default, and `renderFallback()` is an optional loading state for re-fetches only. Errors isolate per component automatically, the fetch is one isomorphic line that runs on both sides, display-only components ship zero JavaScript, and SSR seeding means no wasted re-fetch on hydration. When a query is slow enough that blocking the first byte hurts, wrap it in `<webjs-suspense>` and stream it. That is data fetching that starts from the server instead of fighting to catch up to it.

--- a/blog/csrf-protection-without-tokens.md
+++ b/blog/csrf-protection-without-tokens.md
@@ -1,0 +1,120 @@
+---
+title: "CSRF Protection Without Tokens, Cookies, or Config"
+date: 2026-06-10T11:00:00+05:30
+slug: csrf-protection-without-tokens
+description: "How WebJs does CSRF protection with a Sec-Fetch-Site and Origin check instead of a token cookie. CSRF without a token keeps your SSR pages same-origin safe and CDN-edge-cacheable, the modern browser-native approach explained for beginners."
+tags: security, csrf, sec-fetch-site, server-actions, caching
+author: Vivek
+---
+
+Let me start with the attack, because the name is scarier than the idea.
+
+CSRF stands for Cross-Site Request Forgery. Here is the whole thing in one sentence. You are logged into your bank in one tab. You open a malicious page in another tab. That page quietly submits a form (or fires a request) at your bank, and because your browser helpfully attaches your bank's cookies to any request headed for your bank, the bank sees a fully authenticated "transfer money" request that you never meant to send.
+
+The malicious site never sees your cookies. It does not need to. It just needs your browser to send them for it. That is the trick. The request is forged to look like it came from you, because in a cookie sense it did.
+
+So every framework needs an answer to "was this state-changing request actually initiated by my own site, or by some other site riding on the user's session?"
+
+
+# The classic answer, and why it is fiddly
+
+The traditional fix is the anti-CSRF token. The server generates a random secret, embeds it in a hidden form field on every page, and also stores a copy (often in a cookie). When the form submits, the server checks that the hidden field matches the stored copy. A malicious cross-site page cannot read your pages, so it cannot know the token, so its forged request fails the check.
+
+This works. It has protected the web for two decades. But it is a lot of moving parts for a beginner to wire up correctly.
+
+- Every form needs the hidden token field, so you need a way to inject it everywhere.
+- The token has to be tied to the session, rotated sensibly, and validated on every mutating request.
+- The "double-submit cookie" variant sets the token as a cookie and asks the form to echo it back, which means you now have a cookie you must set on the SSR response.
+
+That last point is the one that quietly hurts, and I will come back to it, because it is the reason WebJs went a different way.
+
+
+# The modern answer: ask the browser where the request came from
+
+Here is the thing that changed. Modern browsers now tell the server, on every request, whether the request came from the same site or a different one. They send a header called `Sec-Fetch-Site`, and its value is one of `same-origin`, `same-site`, `cross-site`, or `none` (a direct navigation, like typing the URL or clicking a bookmark).
+
+The malicious page cannot forge this header. It is set by the browser itself, and JavaScript is not allowed to touch it. So the server can just read it. If a state-changing request claims to come from `cross-site`, it is exactly the forgery you were worried about, and you reject it.
+
+This is the Remix 3 and Go 1.25 model, and it is what WebJs server actions use. No token to generate, no hidden field to inject, no extra cookie to set.
+
+
+# What WebJs actually checks
+
+In WebJs, a server action is a function in a `*.server.ts` file marked `'use server'`. When you import it from client code, the import is rewritten into a typed RPC stub that POSTs to `/__webjs/action/<hash>/<fn>`. That RPC boundary is where the CSRF check lives.
+
+For a state-changing verb (POST, PUT, PATCH, DELETE), the request passes only when one of these is true.
+
+1. `Sec-Fetch-Site` is `same-origin` or `none`. Your own site, or a direct navigation.
+2. The browser is older and sent no `Sec-Fetch-Site`, but the `Origin` header's host matches the request host. A same-host fallback.
+3. The source origin is listed in `webjs.allowedOrigins` in your `package.json`. An explicit opt-in for a trusted cross-origin caller.
+
+Otherwise the request is rejected with a `403`. That is the entire policy.
+
+```jsonc
+// package.json
+{
+  "webjs": {
+    "allowedOrigins": ["https://admin.example.com"]
+  }
+}
+```
+
+Most apps never touch `allowedOrigins` at all. The default (same-origin or a matching host) is what you want almost always.
+
+And a safe read is exempt. A GET action is CSRF-exempt by design, because a GET is not supposed to change state, so there is nothing to forge. (If a GET of yours does mutate state, that is the bug to fix, not the check to loosen.)
+
+
+# The payoff nobody advertises: your pages stay cacheable at the edge
+
+Now back to the cookie problem, because this is the part I actually find exciting.
+
+Remember the double-submit token needs a cookie on the SSR response. The moment your server sends a `Set-Cookie` header with an HTML page, that page becomes per-user by definition. A CDN cannot cache it, because caching one visitor's cookie and serving it to the next visitor would be a security disaster. So the token approach quietly makes your HTML uncacheable at the edge.
+
+WebJs sends no `Set-Cookie` riding the SSR HTML for CSRF, because there is no token to plant. That means a page that is genuinely identical for every visitor can opt into a public `Cache-Control` and be cached at the CDN edge.
+
+```ts
+// app/layout.ts (root layout for a visitor-identical app)
+import { html } from '@webjsdev/core';
+import type { Metadata } from '@webjsdev/core';
+
+export const metadata: Metadata = {
+  cacheControl: 'public, max-age=300',
+};
+
+export default function RootLayout({ children }: { children: unknown }) {
+  return html`<main class="max-w-[760px]">${children}</main>`;
+}
+```
+
+You can set `metadata.cacheControl` on a single page, or on a root layout to cover a whole visitor-identical app. The edge serves the cached HTML, your origin does less work, and the first paint is faster. This is the real argument. The Sec-Fetch-Site approach is not just simpler to write, it keeps your SSR output CDN-cacheable, which a CSRF-token cookie fundamentally would not.
+
+
+# CORS is a separate control (do not confuse the two)
+
+CSRF protection guards your own site's mutating requests. CORS is a different concern, which is letting a browser on another origin read your responses on purpose. For that, WebJs ships a `cors()` middleware in `@webjsdev/server`.
+
+```ts
+// middleware.ts
+import { cors } from '@webjsdev/server';
+
+export default cors({
+  origin: ['https://app.example.com'],
+  credentials: true,
+});
+```
+
+One hard rule here. If you set `credentials: true` (so the browser sends cookies on the cross-origin request), you MUST pass an explicit origin allowlist. Never combine `credentials: true` with `origin: '*'`. A credentialed wildcard effectively hands cookie-authenticated access to every origin on the web, which is the exact footgun CORS is supposed to prevent. WebJs will narrow a wildcard-plus-credentials combination to the reflected origin and warn you, but the correct fix is a real allowlist.
+
+
+# The one caveat: this covers actions, not your hand-written routes
+
+The Sec-Fetch-Site check protects the action RPC boundary. It does NOT automatically cover a `route.ts` REST endpoint you write by hand.
+
+A `route.ts` handler is a raw HTTP handler (named `GET` / `POST` exports). It is the right tool when you are building a public API, and precisely because it is public and raw, WebJs does not impose the action CSRF policy on it. So if a `route.ts` endpoint mutates state, that is on you. Authenticate every mutating route, validate the input, and rate-limit it. The framework gives you the pieces (`validate`, the auth helpers, `rateLimit()`), but it will not second-guess a route you wrote deliberately.
+
+The rule of thumb: reach for a server action for in-app mutations (you get CSRF protection for free), and reach for `route.ts` when you are exposing a real HTTP API to the outside world (you own the security).
+
+
+# The takeaway
+
+CSRF is a browser trick, so the cleanest defense is a browser fact. Modern browsers stamp every request with `Sec-Fetch-Site`, which JavaScript cannot forge, so WebJs server actions simply reject any state-changing request that is not same-origin (with an Origin-host fallback for old browsers and an `allowedOrigins` escape hatch). There is no token to generate, no hidden field to inject, and no CSRF cookie to set. That last absence is the quiet win, because with no `Set-Cookie` on the SSR HTML, a visitor-identical page can opt into a public `Cache-Control` and be cached at the CDN edge, which a token-cookie approach would break. Just remember that this protection lives on the action boundary, so if you hand-write a mutating `route.ts`, you secure that one yourself.

--- a/blog/fix-relative-import-paths.md
+++ b/blog/fix-relative-import-paths.md
@@ -1,0 +1,97 @@
+---
+title: "How to Fix Those Ugly ../../../ Import Paths"
+date: 2026-06-16T09:30:00+05:30
+slug: fix-relative-import-paths
+description: "Fix relative import paths for good using a path alias backed by the Node package.json imports field. WebJs aliases every top-level folder with no webpack and no tsconfig paths, resolved at runtime by Node 24+ and Bun with no build step."
+tags: imports, path-alias, no-build, dx, nodejs
+author: Vivek
+---
+
+You have seen this line. You have probably written it today.
+
+```ts
+import { db } from '../../../db/connection.server.ts';
+```
+
+It works. Then you move the file one folder deeper to tidy things up, and it breaks. Not with a helpful message, just a red squiggle and a count of `../` that no longer adds up. You add one more `../`, guess wrong, add another, and now you are counting directory hops in your head like it is 1998. Every deep relative import is a little piece of your file structure hardcoded into your code, and it rots the moment you rearrange anything.
+
+I got tired of it. So WebJs apps do not use deep relative paths. They use a path alias.
+
+
+# What a path alias even is
+
+A path alias is a short, stable nickname for a folder. Instead of describing where a file is relative to the file importing it (`../../../db`), you describe where it is relative to the root of your project (`#db`). The import reads the same no matter where the importing file lives, so moving a file never changes the paths inside it.
+
+Here is the same import with the WebJs alias.
+
+```ts
+import { db } from '#db/connection.server.ts';
+import { Button } from '#components/ui/button.ts';
+import { formatDate } from '#lib/utils/date.ts';
+import { listPosts } from '#modules/posts/queries/list-posts.server.ts';
+```
+
+Every one of those points at a top-level folder from the project root. No counting. Move `button.ts` anywhere and its imports of `#lib` and `#db` stay valid.
+
+
+# Why this normally needs a bundler
+
+If you have set up path aliases before, you know they usually come with baggage. In a typical React or Next.js project, an alias like `@/components` exists in two places that have to agree. You add `paths` to `tsconfig.json` so the TypeScript language server stops complaining, and you add a matching alias to your bundler config (webpack `resolve.alias`, or the Vite/esbuild equivalent) so the code actually runs.
+
+That second half is the catch. The alias only works because a build tool rewrites it into a real path before the code ever runs. TypeScript `paths` alone is a type-checker hint. It does not change what the runtime sees. So the alias is really a build-time illusion, and you need the build step to make it true.
+
+WebJs has no build step. The `.ts` files you write are the files that run (Node 24+ strips the types in place, no bundler in sight). So a bundler-rewrite trick was never on the table. Instead WebJs leans on a platform feature that already does exactly this.
+
+
+# The platform already has this: package.json "imports"
+
+Node has a built-in field for private module aliases called `imports`, and it lives right in your `package.json`. Any key that starts with `#` is a subpath import that Node resolves at runtime, no tooling required. This is a real Node feature, not a WebJs invention, and Bun implements it too.
+
+The WebJs scaffold ships one line that does all the work.
+
+```json
+{
+  "imports": {
+    "#*": "./*"
+  }
+}
+```
+
+That single catch-all maps `#anything` to `./anything` from the project root. So `#db/connection.server.ts` resolves to `./db/connection.server.ts`, `#components/ui/button.ts` to `./components/ui/button.ts`, and so on. Add a new top-level folder tomorrow and it is aliased already, with zero config changes. Node 24+ and Bun both resolve it at runtime. No webpack, no tsconfig `paths`, no resolver plugin.
+
+
+# Two rules that will save you a debugging session
+
+The sigil is `#`, not `@`. A lot of ecosystems use `@/` out of habit, but the Node `imports` field only recognizes keys starting with `#`. Reach for `@` and nothing resolves.
+
+There is no slash after the `#`. Write `#lib/...`, never `#/lib/...`. A `#/`-prefixed key does not resolve on Bun, and WebJs runs on both Node and Bun, so the slash-free form is the one that works everywhere.
+
+Get those two right and the alias just works.
+
+
+# When to use it, and when not to
+
+The alias is for reaching across your project, not for reaching next door. A same-directory import stays relative.
+
+```ts
+import { helper } from './sibling.ts';   // same folder, keep it relative
+import { db } from '#db/connection.server.ts';   // deep reach, use the alias
+```
+
+The rule I follow: same-directory imports stay `./`, and only the deep relatives (the `../../../` kind) become `#`. A short local `./` path does not rot when you move files, so there is nothing to fix there.
+
+One more boundary worth knowing. The alias addresses a top-level subdirectory (`#lib`, `#components`, `#modules`, `#db`). A bare file sitting at the project root, like `env.ts`, is imported relatively as `./env.ts`. That is because the browser importmap WebJs generates is scoped per directory, so a `#`-imported root file would have no browser mapping in dev. Point the alias at folders, keep root files relative.
+
+And if you ever want to opt out for a single import, just write a plain relative path. Nothing forces the alias on you.
+
+
+# It is the same map everywhere, so the server boundary still holds
+
+This is the part I like most. Because the alias is a real config value and not a build-time rewrite, WebJs can read the exact same map the runtime reads. The server expands `#*` when it walks your import graph, when it decides which files a browser is allowed to fetch (the auth gate), when it elides display-only components, and when it builds the browser importmap.
+
+The practical payoff: a `#`-aliased `.server.ts` file still trips the server-only boundary. Importing `#db/connection.server.ts` into a client component is caught the same way importing `../../../db/connection.server.ts` would be. The alias is cosmetic to you and fully transparent to the framework. There is no seam where a nicer import path quietly loses a safety guarantee.
+
+
+# The takeaway
+
+Deep relative imports are fragile because they hardcode your folder layout into every file, and they break the instant you rearrange anything. The usual fix, a bundler alias plus tsconfig `paths`, only works because a build step rewrites it. WebJs has no build step, so it uses Node's native `package.json` `imports` field instead. One catch-all line, `"#*": "./*"`, aliases every top-level folder with no webpack and no tsconfig `paths`, resolved at runtime by Node 24+ and Bun. Use `#lib`, `#components`, `#modules`, `#db` for the deep reaches, keep `./sibling.ts` for the neighbors, remember the sigil is `#` with no slash, and never count `../` again.

--- a/blog/full-stack-type-safety-no-build.md
+++ b/blog/full-stack-type-safety-no-build.md
@@ -1,0 +1,103 @@
+---
+title: "Full-Stack Type Safety With No Build Step"
+date: 2026-06-13T10:30:00+05:30
+slug: full-stack-type-safety-no-build
+description: "End-to-end type safety in WebJs with no build TypeScript. Typed server actions flow the real function signature across the network boundary, so full-stack types are just a normal import, with no codegen and no compile step."
+tags: typescript, type-safety, server-actions, no-build, dx
+author: Vivek
+---
+
+Here is a pain most people hit early. You write a server function that returns a user. You call it from the browser. Somewhere between those two lines the data becomes JSON, and now your editor has no idea what shape it is. You pass the wrong argument, you read a field that does not exist, you get `undefined` at runtime instead of a red squiggle while you type. The server and the browser are two programs that happen to talk over HTTP, and the type checker only sees one of them at a time.
+
+"Type safety across the network" means closing that gap. Calling your server from the browser becomes as safe as calling a function in the same file. A typo, a missing field, a wrong argument shape gets caught in your editor before you ever run the code. That is the whole promise, and in WebJs it is not a library you bolt on. It is how a server action already works.
+
+Let me show what that looks like, then explain why it needs no build step at all.
+
+
+# What a build step and codegen usually are
+
+Two quick definitions, because the payoff only makes sense against them.
+
+A **build step** is a program that runs before your code runs. It takes the source you wrote (TypeScript, JSX, whatever) and turns it into something the runtime can execute (plain JavaScript). `tsc`, esbuild, webpack, and Vite are build steps. You edit, the builder compiles, and the thing that actually runs is the compiled output, not the file you opened.
+
+**Codegen** (code generation) is a build step's cousin. A tool inspects your API (a GraphQL schema, an OpenAPI spec, a router definition) and writes TypeScript types into a file so your client code knows the shape of your server responses. You run the generator, it emits `generated.ts`, and you import from that. When your API changes, you rerun the generator, or your types silently lie.
+
+Both are useful. Both are also a step you have to remember, a process that has to be running, and a layer between the code you wrote and the code that runs. Not needing one is nice for a simple reason. There is less to set up, less to keep in sync, and nothing to forget.
+
+
+# Server actions carry the real signature
+
+In WebJs a server action is a function in a `*.server.ts` file marked `'use server'`. You import it into a client component with a normal import. The framework rewrites that import into a typed RPC stub, a small client function that POSTs to `/__webjs/action/<hash>/<fn>` and gives you back the result. You never hand-write the `fetch`. Importing the function IS the API.
+
+The part that matters for types: the type checker never sees the stub. It resolves your import to the real source file, so it reads the actual function signature, arguments and return type included.
+
+```ts
+// modules/posts/actions/create-post.server.ts
+'use server';
+export async function createPost(
+  input: { title: string; body: string },
+): Promise<ActionResult<PostFormatted>> {
+  /* ... */
+}
+
+// modules/posts/components/new-post.ts
+import { createPost } from '../actions/create-post.server.ts';
+
+const r = await createPost({ title, body });
+//        ^ Promise<ActionResult<PostFormatted>>
+if (r.success) r.data.title;   // PostFormatted.title, typed as string
+```
+
+Pass `{ titel: '...' }` and the editor flags it. Read `r.data.slug` when `PostFormatted` has no `slug` and the editor flags that too. There is no separate schema file describing the wire, and no generator to rerun when the function changes. Change the return type of `createPost` and every caller updates on the next keystroke, because they were reading the one real definition the whole time.
+
+
+# The types you get are the types the server returned
+
+A JSON round-trip flattens your data. A `Date` becomes a string. A `Map` becomes `{}`. So even when a tool gives you accurate types, the values at runtime often do not match them, because JSON cannot carry those shapes.
+
+WebJs uses its own wire serializer instead of plain JSON. It round-trips `Date`, `Map`, `Set`, `BigInt`, `Error`, typed arrays, `Blob`, `File`, `FormData`, Symbols, and reference cycles. So a `Date` you return from the server arrives as a real `Date` on the client, not a string you have to reparse.
+
+```ts
+const r = await createPost({ title, body });
+if (r.success) {
+  r.data.createdAt.getFullYear();  // a real Date, .getFullYear() works
+}
+```
+
+This is why the type safety is honest and not just optimistic. The type says `Date`, the value is a `Date`. The one caveat worth knowing: a class instance comes through as a plain object, so prototypes and methods are lost (the same rule as React server actions). If you want that caught at compile time, the optional `SerializableActionFn` annotation turns a non-serializable field or argument into a type error instead of a silent runtime surprise. It is opt-in, because a plain `export async function` stays plain.
+
+
+# Types for the rest of the app too
+
+Server actions are the headline, but the type flow reaches the routing layer as well.
+
+Run `webjs types` and the framework generates `.webjs/routes.d.ts`, an overlay with one entry per route in `app/`. It gives you a typed `Route` union (`navigate('/blog/anything')` is fine, `navigate('/nonexistent')` is a type error) plus per-route params. `webjs dev` regenerates it on startup and after each route rebuild, so the editor always has fresh route types (this is #258, WebJs's no-build answer to Next 15's `typedRoutes`, done through interface declaration-merging instead of a bundler).
+
+Three exported helper types read that union. `PageProps<R>` types a page's `{ params, searchParams, url, actionData }`, `LayoutProps<R>` adds `children`, and `RouteHandlerContext<R>` types a `route.ts` handler's second argument. Pass the route literal and `params` narrows to the exact shape.
+
+```ts
+import type { PageProps } from '@webjsdev/core';
+
+export default function Post({ params }: PageProps<'/blog/[slug]'>) {
+  const slug = params.slug;   // typed as string, not Record<string, string>
+  /* ... */
+}
+```
+
+`Metadata` types a page's `metadata` export so a misspelled field (`titel`, `descripton`) is a compile-time error, and `WebjsConfig` types the `webjs` block in `package.json` so a typo'd config key is diagnosed instead of silently dropped. Every one of these is a pure type. It is erased at runtime with zero cost.
+
+
+# Why none of this needs a build step
+
+Here is the part that surprises people coming from tRPC or GraphQL. There is no build step and no code-generation server anywhere in this.
+
+tRPC gets excellent inference, but you wire up routers and thread a client type through your app to get it. GraphQL is fully typed, but you pay for it with a codegen step that has to run whenever the schema moves. Both are good tools. Both add a process you maintain.
+
+WebJs skips the process because the type flow is just a normal import resolving to a normal file. TypeScript is **erasable** (invariant 10), which means the type annotations can be stripped out with nothing left to compile. On Node 24+ the runtime strips them with the built-in `module.stripTypeScriptTypes`, position-preserving, so the `.ts` file you wrote is the file the browser fetches, with the types whitespace-erased. There is no `tsc` producing output that runs in its place. The only requirement is `erasableSyntaxOnly: true` in `tsconfig.json`, which keeps your TypeScript to the erasable subset (no `enum`, no value `namespace`, no constructor parameter properties) so the editor flags anything the stripper cannot handle before you ever run it.
+
+So the type checker runs in your editor and (optionally) in CI as `tsc --noEmit`. The runtime never type-checks. It just erases. The types are a development-time overlay on files that already run as-is, which is exactly why there is nothing to build and nothing to generate. Full-stack types fall out of the architecture instead of being bolted onto it.
+
+
+# The takeaway
+
+Full-stack type safety in WebJs is not a feature you configure, it is what you get by default. A server action imported into a client component carries its real signature across the network, so calling your backend is as safe as calling a local function, and a wrong argument or a missing field is caught in your editor before the code runs. The wire serializer round-trips `Date`, `Map`, `Set`, and more, so the types you see are the values you actually get, not a JSON-flattened guess. `webjs types`, `PageProps`, `Metadata`, and `WebjsConfig` extend that safety to routing, metadata, and config. And all of it works with no build step and no codegen, because TypeScript is erasable and the file you write is the file that runs.

--- a/blog/mcp-server-for-ai-coding-agents.md
+++ b/blog/mcp-server-for-ai-coding-agents.md
@@ -1,0 +1,67 @@
+---
+title: "Give AI Coding Assistants Live Access to Your App"
+date: 2026-06-19T15:00:00+05:30
+slug: mcp-server-for-ai-coding-agents
+description: "WebJs ships a read-only MCP server for AI coding agents. Learn how the Model Context Protocol lets Claude, Cursor, and other AI assistants read your app's real routes, actions, and components instead of guessing them."
+tags: mcp, ai-first, ai-agents, tooling, dx
+author: Vivek
+---
+
+You have probably felt this already. You ask an AI coding assistant to add a feature, it writes something that looks perfect, and then you notice it invented a route that does not exist, or called a server action with a signature you never wrote. The code compiles in its head. It just does not match your actual app.
+
+This is not the model being dumb. It is the model working with incomplete information. When an assistant only has your files to read, it reconstructs your app's shape from source and fills the gaps with plausible guesses. Most of the time the guess is close. The times it is wrong are the times you lose an hour.
+
+WebJs ships a small thing that fixes a big part of this. Every scaffolded app wires up a read-only MCP server, `@webjsdev/mcp`, that lets the agent ask the running project what actually exists instead of guessing.
+
+# What MCP is, in one sentence
+
+MCP (Model Context Protocol) is the emerging open standard for how an AI tool like Claude or Cursor connects to an outside source of data or tools, so the model can read real information at the moment it needs it rather than working from a static snapshot.
+
+Think of it as a plug. On one side is your AI assistant. On the other is anything that can answer questions (a database, a filesystem, an API, or in this case, your WebJs project). Once the plug is connected, the assistant can pull ground truth on demand.
+
+# What the WebJs MCP server exposes
+
+The server is intentionally small and gives the agent four tools plus a knowledge layer.
+
+- `list_routes` returns every route your app actually serves, derived from the `app/` file tree the same way the router derives it.
+- `list_actions` returns your server actions, including the RPC hash each one is called through and its per-action config (the HTTP verb, the cache settings). This is the big one, more on it below.
+- `list_components` returns the custom elements your app registers.
+- `check` runs the `webjs check` correctness validator and hands back the violations as structured data.
+
+On top of those, there is a knowledge layer that serves the WebJs docs, the recipes, and the framework source. So the agent can look up how a feature is meant to be used, straight from the authoritative reference, without you pasting docs into the chat.
+
+# Why the action hashes matter most
+
+Here is the thing an agent genuinely cannot infer reliably.
+
+In WebJs, a server action is a function in a `*.server.ts` file marked `'use server'`. When a client component imports it, the import is rewritten into an RPC stub that POSTs to a hashed URL like `/__webjs/action/<hash>/<fn>`. The hash and the per-action config (the verb, whether the result is cached) are computed by the framework, not written by you.
+
+So if an agent is reasoning about how a client actually reaches the server, or debugging a request in the network tab, the hash is not sitting in your source in a form it can read off. It is a derived value. Guessing it is hopeless. Reading it live from `list_actions` is trivial.
+
+```sh
+# Run the server directly
+npx @webjsdev/mcp
+
+# Or through the CLI, same thing
+webjs mcp
+```
+
+Point your assistant's MCP config at that command and the tools show up in the agent's toolbox. From then on, "what actions does this app expose" is a lookup, not a search-and-guess.
+
+# It is read-only, which is the point
+
+The WebJs MCP server does not write files, run migrations, or mutate anything. Every tool answers a question. That is a deliberate design choice, because it means pointing an agent at it carries no risk. The worst it can do is tell the agent the truth about your app.
+
+Read-only also keeps the trust model simple. You do not have to review what the MCP server did, because it did nothing except report. The agent still makes its edits through the normal channels you already supervise.
+
+# This is the AI-first thesis, made concrete
+
+I have written before that WebJs being AI-first is plumbing, not a slogan. AGENTS.md, the enforced conventions, the readable source, the lint rules that fail at the seam where mistakes happen. The MCP server is another piece of that same plumbing.
+
+The pattern is always the same. Instead of hoping the agent guesses right, remove the need to guess. AGENTS.md removes the guess about where a file goes. `webjs check` removes the guess about whether the code is correct. The MCP server removes the guess about what the running app actually contains.
+
+Notice that `@webjsdev/mcp` is a standalone package, extracted out of the CLI so it can be installed and pointed at on its own. It is the same read-only introspection the CLI already had, packaged as a protocol any MCP-speaking tool can plug into. A separate note: for UI debugging (clicking through pages, taking screenshots) you would reach for the Playwright MCP server. `@webjsdev/mcp` is about the shape of your app, not driving its browser.
+
+# The takeaway
+
+AI coding assistants are genuinely useful, and they are at their worst when they have to invent your project's details. The WebJs MCP server closes that gap by letting the agent ask the running project for ground truth: the real routes, the real components, and above all the real server actions with their framework-computed RPC hashes and per-action config that no amount of reading source can reliably reconstruct. It is read-only, so it is safe to hand to any agent, and it ships wired up in every scaffold. Run `npx @webjsdev/mcp` or `webjs mcp`, connect it to Claude or Cursor, and your assistant stops guessing what your app looks like and starts reading it.

--- a/blog/prisma-vs-drizzle-default-orm.md
+++ b/blog/prisma-vs-drizzle-default-orm.md
@@ -1,0 +1,110 @@
+---
+title: "Prisma vs Drizzle: Why We Chose Drizzle as Our Default ORM"
+date: 2026-06-28T12:00:00+05:30
+slug: prisma-vs-drizzle-default-orm
+description: "Prisma vs Drizzle for a no-build framework. Why WebJs picked Drizzle ORM as the scaffold's default ORM, how the buildless, source-is-the-runtime model made the decision, and how to bring your own if you prefer Prisma."
+tags: orm, drizzle, prisma, database, defaults
+author: Vivek
+---
+
+Every full-stack framework has to pick a way to talk to your database. When you scaffold a new WebJs app, you get one already wired up, so you can write features instead of spending your first afternoon comparing libraries. That default is Drizzle.
+
+Before anything else, the honest framing. Drizzle, Tailwind, and SQLite are scaffold **defaults**, not lock-in. WebJs is not coupled to any of them. If you prefer Prisma, or Kysely, or raw SQL, or Postgres over SQLite, you swap the `db/` folder and keep going. Nothing else in the framework knows or cares. This post is the story of why we picked Drizzle as the thing you get for free, not a claim that you are stuck with it.
+
+First, the term. An ORM (object-relational mapper) is a library that lets you talk to your database in code, with functions and objects, instead of hand-writing raw SQL strings. Prisma and Drizzle are both ORMs. Both are good. The question was never "which one is better in the abstract." It was "which one fits a framework that has no build step."
+
+That constraint is the whole story.
+
+
+# The one constraint that decided it
+
+WebJs has no build step. The `.ts` files you write are the files the runtime serves. There is no `webjs build` command, because there is nothing to compile ahead of time. What you read in `node_modules` is what runs. That single design choice ("source is the runtime") is the lens every dependency gets held up to.
+
+Prisma, for all its strengths, works differently. You write a schema in Prisma's own schema language, then you run `prisma generate`. That command reads your schema and writes out a generated client, a chunk of TypeScript (and native query-engine bindings) that your code then imports. The client is a build artifact. It has to be regenerated every time the schema changes, and it has to exist before your app can run.
+
+A generated client that must be produced by a codegen step, before the app runs, is exactly the kind of thing WebJs is designed not to have. It is a build step wearing a different hat. Adding it back to the one framework whose entire pitch is "no build step" would have been strange.
+
+Drizzle does not have that step. A Drizzle schema is plain TypeScript. Your tables are TypeScript objects, your queries are TypeScript function calls, and the types flow directly from the schema you wrote. There is no generated client sitting between your code and the database. It is just source, which is exactly what the rest of a WebJs app is.
+
+So the decision was not "Drizzle is better than Prisma." It was "Drizzle is shaped like the rest of WebJs, and Prisma is shaped like a build step." For a buildless framework, that fit is the deciding factor.
+
+
+# What Prisma genuinely does well
+
+I want to be fair here, because Prisma is a genuinely good tool and plenty of teams should reach for it.
+
+Its schema language is lovely to read. A `schema.prisma` file is compact and skimmable, and beginners often find it clearer than a wall of TypeScript table definitions. Prisma Studio, the built-in visual database browser, is excellent. The generated client gives you rich, precise autocomplete because the types were produced from your exact schema. Its migration tooling is mature and well documented. For a team that already has a build pipeline, the codegen step is a non-issue, because everything else in their stack builds too.
+
+None of that is in dispute. The point is fit, not quality. In a framework where every other file is served straight from source, the one dependency that needs a generate step stands out. In a Next.js app that already runs a bundler, it blends right in.
+
+
+# What the Drizzle default looks like
+
+When you scaffold, the database lives in one folder:
+
+```
+db/
+  schema.server.ts       table definitions (plain TypeScript)
+  columns.server.ts       column-type helpers per dialect
+  connection.server.ts    the db client you import everywhere
+```
+
+You define a table in `db/schema.server.ts`, no separate schema language, no generate step:
+
+```ts
+// db/schema.server.ts
+import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
+
+export const posts = sqliteTable('posts', {
+  id: text('id').primaryKey(),
+  title: text('title').notNull(),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+});
+```
+
+Then you query it from a server action or a query module, importing the same `db` client the whole app shares:
+
+```ts
+// modules/posts/queries/list-posts.server.ts
+'use server';
+import { db } from '../../../db/connection.server.ts';
+
+export async function listPosts() {
+  return db.query.posts.findMany({ orderBy: { createdAt: 'desc' } });
+}
+```
+
+That is the entire loop. Edit the schema, and the types update because the schema is the types. No artifact to keep in sync.
+
+
+# The CLI wraps Drizzle Kit, not a codegen step
+
+WebJs ships a thin database CLI that fronts Drizzle's own tooling (Drizzle Kit):
+
+```sh
+webjs db generate   # create a migration from the current schema
+webjs db migrate    # apply pending migrations
+webjs db push       # push the schema straight to the db (dev)
+webjs db studio     # open Drizzle's visual database browser
+webjs db seed       # run db/seed.server.ts
+```
+
+Note what `webjs db generate` does and does not do. It generates a **migration** (a SQL file describing the schema change), not a client you import. Nothing your app code depends on comes out of a codegen step. Your app imports `db` from `connection.server.ts`, and that file is source you can read. And yes, Drizzle has its own studio, so you do not give up the visual database browser by choosing it.
+
+
+# Bring your own dialect (and your own ORM)
+
+The default database is SQLite, which means a new app runs with zero setup, no server to install, just a file. When you are ready for Postgres, one flag at scaffold time picks the dialect:
+
+```sh
+webjs create my-app --db postgres
+```
+
+Here is the part that makes this a default rather than a lock-in. The schema, the queries, and the server actions are **identical across dialects** (the dialect-parity work landed in #563). You do not rewrite your data layer to move from SQLite to Postgres. The `db/columns.server.ts` helper absorbs the per-dialect differences, and the code you wrote against `db.query...` stays the same.
+
+And if you would rather use Prisma, or Kysely, or write raw SQL, that door is open too. The framework's only real contract with the database is "server-only code lives in `.server.ts` files." Whatever you export a `db` client from, and however you built it, WebJs will happily run. Swap the `db/` folder for a Prisma setup, keep `prisma generate` in your own dev script, and the rest of the framework does not change. You lose the buildless purity for that one dependency, which is a trade you are allowed to make.
+
+
+# The takeaway
+
+Drizzle is the default because it is the same shape as everything else in WebJs: plain TypeScript, served from source, with no codegen artifact sitting between you and the runtime. Prisma is an excellent ORM with a lovely schema language and a great studio, and the only strike against it here is that its `prisma generate` step is a build step, which is the one thing a no-build framework is built to avoid. So this was a fit decision, not a quality verdict. Most important: Drizzle, SQLite, and Tailwind are the batteries the scaffold includes so you can ship on day one, not walls you are trapped behind. Prefer a different ORM, database, or styling approach? Swap it in and keep building. The default just means you do not have to decide before you have written a single feature.

--- a/blog/server-side-caching-explained.md
+++ b/blog/server-side-caching-explained.md
@@ -1,0 +1,116 @@
+---
+title: "Server-Side Caching for Beginners (ETags, Tags, and 304s)"
+date: 2026-06-25T11:00:00+05:30
+slug: server-side-caching-explained
+description: "A beginner-friendly guide to server-side caching in webjs: HTTP Cache-Control, the cache() query helper, tag-based cache invalidation, conditional GET with ETags and HTTP 304 Not Modified, and the export const revalidate HTML cache. Plus the safety rule for per-user data."
+tags: caching, performance, etag, http, no-build
+author: Vivek
+---
+
+Here is a pattern I see in almost every new app. A page loads a list of posts. Each request opens the database, runs the same query, gets the same rows, and renders the same HTML. Ten visitors in one second means ten identical trips to the database for a result that did not change. That is slow, and it is wasteful.
+
+Caching is the fix. A cache stores a computed or fetched result so you can skip the work next time. The hard part was never storing the value. The hard part is knowing when the stored value is stale and throwing it away at the right moment. That second half is called invalidation, and it is where most caching bugs live.
+
+webjs gives you a few caching layers, each aimed at a different kind of "same work repeated." This post walks through all of them from scratch, in plain language, and is careful about the one safety rule that matters most (never cache one user's data where another user can see it).
+
+# Layer 1: HTTP Cache-Control on responses
+
+The cheapest cache is the one you never run yourself. Browsers, CDNs, and reverse proxies already know how to hold onto a response if you tell them it is safe to. You tell them with a `Cache-Control` header.
+
+```js
+// app/api/posts/route.js
+export async function GET() {
+  const posts = await db.query.posts.findMany();
+  return new Response(JSON.stringify(posts), {
+    headers: {
+      'Cache-Control': 'public, max-age=60, stale-while-revalidate=300',
+      'Content-Type': 'application/json',
+    },
+  });
+}
+```
+
+`public, max-age=60` means "anyone may reuse this for 60 seconds." For an SSR page, you set the same idea through page metadata with `cacheControl: 'public, max-age=60'`. No framework cache layer runs here at all. You are handing the job to the standards that already ship in every browser and every CDN.
+
+# Layer 2: cache() for query results, with tags
+
+The HTTP header caches a whole response. Often you want to cache one expensive thing inside the request instead, like a database query. webjs ships a `cache()` helper for that. You wrap an async function, give it a key, and give it a time-to-live in seconds.
+
+```ts
+// modules/posts/queries/list-posts.server.ts
+'use server';
+import { cache } from '@webjsdev/server';
+import { db } from '../../../db/connection.server.ts';
+
+export const listPosts = cache(
+  async () => db.query.posts.findMany({ orderBy: { createdAt: 'desc' } }),
+  { key: 'posts', ttl: 60 }
+);
+```
+
+The first call runs the query and stores the result. Every call within the next 60 seconds returns the stored value without touching the database. Values round-trip through webjs's rich serializer, so a row's `createdAt` stays a real `Date` on a warm hit, not a string.
+
+Time-to-live handles the "eventually go stale" case. But what about "go stale the instant someone edits a post"? That is where tags come in. Tag-based invalidation means you label cached data so a write can evict exactly the entries it affected, instead of guessing or clearing everything.
+
+```ts
+export const postById = cache(
+  async (id: string) => db.query.posts.findFirst({ where: { id } }),
+  { key: 'post', ttl: 300, tags: (id) => ['post:' + id] } // per-entity tag
+);
+```
+
+Now a mutation calls `revalidateTag` after it writes, and it works across modules with no import of the query wrapper.
+
+```ts
+// modules/comments/actions/create-comment.server.ts
+'use server';
+import { revalidateTag } from '@webjsdev/server';
+
+export async function createComment(input) {
+  await db.insert(comments).values(input);
+  await revalidateTag('post:' + input.postId); // recompute just this post
+  return { success: true };
+}
+```
+
+`revalidateTag('post:5')` evicts only the id-5 entry and leaves every other id cached. That precision is the whole point. An untagged `cache()` is never touched by `revalidateTag`, so tagging is opt-in per query.
+
+# Layer 3: caching the whole page's HTML (revalidate)
+
+For a page that renders identical HTML for everyone, you can cache the finished HTML so the SSR pipeline runs once per window instead of once per request. This is webjs's no-build take on Next.js's ISR. You declare a window on the page module.
+
+```ts
+// app/blog/page.ts
+export const revalidate = 60;   // cache this page's HTML for 60 seconds
+
+export default async function Blog() {
+  const posts = await listPosts();
+  return html`...`;
+}
+```
+
+Evict it early on a write with `revalidatePath('/blog')` from a server action. Time-based eviction happens on its own when the window expires.
+
+# The safety rule you must not skip
+
+Read this part twice. `export const revalidate` is you asserting "this page is the same for every visitor for N seconds." The HTML cache is keyed by the full URL only, with no per-user keying. So a page that reads `cookies()`, a session, or any per-user data MUST NOT set `revalidate`. If it does, the first visitor's rendered HTML can be served to the next visitor. A wrongly-cached per-user page is a data leak, plain and simple.
+
+webjs backs this with a framework defense. When your render reads per-user state through a framework helper (`cookies()`, `headers()`, `getSession()`, or `auth()`), the framework auto-marks the request dynamic and refuses to cache it even if you set `revalidate`, warning you once. So a dashboard page that does `const session = await auth()` fails safe. The loud caveat: this only catches reads THROUGH those helpers. If you read an auth cookie raw instead of via `cookies()`, the page can still be cached wrongly. The rule holds regardless. Read per-user state through the helpers, or never set `revalidate` on a per-user page.
+
+# Layer 4: conditional GET (ETags and 304s)
+
+The layers above avoid recomputing. This last one avoids re-sending bytes the client already has.
+
+An ETag is a short fingerprint of a response, like a version stamp. webjs puts one on every cacheable response. The browser stores it, and on the next request it sends it back in an `If-None-Match` header, effectively asking "do you still have exactly this?" If the fingerprint still matches, the server replies `304 Not Modified` with an empty body, meaning "unchanged, reuse what you have." A tiny 304 instead of the full payload.
+
+This is on by default and needs no code. It covers cacheable SSR pages, static assets in `public/`, your app's source modules, and the core and vendor runtime uniformly. The ETag is the hash of the response body, so an identical body always produces an identical ETag.
+
+Crucially, it is careful about privacy. A `no-store` page (the default for dynamic and per-user pages) and any `private` response get no ETag and never 304, because a shared cache keyed on the URL could otherwise replay one user's validator to another. The same private-content instinct as the `revalidate` rule, applied one layer down.
+
+# Layer 5: content-hash asset URLs
+
+One more, for completeness. In production webjs appends a per-file content hash to asset URLs as `?v=<hash>` and serves those with `Cache-Control: public, max-age=31536000, immutable`. Because the hash changes whenever the file's bytes change, the browser can cache the file forever and still pick up a new version after a deploy (the URL changes, so it fetches fresh). This is a no-op in dev, so your source stays byte-identical to what you wrote.
+
+# The takeaway
+
+Recomputing or refetching the same result on every request is slow and wasteful, and webjs gives you four honest ways to stop doing it plus asset fingerprinting on top. Use `Cache-Control` to let browsers and CDNs hold whole responses, `cache()` with tags to memoize expensive queries and evict them precisely, `export const revalidate` to cache a page's HTML, and conditional GET (ETags into 304s) to skip re-sending unchanged bytes, all of it standing on plain HTTP. The one rule to internalize before you cache anything: a cache keyed by URL is shared across users, so only cache data that is truly the same for every visitor, and read per-user state through the framework helpers so webjs can fail safe for you.

--- a/blog/stop-ai-agents-breaking-your-code.md
+++ b/blog/stop-ai-agents-breaking-your-code.md
@@ -1,0 +1,99 @@
+---
+title: "How WebJs Stops AI Coding Agents From Breaking Your Code"
+date: 2026-06-30T10:00:00+05:30
+slug: stop-ai-agents-breaking-your-code
+description: "AI coding agents write a lot of your code now, and left unsupervised they commit to main, skip tests, and ignore your conventions. WebJs is an AI-first framework that bakes agent guardrails into tooling, so drift gets caught at the seam instead of buried in a doc nobody reads."
+tags: ai-first, ai-agents, guardrails, tooling, dx
+author: Vivek
+---
+
+If you build software in 2026, an AI agent writes a good chunk of your code. Claude Code, Cursor, Copilot, Antigravity, Aider. You describe a feature, the agent produces files, you skim and accept. It is genuinely fast.
+
+It is also, left to its own devices, a little reckless. An agent will happily commit straight to `main`. It will ship a feature with no test, because the feature "works". It will drop a helper in the wrong directory because it did not read your project layout. It will confidently add a bundler config to a framework that has no build step. None of this is malice. The agent is doing what its training data suggests, and your project's rules live in a `CONTRIBUTING.md` it never opened.
+
+I wrote about the philosophy of this in an earlier post ("AI-first is plumbing, not a marketing tag"). This post is the concrete version. Here is exactly how WebJs stops an agent from breaking your code, mechanism by mechanism. Every piece below is real and ships in the scaffold.
+
+# The rules go where the agent will actually read them
+
+An agent reads whichever instruction file matches its tool. So WebJs ships all of them, and they all say the same thing.
+
+```
+AGENTS.md                        the contract (source of truth)
+CONVENTIONS.md                   project conventions, overridable
+CLAUDE.md                        Claude Code (imports AGENTS.md)
+.cursorrules                     Cursor
+.agents/rules/workflow.md        Antigravity
+.github/copilot-instructions.md  GitHub Copilot
+```
+
+Plus a `.claude/settings.json` wiring up hooks, a PR template, and an `.editorconfig`. The point is not the file count. The point is that whichever agent you happen to be driving, it lands in the project and finds the same conventions in its own native format. There is no "the agent didn't know" excuse, because the knowledge is in the file the agent reads first.
+
+But a document is advisory. An agent can read a rule and still forget it three tool-calls later. That is why the load-bearing enforcement is not the docs. It is the hooks.
+
+# Hooks that block bad commits and bad prompts
+
+Claude Code fires shell hooks on tool events (before an edit, before a Bash command, after a write, on every prompt). WebJs ships a set of them under `.claude/hooks/`, and they turn "please follow the rules" into "you literally cannot do that". Here is what each one does, verified against the scripts themselves.
+
+`guard-branch-context.sh` runs before any edit. If you are on `main` or `master`, it pauses and asks you to create a feature branch first (`git checkout -b feature/<name>`) before it lets the edit through. No more accidental direct-to-main commits from an agent that skipped the git etiquette.
+
+`require-tests-with-src.sh` runs before `git commit`. It inspects the staged diff, and if you staged framework source with no accompanying test file, it stops the commit and names the layers you might need (unit, browser, e2e, smoke, Bun). It even catches the sneaky failure mode where an agent trims tests to make the suite pass. It counts staged test lines, and a net-negative count next to a source change gets blocked as "tests removed to slip through". In the framework repo this hook blocks; in a scaffolded app it warns by default (set `WEBJS_TEST_GATE=block` to make it hard).
+
+`require-docs-with-src.sh` is the documentation twin. Change a public-facing surface and stage no doc update, and the commit is blocked until you bring a doc surface along. This exists because the recurring failure was updating one surface and leaving the rest stale.
+
+`require-bun-parity-with-runtime-src.sh` guards the fact that WebJs runs on Node 24+ and Bun. Touch a runtime-sensitive file (the serializer, the listener, streams, crypto) with no cross-runtime test staged, and it blocks until you prove the change on both runtimes.
+
+`route-skills.sh` runs on every prompt. A "skill" is a scripted workflow the agent is supposed to invoke, but a model only invokes it when it judges the prompt to match, and that judgement is wobbly. This hook keyword-matches your prompt against each skill's triggers and injects a directive telling the agent to run the matching skill first. It makes routing deterministic instead of hoping the model notices.
+
+`nudge-uncommitted.sh` is the gentle one. After enough edits pile up (four by default), it reminds the agent to commit the current logical unit before sprawling further. Soft, does not block, just keeps the history clean.
+
+`block-prose-punctuation.sh` enforces the writing style, and it is the reason this very post reads the way it does. It blocks em-dashes and a few other patterns in any new content the agent writes. I am composing this under that hook right now, which is why you will not find a single em-dash anywhere above or below.
+
+The theme across all of them is the same. The rule is enforced at the exact seam where the mistake happens (the commit, the edit, the prompt), not in a paragraph the agent skimmed once.
+
+# One task, one git worktree
+
+Here is a subtle one that only bites when more than one agent works the repo at once. Two agents sharing a single checkout collide. A `git checkout` in one moves `HEAD` under the other, so the next commit from the second agent lands on the wrong branch.
+
+This is not hypothetical. It happened to me. A `chore: release` commit landed on an unrelated `feat/` branch, dragging a contaminated changelog with it, because one agent switched branches while another was mid-commit.
+
+The fix is boring and total. One task gets one git worktree.
+
+```sh
+git worktree add -b feature/my-task ../repo-my-task origin/main
+cd ../repo-my-task    # all work for this task happens here
+```
+
+Git enforces one branch per worktree, so two agents in two worktrees physically cannot move each other's `HEAD`. The collision becomes impossible rather than merely discouraged. AGENTS.md documents this as the standing rule for any concurrent work.
+
+# The webjs check command runs correctness rules, and never optionally
+
+WebJs draws a hard line between two kinds of rules, and keeping them separate is what makes each one trustworthy.
+
+`CONVENTIONS.md` holds project conventions. Where actions live, one function per file, how features are tested. These are preferences a reasonable project could do differently, so they are guidance you can customize.
+
+`webjs check` is the other kind. It runs correctness-only rules, the things that are wrong to ship. Code that crashes in production, a server secret leaking into a browser bundle, TypeScript that will not strip, a shell written in a non-root layout. These run unconditionally with no per-project disabling, because the answer to "could a sensible app want this to pass?" is no.
+
+```sh
+webjs check           # report violations
+webjs check --rules   # list every rule
+```
+
+The rules are the concrete failure modes an agent trips over. A few real ones:
+
+- `use-server-needs-extension`, a `'use server'` directive requires a `.server.{js,ts}` filename, so server code cannot leak through a plain module.
+- `no-static-properties`, reactive properties are declared through the `WebComponent({ ... })` factory, not a hand-written `static properties` block that would throw at runtime.
+- `erasable-typescript-only`, the tsconfig must keep types strippable, because WebJs has no bundler to fall back on.
+- `shell-in-non-root-layout`, only the root layout may write `<!doctype>` / `<html>` / `<head>` / `<body>`.
+- `light-dom-css-prefix`, a light-DOM component with custom CSS prefixes every selector with its tag name.
+
+An agent runs `webjs check`, reads concrete violation messages, and fixes them before the code is anywhere near a review. The narrowness is deliberate. It is a short list of "this will break", not a hundred style opinions, so a green check actually means something.
+
+# The scaffold placeholder that refuses to ship
+
+One more small guard I like. When you scaffold an app, the example content (a demo page, a `User` model, a starter component) carries a `webjs-scaffold-placeholder` marker. The `no-scaffold-placeholder` rule fails until you replace that content and delete the marker.
+
+It exists because an agent will otherwise treat the scaffold as the finished product and ship the example todo app as if it were your feature. The sentinel forces the agent to actually build the thing you asked for, not decorate the demo.
+
+# The takeaway
+
+AI agents are fast and a little careless, and a framework built in 2026 has to plan for that. WebJs does it by moving the rules out of prose and into tooling, so an agent that skips the docs still cannot commit to main, ship untested source, drift the docs, or collide with another agent. The guardrails are dull on purpose (a few shell hooks, a correctness linter, one worktree per task), and dull is the point, because they catch mistakes at the seam where they happen instead of in a review three days later. If you want to see them work, scaffold an app with `npm create webjs@latest my-app` and watch your agent get corrected in real time. The friction you feel is the framework doing its job.

--- a/blog/streaming-server-actions-llm.md
+++ b/blog/streaming-server-actions-llm.md
@@ -1,0 +1,114 @@
+---
+title: "How to Stream AI Responses From a Server Action"
+date: 2026-06-06T14:00:00+05:30
+slug: streaming-server-actions-llm
+description: "How to stream an LLM response token by token in WebJs by returning an async generator from a server action. Streaming server actions push each AI token over one RPC response, no WebSockets, no SSE, no hand-written ReadableStream plumbing."
+tags: server-actions, streaming, llm, ai, rpc
+author: Vivek
+---
+
+You have seen the effect. You ask ChatGPT a question and the answer appears word by word, like someone typing on the other end. The alternative is a spinner that sits there for eight seconds and then dumps a wall of text at once. The word-by-word version feels alive. The spinner feels broken.
+
+The catch is that the streaming version usually costs you a lot of plumbing. You reach for WebSockets, or for Server-Sent Events (a one-way stream of text from server to browser), and now you are wiring up a channel, parsing frames on the client, and handling reconnects. That is a lot of ceremony for "show the text as it arrives."
+
+In WebJs you do not write any of that. A server action can return an async generator (a function that `yield`s values over time instead of returning once), and WebJs streams each yielded chunk to the caller over the single RPC response. The call site reads them with a plain `for await` loop. That is the whole feature (#489). Let me show you.
+
+# The action: yield tokens instead of returning a string
+
+A server action is any exported async function in a `*.server.ts` file marked `'use server'`. Normally it returns a value and WebJs round-trips that value back to the caller. The new part is that if you return something streamable (a `ReadableStream`, an async iterable, or an async generator), WebJs streams the pieces instead of buffering the whole thing.
+
+Here is an action that calls an LLM SDK and yields tokens as they come off the model:
+
+```ts
+// modules/chat/actions/stream-answer.server.ts
+'use server';
+import { actionSignal } from '@webjsdev/server';
+import { openai } from '../../../lib/llm.server.ts';
+
+export async function* streamAnswer(prompt: string) {
+  const signal = actionSignal();
+  const completion = await openai.chat.completions.create({
+    model: 'gpt-4o-mini',
+    messages: [{ role: 'user', content: prompt }],
+    stream: true,
+  }, { signal });
+
+  for await (const part of completion) {
+    const token = part.choices[0]?.delta?.content;
+    if (token) yield token;
+  }
+}
+```
+
+The `async function*` syntax (note the asterisk) is a generator. Every `yield token` hands one piece back to whoever is looping over the call. WebJs serializes each yielded value and flushes it down the response as it is produced, so the browser sees token one while the model is still working on token fifty.
+
+Detection is purely on the return value. There is no config export to set, no `export const stream = true`. You return an async generator, you get streaming.
+
+# The call site: a normal import and a `for await` loop
+
+You never hand-write a `fetch`. When a client component imports `streamAnswer`, WebJs rewrites that import into a typed RPC stub that POSTs to the action endpoint under the hood. The import looks like any other import, and the types flow across the network boundary intact.
+
+Because the action streams, awaiting the stub gives you an async iterable. You loop over it:
+
+```ts
+// modules/chat/components/answer-box.ts
+import { html, WebComponent, signal } from '@webjsdev/core';
+import { streamAnswer } from '../actions/stream-answer.server.ts';
+
+class AnswerBox extends WebComponent({ prompt: String }) {
+  #text = signal('');
+
+  async ask() {
+    this.#text.set('');
+    for await (const token of await streamAnswer(this.prompt)) {
+      this.#text.set(this.#text.get() + token);
+    }
+  }
+
+  render() {
+    return html`
+      <button @click=${() => this.ask()}>Ask</button>
+      <p>${this.#text.get()}</p>
+    `;
+  }
+}
+AnswerBox.register('answer-box');
+```
+
+Each token appends to a signal (WebJs's default reactive state primitive), and the built-in watcher re-renders the paragraph on every change. The text grows on screen exactly the way you wanted, one token at a time, and the transport is one HTTP response you never had to think about.
+
+# Back-pressure comes for free
+
+Back-pressure is the mechanism that stops a fast producer from overwhelming a slow consumer. If the model emits tokens faster than the browser can read them, you do not want the server to buffer the entire completion in memory.
+
+WebJs respects back-pressure on the stream. The generator only advances as the response is drained, so a slow client naturally slows the producer instead of ballooning server memory. You get this without writing a single line for it.
+
+# Cancellation is wired end to end
+
+The other half of streaming is stopping. A user closes the tab halfway through a long answer. You do not want the server to keep paying an LLM to generate tokens nobody will read.
+
+WebJs handles this on both sides (#492).
+
+On the server, an action reads the request's `AbortSignal` through `actionSignal()` from `@webjsdev/server`. That is the `signal` I passed to the OpenAI SDK above. When the client disconnects, the signal aborts, the SDK call stops, and the generator is cancelled. (Called outside an action, `actionSignal()` returns a signal that never aborts, so a plain server-to-server call is always safe.)
+
+On the client, a superseded render aborts the previous request automatically. If your component re-renders with a new prompt while an older `streamAnswer` call is still streaming, WebJs aborts the old in-flight fetch rather than leaking it. Each render gets its own `AbortController`, and the RPC stub binds every fetch to it. You do not manage any of this.
+
+# What streaming turns off, and one thing to know
+
+A streamed result is deliberately never cached, never ETagged, and never seeded into the SSR payload. That makes sense: a live token stream is not a static value you can freeze and replay. If the action is a mutation (a POST, PUT, PATCH, or DELETE), it still emits its `X-Webjs-Invalidate` header on completion so the client cache coordinator knows to revalidate related reads.
+
+Errors are the one thing to keep in mind. Because streaming starts the moment the first byte flushes, the HTTP status is already `200` by the time an error can happen mid-stream. So a throw does not become a `500`. It surfaces as an error from the iterable itself, which means your `for await` loop will throw and you can wrap it in a `try/catch`. In production the message is sanitized to the author-facing text, the same rule that governs every WebJs server action error.
+
+```ts
+try {
+  for await (const token of await streamAnswer(this.prompt)) {
+    this.#text.set(this.#text.get() + token);
+  }
+} catch (err) {
+  this.#text.set('Something went wrong. Please try again.');
+}
+```
+
+# The takeaway
+
+Streaming an AI response used to mean standing up a WebSocket or an SSE endpoint and parsing frames by hand. In WebJs you return an async generator from a `'use server'` action, `yield` each token, and consume it with a `for await` loop on a normal import that WebJs turns into a typed RPC stub. Back-pressure is respected, cancellation is wired through `actionSignal()` on the server and an automatic abort on the client, and a mid-stream error surfaces as a throw from the iterable rather than a broken status code. It is the same mechanism you already use for every server action, so streaming LLM tokens is not a new subsystem to learn. It is one keyword: `yield`.


### PR DESCRIPTION
Clears the blog backlog with ten new posts, one per shipped feature that had no writeup. Each is written for SEO and for early-stage developers: keyword-tuned title + description, a plain-language opening that names the pain before jargon, grounded code examples, and a `# The takeaway` close.

## Posts (dated across June 2026)

| Post | Feature |
|---|---|
| Async Data Fetching in Web Components (await Right in render()) | async `render()` + `<webjs-suspense>` (#469/#471/#472/#474) |
| How to Stream AI Responses From a Server Action | streaming actions / async generators (#489/#492) |
| CSRF Protection Without Tokens, Cookies, or Config | Origin / Sec-Fetch-Site check |
| Full-Stack Type Safety With No Build Step | typed RPC stubs + `webjs types` (#258) |
| How to Fix Those Ugly ../../../ Import Paths | `#` path alias (#555) |
| Give AI Coding Assistants Live Access to Your App | `@webjsdev/mcp` server |
| Accessible Web Components Out of the Box | `@webjsdev/ui` a11y defaults |
| Server-Side Caching for Beginners (ETags, Tags, and 304s) | caching stack (#240/#241/#243) |
| Prisma vs Drizzle: Why We Chose Drizzle as Our Default ORM | default ORM (framed as a default, not lock-in) |
| How WebJs Stops AI Coding Agents From Breaking Your Code | scaffold guardrails + hooks + `webjs check` |

## Verification
- All 10 render at `/blog/<slug>` (HTTP 200, correct titles + body) against a live server; blog index picks them up automatically from frontmatter.
- Punctuation compliant (no em-dashes / pause hyphens / pause semicolons), "WebJs" branding consistent.
- Every technical claim grounded in AGENTS.md / agent-docs / source; the `cache()` signature and #563 attribution were re-verified against the real code.

No issue filed (per request to write directly to a PR).