### PR TITLE
docs: tell scaffold agents to use a unique design, not mimic the scaffold

### DIFF
--- a/packages/cli/templates/.agents/rules/workflow.md
+++ b/packages/cli/templates/.agents/rules/workflow.md
@@ -22,8 +22,9 @@ cover what you need, the full hosted docs are at **https://docs.webjs.com**.
 - **Use a unique design (UI apps).** When the app has a UI, give it a design of
   your own (palette, layout, typography, chrome) that fits what the user asked
   for. Do NOT mimic the scaffold's example look (its warm colors, the 760px
-  reading column, the example header/nav). Keep the design tokens and theme
-  setup in `app/layout.ts`, those are infrastructure, and restyle on top of them.
+  reading column, the example header/nav). The `api` template has no UI, so this
+  does not apply there. Keep the design tokens and theme setup in
+  `app/layout.ts`, those are infrastructure, and restyle on top of them.
 - **Only three templates exist:** `webjs create <name>` (default full-stack),
   `--template api`, `--template saas`. The CLI rejects any other `--template`
   value. Pick:

--- a/packages/cli/templates/.agents/rules/workflow.md
+++ b/packages/cli/templates/.agents/rules/workflow.md
@@ -19,6 +19,11 @@ cover what you need, the full hosted docs are at **https://docs.webjs.com**.
   the example `User` model, the example users module, etc. with the app the
   user actually asked for. Do not ship "Hello from <app-name>" as the
   deliverable.
+- **Use a unique design (UI apps).** When the app has a UI, give it a design of
+  your own (palette, layout, typography, chrome) that fits what the user asked
+  for. Do NOT mimic the scaffold's example look (its warm colors, the 760px
+  reading column, the example header/nav). Keep the design tokens and theme
+  setup in `app/layout.ts`, those are infrastructure, and restyle on top of them.
 - **Only three templates exist:** `webjs create <name>` (default full-stack),
   `--template api`, `--template saas`. The CLI rejects any other `--template`
   value. Pick:

--- a/packages/cli/templates/.cursorrules
+++ b/packages/cli/templates/.cursorrules
@@ -18,6 +18,12 @@ cover what you need, the full hosted docs are at **https://docs.webjs.com**.
   `app/page.ts`, the example `User` model, the example users module, etc.
   with the app the user actually asked for. Don't ship "Hello from
   <app-name>" as the deliverable.
+- **Use a unique design (UI apps).** When the app has a UI, give it a
+  design of your own (palette, layout, typography, chrome) that fits what
+  the user asked for. Do NOT mimic the scaffold's example look (its warm
+  colors, the 760px reading column, the example header/nav). Keep the
+  design tokens and theme setup in `app/layout.ts`, those are
+  infrastructure, and restyle on top of them.
 - **Only three templates exist:** `webjs create <name>` (default
   full-stack), `--template api`, `--template saas`. The CLI rejects any
   other `--template` value. Pick:

--- a/packages/cli/templates/.cursorrules
+++ b/packages/cli/templates/.cursorrules
@@ -21,9 +21,10 @@ cover what you need, the full hosted docs are at **https://docs.webjs.com**.
 - **Use a unique design (UI apps).** When the app has a UI, give it a
   design of your own (palette, layout, typography, chrome) that fits what
   the user asked for. Do NOT mimic the scaffold's example look (its warm
-  colors, the 760px reading column, the example header/nav). Keep the
-  design tokens and theme setup in `app/layout.ts`, those are
-  infrastructure, and restyle on top of them.
+  colors, the 760px reading column, the example header/nav). The `api`
+  template has no UI, so this does not apply there. Keep the design tokens
+  and theme setup in `app/layout.ts`, those are infrastructure, and
+  restyle on top of them.
 - **Only three templates exist:** `webjs create <name>` (default
   full-stack), `--template api`, `--template saas`. The CLI rejects any
   other `--template` value. Pick:

--- a/packages/cli/templates/.github/copilot-instructions.md
+++ b/packages/cli/templates/.github/copilot-instructions.md
@@ -18,6 +18,12 @@ the full hosted docs are at **https://docs.webjs.com**.
   `app/page.ts`, the example `User` model, the example users module, etc.
   with the app the user actually asked for. Don't ship "Hello from
   <app-name>" as the deliverable.
+- **Use a unique design (UI apps).** When the app has a UI, give it a
+  design of your own (palette, layout, typography, chrome) that fits what
+  the user asked for. Do NOT mimic the scaffold's example look (its warm
+  colors, the 760px reading column, the example header/nav). Keep the
+  design tokens and theme setup in `app/layout.ts`, those are
+  infrastructure, and restyle on top of them.
 - **Only three templates exist:** `webjs create <name>` (default
   full-stack), `--template api`, `--template saas`. The CLI rejects any
   other `--template` value. Pick:

--- a/packages/cli/templates/.github/copilot-instructions.md
+++ b/packages/cli/templates/.github/copilot-instructions.md
@@ -21,9 +21,10 @@ the full hosted docs are at **https://docs.webjs.com**.
 - **Use a unique design (UI apps).** When the app has a UI, give it a
   design of your own (palette, layout, typography, chrome) that fits what
   the user asked for. Do NOT mimic the scaffold's example look (its warm
