### PR TITLE
chore: release server 0.8.43, cli 0.10.32, mcp 0.1.7

### DIFF
--- a/changelog/cli/0.10.32.md
+++ b/changelog/cli/0.10.32.md
@@ -1,0 +1,19 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.32
+date: 2026-07-08T08:42:54.079Z
+commit_count: 2
+---
+## Features
+
+- **harden scaffold agent discipline (commits, worktrees, design, tailwind)** ([#836](https://github.com/webjsdev/webjs/pull/836)) [`78d17879`](https://github.com/webjsdev/webjs/commit/78d17879)
+  * feat(cli): enforce commit-per-unit and auto-clean merged worktrees in the scaffold
+  
+  * feat(cli): harden unique-design and tailwind-first scaffold guidance
+
+## Fixes
+
+- **service-worker root assets (#830) + all tic-tac-toe dogfood findings (#837)** ([#838](https://github.com/webjsdev/webjs/pull/838)) [`e5eb00b5`](https://github.com/webjsdev/webjs/commit/e5eb00b5)
+  * fix(server): serve service-worker root assets at the site root (#830)
+  
+  * feat(cli): teach redirect-footgun, component browser tests, drizzle reads in the gallery

--- a/changelog/mcp/0.1.7.md
+++ b/changelog/mcp/0.1.7.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/mcp"
+version: 0.1.7
+date: 2026-07-08T08:42:54.216Z
+commit_count: 1
+---
+## Fixes
+
+- **`source` tool no longer reads as "not found" when nothing was searched** ([#838](https://github.com/webjsdev/webjs/pull/838)) [`e5eb00b5`](https://github.com/webjsdev/webjs/commit/e5eb00b5)
+  The `source({ query })` grep returned a misleading "no matches" when zero
+  `@webjsdev/*` packages resolved (so nothing was actually searched); it now
+  reports that distinctly, and a genuine no-match discloses the searched scope so
+  absence is trustworthy (#837).

--- a/changelog/server/0.8.43.md
+++ b/changelog/server/0.8.43.md
@@ -1,0 +1,12 @@
+---
+package: "@webjsdev/server"
+version: 0.8.43
+date: 2026-07-08T08:42:54.020Z
+commit_count: 1
+---
+## Fixes
+
+- **service-worker root assets (#830) + all tic-tac-toe dogfood findings (#837)** ([#838](https://github.com/webjsdev/webjs/pull/838)) [`e5eb00b5`](https://github.com/webjsdev/webjs/commit/e5eb00b5)
+  * fix(server): serve service-worker root assets at the site root (#830)
+  
+  * feat(cli): teach redirect-footgun, component browser tests, drizzle reads in the gallery

--- a/package-lock.json
+++ b/package-lock.json
@@ -6975,7 +6975,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.31",
+      "version": "0.10.32",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -7025,7 +7025,7 @@
     },
     "packages/mcp": {
       "name": "@webjsdev/mcp",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/server": "^0.8.0"
@@ -7039,7 +7039,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.42",
+      "version": "0.8.43",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.31",
+  "version": "0.10.32",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/mcp",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "module",
   "description": "The webjs Model Context Protocol server: live app introspection (routes / actions / components / check) plus the framework knowledge layer (docs, recipes, source) for AI coding agents",
   "bin": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.42",
+  "version": "0.8.43",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Release for the changes accumulated since the last release (#833): #834 (repo config, no package change), #835, #836, #838.

## Version bumps (all patch)

| Package | From | To | Why |
|---|---|---|---|
| @webjsdev/server | 0.8.42 | **0.8.43** | service-worker root assets serve at the site root (#830/#838) |
| @webjsdev/cli | 0.10.31 | **0.10.32** | scaffold discipline hardening (#836) + dogfood gallery/drizzle-pin fixes (#838) |
| @webjsdev/mcp | 0.1.6 | **0.1.7** | `source` tool no longer reads as "not found" when nothing was searched (#838) |

All PATCH to stay within the caret ranges the in-repo apps and the create-webjs / webjsdev wrappers pin (`^0.10.0` / `^0.8.0` / `^0.1.0`); a minor would fall out of range and force nested registry installs (npm ci fails on the sync check). Lockfile updated to the 3 workspace version fields only, verified with `npm ci --dry-run`.

`core`, `ui`, and `intellisense` had no source changes in range, so no bump. #834 (stale-Prisma cleanup) and #835 (worktree hook) touched only repo config / tooling, not published packages.

## Changelogs

Auto-generated by the pre-commit hook. The mcp entry was hand-corrected to describe the actual mcp change (the `source`-tool robustness fix) rather than inheriting #838's headline.

## On merge

`.github/workflows/release.yml` publishes to npm + creates GitHub Releases, and lockstep-publishes the create-webjs / webjsdev wrappers to match cli.

https://claude.ai/code/session_01EM2Bdq3we9kmJzMw88P4q6