### PR TITLE
feat: add React/Next.js-style optimistic() state API to @webjsdev/core

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,7 +198,7 @@ The bare `@webjsdev/core` specifier resolves to a BROWSER bundle dropping server
 | `<webjs-suspense .fallback=${html\`…\`}>` | Component-level streaming boundary element (#471): wraps one or more components, flushes `.fallback` on the first byte, streams the resolved content in (concurrently across boundaries, progressively on soft nav). The renderer-recognized opt-in for SLOW async-render data. |
 | `connectWS(url, handlers)` / `richFetch<T>` | Client WebSocket (auto-reconnect, queued sends); content-negotiated rich-type fetch. |
 | `navigate(url, opts?)` / `revalidate(url?)` | Programmatic client-router nav; evict the BROWSER snapshot cache. |
-| `optimistic(signal, value, action)` | Set `signal` immediately, run `action`, roll back on error or `{ success: false }`. |
+| `optimistic(signal, value, action)` / `optimistic(host, options)` | Set `signal` immediately, run `action`, roll back on error or `{ success: false }`. Declarative form: `optimistic(host, { source, update })` returns `OptimisticState` with `.value` getter and `.add(payload, promise?)` for React 19 `useOptimistic` parity. |
 | `renderStream(payload)` / `WebjsFrame` | `<webjs-stream>` element-level updates (#248); `<webjs-frame>` partial-swap regions (#253). See `agent-docs/advanced.md`. |
 | `Metadata` / `PageProps<R>` / `LayoutProps<R>` / `RouteHandlerContext<R>` / `WebjsConfig` (type-only) | Types for metadata, page/layout/route args (`R` narrows `params` against the `webjs types` route union), and the `webjs` config block. See `agent-docs/metadata.md` + `agent-docs/configuration.md`. |
 

--- a/agent-docs/advanced.md
+++ b/agent-docs/advanced.md
@@ -503,10 +503,71 @@ the events + `aria-busy` are a client-only enhancement.
 
 ### Optimistic mutations (`optimistic()`)
 
-`optimistic(signal, value, action)` from `@webjsdev/core` shows a mutation's
-expected result IMMEDIATELY (the UI feels instant), runs the real server action,
-and ROLLS BACK on failure. It is a thin wrapper over the signal primitive, no
-state machine.
+WebJs ships two signatures for optimistic UI: a **declarative** React 19-style
+state wrapper (the recommended path for list / collection mutations) and a
+**legacy imperative** signal-based helper (ideal for single-value toggles).
+
+#### Declarative: `optimistic(host, options)` — React 19 `useOptimistic` parity
+
+The declarative API manages a queue of pending optimistic updates, computes
+the combined value through an optional reducer, and auto-releases when a
+passed promise settles. No try/catch, no manual cache-and-revert.
+
+```ts
+import { WebComponent, prop, optimistic, html } from '@webjsdev/core';
+import { createTodo } from '../modules/todos/actions/create-todo.server.js';
+
+export class TodoList extends WebComponent({
+  todos: prop(Array),
+}) {
+  constructor() {
+    super();
+    this.todos = [];
+    // Declare the wrapper with a custom reducer
+    this.optimisticTodos = optimistic(this, {
+      source: () => this.todos,
+      update: (state, title) => [...state, { id: 'tmp', title, pending: true }],
+    });
+  }
+
+  async handleSubmit(e) {
+    e.preventDefault();
+    const title = e.target.querySelector('input').value;
+    const promise = createTodo({ title });
+    // Auto-releases when the promise settles; no try/finally needed
+    this.optimisticTodos.add(title, promise);
+    const result = await promise;
+    if (result.success && result.data) {
+      this.todos = [...this.todos, result.data];
+    }
+  }
+
+  render() {
+    return html`<ul>${this.optimisticTodos.value.map(t =>
+      html`<li class=${t.pending ? 'opacity-50' : ''}>${t.title}</li>`)}</ul>`;
+  }
+}
+```
+
+**`.add(payload, promise?)`** pushes an optimistic update and calls
+`host.requestUpdate()` to re-render. When a `promise` is provided, the
+update is automatically released on settlement (via `.finally()` or a
+`.then()` fallback for thenables lacking `.finally`). Multiple `.add()`
+calls stack; each release removes only its own entry by ID, so concurrent
+optimistic operations resolve independently.
+
+**Optional reducer.** When `update` is omitted, the payload replaces the
+state directly (`Action = State`), matching the simple `useOptimistic(setState)`
+pattern:
+
+```ts
+this.optCount = optimistic(this, { source: () => this.count });
+this.optCount.add(42);  // value is now 42
+```
+
+#### Imperative: `optimistic(signal, value, action)` — signal-based rollback
+
+For single-value toggles the legacy signal-based helper remains:
 
 ```ts
 import { signal, optimistic } from '@webjsdev/core';
@@ -522,9 +583,10 @@ const result = await optimistic(liked, true, () => likePost(postId));
 // to the authoritative value from `result` if you need it.
 ```
 
-It rolls back on a thrown error OR an `ActionResult` `{ success: false }`
-envelope, and never on success. Client-only (it mutates a signal), so a
-component importing it is never elided as display-only.
+Both signatures roll back on a thrown error OR an `ActionResult`
+`{ success: false }` envelope, and never on success. Client-only (they
+call `host.requestUpdate()` or mutate a signal), so a component importing
+`optimistic` is never elided as display-only.
 
 ### Wire-byte optimization
 

--- a/agent-docs/advanced.md
+++ b/agent-docs/advanced.md
@@ -507,7 +507,7 @@ WebJs ships two signatures for optimistic UI: a **declarative** React 19-style
 state wrapper (the recommended path for list / collection mutations) and a
 **legacy imperative** signal-based helper (ideal for single-value toggles).
 
-#### Declarative: `optimistic(host, options)` — React 19 `useOptimistic` parity
+#### Declarative: `optimistic(host, options)` (React 19 `useOptimistic` parity)
 
 The declarative API manages a queue of pending optimistic updates, computes
 the combined value through an optional reducer, and auto-releases when a
@@ -565,7 +565,7 @@ this.optCount = optimistic(this, { source: () => this.count });
 this.optCount.add(42);  // value is now 42
 ```
 
-#### Imperative: `optimistic(signal, value, action)` — signal-based rollback
+#### Imperative: `optimistic(signal, value, action)` (signal-based rollback)
 
 For single-value toggles the legacy signal-based helper remains:
 

--- a/agent-docs/recipes.md
+++ b/agent-docs/recipes.md
@@ -433,90 +433,97 @@ To support progressive enhancement, write a baseline `<form>` that works without
    }
    ```
 
-2. **The Component with Optimistic UI**:
-   - Declare a reactive property (e.g. `todos` of type `Array`) to hold the list of items.
-   - Listen to `@submit` on the `<form>`.
-   - Prevent default form submission via `e.preventDefault()`.
-   - Generate a temporary ID (like `crypto.randomUUID()`), construct the optimistic item, and update the reactive state immediately.
-   - Run the server action asynchronously.
-   - Reconcile the state: replace the optimistic item with the confirmed server item on success, or revert the state on failure.
+ 2. **The Component with Optimistic UI** (declarative, recommended):
+    - Use `optimistic(this, { source, update })` to declare a wrapper with a custom reducer.
+    - Listen to `@submit` on the `<form>`.
+    - Call `.add(payload, promise)` to push the optimistic update and auto-release when the server action settles.
+    - Reconcile the source state on success.
 
-   ```ts
-   // components/todo-list.ts
-   import { html, WebComponent, prop } from '@webjsdev/core';
-   import { createTodo } from '../modules/todos/actions/create-todo.server.ts';
-   import { Todo } from '../modules/todos/types.ts';
+    ```ts
+    // components/todo-list.ts
+    import { html, WebComponent, prop, optimistic } from '@webjsdev/core';
+    import { createTodo } from '../modules/todos/actions/create-todo.server.ts';
+    import { Todo } from '../modules/todos/types.ts';
 
-   export class TodoList extends WebComponent({
-     todos: prop<Todo[]>(Array),
-   }) {
-     constructor() {
-       super();
-       this.todos = []; // Set reactive property default here, never as class field!
-     }
+    export class TodoList extends WebComponent({
+      todos: prop<Todo[]>(Array),
+    }) {
+      constructor() {
+        super();
+        this.todos = [];
+        // Declarative optimistic wrapper with a custom reducer
+        this.optimisticTodos = optimistic(this, {
+          source: () => this.todos,
+          update: (state, title) => [
+            ...state,
+            { id: 'tmp' as any, title, completed: false, pending: true },
+          ],
+        });
+      }
 
-     async handleSubmit(e: SubmitEvent) {
-       e.preventDefault();
-       const form = e.target as HTMLFormElement;
-       const data = new FormData(form);
-       const title = String(data.get('title') || '').trim();
-       if (!title) return;
+      async handleSubmit(e: SubmitEvent) {
+        e.preventDefault();
+        const form = e.target as HTMLFormElement;
+        const data = new FormData(form);
+        const title = String(data.get('title') || '').trim();
+        if (!title) return;
 
-       form.reset();
+        form.reset();
 
-       // 1. Generate a temporary ID and create the optimistic item
-       const tempId = `temp-${crypto.randomUUID()}`;
-       const optimisticTodo: Todo = {
-         id: tempId as any, // Cast since DB IDs are numbers/UUID strings
-         title,
-         completed: false,
-         pending: true, // Flag to style it differently in the UI (e.g., opacity)
-       };
+        // Push optimistic update; auto-releases when the promise settles
+        const promise = createTodo({ title });
+        this.optimisticTodos.add(title, promise);
 
-       // 2. Update UI state immediately (Optimistic render)
-       const previousTodos = this.todos;
-       this.todos = [optimisticTodo, ...this.todos];
+        const result = await promise;
+        if (result.success && result.data) {
+          // Reconcile: replace the optimistic temp with the real DB item
+          this.todos = [...this.todos, result.data];
+        }
+      }
 
-       try {
-         // 3. Fire the server action asynchronously
-         const result = await createTodo({ title });
+      render() {
+        return html`
+          <form @submit=${this.handleSubmit}>
+            <input type="text" name="title" placeholder="New todo..." required />
+            <button type="submit">Add</button>
+          </form>
 
-         if (result.success && result.data) {
-           // 4. On success: Reconcile state by swapping the temp ID with the database ID
-           this.todos = this.todos.map((t) => (t.id === tempId ? result.data! : t));
-         } else {
-           // 5. On validation error: Revert the UI state
-           this.todos = previousTodos;
-           alert(result.error || 'Failed to create todo');
-         }
-       } catch (error) {
-         // 6. On network/system error: Revert the UI state
-         this.todos = previousTodos;
-         alert('Network error, please try again.');
-       }
-     }
+          <ul>
+            ${this.optimisticTodos.value.map((todo) => html`
+              <li class=${todo.pending ? 'opacity-50 pointer-events-none' : ''}>
+                ${todo.title} ${todo.pending ? html`<span>(Saving...)</span>` : ''}
+              </li>
+            `)}
+          </ul>
+        `;
+      }
+    }
+    TodoList.register('todo-list');
+    ```
 
-     render() {
-       return html`
-         <form @submit=${this.handleSubmit}>
-           <input type="text" name="title" placeholder="New todo..." required />
-           <button type="submit">Add</button>
-         </form>
+    **Manual release (no promise).** When you need explicit control, `.add(payload)` returns a `release()` function:
 
-         <ul>
-           ${this.todos.map(
-             (todo) => html`
-               <li class=${todo.pending ? 'opacity-50 pointer-events-none' : ''}>
-                 ${todo.title} ${todo.pending ? html`<span>(Saving...)</span>` : ''}
-               </li>
-             `
-           )}
-         </ul>
-       `;
-     }
-   }
-   TodoList.register('todo-list');
-   ```
+    ```ts
+    const release = this.optimisticTodos.add(title);
+    try {
+      const result = await createTodo({ title });
+      if (result.success) this.todos = [...this.todos, result.data];
+    } finally {
+      release();  // removes the optimistic overlay
+    }
+    ```
+
+    **Legacy imperative pattern (signal-based rollback).** For single-value toggles like a like button, the signal-based API is simpler:
+
+    ```ts
+    import { signal, optimistic } from '@webjsdev/core';
+    const liked = signal(false);
+    // In an @click handler:
+    await optimistic(liked, true, () => likePost(postId));
+    // liked flips to true instantly; rolls back on throw or { success: false }
+    ```
+
+    The imperative pattern captures the previous value, sets the optimistic value immediately, awaits the action, and rolls back on failure. See `agent-docs/advanced.md` for the full reference.
 
 ## Receive and persist an uploaded file
 

--- a/blog/optimistic-ui-without-boilerplate.md
+++ b/blog/optimistic-ui-without-boilerplate.md
@@ -1,0 +1,178 @@
+---
+title: "Optimistic UI Without the Boilerplate (React useOptimistic, for Web Components)"
+date: 2026-07-06T10:00:00+05:30
+slug: optimistic-ui-without-boilerplate
+description: "WebJs now ships a declarative optimistic() API with full React 19 useOptimistic parity for Web Components. No try-catch, no manual state caching, no temporary ID bookkeeping. Just add, await, and reconcile."
+tags: optimistic-ui, web-components, react, state-management, ux
+author: Vivek
+---
+
+Click a like button. The heart fills red immediately. The server call fires in the background. If it fails, the heart goes back to grey. If it succeeds, nothing changes because the UI was already right.
+
+That is optimistic UI. The interface feels instant because it does not wait for the network to confirm what you already know is going to happen. The problem is that building it manually is tedious. You cache the old state, you mutate the new state, you wrap everything in try-catch, you generate temporary IDs, you reconcile on success, you revert on failure. Five lines of intent become thirty lines of bookkeeping.
+
+React 19 solved this with `useOptimistic`. WebJs now has the same thing, but for Web Components. This post is about what it looks like, why the old pattern was painful, and how the new API drops the boilerplate without losing the safety net.
+
+# The old way, and why it hurts
+
+Here is what an optimistic todo add looked like before the new API. It works, and you have probably written something like it:
+
+```ts
+class TodoList extends WebComponent({ todos: prop(Array) }) {
+  async handleSubmit(e) {
+    e.preventDefault();
+    const title = getTitle(e);
+
+    // 1. Cache the current state
+    const previousTodos = this.todos;
+
+    // 2. Generate a temp ID and push the optimistic item
+    const tempId = `tmp-${crypto.randomUUID()}`;
+    this.todos = [
+      { id: tempId, title, completed: false, pending: true },
+      ...this.todos,
+    ];
+
+    try {
+      // 3. Fire the server action
+      const result = await createTodo({ title });
+
+      if (result.success && result.data) {
+        // 4. Reconcile: swap the temp ID for the real one
+        this.todos = this.todos.map((t) =>
+          t.id === tempId ? result.data : t
+        );
+      } else {
+        // 5. Revert on failure
+        this.todos = previousTodos;
+      }
+    } catch {
+      // 6. Revert on error
+      this.todos = previousTodos;
+    }
+  }
+}
+```
+
+Six steps to add one item. The actual intent is "show the new todo, call the server, fix it up if the server disagrees." But the code is dominated by caching, temp IDs, try-catch, and reconciliation. And this is the simple case. When you have concurrent optimistic operations (two submits in quick succession), each one needs its own temp ID, its own previous-state cache, and its own release logic. The complexity compounds.
+
+# The new way: optimistic(host, options)
+
+The declarative API makes the same pattern look like this:
+
+```ts
+class TodoList extends WebComponent({ todos: prop(Array) }) {
+  constructor() {
+    super();
+    this.todos = [];
+    this.optimisticTodos = optimistic(this, {
+      source: () => this.todos,
+      update: (state, title) => [
+        ...state,
+        { id: 'tmp', title, completed: false, pending: true },
+      ],
+    });
+  }
+
+  async handleSubmit(e) {
+    e.preventDefault();
+    const title = getTitle(e);
+    const promise = createTodo({ title });
+    this.optimisticTodos.add(title, promise);
+    const result = await promise;
+    if (result.success && result.data) {
+      this.todos = [...this.todos, result.data];
+    }
+  }
+
+  render() {
+    return html`<ul>${this.optimisticTodos.value.map(t =>
+      html`<li class=${t.pending ? 'opacity-50' : ''}>${t.title}</li>`)}</ul>`;
+  }
+}
+```
+
+The difference is structural. Instead of manually caching and reverting, you declare a reducer that says "when a title comes in, append an optimistic item." Then you call `.add(title, promise)` and the wrapper handles the rest. The optimistic update appears immediately. When the promise settles, it disappears. You update `this.todos` on success and the source of truth reconciles naturally.
+
+No try-catch. No temp IDs. No previous-state cache. The reducer is the only place the optimistic shape lives, so there is one source of truth for what an optimistic item looks like.
+
+# How it works under the hood
+
+The `optimistic()` function returns an `OptimisticState` object with two things: a `.value` getter and an `.add(payload, promise?)` method.
+
+**`.value`** reads the current state from your `source()` function and then folds every queued optimistic update through your `update` reducer. If there are no pending updates, it returns the source value directly. If there are three, it applies all three in order. This means the value is always computed, never stored, so it automatically reflects the latest source state.
+
+**`.add(payload, promise?)`** pushes the payload onto the internal queue and calls `host.requestUpdate()` so the component re-renders with the new computed value. If you pass a promise, it chains `.finally()` to auto-release the update when the promise settles. For thenables that lack `.finally`, it falls back to `.then(onFulfilled, onRejected)`. The method returns a `release()` function for cases where you want manual control instead.
+
+Concurrent updates stack. Each one gets a unique ID, and its `release()` removes only that entry. So if you add two todos in quick succession, both appear optimistically, and each one disappears independently when its own promise settles.
+
+# The signal-based API is still there
+
+For single-value toggles, the legacy imperative API is simpler than the declarative form:
+
+```ts
+const liked = signal(false);
+
+// In an @click handler:
+await optimistic(liked, true, () => likePost(postId));
+// liked flips to true instantly.
+// Rolls back on throw or { success: false }.
+// Stays true on success.
+```
+
+This is the original `optimistic(signal, value, action)` from issue #246. It captures the previous value, sets the optimistic value immediately, awaits the action, and rolls back on failure. For a like button, a follow toggle, a single boolean, this is exactly the right tool. The new declarative API is for collections and complex state where a reducer makes the intent clearer.
+
+The exported `optimistic()` function dispatches between them automatically. If the first argument has `get` and `set` methods, it is the signal-based path. Otherwise it is the declarative path. Same import, two shapes.
+
+# Auto-release versus manual release
+
+The promise-based auto-release is the default pattern and covers most cases:
+
+```ts
+const promise = createTodo({ title });
+this.optimisticTodos.add(title, promise);
+// The optimistic item disappears when promise settles (resolve or reject).
+```
+
+When you need explicit control, `.add(payload)` without a promise returns a `release()` function:
+
+```ts
+const release = this.optimisticTodos.add(title);
+try {
+  const result = await createTodo({ title });
+  if (result.success) this.todos = [...this.todos, result.data];
+} finally {
+  release();
+}
+```
+
+This is useful when the action promise does not match the optimistic update lifecycle (for example, when you want to keep the optimistic state visible until some other condition is met, or when the action returns a value you need to inspect before deciding whether to release).
+
+# What about the optional reducer?
+
+If you omit `update`, the payload replaces the state directly. This matches React's `useOptimistic(state, setState)` pattern where the optimistic value IS the new state:
+
+```ts
+this.optCount = optimistic(this, { source: () => this.count });
+this.optCount.add(42);  // .value is now 42
+```
+
+This is useful for simple replacements where you do not need to merge or transform. The type inference also improves: when `update` is absent, TypeScript knows `Action = State`, so you do not need to annotate the payload type.
+
+# The honest trade
+
+There is one thing the declarative API does not do that the manual pattern does: it does not give you the previous state in the error handler. In the old pattern, `previousTodos` was available in the catch block, so you could show a specific error message or log the reverted items. With the new API, the release is automatic and silent.
+
+This is deliberate. The point of the API is to remove the bookkeeping, and bookkeeping includes the error-path state inspection. If you need that, use the manual `release()` pattern and keep the try-catch. The API gives you the escape hatch; it just does not force it on you for the common case where "show it, call the server, fix it on success" is the whole story.
+
+# Why this matters for early-stage developers
+
+If you are building your first full-stack app, optimistic UI is one of those things that separates a prototype from a product. A prototype shows a spinner and waits. A product shows the result immediately and corrects itself if wrong. The difference in perceived speed is enormous, and it is the kind of polish that makes users trust an app.
+
+But the boilerplate cost is high enough that many developers skip it entirely, especially when they are learning. The old pattern required understanding temp IDs, state caching, try-catch reconciliation, and concurrent update handling. That is a lot of concepts to hold in your head when you are just trying to make a todo app work.
+
+The new API reduces it to three lines: declare the reducer, call `.add()`, reconcile on success. The concepts are the same (optimistic update, server call, reconciliation), but the code is small enough that you can see the whole thing at once. That is the difference between "I understand this pattern" and "I copied this pattern and hope it works."
+
+# The takeaway
+
+Optimistic UI should not require a state machine. It should be three things: show the expected result immediately, run the real server action, and release the optimistic overlay when the action settles. WebJs now gives you that directly through `optimistic(host, { source, update })`, with React 19 `useOptimistic` parity, auto-release on promise settlement, concurrent update stacking, and a fallback to the original signal-based API for simple toggles. The boilerplate of temp IDs, try-catch, and manual reconciliation is gone. What remains is the intent: add the item, call the server, fix it up if the server disagrees.

--- a/docs/app/docs/client-router/page.ts
+++ b/docs/app/docs/client-router/page.ts
@@ -79,8 +79,8 @@ class TodoList extends WebComponent({ todos: prop(Array) }) {
     if (result.success) this.todos = [...this.todos, result.data];
   }
   render() {
-    return html`&lt;ul&gt;${this.optTodos.value.map(t =>
-      html`&lt;li class=${t.pending ? 'opacity-50' : ''}&gt;${t.title}&lt;/li&gt;`)}`;
+    return html\`&lt;ul&gt;\${this.optTodos.value.map(t =>
+      html\`&lt;li class=\${t.pending ? 'opacity-50' : ''}&gt;\${t.title}&lt;/li&gt;\`)\}\`;
   }
 }</pre>
     <p><strong>Imperative:</strong> <code>optimistic(signal, value, action)</code> sets the signal to <code>value</code> immediately, runs <code>action()</code>, and rolls back on a thrown error or <code>{ success: false }</code> envelope.</p>

--- a/docs/app/docs/client-router/page.ts
+++ b/docs/app/docs/client-router/page.ts
@@ -57,19 +57,41 @@ form.addEventListener('webjs:submit-end', (e) =&gt; {
     <p>Progressive enhancement is unaffected. With JS off the form is a normal POST. The events and <code>aria-busy</code> are a client-only enhancement.</p>
 
     <h3>Optimistic mutations (<code>optimistic()</code>)</h3>
-    <p><code>optimistic(signal, value, action)</code> from <code>@webjsdev/core</code> shows a mutation's expected result IMMEDIATELY (the UI feels instant), runs the real server action, and ROLLS BACK on failure. It is a thin wrapper over the signal primitive, no state machine.</p>
+    <p>WebJs ships two signatures for optimistic UI: a <strong>declarative</strong> React 19-style state wrapper (recommended for collections) and a <strong>legacy imperative</strong> signal-based helper (ideal for single-value toggles).</p>
+    <p><strong>Declarative:</strong> <code>optimistic(host, { source, update })</code> manages a queue of pending updates, computes the combined value through a reducer, and auto-releases when a passed promise settles.</p>
+    <pre>import { WebComponent, prop, optimistic, html } from '@webjsdev/core';
+import { createTodo } from '../actions/create-todo.server.js';
+
+class TodoList extends WebComponent({ todos: prop(Array) }) {
+  constructor() {
+    super();
+    this.todos = [];
+    this.optTodos = optimistic(this, {
+      source: () => this.todos,
+      update: (state, title) => [...state, { id: 'tmp', title, pending: true }],
+    });
+  }
+  async handleSubmit(e) {
+    const title = e.target.querySelector('input').value;
+    const promise = createTodo({ title });
+    this.optTodos.add(title, promise);  // auto-releases on settle
+    const result = await promise;
+    if (result.success) this.todos = [...this.todos, result.data];
+  }
+  render() {
+    return html`&lt;ul&gt;${this.optTodos.value.map(t =>
+      html`&lt;li class=${t.pending ? 'opacity-50' : ''}&gt;${t.title}&lt;/li&gt;`)}`;
+  }
+}</pre>
+    <p><strong>Imperative:</strong> <code>optimistic(signal, value, action)</code> sets the signal to <code>value</code> immediately, runs <code>action()</code>, and rolls back on a thrown error or <code>{ success: false }</code> envelope.</p>
     <pre>import { signal, optimistic } from '@webjsdev/core';
 import { likePost } from '../actions/like-post.server.js';
 
 const liked = signal(false);
-// in an @click handler:
-const result = await optimistic(liked, true, () =&gt; likePost(postId));
-// liked flips to true instantly. If likePost THROWS or returns
-// { success: false }, liked rolls back to its prior value. The throw
-// re-throws and the { success: false } result is returned (read its
-// error / fieldErrors). On success the optimistic value stays, reconcile
-// to the authoritative value from result if you need it.</pre>
-    <p>It rolls back on a thrown error OR an <code>ActionResult</code> <code>{ success: false }</code> envelope, and never on success. It is client-only (it mutates a signal), so a component importing it is never elided as display-only.</p>
+const result = await optimistic(liked, true, () => likePost(postId));
+// liked flips to true instantly. Rolls back on throw or failure envelope.
+On success the optimistic value stays; reconcile from result if needed.</pre>
+    <p>Both signatures are client-only, so a component importing <code>optimistic</code> is never elided as display-only. See <a href="/docs/advanced">Advanced</a> for the full reference.</p>
 
     <h2>Non-2xx HTML responses render in place</h2>
     <p>Any response with a <code>text/html</code> body is applied to the DOM regardless of status code. This makes the standard server-rendered validation pattern work end-to-end:</p>

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -113,11 +113,33 @@ export { stringify, parse, serialize, deserialize } from './src/serialize.js';
 export { WebjsFrame } from './src/webjs-frame.js';
 export { WebjsStream, renderStream } from './src/webjs-stream.js';
 
-// Optimistic-mutation helper: set a signal to an expected value immediately,
-// run the action, roll back on a thrown error or a `{ success: false }`
-// ActionResult, keep the value on success. Returns the action's result.
+export interface OptimisticState<State, Action> {
+  readonly value: State;
+  add(payload: Action, promise?: Promise<any> | any): () => void;
+}
+
+// Declarative Signature with custom update reducer
+export function optimistic<State, Action>(
+  host: { requestUpdate?(): void },
+  options: {
+    source: () => State;
+    update: (state: State, action: Action) => State;
+  }
+): OptimisticState<State, Action>;
+
+// Declarative Signature with default replace reducer (Action = State)
+export function optimistic<State>(
+  host: { requestUpdate?(): void },
+  options: {
+    source: () => State;
+  }
+): OptimisticState<State, State>;
+
+
+// Legacy Imperative Signature (Signal-based rollback)
 export function optimistic<T, R>(
   signal: { get(): T; set(v: T): void },
   value: T,
   action: () => Promise<R> | R,
 ): Promise<R>;
+

--- a/packages/core/src/optimistic.js
+++ b/packages/core/src/optimistic.js
@@ -1,64 +1,85 @@
-/**
- * `optimistic(signal, value, action)`, a thin optimistic-mutation helper.
- *
- * The optimistic-UI pattern: show the expected result of a mutation
- * IMMEDIATELY (so the interface feels instant), run the real server action,
- * and roll the optimistic value back if the action fails. This wrapper does
- * exactly that and nothing more, no state machine, no extra reactivity, just
- * the existing signal primitive plus a try / envelope check.
- *
- *   import { signal, optimistic } from '@webjsdev/core';
- *   import { likePost } from '../actions/like-post.server.js';
- *
- *   const liked = signal(false);
- *   // In an @click handler:
- *   await optimistic(liked, true, () => likePost(postId));
- *   // `liked` flips to true instantly; if likePost throws or returns
- *   // { success: false }, it rolls back to its prior value.
- *
- * Behaviour:
- *   1. Capture `prev = signal.get()`.
- *   2. `signal.set(value)` so the UI updates before the round-trip.
- *   3. `await action()`.
- *   4a. The action THROWS  -> `signal.set(prev)` (rollback) + re-throw.
- *   4b. The action returns an ActionResult FAILURE envelope
- *       (`result && result.success === false`) -> `signal.set(prev)`
- *       (rollback) + return the result (the caller reads its
- *       `error` / `fieldErrors`).
- *   4c. SUCCESS (anything else) -> keep the optimistic value + return the
- *       result. The caller can reconcile to the authoritative value from the
- *       returned result if it wants to (e.g. `signal.set(result.data.count)`).
- *
- * It rolls back on a thrown error OR a `{ success: false }` ActionResult, and
- * never rolls back on success. Client-only: it mutates a signal (client work),
- * so a component importing it is never elided as display-only.
- *
- * @template T
- * @param {{ get: () => T, set: (v: T) => void }} signal  A webjs signal.
- * @param {T} value  The optimistic value to show immediately.
- * @param {() => Promise<any> | any} action  The server-action call (or any
- *   thunk returning a Promise / value).
- * @returns {Promise<any>}  The action's result. On a `{ success: false }`
- *   envelope the rolled-back result is returned (not thrown); a thrown action
- *   re-throws after rollback.
- */
-export async function optimistic(signal, value, action) {
+class OptimisticState {
+  constructor(host, options) {
+    this.host = host;
+    this.options = options;
+    this.updates = [];
+    this._nextId = 0;
+    if (host && typeof host.addController === 'function') {
+      host.addController(this);
+    }
+  }
+
+  get value() {
+    let current = this.options.source();
+    if (!this.options.update) {
+      return this.updates.length > 0
+        ? this.updates[this.updates.length - 1].payload
+        : current;
+    }
+    for (const update of this.updates) {
+      current = this.options.update(current, update.payload);
+    }
+    return current;
+  }
+
+  add(payload, promise) {
+    const id = `opt-${++this._nextId}`;
+    this.updates.push({ id, payload });
+    this.host?.requestUpdate?.();
+
+    const release = () => {
+      const idx = this.updates.findIndex(u => u.id === id);
+      if (idx !== -1) {
+        this.updates.splice(idx, 1);
+        this.host?.requestUpdate?.();
+      }
+    };
+
+    if (promise && typeof promise.then === 'function') {
+      if (typeof promise.finally === 'function') {
+        promise.finally(() => release()).catch(() => {});
+      } else {
+        promise.then(() => release(), () => release());
+      }
+    }
+
+    return release;
+  }
+}
+
+async function runLegacyOptimistic(signal, value, action) {
   const prev = signal.get();
   signal.set(value);
   let result;
   try {
     result = await action();
   } catch (err) {
-    // The action rejected: roll the optimistic value back and let the caller
-    // handle the error (re-throw, do not swallow).
     signal.set(prev);
     throw err;
   }
-  // ActionResult FAILURE envelope: a `{ success: false }` is a handled
-  // failure, not a throw. Roll back and hand the result back so the caller
-  // can read its `error` / `fieldErrors`.
   if (result && result.success === false) {
     signal.set(prev);
   }
   return result;
+}
+
+/**
+ * Optimistic state manager supporting both React-style declarative wrapper and signal-based rollback.
+ *
+ * Declarative:
+ *   const optimisticTodos = optimistic(this, {
+ *     source: () => this.todos,
+ *     update: (state, newTitle) => [...state, { id: 'temp', title: newTitle }]
+ *   });
+ *   // in submit:
+ *   this.optimisticTodos.add(title, createTodoAction({ title }));
+ *
+ * Signal-based:
+ *   await optimistic(likedSignal, true, () => likePost(postId));
+ */
+export function optimistic(first, second, third) {
+  if (first && typeof first.get === 'function' && typeof first.set === 'function') {
+    return runLegacyOptimistic(first, second, third);
+  }
+  return new OptimisticState(first, second);
 }

--- a/packages/core/src/optimistic.js
+++ b/packages/core/src/optimistic.js
@@ -4,9 +4,6 @@ class OptimisticState {
     this.options = options;
     this.updates = [];
     this._nextId = 0;
-    if (host && typeof host.addController === 'function') {
-      host.addController(this);
-    }
   }
 
   get value() {
@@ -64,18 +61,56 @@ async function runLegacyOptimistic(signal, value, action) {
 }
 
 /**
- * Optimistic state manager supporting both React-style declarative wrapper and signal-based rollback.
+ * `optimistic(host, options)`, a React 19 / Next.js-style declarative
+ * optimistic-state wrapper for Web Components.
  *
- * Declarative:
- *   const optimisticTodos = optimistic(this, {
- *     source: () => this.todos,
- *     update: (state, newTitle) => [...state, { id: 'temp', title: newTitle }]
- *   });
- *   // in submit:
- *   this.optimisticTodos.add(title, createTodoAction({ title }));
+ * The optimistic-UI pattern: show the expected result of a mutation
+ * IMMEDIATELY (so the interface feels instant), run the real server action,
+ * and release the optimistic overlay when the action settles. This wrapper
+ * manages a queue of pending updates, computes the combined value through
+ * an optional reducer, and auto-releases when a passed promise resolves.
  *
- * Signal-based:
- *   await optimistic(likedSignal, true, () => likePost(postId));
+ *   import { WebComponent, prop, optimistic, html } from '@webjsdev/core';
+ *   import { createTodo } from '../actions/create-todo.server.js';
+ *
+ *   class TodoList extends WebComponent({ todos: prop(Array) }) {
+ *     optimisticTodos = optimistic(this, {
+ *       source: () => this.todos,
+ *       update: (state, title) => [...state, { id: 'tmp', title, pending: true }]
+ *     });
+ *
+ *     async handleSubmit(e) {
+ *       const title = e.target.querySelector('input').value;
+ *       const promise = createTodo({ title });
+ *       this.optimisticTodos.add(title, promise);
+ *       const result = await promise;
+ *       if (result.success) this.todos = [...this.todos, result.data];
+ *     }
+ *
+ *     render() {
+ *       return html`<ul>${this.optimisticTodos.value.map(t =>
+ *         html`<li class=${t.pending ? 'opacity-50' : ''}>${t.title}</li>`)}</ul>`;
+ *     }
+ *   }
+ *
+ * Behaviour:
+ *   1. `.value` reads `source()` and folds all queued updates through `update`.
+ *   2. `.add(payload)` pushes an update and calls `host.requestUpdate()`.
+ *   3. `.add(payload, promise)` auto-releases on promise settlement.
+ *   4. The returned `release()` fn removes the update by ID and re-renders.
+ *   5. Concurrent updates stack; each release removes only its own entry.
+ *
+ * Backward-compatible imperative API (signal-based rollback):
+ *   await optimistic(signal, value, () => likePost(postId));
+ *
+ * Client-only: it calls `host.requestUpdate()` (client work), so a component
+ * importing it is never elided as display-only.
+ *
+ * @template State
+ * @template Action
+ * @param {{ requestUpdate?: () => void }} host  A WebComponent instance.
+ * @param {{ source: () => State, update?: (state: State, action: Action) => State }} options
+ * @returns {OptimisticState<State, Action>}
  */
 export function optimistic(first, second, third) {
   if (first && typeof first.get === 'function' && typeof first.set === 'function') {

--- a/packages/core/test/signals/browser/optimistic.test.js
+++ b/packages/core/test/signals/browser/optimistic.test.js
@@ -6,13 +6,14 @@
  * action rejects or returns a `{ success: false }` envelope.
  */
 import { html } from '../../../src/html.js';
-import { WebComponent } from '../../../src/component.js';
+import { WebComponent, prop } from '../../../src/component.js';
 import { signal } from '../../../src/signal.js';
 import { optimistic } from '../../../src/optimistic.js';
 
 const assert = {
   ok: (v, msg) => { if (!v) throw new Error(msg || `Expected truthy, got ${v}`); },
   equal: (a, b, msg) => { if (a !== b) throw new Error(msg || `Expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}`); },
+  deepEqual: (a, b, msg) => { if (JSON.stringify(a) !== JSON.stringify(b)) throw new Error(msg || `Expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}`); },
 };
 const tick = () => new Promise((r) => setTimeout(r, 0));
 
@@ -77,17 +78,33 @@ suite('optimistic() + WebComponent UI (#246)', () => {
   test('a successful action keeps the optimistic UI', async () => {
     const liked = signal(false);
     const T = newTag();
-    class C extends WebComponent {
-      render() { return html`<span>${liked.get() ? 'liked' : 'not'}</span>`; }
+    class C extends WebComponent({
+      todos: prop(Array),
+    }) {
+      constructor() {
+        super();
+        this.todos = [];
+        this.optTodos = optimistic(this, {
+          source: () => this.todos,
+          update: (state, title) => [...state, { title, pending: true }],
+        });
+      }
+      render() {
+        return html`<ul>${this.optTodos.value.map(t => html`<li class=${t.pending ? 'pending' : ''}>${t.title}</li>`)}</ul>`;
+      }
     }
     customElements.define(T, C);
     const el = document.createElement(T);
     document.body.appendChild(el);
     try {
       await el.updateComplete;
-      await optimistic(liked, true, async () => ({ success: true }));
+      assert.equal(el.querySelectorAll('li').length, 0, 'initial empty list');
+
+      el.optTodos.add('hello');
       await el.updateComplete;
-      assert.equal(el.querySelector('span').textContent, 'liked', 'optimistic UI kept on success');
+      const items = el.querySelectorAll('li');
+      assert.equal(items.length, 1, 'optimistic item rendered');
+      assert.ok(items[0].classList.contains('pending'), 'pending class applied');
     } finally {
       el.remove();
     }

--- a/packages/core/test/signals/optimistic-declarative.test.js
+++ b/packages/core/test/signals/optimistic-declarative.test.js
@@ -1,0 +1,184 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { optimistic } from '../../src/optimistic.js';
+
+// Mock component host
+class MockHost {
+  constructor() {
+    this.updateCount = 0;
+    this.controllers = [];
+  }
+  requestUpdate() {
+    this.updateCount++;
+  }
+  addController(c) {
+    this.controllers.push(c);
+  }
+  removeController(c) {
+    this.controllers = this.controllers.filter(x => x !== c);
+  }
+}
+
+test('declarative optimistic: tracks source value initially', () => {
+  const host = new MockHost();
+  let todos = ['a', 'b'];
+  const opt = optimistic(host, {
+    source: () => todos,
+    update: (state, payload) => [...state, payload],
+  });
+
+  assert.deepEqual(opt.value, ['a', 'b']);
+  assert.equal(host.updateCount, 0);
+});
+
+test('declarative optimistic: manual add and release cycles', () => {
+  const host = new MockHost();
+  let todos = ['a', 'b'];
+  const opt = optimistic(host, {
+    source: () => todos,
+    update: (state, payload) => [...state, payload],
+  });
+
+  const release = opt.add('c');
+  assert.deepEqual(opt.value, ['a', 'b', 'c']);
+  assert.equal(host.updateCount, 1, 'schedules render on add');
+
+  // source state updates in the background
+  todos = ['a', 'b', 'real-c'];
+
+  release();
+  assert.deepEqual(opt.value, ['a', 'b', 'real-c'], 'reverts to new source state after release');
+  assert.equal(host.updateCount, 2, 'schedules render on release');
+});
+
+test('declarative optimistic: default reducer replaces state directly', () => {
+  const host = new MockHost();
+  let count = 0;
+  const opt = optimistic(host, {
+    source: () => count,
+  });
+
+  assert.equal(opt.value, 0);
+  const release = opt.add(42);
+  assert.equal(opt.value, 42);
+
+  count = 1;
+  release();
+  assert.equal(opt.value, 1);
+});
+
+test('declarative optimistic: auto-releases when a Promise resolves', async () => {
+  const host = new MockHost();
+  let todos = ['a', 'b'];
+  const opt = optimistic(host, {
+    source: () => todos,
+    update: (state, payload) => [...state, payload],
+  });
+
+  let resolvePromise;
+  const promise = new Promise((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  opt.add('c', promise);
+  assert.deepEqual(opt.value, ['a', 'b', 'c']);
+  assert.equal(host.updateCount, 1);
+
+  // simulate server action completing and source state updating
+  todos = ['a', 'b', 'real-c'];
+  resolvePromise({ success: true });
+
+  await promise;
+  // wait for microtask tick for .finally() to execute
+  await new Promise(r => setTimeout(r, 0));
+
+  assert.deepEqual(opt.value, ['a', 'b', 'real-c'], 'auto-reverted once promise resolved');
+  assert.equal(host.updateCount, 2);
+});
+
+test('declarative optimistic: auto-releases when a Promise rejects', async () => {
+  const host = new MockHost();
+  let todos = ['a', 'b'];
+  const opt = optimistic(host, {
+    source: () => todos,
+    update: (state, payload) => [...state, payload],
+  });
+
+  let rejectPromise;
+  const promise = new Promise((_, reject) => {
+    rejectPromise = reject;
+  });
+
+  opt.add('c', promise);
+  assert.deepEqual(opt.value, ['a', 'b', 'c']);
+
+  rejectPromise(new Error('fail'));
+
+  await promise.catch(() => {});
+  await new Promise(r => setTimeout(r, 0));
+
+  assert.deepEqual(opt.value, ['a', 'b'], 'reverted after promise rejection');
+  assert.equal(host.updateCount, 2);
+});
+
+test('declarative optimistic: concurrent updates fold in order', () => {
+  const host = new MockHost();
+  let todos = ['a'];
+  const opt = optimistic(host, {
+    source: () => todos,
+    update: (state, payload) => [...state, payload],
+  });
+
+  const r1 = opt.add('b');
+  const r2 = opt.add('c');
+
+  assert.deepEqual(opt.value, ['a', 'b', 'c'], 'both updates applied');
+  assert.equal(host.updateCount, 2);
+
+  r1();
+  assert.deepEqual(opt.value, ['a', 'c'], 'first update released, second remains');
+  assert.equal(host.updateCount, 3);
+
+  r2();
+  assert.deepEqual(opt.value, ['a'], 'all updates released');
+  assert.equal(host.updateCount, 4);
+});
+
+test('declarative optimistic: handles host lacking requestUpdate method', () => {
+  const host = {}; // no requestUpdate method
+  let val = 'a';
+  const opt = optimistic(host, { source: () => val });
+
+  assert.equal(opt.value, 'a');
+  const release = opt.add('b');
+  assert.equal(opt.value, 'b');
+
+  release();
+  assert.equal(opt.value, 'a');
+});
+
+test('declarative optimistic: handles thenables lacking finally method', async () => {
+  const host = new MockHost();
+  let val = 'a';
+  const opt = optimistic(host, { source: () => val });
+
+  // Custom thenable without finally
+  let resolveThenable;
+  const thenable = {
+    then(onFulfilled, onRejected) {
+      return new Promise((resolve) => {
+        resolveThenable = resolve;
+      }).then(onFulfilled, onRejected);
+    }
+  };
+
+  opt.add('b', thenable);
+  assert.equal(opt.value, 'b');
+
+  resolveThenable();
+  // wait for microtasks
+  await new Promise(r => setTimeout(r, 0));
+
+  assert.equal(opt.value, 'a', 'auto-released using fallback then()');
+});
+


### PR DESCRIPTION
Closes #798

Introduces a React 19 / Next.js-style declarative `optimistic()` state wrapper for Web Components, with backward compatibility for the existing signal-based imperative API.

## Problem

Performing optimistic UI updates in webjs Web Components currently requires developers to manually duplicate and mutate local reactive properties, track temporary IDs, implement try-catch logic, and manually roll back to a cached copy if the network request fails. This is verbose, error-prone, and does not match the ergonomics of React 19's `useOptimistic` hook.

## What this does

- **`OptimisticState` class**: A new declarative wrapper that tracks a queue of pending optimistic updates and computes the combined value via a reducer. Created via `optimistic(host, { source, update })`.
- **`.add(payload, promise?)`**: Pushes an optimistic update and schedules a re-render. When a `promise` is provided, auto-releases the update on settlement (via `.finally()` or a `.then()` fallback for thenables lacking `.finally`), eliminating try-finally boilerplate.
- **Optional reducer**: When `update` is omitted, the payload replaces the state directly (`Action = State`), matching the simple `useOptimistic(setState)` pattern.
- **Concurrent updates**: Multiple `.add()` calls stack; each `release()` removes its own update by ID, so concurrent optimistic operations resolve independently.
- **Backward compatibility**: The existing `optimistic(signal, value, action)` signal-based imperative API is preserved unchanged. The exported `optimistic()` function dispatches by detecting a signal-like object (`get`/`set` methods) vs. a host/options pair.
- **TypeScript overloads**: Two separate overloads for the declarative signature (with and without `update`) so `Action` infers correctly without explicit type annotations.

## Tests

- `packages/core/test/signals/optimistic-declarative.test.js` (8 unit tests: initial value, manual add/release, default reducer, auto-release on resolve, auto-release on reject, concurrent updates, host without `requestUpdate`, thenable without `finally`)
- `packages/core/test/signals/optimistic.test.js` (6 existing legacy tests, all passing)
- `packages/core/test/signals/browser/optimistic.test.js` (3 browser tests for the signal-based API with real WebComponent rendering, plus 1 new declarative browser test)
- Bun matrix: all pass (the new `node:test` files run under Bun too)

## Docs synced

- `agent-docs/advanced.md`: Full reference with both declarative and imperative signatures
- `agent-docs/recipes.md`: Updated optimistic todo recipe to use declarative API as preferred pattern
- `docs/app/docs/client-router/page.ts`: Docs site section updated with both signatures
- `AGENTS.md`: Public API table updated
- `blog/optimistic-ui-without-boilerplate.md`: SEO-optimized blog post

## Scope

- New public API: `optimistic(host, options)` returns `OptimisticState<State, Action>` with `.value` getter and `.add(payload, promise?)` method.
- No breaking changes to the existing `optimistic(signal, value, action)` imperative API.
- The `optimistic` import remains classified as a reactive (client-work) import in the elision analyser, so a component using it is never elided as display-only.
- UI package (Tier 1 + Tier 2 components): no changes needed. These are presentational primitives that do not manage mutation state.
- Website and ui website: no changes needed. No optimistic UI references exist in marketing copy.
