### PR TITLE
chore: release core 0.7.29, server 0.8.41, cli 0.10.30, ui 0.3.7

### DIFF
--- a/changelog/cli/0.10.30.md
+++ b/changelog/cli/0.10.30.md
@@ -1,0 +1,22 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.30
+date: 2026-07-06T17:13:17.002Z
+commit_count: 3
+---
+## Fixes
+
+- **address four dogfood issues (#791, #792, #793, #794)** ([#800](https://github.com/webjsdev/webjs/pull/800)) [`3cb3c3db`](https://github.com/webjsdev/webjs/commit/3cb3c3db)
+  - #794: Fix block-comment-close bug in hello.test.ts template. The glob
+    test/**/*.test.ts closed the enclosing /* */ comment early. Switched
+    to single-line comments.
+  - #793: Add no-redirect-in-api-route check rule. redirect() from
+- **eliminate first-iteration failure traps for AI agents** ([#810](https://github.com/webjsdev/webjs/pull/810)) [`cb9001c7`](https://github.com/webjsdev/webjs/commit/cb9001c7)
+  * fix: stop no-server-import check flagging a type-only import (#805)
+  
+  A TYPE-ONLY `import type { Todo } from '#db/schema.server.ts'` in a
+  browser-shipped page or component is fully erased by the TS stripper, so
+- **run real component tests under webjs test --browser (#806)** ([#812](https://github.com/webjsdev/webjs/pull/812)) [`b9defd4d`](https://github.com/webjsdev/webjs/commit/b9defd4d)
+  * chore: start browser-test harness (#806)
+  
+  * feat: browser-test handler + test-mode serve gate (#806)

--- a/changelog/core/0.7.29.md
+++ b/changelog/core/0.7.29.md
@@ -1,0 +1,20 @@
+---
+package: "@webjsdev/core"
+version: 0.7.29
+date: 2026-07-06T17:13:16.889Z
+commit_count: 2
+---
+## Features
+
+- **add React/Next.js-style optimistic() state API to @webjsdev/core** ([#799](https://github.com/webjsdev/webjs/pull/799)) [`f7adcd94`](https://github.com/webjsdev/webjs/commit/f7adcd94)
+  * feat: add React/Next.js-style optimistic() state API to @webjsdev/core
+  
+  * improve optimistic() JSDoc, remove dead controller registration, add declarative browser test
+
+## Fixes
+
+- **eliminate first-iteration failure traps for AI agents** ([#810](https://github.com/webjsdev/webjs/pull/810)) [`cb9001c7`](https://github.com/webjsdev/webjs/commit/cb9001c7)
+  * fix: stop no-server-import check flagging a type-only import (#805)
+  
+  A TYPE-ONLY `import type { Todo } from '#db/schema.server.ts'` in a
+  browser-shipped page or component is fully erased by the TS stripper, so

--- a/changelog/server/0.8.41.md
+++ b/changelog/server/0.8.41.md
@@ -1,0 +1,22 @@
+---
+package: "@webjsdev/server"
+version: 0.8.41
+date: 2026-07-06T17:13:16.940Z
+commit_count: 3
+---
+## Fixes
+
+- **address four dogfood issues (#791, #792, #793, #794)** ([#800](https://github.com/webjsdev/webjs/pull/800)) [`3cb3c3db`](https://github.com/webjsdev/webjs/commit/3cb3c3db)
+  - #794: Fix block-comment-close bug in hello.test.ts template. The glob
+    test/**/*.test.ts closed the enclosing /* */ comment early. Switched
+    to single-line comments.
+  - #793: Add no-redirect-in-api-route check rule. redirect() from
+- **eliminate first-iteration failure traps for AI agents** ([#810](https://github.com/webjsdev/webjs/pull/810)) [`cb9001c7`](https://github.com/webjsdev/webjs/commit/cb9001c7)
+  * fix: stop no-server-import check flagging a type-only import (#805)
+  
+  A TYPE-ONLY `import type { Todo } from '#db/schema.server.ts'` in a
+  browser-shipped page or component is fully erased by the TS stripper, so
+- **run real component tests under webjs test --browser (#806)** ([#812](https://github.com/webjsdev/webjs/pull/812)) [`b9defd4d`](https://github.com/webjsdev/webjs/commit/b9defd4d)
+  * chore: start browser-test harness (#806)
+  
+  * feat: browser-test handler + test-mode serve gate (#806)

--- a/changelog/ui/0.3.7.md
+++ b/changelog/ui/0.3.7.md
@@ -1,0 +1,46 @@
+---
+package: "@webjsdev/ui"
+version: 0.3.7
+date: 2026-07-06T17:13:17.107Z
+commit_count: 7
+---
+## Features
+
+- **webjs:before-cache hook; kit overlays reset on back/forward (#766)** ([#769](https://github.com/webjsdev/webjs/pull/769)) [`4e569110`](https://github.com/webjsdev/webjs/commit/4e569110)
+  The client router keeps a Turbo-style outerHTML snapshot cache for instant
+  back/forward. An overlay that is open when you navigate away is captured open
+  and restored open on Forward (repro: open a hover-card, Back, Forward, still
+  open). Add a webjs:before-cache event the router dispatches on document.
+
+## Fixes
+
+- **dialog/alert-dialog invisible on iOS (viewport host, not 0x0) (#730)** ([#734](https://github.com/webjsdev/webjs/pull/734)) [`e0ba4d2f`](https://github.com/webjsdev/webjs/commit/e0ba4d2f)
+  Root cause (confirmed on a real iPhone via /diag): the native <dialog> host was
+  w-0 h-0. WebKit makes a top-layer <dialog> the containing block for its
+  position:fixed descendants, so the fixed content panel (w-full) collapsed to 0x0
+  and the dialog was invisible on iOS, while Blink (Android/Chromium) resolves the
+- **dialog/alert-dialog open via querySelector, not the iOS-null ref (#730)** ([#735](https://github.com/webjsdev/webjs/pull/735)) [`6fd7ea3d`](https://github.com/webjsdev/webjs/commit/6fd7ea3d)
+  v4 on a real iPhone: the dialog set open=true + locked scroll but the native
+  <dialog> never opened (nativeOpen=n), while a direct showModal() worked (v3).
+  The component reached the native <dialog> through this.#dialog.value (a ref)
+  which came back NULL on iOS WebKit (the ref did not populate through SSR
+- **assign tabs scope id in willUpdate so it serializes at SSR (#730)** ([#737](https://github.com/webjsdev/webjs/pull/737)) [`75c2e5c5`](https://github.com/webjsdev/webjs/commit/75c2e5c5)
+  The served HTML showed tab triggers with id=ui-tabs-25-trigger-* but the
+  <ui-tabs> host had NO id: ensureId(this) ran lazily during a child trigger's
+  render, AFTER the host's opening tag was serialized, so the host shipped no id.
+  On hydration the client re-minted a DIFFERENT counter id, so the trigger/panel
+- **hover-card, dropdown submenu, sonner on iOS/touch (#745)** ([#746](https://github.com/webjsdev/webjs/pull/746)) [`ea82838b`](https://github.com/webjsdev/webjs/commit/ea82838b)
+  * fix(ui): route sonner toast bus through globalThis, not module scope (#745)
+  
+  The app registers <ui-sonner> from the version-hashed sonner.ts?v=<hash> while a
+  caller may import('/components/ui/sonner.ts') bare. Those are distinct module
+- **hover-card stays open on iOS touch; gate hover handlers (#745)** ([#758](https://github.com/webjsdev/webjs/pull/758)) [`6b5cae46`](https://github.com/webjsdev/webjs/commit/6b5cae46)
+  The #746 fix added tap-to-open but left the mouseenter/mouseleave/focusin/
+  focusout handlers active. On a real iPhone, iOS Safari fires SYNTHETIC
+  mouse/focus events around a tap, so _onEnter/_onLeave still ran and immediately
+  re-closed the tap-opened card (the card opened then vanished; emulation does not
+- **hover-card trigger tap never navigates on touch (no history pollution) (#745)** ([#760](https://github.com/webjsdev/webjs/pull/760)) [`95398eed`](https://github.com/webjsdev/webjs/commit/95398eed)
+  The #758 fix only preventDefault'd on the OPENING tap; a re-tap while the card
+  was open fell through, so the inner <a>'s bubble-phase click reached the client
+  router, which pushState()s when the event is not defaultPrevented. Each tap
+  pushed a history entry, so Back needed N presses to leave the page. On touch the

--- a/package-lock.json
+++ b/package-lock.json
@@ -6975,7 +6975,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.29",
+      "version": "0.10.30",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -6991,7 +6991,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.28",
+      "version": "0.7.29",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.25.0"
@@ -7039,7 +7039,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.40",
+      "version": "0.8.41",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",
@@ -7075,7 +7075,7 @@
     },
     "packages/ui": {
       "name": "@webjsdev/ui",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.29",
+  "version": "0.10.30",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.28",
+  "version": "0.7.29",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.40",
+  "version": "0.8.41",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/ui",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "type": "module",
   "description": "An AI-first component library - class-helper functions for visuals, custom elements only where state matters. Source-copied into your repo, you own it. Works with any Tailwind v4 project.",
   "bin": {


### PR DESCRIPTION
Release PR clearing accumulated debt across four published packages. Patch bumps (each stays within its current minor line; all dependents pin `^0.x`, so no range edits and no lockfile-range churn beyond the version lines).

## Bumps

| Package | From | To | What ships |
|---|---|---|---|
| `@webjsdev/core` | 0.7.28 | 0.7.29 | declarative `optimistic()` state API (#799); type-only-import check fix plus `TemplateResult` type export (#810) |
| `@webjsdev/server` | 0.8.40 | 0.8.41 | module-graph/check fixes (#810), browser-test harness handler (#812), four dogfood fixes (#800) |
| `@webjsdev/cli` | 0.10.29 | 0.10.30 | scaffold template plus `create.js` updates (#806 harness config, #810 type-only notes, #800 dogfood) |
| `@webjsdev/ui` | 0.3.6 | 0.3.7 | `webjs:before-cache` overlay reset (#769) plus iOS/touch registry fixes for dialog, tabs, hover-card, sonner, dropdown (#734/#735/#737/#746/#758/#760) |

## Notes

- Changelogs auto-generated by the pre-commit backfill from the conventional squash subjects. The `@webjsdev/ui` changelog was hand-corrected: the generator attributes by the whole `packages/ui/` tree, which includes the non-published nested `packages/ui/packages/website/` sub-app, so it had pulled in four commits that never shipped in the published library (#660 CSRF, #779 website reposition, #788 dev-build, #744 core hydration marker). Trimmed to the seven commits that actually touched the published surface (`src`/`bin`/`registry`/`README`).
- `mcp`, `intellisense`, `vscode`, `nvim` have no qualifying commits since their last release, so they are not bumped.
- `create-webjs` / `webjsdev` wrappers intentionally left alone (the release workflow owns them, in lockstep with cli).
- `package-lock.json` regenerated for the four new versions.
- Merging adds the `changelog/**.md` files to `main`, which triggers `release.yml` to `npm publish` and cut GitHub Releases (idempotent).

This PR changes only version lines plus generated changelogs plus the lockfile, so Conventions + Build + Unit carry all the release-specific signal (the slow E2E/Browser jobs re-test source byte-identical to `main`).