-  colors, the 760px reading column, the example header/nav). Keep the
-  design tokens and theme setup in `app/layout.ts`, those are
-  infrastructure, and restyle on top of them.
+  colors, the 760px reading column, the example header/nav). The `api`
+  template has no UI, so this does not apply there. Keep the design tokens
+  and theme setup in `app/layout.ts`, those are infrastructure, and
+  restyle on top of them.
 - **Only three templates exist:** `webjs create <name>` (default
   full-stack), `--template api`, `--template saas`. The CLI rejects any
   other `--template` value. Pick:

--- a/packages/cli/templates/AGENTS.md
+++ b/packages/cli/templates/AGENTS.md
@@ -20,7 +20,13 @@ example `Home` nav, and pick a content-width container that fits. The
 default `<main class="max-w-[760px]">` is a reading column for prose and
 forms, so for a full-bleed app, dashboard, or board, widen the cap or
 remove it (keep the theme tokens). A wide layout left in the 760px
-reading column overflows into a horizontal scrollbar. This is ENFORCED:
+reading column overflows into a horizontal scrollbar. **Give the app a
+unique design.** When it has a UI, choose its palette, layout, typography,
+and chrome to fit what the user asked for, rather than mimicking the
+scaffold's example look (the warm accent, the reading column, the serif
+display, the example header/nav) or just recoloring the same layout. The
+`api` template has no UI, so this does not apply there. The design tokens
+and theme wiring are infrastructure to keep and restyle on top of. This is ENFORCED:
 the example `app/page.ts` and `app/layout.ts` carry a
 `webjs-scaffold-placeholder` marker comment, and `webjs check` fails
 while any marker remains, so this freshly scaffolded app fails the check

--- a/packages/cli/templates/CONVENTIONS.md
+++ b/packages/cli/templates/CONVENTIONS.md
@@ -333,7 +333,15 @@ When the user asks the agent to build their actual app:
    dashboard, or board, or a wide layout overflows into an unnecessary
    horizontal scrollbar. Keep the design tokens and theme setup, those
    are infrastructure.
-6. **Keep:** the Drizzle setup, the test config, the agent config files
+6. **Use a unique design (UI apps).** Give the app a look of its own that
+   fits what the user asked for. Choose the palette, layout, typography,
+   spacing, and chrome deliberately. Do NOT mimic the scaffold's example
+   look (its warm accent, the 760px reading column, the serif display, the
+   example header/nav), and do not just recolor the same layout. The
+   `api` template has no UI, so this does not apply there. The design
+   tokens and theme wiring in `app/layout.ts` are infrastructure to keep
+   and restyle on top of, not the example look to preserve.
+7. **Keep:** the Drizzle setup, the test config, the agent config files
    (`AGENTS.md`, `CONVENTIONS.md`, `CLAUDE.md`, `.cursorrules`, etc.),
    `db/connection.server.ts` + `db/columns.server.ts`, the directory
    conventions, the design tokens in `app/layout.ts`. These are the


### PR DESCRIPTION
Closes #815

## Summary

The scaffold's per-agent rule files already tell the building agent to REPLACE the example content ("the scaffold is reference, not the final product"), but none of them said to give the app a DISTINCT visual design. So agents kept shipping an app that still looked like the scaffold (the warm accent, the 760px reading column, the serif display, the example chrome), just with different copy. A platform embedding webjs (crisp) had to bolt this instruction onto its own build prompt; it belongs in the scaffold so every agent on every platform (Claude, Cursor, Copilot, Gemini, OpenCode, Aider) gets it for free.

## Change

Added a UI-scoped "use a unique design, do not mimic the scaffold's example look" guideline alongside the existing scaffold-is-reference guidance, in all five prose surfaces in lockstep:
- `packages/cli/templates/AGENTS.md`
- `packages/cli/templates/CONVENTIONS.md` (new numbered item 6)
- `packages/cli/templates/.cursorrules`
- `packages/cli/templates/.github/copilot-instructions.md`
- `packages/cli/templates/.agents/rules/workflow.md`

Scoped to UI so it is a natural no-op for the `api` template (no UI), and it explicitly says to KEEP the design tokens / theme wiring (infrastructure) and restyle on top.

## Doc surfaces

- Scaffold templates (item 4): updated (the change IS the scaffold templates).
- Every markdown (item 2): the five files above are the surfaces that carry these rules; `CLAUDE.md` `@`-includes AGENTS.md + CONVENTIONS.md so it inherits; `.gemini` / `.opencode` / `.claude` are hooks, not prose.
- Docs site (item 3): N/A because this is scaffold-authoring guidance for the building agent, not framework API a docs reader consumes.
- MCP (item 5): N/A because the guideline is prose in the scaffold rule files, not an introspection surface or a `webjs check` rule.
- Editor plugins (item 6), marketing (item 7), version bump (item 9): N/A because no source, editor surface, landing claim, or published-package version changed.

## Test plan

- [ ] Scaffold tests still pass (`packages/cli/test/`, `test/scaffolds/*`).
- [ ] A freshly scaffolded app still passes `webjs check` (the guideline is prose, not an enforced marker).
- [ ] `test/docs/doc-source-consistency.test.mjs` still passes (it gates the scaffold agent files).
- Invariant 11 (prose punctuation) respected in the added lines.