### PR TITLE
chore: remind to update the global CLI after a release publishes

### DIFF
--- a/.claude/hooks/release-global-update.sh
+++ b/.claude/hooks/release-global-update.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Claude Code PostToolUse hook (matcher: Bash).
+#
+# After a RELEASE PR (`chore/release-*`, or a "chore: release ..." title) merges,
+# the just-published packages are live on npm a minute or two later. The globally
+# installed `webjs` CLI (used to scaffold / dogfood) then lags the release. This
+# hook fires on that merge and injects a directive to update the global CLI on
+# BOTH package managers once the publish is confirmed:
+#
+#   npm update -g webjsdev
+#   bun add -g webjsdev
+#
+# It REMINDS rather than runs, on purpose: those commands pull the LATEST
+# PUBLISHED version, so they must run AFTER `.github/workflows/release.yml`
+# publishes (verify with `npm view @webjsdev/cli version`), not at merge time.
+# Only fires for a release PR (a normal PR merge is ignored). Needs `gh`.
+# Disable with WEBJS_NO_RELEASE_GLOBAL_UPDATE=1.
+#
+# Rule: the "Update global CLI after a release" memory + the release flow in
+# agent-docs/framework-dev.md.
+
+set -uo pipefail
+
+payload=$(cat 2>/dev/null || true)
+if [ "${WEBJS_NO_RELEASE_GLOBAL_UPDATE:-}" = "1" ]; then exit 0; fi
+
+cmd=$(printf '%s' "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+if [ -z "$cmd" ]; then exit 0; fi
+
+# Only after a `gh pr merge`.
+if ! printf '%s' "$cmd" | grep -Eq '(^|[^[:alnum:]-])gh pr merge([^[:alnum:]-]|$)'; then
+  exit 0
+fi
+command -v gh >/dev/null 2>&1 || exit 0
+
+# The PR number is the first bare number after `gh pr merge`.
+num=$(printf '%s' "$cmd" | grep -oE 'gh pr merge[[:space:]]+#?[0-9]+' | grep -oE '[0-9]+' | head -1)
+if [ -z "$num" ]; then exit 0; fi
+
+info=$(gh pr view "$num" --json headRefName,title 2>/dev/null || true)
+if [ -z "$info" ]; then exit 0; fi
+head=$(printf '%s' "$info" | jq -r '.headRefName // ""' 2>/dev/null || true)
+title=$(printf '%s' "$info" | jq -r '.title // ""' 2>/dev/null || true)
+
+# Release PRs only: a `chore/release-*` branch or a "chore: release" title.
+is_release=no
+printf '%s' "$head" | grep -q '^chore/release-' && is_release=yes
+printf '%s' "$title" | grep -qi '^chore: release' && is_release=yes
+if [ "$is_release" != "yes" ]; then exit 0; fi
+
+read -r -d '' MSG <<'EOF' || true
+A release PR just merged. Once .github/workflows/release.yml has published the
+new versions to npm (verify with `npm view @webjsdev/cli version` matching the
+released version), update the globally installed CLI on BOTH package managers so
+local scaffolding / dogfooding uses the new release:
+  npm update -g webjsdev
+  bun add -g webjsdev
+Run them AFTER the publish is confirmed, not before (they pull the latest
+PUBLISHED version). Disable this reminder with WEBJS_NO_RELEASE_GLOBAL_UPDATE=1.
+EOF
+
+jq -n --arg ctx "$MSG" '{
+  hookSpecificOutput: {
+    hookEventName: "PostToolUse",
+    additionalContext: $ctx
+  }
+}' 2>/dev/null || true
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -67,6 +67,10 @@
           {
             "type": "command",
             "command": ".claude/hooks/cleanup-merged-worktree.sh"
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/release-global-update.sh"
           }
         ]
       }

--- a/agent-docs/framework-dev.md
+++ b/agent-docs/framework-dev.md
@@ -62,6 +62,8 @@ npm runs first; if it fails (auth, network, transient registry error), the GitHu
 
 The workflow uses `NPM_TOKEN` (repo secret) and the auto-provisioned `GITHUB_TOKEN`. Free for public repos.
 
+**Update the global CLI after the publish lands.** The maintainer scaffolds and dogfoods with the globally installed `webjs` CLI, which lags a release until refreshed. So once `release.yml` has published (verify `npm view @webjsdev/cli version` matches the released version), run BOTH `npm update -g webjsdev` and `bun add -g webjsdev`. Run them AFTER the publish, never at merge time (they pull the LATEST PUBLISHED version). This is reminded automatically by the `.claude/hooks/release-global-update.sh` PostToolUse hook, which fires when a `chore/release-*` PR merges (escape hatch `WEBJS_NO_RELEASE_GLOBAL_UPDATE=1`, regression test `test/hooks/release-global-update.test.mjs`).
+
 ---
 
 ## Dev error overlay: rich, pushed live over SSE (dev-only) (#264)

