### PR TITLE
fix: service-worker root assets (#830) + all tic-tac-toe dogfood findings (#837)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,7 +156,7 @@ sitemap.js robots.js manifest.js icon.js opengraph-image.js twitter-image.js app
 lib/                        app-wide code (lib/*.server.js infra, lib/utils/ browser-safe helpers)
 modules/<feature>/          feature-scoped: actions/ (mutations), queries/ (reads), components/, utils/, types.js
 components/*.js             SHARED presentational primitives
-public/*                    static assets, served at /<name>
+public/*                    static assets, served at /public/<name> (favicon, sw.js, offline.html serve at root)
 db/*.server.{js,ts}         data layer (Drizzle: schema, columns, connection)
 ```
 

--- a/agent-docs/service-worker.md
+++ b/agent-docs/service-worker.md
@@ -39,7 +39,11 @@ and emit `<script nonce="${cspNonce()}">…`.
 ## What the worker does (scope + strategy)
 
 Registered from `/sw.js`, the worker's scope is the site root (`/`), so it sees
-every navigation and same-origin asset request.
+every navigation and same-origin asset request. Your worker file lives at
+`public/sw.js`, and although most `public/*` assets serve at `/public/<name>`,
+the framework serves this one (and `public/offline.html`) at the SITE ROOT with a
+`Service-Worker-Allowed: /` header, so `register('/sw.js')` resolves to a 200 and
+the worker controls the whole origin (#830).
 
 - **Navigations are network-first.** The worker always tries the network first,
   so the user sees fresh server-rendered HTML, and caches each successful page

--- a/docs/app/docs/getting-started/page.ts
+++ b/docs/app/docs/getting-started/page.ts
@@ -14,13 +14,12 @@ export default function GettingStarted() {
     </ul>
 
     <h2>Quick Start</h2>
-    <pre># install once
-npm i -g webjsdev
-
-# scaffold a new app
-webjs create my-app
+    <pre># scaffold a new app (no global install needed)
+npm create webjs@latest my-app
 cd my-app && npm run dev
 # → http://localhost:8080</pre>
+
+    <p><strong><code>npm create webjs@latest</code> is the canonical way to scaffold.</strong> It always fetches the latest <code>create-webjs</code>, so you never need a global install. Prefer it over a bare <code>webjs create</code>, because a globally installed or version-manager-shimmed <code>webjs</code> (or a stray <code>npx webjs</code>) can shadow the real CLI or resolve to an unrelated package. If you DO want the global CLI for <code>webjs dev</code> / <code>db</code> and friends, install it with <code>npm i -g webjsdev</code>.</p>
 
     <p>Every scaffold ships with Drizzle + SQLite wired up (<code>db/schema.server.ts</code> with an example <code>User</code> model and <code>db/connection.server.ts</code> exporting the <code>db</code> connection). Run <code>npm run db:migrate</code> the first time to create <code>db/dev.db</code>.</p>
 

--- a/packages/cli/lib/create.js
+++ b/packages/cli/lib/create.js
@@ -401,14 +401,18 @@ export async function scaffoldApp(name, cwd, opts = {}) {
       // for relations v2. SQLite needs NO driver dependency: the connection
       // uses the built-in node:sqlite (Node) / bun:sqlite (Bun) via Drizzle's
       // node-sqlite / bun-sqlite adapters. Postgres still needs the pg driver.
-      'drizzle-orm': '^1.0.0-rc.3',
+      // Pinned EXACTLY (no caret): a caret on a prerelease still admits later
+      // rc.N of 1.0.0, and the relations-v2 query API the scaffold is written and
+      // tested against is rc.3 (#562). An exact pin keeps generated apps
+      // deterministic instead of silently drifting to a newer rc.
+      'drizzle-orm': '1.0.0-rc.3',
       ...(dialect === 'postgres' ? { pg: '^8.13.0' } : {}),
       '@webjsdev/cli': 'latest',
       '@webjsdev/core': 'latest',
       '@webjsdev/server': 'latest',
     },
     devDependencies: {
-      'drizzle-kit': '^1.0.0-rc.3',
+      'drizzle-kit': '1.0.0-rc.3',
       ...(dialect === 'postgres' ? { '@types/pg': '^8.11.0' } : {}),
       // The TypeScript compiler, for `npm run typecheck` (webjs typecheck runs
       // tsc --noEmit). Not needed at runtime (Node strips types in place), only

--- a/packages/cli/templates/AGENTS.md
+++ b/packages/cli/templates/AGENTS.md
@@ -381,10 +381,14 @@ db/
   dev.db                 SQLite file (gitignored); created when migrations apply (\`dev\`/\`start\` run \`webjs db migrate\`)
   migrations/            generated migration SQL (committed)
 drizzle.config.ts        drizzle-kit config (root; SQLite by default, --db postgres to switch)
-public/                  static assets, served at /public/*
+public/                  static assets at /public/* (favicon, sw.js, offline.html serve at root)
 test/<feature>/                feature-scoped tests, one folder per concern
   <name>.test.ts                node unit / integration test (node --test)
-  browser/<name>.test.js        real-browser test (web-test-runner)
+  browser/<name>.test.js        real-browser test (web-test-runner); may ALSO be
+                                co-located next to a component, e.g.
+                                modules/<feature>/components/browser/<name>.test.js
+                                (see the gallery counter-card test for the idioms:
+                                suite/test, ssrFixture, inline assert, no chai)
   e2e/<name>.test.ts            end-to-end test (full app boot, opt in via WEBJS_E2E=1)
   smoke/<name>.test.ts          fast post-deploy sanity check
 middleware.ts            root middleware (optional, outermost)

--- a/packages/cli/templates/gallery/app/features/forms/page.ts
+++ b/packages/cli/templates/gallery/app/features/forms/page.ts
@@ -58,6 +58,12 @@ export default function FormsFeature({ searchParams, actionData }: { searchParam
 // The page action runs on a non-GET submission to this URL (the no-JS write
 // path). Validate, then return a failure (re-renders at 422 with fieldErrors +
 // values) or a success with a same-site `redirect` (a 303 PRG to the confirmation).
+//
+// FOOTGUN: to redirect on success, RETURN `{ success: true, redirect: '/path' }`
+// (a 303 See Other, so the browser follows with a GET). Do NOT THROW `redirect()`
+// from a page action, that is a 307 which PRESERVES the POST method and body, so
+// the browser re-POSTs to the target and re-runs the mutation (a duplicate write).
+// Throw `redirect()` only from a page render / GET context, never a page action.
 export async function action({ formData }: { formData: FormData }): Promise<Result> {
   const name = String(formData.get('name') ?? '').trim();
   const email = String(formData.get('email') ?? '').trim();

--- a/packages/cli/templates/gallery/app/features/service-worker/page.ts
+++ b/packages/cli/templates/gallery/app/features/service-worker/page.ts
@@ -22,7 +22,8 @@ export default function ServiceWorkerExample() {
     <pre class="bg-card border border-border rounded-xl p-4 overflow-x-auto text-sm font-mono mb-4"><code>connectedCallback() {
   super.connectedCallback();
   if ('serviceWorker' in navigator) {
-    // Register at the site root so the worker's scope is the whole origin.
+    // The framework serves your public/sw.js at the site root /sw.js (with a
+    // Service-Worker-Allowed: / header), so the worker's scope is the whole origin.
     navigator.serviceWorker.register('/sw.js');
   }
 }</code></pre>

--- a/packages/cli/templates/gallery/modules/components/components/browser/counter-card.test.js
+++ b/packages/cli/templates/gallery/modules/components/components/browser/counter-card.test.js
@@ -1,0 +1,36 @@
+// Co-located browser test for the <counter-card> component. This is the webjs
+// component-test SHAPE, so copy it for your own components:
+//   - It runs in REAL Chromium (webjs test --browser, or npx wtr), not jsdom. If
+//     the browser binary is missing, install it once: npx playwright install chromium.
+//   - The runner's mocha UI is `tdd`, so use suite() / test(), NOT describe / it().
+//   - There is NO assertion library in the importmap (no chai, no expect). Throw
+//     to fail. A tiny inline `assert` is plenty.
+//   - `ssrFixture` server-renders AND hydrates the component, so you exercise the
+//     REAL SSR output and the client interactivity, not a jsdom approximation.
+// It lives NEXT TO the component (a `browser/` dir inside the module), the
+// co-located default; the runner discovers browser tests under any browser dir.
+import { html } from '@webjsdev/core';
+import { ssrFixture } from '@webjsdev/core/testing';
+import '../counter-card.ts';
+
+const assert = (cond, msg) => { if (!cond) throw new Error(msg || 'assertion failed'); };
+
+suite('<counter-card>', () => {
+  test('SSRs its initial state and the default label', async () => {
+    const el = await ssrFixture(html`<counter-card></counter-card>`);
+    assert(el.textContent.includes('0'), 'the count starts at 0');
+    assert(el.textContent.includes('Clicks'), 'the default label renders');
+  });
+
+  test('reads the label reactive prop', async () => {
+    const el = await ssrFixture(html`<counter-card label="Taps"></counter-card>`);
+    assert(el.textContent.includes('Taps'), 'the provided label renders');
+  });
+
+  test('increments on click (hydrated interactivity)', async () => {
+    const el = await ssrFixture(html`<counter-card></counter-card>`);
+    el.querySelector('button').click();
+    await el.updateComplete;
+    assert(el.textContent.includes('1'), 'the count becomes 1 after one click');
+  });
+});

--- a/packages/cli/templates/gallery/modules/todo/queries/list-todos.server.ts
+++ b/packages/cli/templates/gallery/modules/todo/queries/list-todos.server.ts
@@ -14,6 +14,12 @@ export async function listTodos(): Promise<Todo[]> {
   // imported column mis-compiles to a bad SQL alias in rc.3. Do NOT use
   // `db.select({ col })` either (its projection overload trips TS2554 in rc.3).
   // See the Database (Drizzle) section in this app's AGENTS.md.
+  //
+  // Two equivalent read styles, both fine: the relational query API
+  // (`db.query.todos.findFirst({ where: { id } })` / `findMany`, used here and in
+  // toggle-todo) reads by an object filter; the core builder
+  // (`db.select().from(todos).where(eq(todos.id, id))`) reads with the `eq()`
+  // helper. Reach for whichever fits; the relational form is terser for by-id reads.
   const rows = await db.query.todos.findMany({ orderBy: { createdAt: 'desc' } });
   return rows as Todo[];
 }

--- a/packages/cli/templates/test/hello/browser/hello.test.js
+++ b/packages/cli/templates/test/hello/browser/hello.test.js
@@ -3,6 +3,12 @@
  *
  * Run:  webjs test --browser
  *       npx wtr
+ * First run only, if Chromium is missing:  npx playwright install chromium
+ *
+ * The runner's mocha UI is `tdd`: use suite() / test() (NOT describe / it), and
+ * throw to fail (there is no chai / expect in the importmap; a tiny inline assert
+ * like the one below is the idiom). See modules/components/components/browser for
+ * a co-located COMPONENT browser test using ssrFixture.
  *
  * Tests here have full access to real browser APIs: Shadow DOM,
  * adoptedStyleSheets, IntersectionObserver, events, etc.

--- a/packages/cli/templates/web-test-runner.config.js
+++ b/packages/cli/templates/web-test-runner.config.js
@@ -33,7 +33,15 @@ export default {
   // Browser tests are `.js` (web-test-runner serves them through its own test
   // framework); the components + modules they import are `.ts`, served
   // transformed by the webjs middleware below.
-  files: ['test/**/browser/**/*.test.js'],
+  // Browser tests live under any `browser/` dir: the top-level `test/<feature>/
+  // browser/`, OR co-located next to the code they exercise (a component's
+  // `modules/<feature>/components/browser/`, the modules-architecture default).
+  files: [
+    'test/**/browser/**/*.test.js',
+    'app/**/browser/**/*.test.js',
+    'modules/**/browser/**/*.test.js',
+    'components/**/browser/**/*.test.js',
+  ],
   // webjs's importmap resolves `@webjsdev/core`, the `#` app aliases, and
   // vendors, so web-test-runner must NOT rewrite bare specifiers to
   // node_modules paths.

--- a/packages/mcp/src/mcp-source.js
+++ b/packages/mcp/src/mcp-source.js
@@ -153,6 +153,13 @@ export function listSources(deps, pkgFilter) {
 export async function grepSources(deps, query) {
   const q = String(query).toLowerCase();
   if (!q) return 'Provide a non-empty `query`.';
+  // No resolvable packages means NOTHING was searched. Returning "no matches"
+  // here would read as authoritative absence when the search never ran, which
+  // is the #837 dogfood failure: an odd/shimmed node_modules layout resolved
+  // zero roots, so a real symbol looked missing and the agent lost trust.
+  if (!deps.roots.length) {
+    return 'No @webjsdev/* source is resolvable here, so NOTHING was searched (run inside a webjs app or the monorepo). This is not the same as "not found".';
+  }
   /** @type {string[]} */
   const hits = [];
   let capped = false;
@@ -170,7 +177,10 @@ export async function grepSources(deps, query) {
       }
     }
   }
-  if (!hits.length) return `No matches for "${query}" in the @webjsdev/* source.`;
+  // Disclose the SEARCHED scope on a no-match, so "no matches" reads as a
+  // comprehensive-search result the agent can trust, not a silent gap (#837).
+  const searched = deps.roots.map((r) => r.pkg).join(', ');
+  if (!hits.length) return `No matches for "${query}" in the searched @webjsdev/* source (${searched}).`;
   if (capped) hits.push(`... (truncated at ${MAX_HITS} matches; narrow the query or read a file with \`path\`)`);
   return hits.join('\n');
 }

--- a/packages/mcp/test/mcp-source.test.mjs
+++ b/packages/mcp/test/mcp-source.test.mjs
@@ -89,6 +89,26 @@ test('grepSources: returns pkg-qualified file:line hits; no-match message', asyn
   assert.match(await grepSources(fakeTree(), ''), /non-empty/);
 });
 
