### PR TITLE
fix(cli): author the initial DB migration during scaffold (first run works out of the box)

### DIFF
--- a/docs/app/docs/getting-started/page.ts
+++ b/docs/app/docs/getting-started/page.ts
@@ -21,7 +21,7 @@ cd my-app && npm run dev
 
     <p><strong><code>npm create webjs@latest</code> is the canonical way to scaffold.</strong> It always fetches the latest <code>create-webjs</code>, so you never need a global install. Prefer it over a bare <code>webjs create</code>, because a globally installed or version-manager-shimmed <code>webjs</code> (or a stray <code>npx webjs</code>) can shadow the real CLI or resolve to an unrelated package. If you DO want the global CLI for <code>webjs dev</code> / <code>db</code> and friends, install it with <code>npm i -g webjsdev</code>.</p>
 
-    <p>Every scaffold ships with Drizzle + SQLite wired up (<code>db/schema.server.ts</code> with an example <code>User</code> model and <code>db/connection.server.ts</code> exporting the <code>db</code> connection). Run <code>npm run db:migrate</code> the first time to create <code>db/dev.db</code>.</p>
+    <p>Every scaffold ships with Drizzle + SQLite wired up (<code>db/schema.server.ts</code> with an example <code>User</code> model and <code>db/connection.server.ts</code> exporting the <code>db</code> connection). <code>webjs create</code> authors the initial migration for you during setup, and the first <code>npm run dev</code> applies it automatically (the <code>webjs.dev.before</code> step runs <code>webjs db migrate</code>), so the shipped app works with no manual database step. When you later change the schema, run <code>npm run db:generate</code> and the next <code>npm run dev</code> applies the new migration.</p>
 
     <h2>Create a New App</h2>
 

--- a/packages/cli/lib/create.js
+++ b/packages/cli/lib/create.js
@@ -49,6 +49,27 @@ function runInstall(appDir, pm) {
   return r.status === 0;
 }
 
+/**
+ * Author the INITIAL Drizzle migration for the shipped schema, so the app boots
+ * with its tables and the very first `run dev` works with no manual step. The
+ * scaffold's schema is TypeScript (`db/schema.server.ts`); `db migrate` (run in
+ * `webjs.dev.before` / `webjs.start.before`) only applies migration SQL FILES, so
+ * with no file the shipped example hits "no such table". `db generate` turns the
+ * schema into that first `db/migrations/*.sql`. It runs OFFLINE (a schema-to-SQL
+ * diff, no database connection), so it is safe for sqlite AND postgres here, well
+ * before any `DATABASE_URL` exists. Needs `drizzle-kit`, so it only runs after a
+ * successful install; on `--no-install` the printed next-steps still show
+ * `db:generate`. Returns whether a migration was authored.
+ *
+ * @param {string} appDir
+ * @param {string} pm
+ * @returns {boolean}
+ */
+function runDbGenerate(appDir, pm) {
+  const r = spawnSync(pm, ['run', 'db:generate'], { cwd: appDir, stdio: 'inherit' });
+  return r.status === 0;
+}
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEMPLATES = resolve(__dirname, '..', 'templates');
 
@@ -1676,11 +1697,21 @@ For AI agents, read this before editing scaffolded files:
   // (#541). Otherwise honour the invoking PM (npm / pnpm / yarn / bun).
   const pm = isBun ? 'bun' : detectPackageManager();
   let installed = false;
+  let generatedMigration = false;
   if (shouldInstall) {
     console.log(`Running '${pm} install' in ${name}/ ...\n`);
     installed = runInstall(appDir, pm);
     if (!installed) {
       console.log(`\n[warn] ${pm} install failed. Run '${pm} install' manually in ${name}/ to finish setup.\n`);
+    } else {
+      // Author the initial migration NOW (drizzle-kit is installed), so the
+      // shipped schema's tables exist and the very first `run dev` works with no
+      // manual step (webjs.*.before applies the migration on boot). See runDbGenerate.
+      console.log(`Authoring the initial database migration ('${pm} run db:generate') ...\n`);
+      generatedMigration = runDbGenerate(appDir, pm);
+      if (!generatedMigration) {
+        console.log(`\n[warn] '${pm} run db:generate' failed. Run it manually in ${name}/ before '${pm} run dev'.\n`);
+      }
     }
   }
 
@@ -1691,14 +1722,14 @@ For AI agents, read this before editing scaffolded files:
   // templates ship with @webjsdev/ui already initialised; the api
   // template has no UI but may add one later.
   const installSegment = installed ? '' : `${pm} install && `;