--- a/test/hooks/release-global-update.test.mjs
+++ b/test/hooks/release-global-update.test.mjs
@@ -1,0 +1,86 @@
+// Tests for the release-global-update PostToolUse hook
+// (.claude/hooks/release-global-update.sh). After a RELEASE PR (chore/release-*
+// branch or "chore: release" title) merges via `gh pr merge`, it injects a
+// reminder to run `npm update -g webjsdev` + `bun add -g webjsdev` once the
+// publish lands. A normal PR merge, a non-merge command, and the escape hatch
+// produce no reminder. It never blocks the tool (always exits 0).
+//
+// `gh pr view` is stubbed with a fake `gh` on PATH so the test is offline and
+// deterministic.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve, delimiter } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HOOK = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../.claude/hooks/release-global-update.sh',
+);
+
+/** A fake `gh` on PATH whose `pr view` prints the given headRefName + title. */
+function fakeGhDir(headRefName, title) {
+  const dir = mkdtempSync(join(tmpdir(), 'webjs-relhook-'));
+  const gh = join(dir, 'gh');
+  writeFileSync(gh, `#!/usr/bin/env bash\necho '${JSON.stringify({ headRefName, title })}'\n`);
+  chmodSync(gh, 0o755);
+  return dir;
+}
+
+function runHook(command, { headRefName = '', title = '', env = {} } = {}) {
+  const ghDir = fakeGhDir(headRefName, title);
+  try {
+    const r = spawnSync('bash', [HOOK], {
+      input: JSON.stringify({ tool_input: { command } }),
+      encoding: 'utf8',
+      env: { ...process.env, PATH: `${ghDir}${delimiter}${process.env.PATH}`, ...env },
+    });
+    return { code: r.status, out: (r.stdout || '') };
+  } finally {
+    rmSync(ghDir, { recursive: true, force: true });
+  }
+}
+
+test('reminds after a chore/release-* branch PR merge', () => {
+  const { code, out } = runHook('gh pr merge 839 --squash --admin --delete-branch', {
+    headRefName: 'chore/release-2026-07-08b',
+    title: 'chore: release server 0.8.43',
+  });
+  assert.equal(code, 0);
+  assert.match(out, /npm update -g webjsdev/, 'reminds about npm global update');
+  assert.match(out, /bun add -g webjsdev/, 'reminds about bun global add');
+});
+
+test('reminds when the title is "chore: release" even if the branch differs', () => {
+  const { out } = runHook('gh pr merge 1 --squash', {
+    headRefName: 'some-branch',
+    title: 'chore: release cli 0.10.32',
+  });
+  assert.match(out, /npm update -g webjsdev/);
+});
+
+test('does NOTHING for a normal (non-release) PR merge', () => {
+  const { code, out } = runHook('gh pr merge 840 --squash', {
+    headRefName: 'feat/thing',
+    title: 'feat: a normal feature',
+  });
+  assert.equal(code, 0);
+  assert.doesNotMatch(out, /webjsdev/, 'no reminder for a non-release PR');
+});
+
+test('does NOTHING for a command that is not `gh pr merge`', () => {
+  const { out } = runHook('git status', { headRefName: 'chore/release-x', title: 'chore: release x' });
+  assert.doesNotMatch(out, /webjsdev/);
+});
+
+test('honours the WEBJS_NO_RELEASE_GLOBAL_UPDATE escape hatch', () => {
+  const { out } = runHook('gh pr merge 839 --squash', {
+    headRefName: 'chore/release-2026-07-08b',
+    title: 'chore: release server 0.8.43',
+    env: { WEBJS_NO_RELEASE_GLOBAL_UPDATE: '1' },
+  });
+  assert.doesNotMatch(out, /webjsdev/);
+});


### PR DESCRIPTION
Enforces the "after a release publishes, refresh the global CLI" step so it is never forgotten.

## What

A `.claude/hooks/release-global-update.sh` PostToolUse hook (matcher `Bash`) fires when a RELEASE PR merges (a `chore/release-*` branch or a "chore: release" title) via `gh pr merge`, and injects a directive to run BOTH:

```
npm update -g webjsdev
bun add -g webjsdev
```

## Why it reminds instead of auto-running

Those commands pull the LATEST PUBLISHED version, so they must run AFTER `release.yml` publishes (a minute or two post-merge), not at merge time. So the hook fires deterministically on every release-PR merge and tells the agent to run them once the publish is confirmed (`npm view @webjsdev/cli version`). A normal PR merge, a non-merge command, and the `WEBJS_NO_RELEASE_GLOBAL_UPDATE=1` escape hatch produce no reminder. It never blocks the tool.

## Tests + docs

- `test/hooks/release-global-update.test.mjs`: reminds on a release branch/title, silent on a normal PR, silent on a non-merge command, honours the escape hatch (5 cases, `gh` stubbed on PATH, all green).
- Documented in the release-flow section of `agent-docs/framework-dev.md`.

Framework-repo tooling only (releasing `@webjsdev/*`), not shipped to the scaffold. No published-package source changed.

https://claude.ai/code/session_01EM2Bdq3we9kmJzMw88P4q6