### PR TITLE
chore: release core 0.7.31, server 0.8.44, cli 0.10.34

### DIFF
--- a/changelog/cli/0.10.34.md
+++ b/changelog/cli/0.10.34.md
@@ -1,0 +1,10 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.34
+date: 2026-07-08T15:22:30.343Z
+commit_count: 1
+---
+## Fixes
+
+- **four verified webjs iteration-loop gaps from the tic-tac-toe dogfood (#845)** ([#846](https://github.com/webjsdev/webjs/pull/846)) [`34ba0a74`](https://github.com/webjsdev/webjs/commit/34ba0a74)
+  Ship the scaffold `gitignore` template as a non-dotfile so npm cannot strip it from the published tarball (a `.gitignore` was stripped at publish, so a generated app shipped without a `.env` ignore and a real `.env` became trackable). Also mark the generated layout's light/dark theme apparatus as one removable block so a custom single-theme palette is easy to adopt, and ship the Next.js and raw-text-interpolation gotchas guidance. Found dogfooding a tic-tac-toe app (#845).

--- a/changelog/core/0.7.31.md
+++ b/changelog/core/0.7.31.md
@@ -1,0 +1,12 @@
+---
+package: "@webjsdev/core"
+version: 0.7.31
+date: 2026-07-08T15:22:30.219Z
+commit_count: 1
+---
+## Fixes
+
+- **four verified webjs iteration-loop gaps from the tic-tac-toe dogfood (#845)** ([#846](https://github.com/webjsdev/webjs/pull/846)) [`34ba0a74`](https://github.com/webjsdev/webjs/commit/34ba0a74)
+  * fix(core): rebuild a mixed attribute when only a later hole changes
+  
+  A multi-hole attribute (class="a ${x} b ${y}") is anchored at its first hole with the remaining holes as noop parts, so updateInstance's per-hole dirty-check dropped a change confined to a later hole and the attribute went stale. Point every non-anchor member at the anchor so any hole change rebuilds the whole attribute. Found dogfooding a tic-tac-toe app (#845): a cell kept a stale class when only its second class hole changed.

--- a/changelog/server/0.8.44.md
+++ b/changelog/server/0.8.44.md
@@ -1,0 +1,10 @@
+---
+package: "@webjsdev/server"
+version: 0.8.44
+date: 2026-07-08T15:22:30.278Z
+commit_count: 1
+---
+## Fixes
+
+- **four verified webjs iteration-loop gaps from the tic-tac-toe dogfood (#845)** ([#846](https://github.com/webjsdev/webjs/pull/846)) [`34ba0a74`](https://github.com/webjsdev/webjs/commit/34ba0a74)
+  Add the `no-interpolation-in-raw-text-element` convention check. It flags a template interpolation (`${...}`) placed as a child of a `<style>` or `<script>` element in a component. The server renderer emits it but the client renderer drops the raw-text hole, so it paints at SSR then wipes to empty on hydrate. Scoped to components, so a page or layout interpolating a `css` result into `<style>` (which renders server-only) is not flagged. Found dogfooding a tic-tac-toe app (#845).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.33",
+  "version": "0.10.34",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.30",
+  "version": "0.7.31",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.43",
+  "version": "0.8.44",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Release the fixes from #846 (dogfood #845) to the published packages.

| Package | Bump | Change |
|---|---|---|
| `@webjsdev/core` | 0.7.30 → 0.7.31 | Rebuild a multi-hole attribute when only a later hole changes (the stale-class bug) |
| `@webjsdev/server` | 0.8.43 → 0.8.44 | New `no-interpolation-in-raw-text-element` check (component `<style>`/`<script>` interpolation) |
| `@webjsdev/cli` | 0.10.33 → 0.10.34 | Ship `gitignore` as a non-dotfile (npm-strip fix), removable theme block, Next.js + raw-text gotchas |

`mcp` / `ui` / `intellisense` have no unreleased changes. Lockstep wrappers (`create-webjs` / `webjsdev`) are owned by the release workflow, not bumped here.

Changelogs auto-generated by the pre-commit hook, with the server/cli sub-bullets hand-corrected to describe each package's own change (the squash commit body only carried the core message).

On merge, `release.yml` publishes to npm and creates the GitHub Releases.