### PR TITLE
fix: run full pre-serve build in dev, matching start

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,7 @@
     "css:build": "tailwindcss -i ./public/input.css -o ./public/tailwind.css --minify"
   },
   "webjs": {
-    "dev": { "parallel": ["tailwindcss -i ./public/input.css -o ./public/tailwind.css --watch"] },
+    "dev": { "before": ["npm run css:build"], "parallel": ["tailwindcss -i ./public/input.css -o ./public/tailwind.css --watch"] },
     "start": { "before": ["npm run css:build"] }
   },
   "dependencies": {

--- a/examples/blog/package.json
+++ b/examples/blog/package.json
@@ -17,13 +17,18 @@
   },
   "webjs": {
     "dev": {
+      "before": [
+        "webjs db migrate",
+        "npm run css:build"
+      ],
       "parallel": [
         "tailwindcss -i ./public/input.css -o ./public/tailwind.css --watch"
       ]
     },
     "start": {
       "before": [
-        "webjs db migrate"
+        "webjs db migrate",
+        "npm run css:build"
       ]
     }
   },

--- a/packages/ui/packages/website/package.json
+++ b/packages/ui/packages/website/package.json
@@ -15,7 +15,7 @@
   },
   "webjs": {
     "dev": {
-      "before": ["node scripts/copy-registry.js"],
+      "before": ["node scripts/copy-registry.js", "npm run css:build"],
       "parallel": ["tailwindcss -i ./public/input.css -o ./public/tailwind.css --watch"]
     },
     "start": { "before": ["node scripts/copy-registry.js", "npm run css:build"] }

--- a/website/package.json
+++ b/website/package.json
@@ -14,7 +14,7 @@
     "css:build": "tailwindcss -i ./public/input.css -o ./public/tailwind.css --minify"
   },
   "webjs": {
-    "dev": { "parallel": ["tailwindcss -i ./public/input.css -o ./public/tailwind.css --watch"] },
+    "dev": { "before": ["npm run css:build"], "parallel": ["tailwindcss -i ./public/input.css -o ./public/tailwind.css --watch"] },
     "start": { "before": ["npm run css:build"] }
   },
   "dependencies": {


### PR DESCRIPTION
## Problem

`public/tailwind.css` is a gitignored build artifact. The in-repo apps built it (and, for the blog, ran migrations) only in `webjs.start.before`; `webjs.dev` merely started the `tailwindcss --watch` task with no initial build.

So if the on-disk `tailwind.css` was stale (e.g. after the #779 redesign landed over a 3-week-old local build), `webjs dev` served the **stale CSS** until the watcher happened to rebuild, making the local site look broken while production stayed fine (every deploy runs a fresh `css:build`).

## Fix

Bring each app's `webjs.dev.before` to parity with `webjs.start.before`:

| App | `before` (dev = start) |
|---|---|
| website | `npm run css:build` |
| docs | `npm run css:build` |
| ui-website | `node scripts/copy-registry.js`, `npm run css:build` |
| example-blog | `webjs db migrate`, `npm run css:build` |

Also fixes two pre-existing gaps in `example-blog`: `dev.before` was empty (no migrate, no CSS), and `start.before` never built CSS at all.

The `--watch` task still keeps CSS current after boot. `webjs dev` already runs before-steps (verified: ui's `copy-registry` runs on dev boot), so this needs no framework change.

## Scope

- The **scaffold is unaffected**: scaffolded apps use the Tailwind browser runtime (`<style type="text/tailwindcss">`), not a CLI build, so there is no gitignored CSS artifact to go stale. The scaffold's DB config already runs `migrate` in both dev and start.
- Config-only change to four in-repo apps; no public API or framework source touched.