### PR TITLE
chore: release cli 0.10.33

### DIFF
--- a/changelog/cli/0.10.33.md
+++ b/changelog/cli/0.10.33.md
@@ -1,0 +1,12 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.33
+date: 2026-07-08T13:04:30.547Z
+commit_count: 1
+---
+## Fixes
+
+- **author the initial migration during scaffold so first run works out of the box** ([#843](https://github.com/webjsdev/webjs/pull/843)) [`2c9184d5`](https://github.com/webjsdev/webjs/commit/2c9184d5)
+  `webjs create` now runs `webjs db generate` after install, so the shipped
+  example works on the first `npm run dev` and container boot with no manual
+  database step.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6975,7 +6975,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.32",
+      "version": "0.10.33",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.32",
+  "version": "0.10.33",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {


### PR DESCRIPTION
Cli-only patch for the scaffold initial-migration fix (#843), the one published-package change since the last release (#839). `core`, `server`, `mcp`, `ui`, `intellisense` had no source changes in range.

| Package | From | To | Why |
|---|---|---|---|
| @webjsdev/cli | 0.10.32 | **0.10.33** | `webjs create` authors the initial DB migration during scaffold, so the shipped example works on the first `npm run dev` / container boot (#843) |

Patch stays within the `^0.10.0` caret the in-repo apps and create-webjs / webjsdev wrappers pin. Lockfile updated to the one workspace version field, verified with `npm ci --dry-run`.

On merge, `release.yml` publishes `@webjsdev/cli@0.10.33` + lockstep-publishes the wrappers, and (once live) the `release-global-update.sh` hook reminds to refresh the global CLI.

https://claude.ai/code/session_01EM2Bdq3we9kmJzMw88P4q6