### PR TITLE
chore: release core 0.7.32, server 0.8.45, cli 0.10.35

### DIFF
--- a/changelog/cli/0.10.35.md
+++ b/changelog/cli/0.10.35.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.35
+date: 2026-07-08T18:24:58.116Z
+commit_count: 1
+---
+## Features
+
+- **close Next.js 16 file-routing parity gaps (#848)** ([#849](https://github.com/webjsdev/webjs/pull/849)) [`09c416a7`](https://github.com/webjsdev/webjs/commit/09c416a7)
+  * docs: clarify proxy/middleware and 'use server' in nextjs gotchas
+  
+  Next 16 renamed middleware->proxy; webjs deliberately keeps middleware
+  (Remix/Koa-style chainable per-segment). Document the distinction and

--- a/changelog/core/0.7.32.md
+++ b/changelog/core/0.7.32.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/core"
+version: 0.7.32
+date: 2026-07-08T18:24:57.984Z
+commit_count: 1
+---
+## Features
+
+- **close Next.js 16 file-routing parity gaps (#848)** ([#849](https://github.com/webjsdev/webjs/pull/849)) [`09c416a7`](https://github.com/webjsdev/webjs/commit/09c416a7)
+  * docs: clarify proxy/middleware and 'use server' in nextjs gotchas
+  
+  Next 16 renamed middleware->proxy; webjs deliberately keeps middleware
+  (Remix/Koa-style chainable per-segment). Document the distinction and

--- a/changelog/server/0.8.45.md
+++ b/changelog/server/0.8.45.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/server"
+version: 0.8.45
+date: 2026-07-08T18:24:58.045Z
+commit_count: 1
+---
+## Features
+
+- **close Next.js 16 file-routing parity gaps (#848)** ([#849](https://github.com/webjsdev/webjs/pull/849)) [`09c416a7`](https://github.com/webjsdev/webjs/commit/09c416a7)
+  * docs: clarify proxy/middleware and 'use server' in nextjs gotchas
+  
+  Next 16 renamed middleware->proxy; webjs deliberately keeps middleware
+  (Remix/Koa-style chainable per-segment). Document the distinction and

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.34",
+  "version": "0.10.35",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.31",
+  "version": "0.7.32",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.44",
+  "version": "0.8.45",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Release the Next.js 16 file-routing parity work (#849, closes #848).

Bumps + auto-generated changelogs for the three packages the PR touched:
- **@webjsdev/core** 0.7.31 -> 0.7.32 (forbidden()/unauthorized() throwers, Awaitable param types)
- **@webjsdev/server** 0.8.44 -> 0.8.45 (thenable params, forbidden/unauthorized + global boundaries, nested not-found nearest-wins fix, instrumentation + setOnError)
- **@webjsdev/cli** 0.10.34 -> 0.10.35 (scaffold rule files + gallery demo for the new conventions)

On merge, release.yml publishes to npm and creates the GitHub releases.

https://claude.ai/code/session_013fyU1eSR1fqaaHV8p7r6eN