### PR TITLE
fix: release-update hook matches release PRs by title, not branch prefix

### DIFF
--- a/.claude/hooks/release-global-update.sh
+++ b/.claude/hooks/release-global-update.sh
@@ -2,7 +2,7 @@
 #
 # Claude Code PostToolUse hook (matcher: Bash).
 #
-# After a RELEASE PR (`chore/release-*`, or a "chore: release ..." title) merges,
+# After a RELEASE PR (a canonical "chore: release <pkgs>" title) merges,
 # the just-published packages are live on npm a minute or two later. The globally
 # installed `webjs` CLI (used to scaffold / dogfood) then lags the release. This
 # hook fires on that merge and injects a directive to update the global CLI on
@@ -44,11 +44,12 @@ if [ -z "$info" ]; then exit 0; fi
 head=$(printf '%s' "$info" | jq -r '.headRefName // ""' 2>/dev/null || true)
 title=$(printf '%s' "$info" | jq -r '.title // ""' 2>/dev/null || true)
 
-# Release PRs only: a `chore/release-*` branch or a "chore: release" title.
-is_release=no
-printf '%s' "$head" | grep -q '^chore/release-' && is_release=yes
-printf '%s' "$title" | grep -qi '^chore: release' && is_release=yes
-if [ "$is_release" != "yes" ]; then exit 0; fi
+# A real release PR carries the canonical "chore: release <pkgs>" title (the
+# release process always titles it exactly that). Match the TITLE, not the
+# branch prefix: a `chore/release-*` branch that is NOT a package release (a hook
+# tweak, a doc change) would otherwise fire a false reminder with nothing to
+# publish. `head` is unused now but kept in the fetch for future signals.
+if ! printf '%s' "$title" | grep -qiE '^chore: release '; then exit 0; fi
 
 read -r -d '' MSG <<'EOF' || true
 A release PR just merged. Once .github/workflows/release.yml has published the

--- a/test/hooks/release-global-update.test.mjs
+++ b/test/hooks/release-global-update.test.mjs
@@ -72,6 +72,15 @@ test('does NOTHING for a normal (non-release) PR merge', () => {
   assert.doesNotMatch(out, /webjsdev/, 'no reminder for a non-release PR');
 });
 
+test('does NOTHING for a chore/release-* branch that is not a package release (the #841 false positive)', () => {
+  const { code, out } = runHook('gh pr merge 841 --squash --admin --delete-branch', {
+    headRefName: 'chore/release-hook-mise',
+    title: 'chore: also refresh the mise-shimmed webjs CLI after a release',
+  });
+  assert.equal(code, 0);
+  assert.doesNotMatch(out, /webjsdev/, 'a chore/release-* branch with a non-release title must not fire');
+});
+
 test('does NOTHING for a command that is not `gh pr merge`', () => {
   const { out } = runHook('git status', { headRefName: 'chore/release-x', title: 'chore: release x' });
   assert.doesNotMatch(out, /webjsdev/);


### PR DESCRIPTION
The `release-global-update.sh` hook (#840/#841) fired a FALSE reminder when #841 merged: that PR was a hook tweak on a `chore/release-hook-mise` branch (matched the `^chore/release-` prefix) but published nothing, so the "run npm/bun/mise global update" reminder had nothing to act on.

Fix: detect a real release by the canonical `chore: release <pkgs>` PR TITLE only (the release process always titles it exactly that), dropping the branch-prefix match. A `chore/release-*` branch with a non-release title no longer fires.

Regression test added for the exact #841 scenario (a `chore/release-*` branch + a non-`chore: release` title must not fire); 6/6 green. Framework-repo tooling only.

https://claude.ai/code/session_01EM2Bdq3we9kmJzMw88P4q6