### PR TITLE
docs: instruct agents to default to optimistic UI for mutations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,7 +198,7 @@ The bare `@webjsdev/core` specifier resolves to a BROWSER bundle dropping server
 | `<webjs-suspense .fallback=${html\`…\`}>` | Component-level streaming boundary element (#471): wraps one or more components, flushes `.fallback` on the first byte, streams the resolved content in (concurrently across boundaries, progressively on soft nav). The renderer-recognized opt-in for SLOW async-render data. |
 | `connectWS(url, handlers)` / `richFetch<T>` | Client WebSocket (auto-reconnect, queued sends); content-negotiated rich-type fetch. |
 | `navigate(url, opts?)` / `revalidate(url?)` | Programmatic client-router nav; evict the BROWSER snapshot cache. |
-| `optimistic(signal, value, action)` / `optimistic(host, options)` | Set `signal` immediately, run `action`, roll back on error or `{ success: false }`. Declarative form: `optimistic(host, { source, update })` returns `OptimisticState` with `.value` getter and `.add(payload, promise?)` for React 19 `useOptimistic` parity. |
+| `optimistic(signal, value, action)` / `optimistic(host, { source, update })` | Imperative: set `signal` immediately, run `action`, roll back on error. Declarative (preferred): queue optimistic updates with auto-release via `.add(payload, promise?)`. See `agent-docs/advanced.md`. |
 | `renderStream(payload)` / `WebjsFrame` | `<webjs-stream>` element-level updates (#248); `<webjs-frame>` partial-swap regions (#253). See `agent-docs/advanced.md`. |
 | `Metadata` / `PageProps<R>` / `LayoutProps<R>` / `RouteHandlerContext<R>` / `WebjsConfig` (type-only) | Types for metadata, page/layout/route args (`R` narrows `params` against the `webjs types` route union), and the `webjs` config block. See `agent-docs/metadata.md` + `agent-docs/configuration.md`. |
 
@@ -331,6 +331,83 @@ type ActionResult<T> =
 The router auto-enables when `@webjsdev/core` loads (any page with a component), so there is nothing to opt INTO. An app that wants plain full-page (MPA) navigation can opt OUT app-wide with `{ "webjs": { "clientRouter": false } }` (#629), or per-moment at runtime with `disableClientRouter()`. Nested layouts auto-emit `<!--wj:children:<segment-path>-->` markers; the client router walks both DOMs and replaces only the deepest shared layout's children slot, preserving outer-layout DOM identity. Form submissions ride the same pipeline (`data-no-router` opts out). Wire bytes are minimized via the `X-Webjs-Have` header (the server returns only the divergent fragment); scroll is restored on back/forward. A non-GET `<form>` whose target page exports an `action` is the no-JS write-path (with JS the router applies the response in place: a `422` swaps without reload, a `303` is followed via fetch). A failed navigation recovers in place (a cancelable `webjs:navigation-error` event, else a minimal in-place alert), never a destructive full reload.
 
 The advanced client-router surface is in `agent-docs/advanced.md`: **link prefetch** (on by default, device-adaptive default: `intent` on a hover pointer, `viewport` (dwell-gated, cancel-on-scroll-out) on touch, per-link `data-prefetch` override), **`<webjs-frame>`** partial-swap regions, **View Transitions** (opt-in via `<meta name="view-transition">`, plus `data-webjs-permanent` to persist a live element), **stream actions** (`<webjs-stream>` element-level updates, #248), and the **opt-in nav-loading indicator** (`<html data-webjs-nav-progress>` exposes a `data-navigating` attribute during a nav so you can style a CSS-only progress affordance, off by default because toggling a root attribute re-resolves `oklch()` tokens to a one-frame repaint flash on iOS WebKit, #610). Production benefits from HTTP/2 at the edge; `npm run start` speaks plain HTTP/1.1 (put a reverse proxy in front for TLS + HTTP/2).
+
+---
+
+## Mutations: default to optimistic UI
+
+**Use `optimistic()` from `@webjsdev/core` for every user-facing mutation** (create, update, delete, like, toggle, reorder) where the client can predict the result. The UI should feel instant; roll back automatically on failure.
+
+### Preferred: declarative API
+
+```ts
+import { WebComponent, prop, optimistic, html } from '@webjsdev/core';
+import { createTodo } from '#modules/todos/actions/create-todo.server.ts';
+
+class TodoList extends WebComponent({
+  todos: prop<Todo[]>(Array),
+}) {
+  private optimisticTodos = optimistic(this, {
+    source: () => this.todos,
+    update: (state, title: string) => [
+      ...state,
+      { id: crypto.randomUUID() as any, title, completed: false, pending: true },
+    ],
+  });
+
+  async handleSubmit(e: SubmitEvent) {
+    e.preventDefault();
+    const title = new FormData(e.target as HTMLFormElement).get('title') as string;
+    if (!title) return;
+    (e.target as HTMLFormElement).reset();
+
+    const promise = createTodo({ title });
+    this.optimisticTodos.add(title, promise);
+
+    const result = await promise;
+    if (result.success && result.data) {
+      this.todos = [...this.todos.filter(t => t.pending), result.data, ...this.todos.filter(t => !t.pending)];
+    }
+  }
+
+  render() {
+    return html`<ul>${this.optimisticTodos.value.map(todo => html`
+      <li class=${todo.pending ? 'opacity-50' : ''}>${todo.title}</li>
+    `)}</ul>`;
+  }
+}
+TodoList.register('todo-list');
+```
+
+`.add(payload, promise)` auto-releases when the promise settles (resolve or reject). No try-catch, no manual rollback, no temp-ID bookkeeping.
+
+### Simple flips: imperative API
+
+For boolean toggles where the value itself is the mutation:
+
+```ts
+import { signal, optimistic } from '@webjsdev/core';
+import { likePost } from '#actions/like-post.server.ts';
+
+const liked = signal(false);
+// in an @click handler:
+const result = await optimistic(liked, true, () => likePost(postId));
+```
+
+### When to skip optimistic UI
+
+- The result is unpredictable (AI-generated content, server-computed values the client cannot guess).
+- The mutation has side effects the user must wait for (payment processing, email sending, OAuth).
+- The action validates against data that may have changed server-side (unique constraints, race conditions).
+- The mutation is destructive and irreversible with no undo (confirm-first UX is better).
+
+### When optimistic UI is appropriate
+
+- Todo items, comments, posts, likes, follows, toggles, reorders, renames, status changes.
+- Any mutation where the client can construct the expected result from the input.
+- CRUD operations where the server returns the same shape the client already has.
+
+**Never write manual try-catch / cache-and-restore / temp-ID reconciliation** when `optimistic()` covers the pattern. See `agent-docs/advanced.md` for the full reference and `agent-docs/recipes.md` for complete examples.
 
 ---
 

--- a/agent-docs/advanced.md
+++ b/agent-docs/advanced.md
@@ -503,71 +503,56 @@ the events + `aria-busy` are a client-only enhancement.
 
 ### Optimistic mutations (`optimistic()`)
 
-WebJs ships two signatures for optimistic UI: a **declarative** React 19-style
-state wrapper (the recommended path for list / collection mutations) and a
-**legacy imperative** signal-based helper (ideal for single-value toggles).
+`optimistic()` from `@webjsdev/core` shows a mutation's expected result IMMEDIATELY (the UI feels instant), runs the real server action, and ROLLS BACK on failure. **Use it for every user-facing mutation where the client can predict the result** (create, update, delete, like, toggle, reorder). See `agent-docs/recipes.md` for complete examples.
 
-#### Declarative: `optimistic(host, options)` (React 19 `useOptimistic` parity)
+#### Declarative API (preferred)
 
-The declarative API manages a queue of pending optimistic updates, computes
-the combined value through an optional reducer, and auto-releases when a
-passed promise settles. No try/catch, no manual cache-and-revert.
+`optimistic(host, { source, update })` returns an `OptimisticState<State, Action>` with a `.value` getter and `.add(payload, promise?)` method. The reducer transforms the current state with each payload; `.add()` pushes an update and schedules a re-render. When a `promise` is passed, the update auto-releases on settlement (`.finally()` or a `.then()` fallback for thenables lacking `.finally`).
 
 ```ts
 import { WebComponent, prop, optimistic, html } from '@webjsdev/core';
-import { createTodo } from '../modules/todos/actions/create-todo.server.js';
+import { createTodo } from '#modules/todos/actions/create-todo.server.ts';
 
-export class TodoList extends WebComponent({
-  todos: prop(Array),
+class TodoList extends WebComponent({
+  todos: prop<Todo[]>(Array),
 }) {
-  constructor() {
-    super();
-    this.todos = [];
-    // Declare the wrapper with a custom reducer
-    this.optimisticTodos = optimistic(this, {
-      source: () => this.todos,
-      update: (state, title) => [...state, { id: 'tmp', title, pending: true }],
-    });
-  }
+  private optimisticTodos = optimistic(this, {
+    source: () => this.todos,
+    update: (state, title: string) => [
+      ...state,
+      { id: crypto.randomUUID() as any, title, completed: false, pending: true },
+    ],
+  });
 
-  async handleSubmit(e) {
+  async handleSubmit(e: SubmitEvent) {
     e.preventDefault();
-    const title = e.target.querySelector('input').value;
+    const title = new FormData(e.target as HTMLFormElement).get('title') as string;
+    if (!title) return;
+    (e.target as HTMLFormElement).reset();
+
     const promise = createTodo({ title });
-    // Auto-releases when the promise settles; no try/finally needed
     this.optimisticTodos.add(title, promise);
+
     const result = await promise;
     if (result.success && result.data) {
-      this.todos = [...this.todos, result.data];
+      this.todos = [...this.todos.filter(t => t.pending), result.data, ...this.todos.filter(t => !t.pending)];
     }
   }
 
   render() {
-    return html`<ul>${this.optimisticTodos.value.map(t =>
-      html`<li class=${t.pending ? 'opacity-50' : ''}>${t.title}</li>`)}</ul>`;
+    return html`<ul>${this.optimisticTodos.value.map(todo => html`
+      <li class=${todo.pending ? 'opacity-50' : ''}>${todo.title}</li>
+    `)}</ul>`;
   }
 }
+TodoList.register('todo-list');
 ```
 
-**`.add(payload, promise?)`** pushes an optimistic update and calls
-`host.requestUpdate()` to re-render. When a `promise` is provided, the
-update is automatically released on settlement (via `.finally()` or a
-`.then()` fallback for thenables lacking `.finally`). Multiple `.add()`
-calls stack; each release removes only its own entry by ID, so concurrent
-optimistic operations resolve independently.
+Multiple `.add()` calls stack independently; each `release()` removes its own update by ID. When `update` is omitted, the payload replaces the state directly (`Action = State`), matching the simple `useOptimistic(setState)` pattern.
 
-**Optional reducer.** When `update` is omitted, the payload replaces the
-state directly (`Action = State`), matching the simple `useOptimistic(setState)`
-pattern:
+#### Imperative API (simple flips)
 
-```ts
-this.optCount = optimistic(this, { source: () => this.count });
-this.optCount.add(42);  // value is now 42
-```
-
-#### Imperative: `optimistic(signal, value, action)` (signal-based rollback)
-
-For single-value toggles the legacy signal-based helper remains:
+`optimistic(signal, value, action)` is a thin wrapper over the signal primitive for simple boolean flips:
 
 ```ts
 import { signal, optimistic } from '@webjsdev/core';
@@ -583,10 +568,7 @@ const result = await optimistic(liked, true, () => likePost(postId));
 // to the authoritative value from `result` if you need it.
 ```
 
-Both signatures roll back on a thrown error OR an `ActionResult`
-`{ success: false }` envelope, and never on success. Client-only (they
-call `host.requestUpdate()` or mutate a signal), so a component importing
-`optimistic` is never elided as display-only.
+It rolls back on a thrown error OR an `ActionResult` `{ success: false }` envelope, and never on success. Client-only (it mutates a signal), so a component importing it is never elided as display-only.
 
 ### Wire-byte optimization
 

--- a/agent-docs/recipes.md
+++ b/agent-docs/recipes.md
@@ -409,7 +409,7 @@ See `agent-docs/advanced.md` for the client-router side (how the enhanced
 
 ## Snappy UX: Form mutation with Optimistic UI updates
 
-When building interactive applications (like a Todo app, chat app, or likes toggle), using Optimistic UI creates a Snappy UX by immediately updating the UI state in the browser before the server confirms the operation. 
+When building interactive applications (like a Todo app, chat app, or likes toggle), using Optimistic UI creates a Snappy UX by immediately updating the UI state in the browser before the server confirms the operation. **Default to `optimistic()` from `@webjsdev/core` for every mutation where the client can predict the result.** Only skip it when the result is unpredictable (AI-generated content), the user must wait for side effects (payment, email), or the mutation is destructive with no undo.
 
 To support progressive enhancement, write a baseline `<form>` that works without JS, then enhance the component in the browser using JS.
 
@@ -433,97 +433,115 @@ To support progressive enhancement, write a baseline `<form>` that works without
    }
    ```
 
- 2. **The Component with Optimistic UI** (declarative, recommended):
-    - Use `optimistic(this, { source, update })` to declare a wrapper with a custom reducer.
-    - Listen to `@submit` on the `<form>`.
-    - Call `.add(payload, promise)` to push the optimistic update and auto-release when the server action settles.
-    - Reconcile the source state on success.
+2. **The Component with `optimistic()` (preferred)**:
+   Use the declarative `optimistic(host, { source, update })` API. It tracks a queue of pending updates, computes the combined value via a reducer, and auto-releases when the promise settles. No try-catch, no manual rollback, no temp-ID bookkeeping.
 
-    ```ts
-    // components/todo-list.ts
-    import { html, WebComponent, prop, optimistic } from '@webjsdev/core';
-    import { createTodo } from '../modules/todos/actions/create-todo.server.ts';
-    import { Todo } from '../modules/todos/types.ts';
+   ```ts
+   // components/todo-list.ts
+   import { html, WebComponent, prop, optimistic } from '@webjsdev/core';
+   import { createTodo } from '../modules/todos/actions/create-todo.server.ts';
+   import { Todo } from '../modules/todos/types.ts';
 
-    export class TodoList extends WebComponent({
-      todos: prop<Todo[]>(Array),
-    }) {
-      constructor() {
-        super();
-        this.todos = [];
-        // Declarative optimistic wrapper with a custom reducer
-        this.optimisticTodos = optimistic(this, {
-          source: () => this.todos,
-          update: (state, title) => [
-            ...state,
-            { id: 'tmp' as any, title, completed: false, pending: true },
-          ],
-        });
-      }
+   export class TodoList extends WebComponent({
+     todos: prop<Todo[]>(Array),
+   }) {
+     private optimisticTodos = optimistic(this, {
+       source: () => this.todos,
+       update: (state, title: string) => [
+         ...state,
+         { id: crypto.randomUUID() as any, title, completed: false, pending: true },
+       ],
+     });
 
-      async handleSubmit(e: SubmitEvent) {
-        e.preventDefault();
-        const form = e.target as HTMLFormElement;
-        const data = new FormData(form);
-        const title = String(data.get('title') || '').trim();
-        if (!title) return;
+     async handleSubmit(e: SubmitEvent) {
+       e.preventDefault();
+       const form = e.target as HTMLFormElement;
+       const title = String(new FormData(form).get('title') || '').trim();
+       if (!title) return;
 
-        form.reset();
+       form.reset();
 
-        // Push optimistic update; auto-releases when the promise settles
-        const promise = createTodo({ title });
-        this.optimisticTodos.add(title, promise);
+       const promise = createTodo({ title });
+       this.optimisticTodos.add(title, promise);
 
-        const result = await promise;
-        if (result.success && result.data) {
-          // Reconcile: replace the optimistic temp with the real DB item
-          this.todos = [...this.todos, result.data];
-        }
-      }
+       const result = await promise;
+       if (result.success && result.data) {
+         this.todos = [
+           ...this.todos.filter(t => t.pending),
+           result.data,
+           ...this.todos.filter(t => !t.pending),
+         ];
+       }
+     }
 
-      render() {
-        return html`
-          <form @submit=${this.handleSubmit}>
-            <input type="text" name="title" placeholder="New todo..." required />
-            <button type="submit">Add</button>
-          </form>
+     render() {
+       return html`
+         <form @submit=${this.handleSubmit}>
+           <input type="text" name="title" placeholder="New todo..." required />
+           <button type="submit">Add</button>
+         </form>
 
-          <ul>
-            ${this.optimisticTodos.value.map((todo) => html`
-              <li class=${todo.pending ? 'opacity-50 pointer-events-none' : ''}>
-                ${todo.title} ${todo.pending ? html`<span>(Saving...)</span>` : ''}
-              </li>
-            `)}
-          </ul>
-        `;
-      }
-    }
-    TodoList.register('todo-list');
-    ```
+         <ul>
+           ${this.optimisticTodos.value.map(
+             (todo) => html`
+               <li class=${todo.pending ? 'opacity-50 pointer-events-none' : ''}>
+                 ${todo.title}
+               </li>
+             `
+           )}
+         </ul>
+       `;
+     }
+   }
+   TodoList.register('todo-list');
+   ```
 
-    **Manual release (no promise).** When you need explicit control, `.add(payload)` returns a `release()` function:
+   For simple boolean flips, the imperative `optimistic(signal, value, action)` is cleaner:
 
-    ```ts
-    const release = this.optimisticTodos.add(title);
-    try {
-      const result = await createTodo({ title });
-      if (result.success) this.todos = [...this.todos, result.data];
-    } finally {
-      release();  // removes the optimistic overlay
-    }
-    ```
+   ```ts
+   import { signal, optimistic } from '@webjsdev/core';
+   import { likePost } from '#actions/like-post.server.ts';
 
-    **Legacy imperative pattern (signal-based rollback).** For single-value toggles like a like button, the signal-based API is simpler:
+   const liked = signal(false);
+   // in an @click handler:
+   await optimistic(liked, true, () => likePost(postId));
+   ```
 
-    ```ts
-    import { signal, optimistic } from '@webjsdev/core';
-    const liked = signal(false);
-    // In an @click handler:
-    await optimistic(liked, true, () => likePost(postId));
-    // liked flips to true instantly; rolls back on throw or { success: false }
-    ```
+3. **Manual optimistic (when you cannot use `optimistic()`)**:
+   If you need fine-grained control (custom loading states, partial rollbacks, multi-step reconciliation), write the manual pattern:
 
-    The imperative pattern captures the previous value, sets the optimistic value immediately, awaits the action, and rolls back on failure. See `agent-docs/advanced.md` for the full reference.
+   - Declare a reactive property to hold the list.
+   - Generate a temporary ID, construct the optimistic item, update state immediately.
+   - Run the server action.
+   - Reconcile: replace the optimistic item on success, revert on failure.
+
+   ```ts
+   async handleSubmit(e: SubmitEvent) {
+     e.preventDefault();
+     const form = e.target as HTMLFormElement;
+     const title = String(new FormData(form).get('title') || '').trim();
+     if (!title) return;
+     form.reset();
+
+     const tempId = `temp-${crypto.randomUUID()}`;
+     const previousTodos = this.todos;
+     this.todos = [
+       { id: tempId as any, title, completed: false, pending: true },
+       ...this.todos,
+     ];
+
+     try {
+       const result = await createTodo({ title });
+       if (result.success && result.data) {
+         this.todos = this.todos.map((t) => (t.id === tempId ? result.data! : t));
+       } else {
+         this.todos = previousTodos;
+       }
+     } catch {
+       this.todos = previousTodos;
+     }
+   }
+   ```
 
 ## Receive and persist an uploaded file
 


### PR DESCRIPTION
Closes #802

## Summary

- Adds a dedicated "Mutations: default to optimistic UI" section to `AGENTS.md` with declarative and imperative API examples, when-to-skip guidance, and when-to-use guidance
- Updates `agent-docs/advanced.md` to use the declarative `optimistic()` API as the preferred pattern with improved code examples (`#`-imports, TypeScript types, FormData handling)
- Updates `agent-docs/recipes.md` to use the declarative API as the primary example, keeping the manual pattern as a "when you cannot use optimistic()" footnote

## Changes

| File | What changed |
|---|---|
| `AGENTS.md` | Updated `optimistic` API table row; added full "Mutations: default to optimistic UI" section with code examples, skip/use guidance |
| `agent-docs/advanced.md` | Replaced the PR #799 optimistic section with improved examples (proper `#` imports, TypeScript types, `FormData` handling, `TodoList.register()`) |
| `agent-docs/recipes.md` | Rewrote the optimistic UI recipe to use the declarative API as preferred, added imperative shortcut for boolean flips, kept manual pattern as footnote |

## Tests

- `npm test`: 2836 pass, 0 fail
- `webjs check`: 0 new violations (pre-existing violations unchanged)