### PR TITLE
fix(docs): match logo mark to the website in dark theme

### DIFF
--- a/docs/app/docs/layout.ts
+++ b/docs/app/docs/layout.ts
@@ -199,7 +199,7 @@ export default function DocsLayout({ children }: { children: unknown }) {
 
     <header class="hidden max-[860px]:flex fixed inset-x-0 top-0 z-[25] items-center gap-4 px-4 py-3 border-b border-border bg-[color-mix(in_oklch,var(--bg)_85%,transparent)] backdrop-blur-[18px] backdrop-saturate-[180%]">
       <a href="/" class="mr-auto inline-flex items-center gap-2 no-underline text-fg font-semibold text-[15px] leading-none tracking-tight">
-        <span class="inline-block w-[22px] h-[22px] rounded-md bg-gradient-to-br from-accent to-[color-mix(in_oklch,var(--accent)_55%,var(--fg))] shadow-[inset_0_0_0_1px_oklch(1_0_0/0.15),0_1px_4px_var(--accent-tint)]"></span>
+        <span class="inline-block w-[22px] h-[22px] rounded-[7px] bg-gradient-to-br from-[var(--logo-from)] to-[var(--logo-to)] shadow-[0_2px_10px_var(--accent-tint)]"></span>
         <span>webjs docs</span>
       </a>
       <button
@@ -223,7 +223,7 @@ export default function DocsLayout({ children }: { children: unknown }) {
       >
         <div class="flex items-center justify-between mb-6">
           <a class="flex items-center gap-2 no-underline text-fg font-semibold text-base leading-none" href="/">
-            <span class="w-[22px] h-[22px] rounded-md bg-gradient-to-br from-accent to-[color-mix(in_oklch,var(--accent)_55%,var(--fg))]"></span>
+            <span class="w-[22px] h-[22px] rounded-[7px] bg-gradient-to-br from-[var(--logo-from)] to-[var(--logo-to)]"></span>
             webjs docs
           </a>
           <theme-toggle class="max-[860px]:hidden"></theme-toggle>

--- a/docs/app/layout.ts
+++ b/docs/app/layout.ts
@@ -106,6 +106,12 @@ export default function RootLayout({ children }: { children: unknown }) {
         --accent-text:   var(--accent);
         --accent-surface: color-mix(in oklch, var(--accent-live) 12%, transparent);
         --accent-border:  color-mix(in oklch, var(--accent-live) 28%, transparent);
+        /* Dedicated logo-mark gradient stops, shared with website/app/layout.ts.
+           Do NOT derive the mark from --accent mixed toward --fg: in dark mode
+           --fg is near-white so the top stop washes out and diverges from the
+           website mark. Keep these two orange stops per theme instead. */
+        --logo-from:     oklch(0.63 0.17 50);
+        --logo-to:       oklch(0.44 0.11 52);
         --glow-a:        oklch(0.63 0.17 44);
         --glow-strength: 0.16;
 
@@ -143,6 +149,8 @@ export default function RootLayout({ children }: { children: unknown }) {
           --accent:        oklch(0.7 0.16 52);
           --accent-hover:  oklch(0.75 0.16 52);
           --accent-fg:     oklch(0.17 0.02 52);
+          --logo-from:     oklch(0.8 0.16 58);
+          --logo-to:       oklch(0.62 0.18 44);
           --glow-strength: 0.16;
         }
       }
@@ -166,6 +174,8 @@ export default function RootLayout({ children }: { children: unknown }) {
         --accent:        oklch(0.7 0.16 52);
         --accent-hover:  oklch(0.75 0.16 52);
         --accent-fg:     oklch(0.17 0.02 52);
+        --logo-from:     oklch(0.8 0.16 58);
+        --logo-to:       oklch(0.62 0.18 44);
         --glow-strength: 0.16;
       }
 


### PR DESCRIPTION
The docs shell derived its logo gradient from `from-accent to-[color-mix(accent, fg)]`. In dark mode `--fg` is near-white, so the top-right stop washed out and the mark diverged from the website (which uses two dedicated orange stops). This adds the shared `--logo-from` / `--logo-to` tokens to the docs `@theme` blocks (identical values to `website/app/layout.ts` across light and dark) and points both docs logo marks (mobile header + sidebar) at them, also matching the website's `rounded-[7px]` radius and shadow.

Verified in a booted docs app: the computed gradient now resolves to `oklch(0.8 0.16 58) -> oklch(0.62 0.18 44)` in dark and `oklch(0.63 0.17 50) -> oklch(0.44 0.11 52)` in light, matching the website exactly in both themes.

https://claude.ai/code/session_01EM2Bdq3we9kmJzMw88P4q6