+test('grepSources: a cross-package symbol is found (server src, the actionData case #837)', async () => {
+  const out = await grepSources(fakeTree(), 'renderToString');
+  assert.match(out, /\[@webjsdev\/server\/src\/ssr\.js:1\]/, 'finds a symbol in the server package src');
+});
+
+test('grepSources: empty roots report NOTHING searched, not a false "no match" (#837)', async () => {
+  // The dogfood failure: a shimmed/odd node_modules layout resolved zero roots,
+  // so a real symbol looked missing. "No matches" must NOT be returned when the
+  // search never ran; that reads as authoritative absence.
+  const noRoots = { ...fakeTree(), roots: [] };
+  const out = await grepSources(noRoots, 'renderToString');
+  assert.doesNotMatch(out, /No matches for/, 'not a false "no match" when nothing was searched');
+  assert.match(out, /nothing was searched/i, 'says nothing was searched');
+});
+
+test('grepSources: a genuine no-match discloses the searched packages (#837)', async () => {
+  const out = await grepSources(fakeTree(), 'zzzznotfound');
+  assert.match(out, /core, server, cli/, 'discloses the searched scope so absence is trustworthy');
+});
+
 test('grepSources: discloses the cap at > 60 matches (no silent truncation)', async () => {
   const many = Array.from({ length: 70 }, (_, i) => `hit signal ${i}`).join('\n');
   const out = await grepSources(fakeTree({ '/fw/core/src/big.js': many }), 'hit signal');

--- a/packages/server/src/dev.js
+++ b/packages/server/src/dev.js
@@ -1825,9 +1825,14 @@ async function handleCore(req, ctx) {
     return invokeAction(state.actionIndex, actMatch[1], actMatch[2], req, onActionError, allowedOrigins);
   }
 
-  // Static: /public/*
-  if (path.startsWith('/public/') || path === '/favicon.ico') {
-    const p = path === '/favicon.ico' ? '/public/favicon.ico' : path;
+  // Static: /public/*, plus a small set of ROOT assets that must serve at the
+  // site root even though they live under public/. A service worker registered
+  // at /sw.js scopes to the origin root, so it MUST serve at / (not
+  // /public/sw.js), and so must its offline fallback. Same remap shape as the
+  // /favicon.ico special-case below. (#830)
+  const ROOT_ASSETS = { '/sw.js': '/public/sw.js', '/offline.html': '/public/offline.html' };
+  if (path.startsWith('/public/') || path === '/favicon.ico' || path in ROOT_ASSETS) {
+    const p = path === '/favicon.ico' ? '/public/favicon.ico' : (ROOT_ASSETS[path] || path);
     const abs = join(appDir, p);
     // Containment check. `join` normalises `..` segments, so a path
     // like `/public/%2E%2E/secret/x.svg` decodes (after URL parsing,
@@ -1843,7 +1848,13 @@ async function handleCore(req, ctx) {
       return new Response(null, { status: 404 });
     }
     // A `?v=<hash>` public asset is content-addressed -> immutable (#243).
-    if (await exists(abs)) return fileResponse(abs, { dev, immutable: versioned });
+    if (await exists(abs)) {
+      const res = await fileResponse(abs, { dev, immutable: versioned });
+      // A worker served below its registration path only controls that subtree
+      // unless the response opts it up to the root scope. (#830)
+      if (path === '/sw.js') res.headers.set('Service-Worker-Allowed', '/');
+      return res;
+    }
   }
 
   // User source modules (served as ES modules, with action-file rewriting).

--- a/packages/server/test/dev/root-assets.test.js
+++ b/packages/server/test/dev/root-assets.test.js
@@ -1,0 +1,69 @@
+/**
+ * Integration tests for #830: the service-worker root assets. A worker
+ * registered at /sw.js scopes to the origin root, so the framework must serve
+ * public/sw.js (and its offline fallback) at the SITE ROOT, not only at
+ * /public/*, and the /sw.js response must carry Service-Worker-Allowed: / so it
+ * controls the whole origin.
+ *
+ * Exercised through createRequestHandler against a minimal app fixture, in dev
+ * AND prod (dev: false), since the static branch is the shared runtime-agnostic
+ * handler (so this also covers the Bun listener, which calls the same handle()).
+ *
+ * COUNTERFACTUAL: assert GET /sw.js is 200. Reverting the ROOT_ASSETS remap in
+ * dev.js makes /sw.js fall through to a 404, turning this red.
+ */
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { createRequestHandler } from '../../src/dev.js';
+
+let tmpRoot;
+before(() => { tmpRoot = mkdtempSync(join(tmpdir(), 'webjs-rootassets-')); });
+after(() => { rmSync(tmpRoot, { recursive: true, force: true }); });
+
+function makeApp() {
+  const appDir = mkdtempSync(join(tmpRoot, 'app-'));
+  mkdirSync(join(appDir, 'public'), { recursive: true });
+  writeFileSync(join(appDir, 'public', 'sw.js'), "self.addEventListener('install', () => {});\n");
+  writeFileSync(join(appDir, 'public', 'offline.html'), '<!doctype html><title>offline</title>\n');
+  return appDir;
+}
+
+for (const dev of [true, false]) {
+  test(`/sw.js serves public/sw.js at the site root with Service-Worker-Allowed (dev=${dev})`, async () => {
+    const app = await createRequestHandler({ appDir: makeApp(), dev });
+    const res = await app.handle(new Request('http://x/sw.js'));
+    assert.equal(res.status, 200, '/sw.js is served at the root');
+    assert.match(res.headers.get('content-type') || '', /javascript/, 'served as JS');
+    assert.equal(res.headers.get('service-worker-allowed'), '/',
+      '/sw.js opts into the root scope');
+    assert.match(await res.text(), /addEventListener/, 'body is the worker source');
+  });
+
+  test(`/offline.html serves public/offline.html at the site root (dev=${dev})`, async () => {
+    const app = await createRequestHandler({ appDir: makeApp(), dev });
+    const res = await app.handle(new Request('http://x/offline.html'));
+    assert.equal(res.status, 200, '/offline.html is served at the root');
+    assert.match(await res.text(), /offline/, 'body is the offline fallback');
+  });
+}
+
+test('the underlying /public/* path still serves (backward compatible)', async () => {
+  const app = await createRequestHandler({ appDir: makeApp(), dev: true });
+  const res = await app.handle(new Request('http://x/public/sw.js'));
+  assert.equal(res.status, 200, '/public/sw.js still works');
+  // The root-scope header is only added for the root /sw.js path.
+  assert.equal(res.headers.get('service-worker-allowed'), null,
+    'the /public/* path does not carry the root-scope header');
+});
+
+test('a non-remapped root path is not exposed (no traversal, no accidental root serving)', async () => {
+  const appDir = makeApp();
+  writeFileSync(join(appDir, 'secret.txt'), 'nope\n');
+  const app = await createRequestHandler({ appDir, dev: true });
+  const res = await app.handle(new Request('http://x/secret.txt'));
+  assert.notEqual(res.status, 200, 'only the allowlisted root assets are remapped');
+});

--- a/test/bun/sw-root-assets.mjs
+++ b/test/bun/sw-root-assets.mjs
@@ -1,0 +1,41 @@
+/**
+ * Cross-runtime parity (#830 + #508): the service-worker root assets serve at
+ * the SITE ROOT under WHICHEVER runtime executes this file. The static branch
+ * lives in the shared handler and reads the file via `readFile`, whose behaviour
+ * differs Node vs Bun, so the same assertions must hold on both shells:
+ *
+ *   node test/bun/sw-root-assets.mjs
+ *   bun  test/bun/sw-root-assets.mjs
+ *
+ * A plain assert script (not `*.test.mjs`) so the SAME file runs identically on
+ * both runtimes; it exits non-zero on failure. Run from the repo root so the
+ * bare `@webjsdev/server` specifier resolves to the workspace package.
+ */
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createRequestHandler } from '@webjsdev/server';
+
+const runtime = process.versions.bun ? `bun ${process.versions.bun}` : `node ${process.versions.node}`;
+
+const appDir = mkdtempSync(join(tmpdir(), 'webjs-sw-'));
+mkdirSync(join(appDir, 'public'), { recursive: true });
+writeFileSync(join(appDir, 'public', 'sw.js'), "self.addEventListener('install', () => {});\n");
+writeFileSync(join(appDir, 'public', 'offline.html'), '<!doctype html><title>offline</title>\n');
+
+try {
+  const app = await createRequestHandler({ appDir, dev: false });
+
+  const sw = await app.handle(new Request('http://x/sw.js'));
+  assert.equal(sw.status, 200, `[${runtime}] /sw.js serves at the site root`);
+  assert.equal(sw.headers.get('service-worker-allowed'), '/', `[${runtime}] /sw.js opts into root scope`);
+  assert.match(await sw.text(), /addEventListener/, `[${runtime}] /sw.js body is the worker source`);
+
+  const offline = await app.handle(new Request('http://x/offline.html'));
+  assert.equal(offline.status, 200, `[${runtime}] /offline.html serves at the site root`);
+
+  console.log(`ok  ${runtime}  service-worker root assets (#830)`);
+} finally {
+  rmSync(appDir, { recursive: true, force: true });
+}

--- a/test/bun/sw-root-assets.test.mjs
+++ b/test/bun/sw-root-assets.test.mjs
@@ -1,0 +1,12 @@
+/**
+ * Run the service-worker root-asset parity proof (#830) under WHICHEVER runtime
+ * executes the suite. The root `node --test` runner picks this up (so `npm test`
+ * exercises the node path); CI runs `bun test/bun/sw-root-assets.mjs` for Bun.
+ * The proof is a plain assert script (`sw-root-assets.mjs`, not `*.test.mjs`) so
+ * the runner does not double-run it.
+ */
+import { test } from 'node:test';
+
+test('service-worker root assets serve at the site root on this runtime (#830)', async () => {
+  await import('./sw-root-assets.mjs');
+});


### PR DESCRIPTION
Fixes the service-worker path bug and every finding from the tic-tac-toe dogfood session.

Closes #830
Closes #837

## #830: service-worker root assets serve at the site root

A worker registered at `/sw.js` scopes to the origin root, but the scaffold served `public/*` only at `/public/*`, so `GET /sw.js` was a 404 and the `app/features/service-worker` gallery demo could never register.

- `packages/server/src/dev.js`: the shared static branch now remaps `/sw.js` and `/offline.html` to `public/` and adds `Service-Worker-Allowed: /`. One place (the runtime-agnostic handler), so it covers dev, prod, Node, and Bun.
- Tests: `packages/server/test/dev/root-assets.test.js` + a Bun parity proof `test/bun/sw-root-assets.mjs` (green on node 26 AND bun 1.3.14).
- Docs reconciled: root `AGENTS.md`, `agent-docs/service-worker.md`, the scaffold `AGENTS.md`, and the gallery demo.

## #837: all 7 dogfood findings

1. **Redirect footgun (307 vs 303).** The forms demo now warns: RETURN `{ redirect }` (303 PRG); do NOT THROW `redirect()` from a page action (a 307 that re-POSTs and re-runs the mutation, the phantom-move bug).
2. **Component browser test.** A co-located `modules/components/components/browser/counter-card.test.js` teaches the real idioms (`suite`/`test`, `ssrFixture`, inline assert, no chai); the WTR glob now discovers co-located `**/browser/**` tests. Verified passing in real Chromium (3/3).
3. **Drizzle reads.** The todo query names both equivalent read styles (relational `db.query` vs core `db.select().where(eq())`).
4. **MCP `source` tool "no matches".** `grepSources` no longer returns a misleading "no matches" when ZERO packages resolved (nothing was searched), and a genuine no-match now discloses the searched scope so absence is trustworthy. `packages/mcp/test/mcp-source.test.mjs` covers empty-roots, scope disclosure, and a cross-package (server src) find.
5. **Drizzle rc pin.** The generated `drizzle-orm` / `drizzle-kit` are pinned EXACTLY to `1.0.0-rc.3` (the tested relations-v2 API), not `^`, so a scaffold no longer drifts to a newer rc.
6. **Install crispness.** Getting-started now leads with `npm create webjs@latest my-app` (no global install) and warns that a global/shimmed `webjs` can shadow the CLI.
7. **Browser-test prereq.** The hello browser-test header notes the one-time `npx playwright install chromium` and the `tdd`-UI idioms.

## Verification

Generated full-stack + saas + api; `webjs check` clean (only intended placeholder markers); co-located browser test green in Chromium; #830 server tests green on Node and Bun; the 12 MCP source tests pass. No published-package version bump in this PR.

https://claude.ai/code/session_01EM2Bdq3we9kmJzMw88P4q6