-  // Some examples query the db on their first request, so a migration must be
-  // authored first: `db:generate` writes it and the `webjs.dev.before` migrate
-  // applies it on `run dev` (Drizzle splits Prisma's `migrate dev` into
-  // generate-then-migrate). The saas example queries users (auth); the
-  // full-stack scaffold ships the gallery's /examples/todo route (queries todos).
-  // The api template has no such first-request query, so it boots with just
-  // `run dev`; once you add a db route, `db:generate` then `run dev` is the loop.
-  const dbSegment = isApi ? '' : `${pm} run db:generate && `;
+  // The shipped schema is applied on the first `run dev` (webjs.*.before runs
+  // `db migrate`), but only if a migration FILE exists. When we installed, we
+  // already authored it above (runDbGenerate), so the run command is just
+  // `run dev`. Otherwise (--no-install, or generate failed) the user authors it
+  // first: `db:generate` writes the migration from db/schema.server.ts, then
+  // `run dev` applies it (Drizzle splits Prisma's `migrate dev` into
+  // generate-then-migrate).
+  const dbSegment = generatedMigration ? '' : `${pm} run db:generate && `;
   const runCommand = `cd ${name} && ${installSegment}${dbSegment}${pm} run dev`;
   // Postgres needs a reachable DATABASE_URL before any migrate (sqlite uses a
   // local file with no .env). Point it at a running database; `dev` / `start`

--- a/packages/cli/templates/AGENTS.md
+++ b/packages/cli/templates/AGENTS.md
@@ -549,6 +549,7 @@ Scripts (all wrap `drizzle-kit`):
 - `npm run db:studio`: `webjs db studio` (visual DB browser)
 - `npm run db:seed`: `webjs db seed` (run `db/seed.server.ts`)
 - `webjs.dev.before` and `webjs.start.before` both run `webjs db migrate` inside `webjs dev` / `webjs start` (idempotent; replaces the old `prestart` hook), so after you `db:generate` a migration it is applied on the next boot with no manual `db:migrate` step.
+- The INITIAL migration for the shipped schema is authored by `webjs create` at setup time (right after install), so `db/migrations/` is populated and the first `run dev` works with no manual database step. You run `db:generate` yourself only when you CHANGE `db/schema.server.ts` (a new table or column), then the next `run dev` applies it.
 
 Always import `db` from `db/connection.server.ts` (the globalThis-cached
 singleton avoids opening a new connection on every dev-server reload), and

--- a/test/scaffolds/scaffold-integration.test.js
+++ b/test/scaffolds/scaffold-integration.test.js
@@ -126,6 +126,16 @@ test('scaffoldApp full-stack: writes the canonical full-stack app layout', async
     assert.ok(existsSync(join(appDir, 'db', 'connection.server.ts')), 'db/connection.server.ts written');
     assert.ok(existsSync(join(appDir, 'drizzle.config.ts')), 'drizzle.config.ts written');
     assert.ok(!existsSync(join(appDir, 'prisma')), 'no prisma/ dir (counterfactual: fails if db files not written)');
+    // The INITIAL migration is authored by `webjs create` only AFTER a successful
+    // install (drizzle-kit is needed). This test scaffolds with install:false, so
+    // no migration is authored here; the printed next-steps still show db:generate
+    // for that path. (The install:true path that authors it is verified manually /
+    // via a docker build, per the CLI AGENTS.md e2e note.)
+    const migDir = join(appDir, 'db', 'migrations');
+    const migrationSql = existsSync(migDir)
+      ? readdirSync(migDir).some((d) => existsSync(join(migDir, d, 'migration.sql')))
+      : false;
+    assert.equal(migrationSql, false, 'install:false authors no migration (db:generate needs drizzle-kit)');
     assert.ok(!existsSync(join(appDir, 'lib', 'prisma.server.ts')), 'no lib/prisma.server.ts');
 
     // # path-alias imports (#555/#556): the scaffold ships the single #* catch-all


### PR DESCRIPTION
The shipped todo example queries the `todos` table, but the scaffold shipped NO migration, and a bare `npm run dev` only runs `webjs db migrate` (which had nothing to apply). So following the documented first-run landed on `no such table: todos`. This bit a dogfood agent, my own test, and a user's `npm create webjs@latest` preview app.

## Fix

`webjs create` now runs `webjs db generate` during scaffolding, right after `npm install` (when `drizzle-kit` is present). The app ships with `db/migrations/0000_*.sql`, and the first `npm run dev` / container boot applies it via the existing `webjs.*.before` migrate. `generate` runs OFFLINE (a schema-to-SQL diff, no DB connection), so it is safe for sqlite AND postgres, before any `DATABASE_URL` exists. This keeps the "generate explicit, migrate auto" model: the one-time initial generate just moves to scaffold time; a user editing the schema later still runs `db:generate` for their change.

On `--no-install` (no drizzle-kit yet) the migration is not authored and the printed next-steps still show `db:generate`.

## Verified (generate + boot + check, all three templates)

- full-stack: migration creates `todos` + `users`; booted app serves `/examples/todo` -> 200 (`todo-app`), no error.
- saas + api: migration authored (`todos`+`users` / `users`).
- **Docker: built the image and ran it** -> `/examples/todo` 200, `todos`/`users` present inside the container (the Dockerfile `COPY . .` ships `db/migrations`, `.dockerignore` keeps them, CMD `webjs start` applies them at boot). The Dockerfile + compose + Bun rewrite were already structurally correct for shipping migrations; this fix provides the migration they ship. (This also fixes the same latent bug in the container path.)
- `webjs check` clean (only placeholder markers); 17 scaffold tests green, plus a new guard that `install:false` authors no migration.

## Docs synced

getting-started (the first-run note now says the migration is authored for you and the first `run dev` applies it) and the scaffold `AGENTS.md` db section.

https://claude.ai/code/session_01EM2Bdq3we9kmJzMw88P4q6