### PR TITLE
chore: release core 0.7.30, server 0.8.42, cli 0.10.31, ui 0.3.8

### DIFF
--- a/changelog/cli/0.10.31.md
+++ b/changelog/cli/0.10.31.md
@@ -1,0 +1,24 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.31
+date: 2026-07-08T05:40:46.357Z
+commit_count: 3
+---
+## Features
+
+- **collapse first-pass scaffold friction (check chain, agent-docs, cn split, prose)** ([#825](https://github.com/webjsdev/webjs/pull/825)) [`47a78542`](https://github.com/webjsdev/webjs/commit/47a78542)
+  * chore: start scaffold example-gallery work (#824)
+  
+  * fix(ui): split registry lib/utils.ts so importing cn() does not pin a page (#819)
+- **ship an idiomatic feature gallery + example app in the scaffold** ([#826](https://github.com/webjsdev/webjs/pull/826)) [`96b72150`](https://github.com/webjsdev/webjs/commit/96b72150)
+  * chore: start the scaffold feature-gallery (#824)
+  
+  * feat(cli): gallery flagship /todo example (optimistic + a11y + PE + modules) (#824)
+
+## Fixes
+
+- **fix saas dashboard greeting and auth redirects (#831)** ([#832](https://github.com/webjsdev/webjs/pull/832)) [`87e3e85d`](https://github.com/webjsdev/webjs/commit/87e3e85d)
+  Three saas-template bugs found by running a generated app:
+  
+  - The dashboard and settings greetings were over-escaped, so a signed-in
+    user saw the literal text ${user?.name || user?.email}. The saas pages

--- a/changelog/core/0.7.30.md
+++ b/changelog/core/0.7.30.md
@@ -1,0 +1,9 @@
+---
+package: "@webjsdev/core"
+version: 0.7.30
+date: 2026-07-08T05:05:10.085Z
+commit_count: 1
+---
+## Fixes
+
+- **Correct the docs URL in the reactive-property error message** (docs.webjs.com to docs.webjs.dev) ([#826](https://github.com/webjsdev/webjs/pull/826)) [`96b72150`](https://github.com/webjsdev/webjs/commit/96b72150)

--- a/changelog/server/0.8.42.md
+++ b/changelog/server/0.8.42.md
@@ -1,0 +1,16 @@
+---
+package: "@webjsdev/server"
+version: 0.8.42
+date: 2026-07-08T05:40:46.300Z
+commit_count: 2
+---
+## Features
+
+- **collapse first-pass scaffold friction (check chain, agent-docs, cn split, prose)** ([#825](https://github.com/webjsdev/webjs/pull/825)) [`47a78542`](https://github.com/webjsdev/webjs/commit/47a78542)
+  * chore: start scaffold example-gallery work (#824)
+  
+  * fix(ui): split registry lib/utils.ts so importing cn() does not pin a page (#819)
+- **ship an idiomatic feature gallery + example app in the scaffold** ([#826](https://github.com/webjsdev/webjs/pull/826)) [`96b72150`](https://github.com/webjsdev/webjs/commit/96b72150)
+  * chore: start the scaffold feature-gallery (#824)
+  
+  * feat(cli): gallery flagship /todo example (optimistic + a11y + PE + modules) (#824)

--- a/changelog/ui/0.3.8.md
+++ b/changelog/ui/0.3.8.md
@@ -1,0 +1,16 @@
+---
+package: "@webjsdev/ui"
+version: 0.3.8
+date: 2026-07-08T05:40:46.467Z
+commit_count: 2
+---
+## Features
+
+- **collapse first-pass scaffold friction (check chain, agent-docs, cn split, prose)** ([#825](https://github.com/webjsdev/webjs/pull/825)) [`47a78542`](https://github.com/webjsdev/webjs/commit/47a78542)
+  * chore: start scaffold example-gallery work (#824)
+  
+  * fix(ui): split registry lib/utils.ts so importing cn() does not pin a page (#819)
+- **ship an idiomatic feature gallery + example app in the scaffold** ([#826](https://github.com/webjsdev/webjs/pull/826)) [`96b72150`](https://github.com/webjsdev/webjs/commit/96b72150)
+  * chore: start the scaffold feature-gallery (#824)
+  
+  * feat(cli): gallery flagship /todo example (optimistic + a11y + PE + modules) (#824)

--- a/package-lock.json
+++ b/package-lock.json
@@ -6975,7 +6975,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.30",
+      "version": "0.10.31",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -6991,7 +6991,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.29",
+      "version": "0.7.30",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.25.0"
@@ -7039,7 +7039,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.41",
+      "version": "0.8.42",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",
@@ -7075,7 +7075,7 @@
     },
     "packages/ui": {
       "name": "@webjsdev/ui",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.0",

--- a/packages/cli/lib/create.js
+++ b/packages/cli/lib/create.js
@@ -294,9 +294,12 @@ export async function scaffoldApp(name, cwd, opts = {}) {
   }
   const isApi = template === 'api';
   const isSaas = template === 'saas';
-  // The example gallery ships in the DEFAULT full-stack scaffold only: api has no
-  // UI, and saas overwrites db/schema.server.ts (users-only, so the gallery's
-  // todos table would vanish) and already carries its own idiomatic auth example.
+  // The example gallery ships in every UI scaffold (full-stack AND saas). The
+  // copyGallery gate below is !isApi, since only the api template has no UI. saas
+  // overwrites db/schema.server.ts with its own schema (which includes the
+  // gallery's todos table) and renders the gallery below its auth landing.
+  // isFullStack distinguishes the plain full-stack app from saas for the parts
+  // that differ (its own home page and the create.js-written schema).
   const isFullStack = !isApi && !isSaas;
 
   // Database dialect (#563): sqlite (default) or postgres. Drizzle is the ORM;

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.30",
+  "version": "0.10.31",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.29",
+  "version": "0.7.30",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.41",
+  "version": "0.8.42",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/ui",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "type": "module",
   "description": "An AI-first component library - class-helper functions for visuals, custom elements only where state matters. Source-copied into your repo, you own it. Works with any Tailwind v4 project.",
   "bin": {


### PR DESCRIPTION
Release cut for the first-pass scaffold work (the only commits on main since the last release, dd842017).

## Version bumps (all patch)

| Package | From | To | Why |
|---|---|---|---|
| @webjsdev/cli | 0.10.30 | **0.10.31** | Feature gallery + example app (#826), first-pass friction collapse (#825), saas auth fix (#832) |
| @webjsdev/server | 0.8.41 | **0.8.42** | check-chain enhancements in check.js (#825) |
| @webjsdev/ui | 0.3.7 | **0.3.8** | registry cn()/dom.ts split so importing cn does not pin a page (#819/#825), gallery-driven registry refactor (#826) |
| @webjsdev/core | 0.7.29 | **0.7.30** | fix docs URL in the reactive-property error message (docs.webjs.com to docs.webjs.dev) (#826) |

All four are PATCH bumps on purpose: the in-repo apps and the create-webjs / webjsdev wrappers all pin these packages with `^0.10.0` / `^0.8.0` / `^0.3.1` / `^0.7.0` caret ranges, so a MINOR (e.g. cli 0.11.0) would fall outside those ranges and force nested registry installs into the lockfile (npm ci then fails on the sync check). Staying in-range keeps the lockfile change to just the four workspace version fields, matching the previous release (#814). The gallery is still surfaced as a Features entry in the cli changelog. mcp and intellisense had no source changes, so no bump.

## Lockfile

package-lock.json updated to the four workspace version fields only (hand-synced, no re-resolution), verified with `npm ci --dry-run` (in sync, no missing packages).

## Changelogs

Auto-generated by the pre-commit hook under changelog/{cli,server,ui,core}/. The core entry was hand-corrected to describe the actual change (a docs-URL fix) rather than inheriting the gallery headline from the #826 squash.

## Also folded in

A one-line docs fix to a stale comment in packages/cli/lib/create.js (it said the gallery ships in full-stack only; it now correctly notes full-stack AND saas).

## On merge

.github/workflows/release.yml publishes each package to npm and creates the GitHub Releases from the new changelog files (idempotent). The create-webjs / webjsdev lockstep wrappers are bumped by the release workflow, not here.

https://claude.ai/code/session_01EM2Bdq3we9kmJzMw88P4q6