### PR TITLE
feat: add framework comparison pages (vs Next.js, Lit, Remix 3, Astro, Rails)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,11 @@ COPY changelog ./changelog
 # reason as changelog: without the tree in the image, /blog renders
 # "No posts yet."
 COPY blog ./blog
+# website/app/compare/[slug]/page.ts and app/sitemap.ts read
+# ../../../../compare/<slug>.md at SSR time (via
+# modules/compare/queries/*.server.ts). Same reason as blog: without the
+# tree in the image, /compare renders "No comparisons yet."
+COPY compare ./compare
 
 # --- 3. Build-time work --------------------------------------------------
 # Core: build the dist/ bundles. The package.json `prepare` hook is a

--- a/compare/webjs-vs-astro.md
+++ b/compare/webjs-vs-astro.md
@@ -1,0 +1,60 @@
+---
+title: "WebJs vs Astro: Islands, Zero JS, and a Full Server Story"
+date: 2026-07-09T10:00:00+05:30
+slug: webjs-vs-astro
+description: "An honest comparison of WebJs and Astro. Both ship little JavaScript by default and use an islands model, but WebJs is a no-build full-stack framework with server actions and a data layer, where Astro is a build-time content framework you add islands to."
+competitor: "Astro"
+tagline: "Islands and near-zero JS, plus a full server-action and data story."
+tags: comparison, astro, islands, zero-js, no-build
+author: Vivek
+---
+
+Astro and WebJs share a headline idea: send as little JavaScript as possible and hydrate only the interactive parts. Astro popularized the islands architecture, and WebJs arrives at a similar place from a different direction. Of the frameworks people compare WebJs to, Astro is arguably the closest in spirit. The differences are about what happens at build time versus request time, and how much of a full-stack backend each one is.
+
+
+# What the two agree on
+
+- **Ship less JavaScript.** Both default to HTML-first output and treat client JS as opt-in, not the baseline.
+- **Islands.** Astro hydrates interactive islands with `client:*` directives; WebJs hydrates interactive web components per element. Same core idea, static shell plus interactive leaves.
+- **Standards-friendly.** Both are comfortable with plain HTML, and both let you use web components directly.
+
+If Astro's "mostly static, sprinkle interactivity" model appeals to you, WebJs's model will feel related.
+
+
+# Difference one: build-time vs no build at all
+
+Astro has a build step. It compiles `.astro` components and your islands into optimized output, and it excels at static and content-heavy sites, with a build to run for each deploy. WebJs has no build step. The `.ts` files you write are served directly with types stripped in place. There is no compile, and there is no static-generation build either; pages are rendered per request (with an opt-in HTML response cache for pages identical to every visitor).
+
+So Astro is at its best when the content is known at build time and can be generated ahead. WebJs is at its best when content is dynamic and request-time, and it skips the build entirely.
+
+
+# Difference two: islands model
+
+Astro's islands are components from a UI framework of your choice (React, Vue, Svelte, or web components) that you hydrate with explicit `client:load`, `client:visible`, and similar directives. You choose the framework and mark the hydration strategy.
+
+WebJs's islands are always native web components, and the hydration is automatic. A component with an interactive signal hydrates; a display-only component with no signal renders identical HTML with or without its script, so WebJs strips its module from the download automatically. You do not annotate hydration; the framework derives it. The trade is less explicit control in exchange for not having to think about it, and a single component model rather than any-framework-you-like.
+
+
+# Difference three: how much backend you get
+
+This is the largest difference. Astro is primarily a frontend and content framework. It has server endpoints and server-side rendering, and it added Server Actions, but the center of gravity is content: collections, markdown, static generation. You typically bring your own data and backend patterns.
+
+WebJs is a full-stack framework first. Server actions are the core mechanism, with a `.server.ts` file becoming a typed RPC stub across the network boundary. It ships built-in auth, sessions, cookies, caching, and rate limiting over one pluggable store, plus Drizzle and Tailwind wired out of the box, plus a client router that preserves layout DOM across navigations. The backend is the point, not an addition.
+
+
+# Where Astro is the better pick
+
+- You are building a content site, a blog, docs, or marketing pages where most content is known at build time and can be statically generated. Astro is superb at this and it is what it was built for.
+- You want to mix components from React, Vue, and Svelte in one project, or bring an existing component from one of those frameworks.
+- You want Astro's large content ecosystem: content collections, integrations, and a mature community.
+- You want to deploy pure static output to any CDN with no server at all.
+
+
+# Where WebJs is the better pick
+
+- You are building a dynamic application with real reads and writes, not a mostly-static content site, and you want the backend to be first-class.
+- You want no build step for either dev or deploy, and request-time rendering rather than a static-generation step.
+- You want automatic islands with native web components and automatic zero-JS elision, without annotating hydration.
+- You want auth, sessions, caching, a data layer, and a typed server-action boundary built in rather than assembled.
+
+Astro and WebJs both refuse to ship JavaScript you do not need. Astro reaches that as a build-time content framework you add islands to; WebJs reaches it as a no-build full-stack framework where the interactive web component is the unit and the server is built in.

--- a/compare/webjs-vs-lit.md
+++ b/compare/webjs-vs-lit.md
@@ -1,0 +1,83 @@
+---
+title: "WebJs vs Lit: The Same Component API, Now a Full Framework"
+date: 2026-07-09T10:00:00+05:30
+slug: webjs-vs-lit
+description: "An honest comparison of WebJs and Lit. WebJs deliberately matches Lit's component API (html templates, reactive properties, lifecycle, directives) and wraps it in a full-stack framework with routing, SSR, server actions, and a client router, all with no build step."
+competitor: "Lit"
+tagline: "Lit's component model you already know, wrapped in a full-stack framework."
+tags: comparison, lit, web-components, ssr, no-build
+author: Vivek
+---
+
+If you write Lit, WebJs will feel immediately familiar, and that is on purpose. WebJs's component API is aligned with Lit's so the muscle memory and the training data transfer directly. The difference is scope: Lit is an excellent library for building web components, and WebJs is a full-stack framework that uses a Lit-shaped component layer as its view.
+
+This page is for Lit users deciding whether to reach for a framework, and for people choosing between the two.
+
+
+# The component API is intentionally the same
+
+WebJs matches the Lit surface you already know:
+
+- `render()` returning `` html`...` `` tagged-template literals.
+- The `css` tagged template for scoped styles.
+- Reactive properties, reflection, and attribute mapping.
+- The full lit lifecycle (`willUpdate`, `firstUpdated`, `updated`, `updateComplete`, and the rest), each receiving a `changedProperties` map.
+- `ReactiveController` and `ReactiveControllerHost`.
+- The lit-html directive set (`repeat`, `unsafeHTML`, `live`, `keyed`, `guard`, `ref`, `cache`, `until`, `asyncAppend`, and more).
+
+Code you have written against Lit reads almost unchanged in WebJs. There is one deliberate divergence, covered below.
+
+
+# The one deliberate difference: reactive properties
+
+Lit declares reactive properties with the `@property()` decorator or a `static properties` block. WebJs declares them through a declare-free base-class factory instead:
+
+```ts
+class Counter extends WebComponent({ count: Number }) {
+  constructor() {
+    super();
+    this.count = 0;   // fully typed, no `declare`
+  }
+  render() {
+    return html`<button @click=${() => this.count++}>${this.count}</button>`;
+  }
+}
+Counter.register('my-counter');
+```
+
+The reason is the no-build constraint. WebJs strips TypeScript with Node's built-in eraser, which requires erasable syntax only, so legacy decorators with metadata are out. The factory gives you the same typed reactive properties without a decorator and without a `declare` line. It is the single place the API departs from Lit, and it exists so the framework can run your `.ts` with no compile step.
+
+
+# What WebJs adds around the component
+
+Lit stops at the component, and that is the right scope for a library. You bring your own router, your own SSR story, your own data layer, your own server. WebJs ships those as a coherent whole:
+
+- **File-based routing:** `page`, `layout`, `route`, dynamic segments, route groups, error and loading boundaries.
+- **Server-side rendering** of your components, including Declarative Shadow DOM, with streaming Suspense.
+- **Server actions:** a `.server.ts` file with `'use server'` becomes a typed RPC stub when a component imports it, so calling the server is a normal function call with types across the wire.
+- **A client router** that preserves layout DOM across navigations, with prefetch, and no white flash.
+- **Built-ins:** auth, sessions, cookies, caching, and rate limiting over one pluggable store, plus Drizzle and Tailwind wired out of the box.
+
+Lit does have `@lit-labs/ssr`, but server rendering, hydration, routing, and data flow are pieces you assemble yourself. WebJs makes those decisions for you and controls the SSR pipeline end to end so hydration is not something you configure.
+
+
+# Progressive enhancement and elision
+
+Because WebJs owns the SSR path, it can do things a component library on its own cannot. Pages are server-rendered HTML that work with JavaScript off. A display-only component, one with no interactive signal, renders identical HTML with or without its script, so WebJs strips its module from what the browser downloads. You write a normal component and it ships zero JavaScript when it does not need any. With plain Lit you would ship the element's definition regardless.
+
+
+# Where Lit is the better pick
+
+- You are adding a few interactive elements to an existing app (any stack, any backend) and do not want a framework at all. Lit is purpose-built for that, and a full framework is more than that job needs.
+- You are building a design system or a widget library meant to be consumed anywhere. Lit's narrow scope is exactly what you want; you should not ship a full framework inside a distributable component.
+- You need Lit's exact ecosystem: a specific Lit Labs package, an established Lit-based design system, or an integration built for Lit.
+
+
+# Where WebJs is the better pick
+
+- You are building a whole application, not a handful of elements, and you want routing, SSR, a data layer, and a server without assembling them yourself.
+- You like the Lit component model and want to keep it while getting a Next.js-style developer experience above it.
+- You want SSR and progressive enhancement to be the default rather than a configuration exercise.
+- You want no build step across the entire stack, not just clever templates in the browser.
+
+The short version: if you love the Lit way of writing components but want a framework around it, WebJs is that framework. You keep the model and stop hand-rolling everything above it.

--- a/compare/webjs-vs-nextjs.md
+++ b/compare/webjs-vs-nextjs.md
@@ -1,0 +1,78 @@
+---
+title: "WebJs vs Next.js: No Build Step, No RSC, Web Components"
+date: 2026-07-09T10:00:00+05:30
+slug: webjs-vs-nextjs
+description: "An honest comparison of WebJs and Next.js. WebJs keeps the Next-style developer experience (file routing, server actions, streaming SSR) but drops the build step and the React Server Component split, building the view layer on native web components instead."
+competitor: "Next.js"
+tagline: "The Next.js developer experience, minus the build step and the RSC mental model."
+tags: comparison, nextjs, react, web-components, no-build
+author: Vivek
+---
+
+I built WebJs because I wanted the developer experience I enjoy in Next.js without the two things that make it heavy: the build step, and the React Server Component split you now have to reason about on every component. This page is an honest account of where the two frameworks agree, where they genuinely differ, and who should pick which.
+
+If you already ship Next.js and it works for you, nothing here says you are wrong. WebJs is for people who want the same app shape on web standards.
+
+
+# What the two share
+
+The surface is close on purpose, because the Next.js app-router shape is good and the muscle memory is worth keeping. Both give you:
+
+- File-based routing with `page`, `layout`, dynamic `[param]` segments, catch-all routes, route groups, and per-segment error and loading boundaries.
+- Server-side rendering with streaming Suspense.
+- Server actions you import into client code and call like normal functions.
+- Metadata as data (`metadata` and `generateMetadata`) that becomes your `<head>`.
+- Sensible built-in defaults so you write features instead of wiring integrations.
+
+Someone fluent in the Next.js app router can read a WebJs `app/` tree and know what every file does on the first try.
+
+
+# Difference one: there is no build step
+
+The `.ts` files you write are the files the browser fetches. WebJs uses Node 24's built-in `module.stripTypeScriptTypes` to erase types in place, so the source you read is the source that runs, with stack traces that point at your real line numbers and no sourcemap layer in between.
+
+There is no `webjs build` command because there is nothing to build. Production performance comes from HTTP/2 multiplex plus `<link rel="modulepreload">` hints emitted at render time, the same model as Rails 7 with `importmap-rails`. Next.js takes the opposite bet: a highly optimized bundler (Turbopack) that produces excellent output, at the cost of a compile step between you and the browser and a build to wait on in CI.
+
+The practical effect for day-to-day work is the dev loop. Edit, save, refresh. Nothing recompiles.
+
+
+# Difference two: no React Server Component split
+
+This is the big one. Next.js is built on RSC now. Every component is a Server Component until you write `'use client'`, and you spend real attention tracking which side of that boundary a given piece of code lives on, what can cross it, and how the Flight protocol serializes the tree.
+
+WebJs has no server/client component split at all. There is no RSC render tree, no Flight protocol, no `'use client'`. Instead:
+
+- **Pages and layouts run only on the server.** They produce HTML and are never re-invoked in the browser.
+- **Components hydrate.** A component module loads in the browser, the custom element upgrades, and its interactivity runs client-side, islands-style, per element.
+- **`.server.ts` is the one server boundary.** A file with `'use server'` exports becomes a typed RPC stub when imported from client code. A file without it is a server-only utility whose browser import is a load-time error, which is how a dependency is kept off the client.
+
+Reads and writes both flow through that one action mechanism, so there is a single boundary to learn rather than a component-coloring rule applied everywhere.
+
+
+# Difference three: web components, not a React runtime
+
+The WebJs view layer is native web components: `customElements.define`, shadow DOM when you want it, `<slot>` projection. The authoring API is lit-shaped (`render()` returning `html` templates, reactive properties, the lit lifecycle and directive set), so lit muscle memory transfers, but the runtime is WebJs's own so the SSR pipeline is controlled end to end.
+
+That means no virtual DOM, no reconciler, and no custom hydration protocol to ship. The elements render without a framework and survive framework churn. Next.js gives you the enormous React ecosystem in exchange; WebJs gives you smaller, standards-based output and elements that keep working when the framework does not.
+
+
+# Progressive enhancement is the default, not a mode
+
+A WebJs page is server-rendered HTML that reads, navigates, and submits forms with JavaScript disabled. JS is opt-in per interactive behavior. Display-only components are detected and their code is stripped from what the browser downloads, so a static component ships zero JavaScript. In Next.js, progressive enhancement is possible but it is something you architect toward, not the default you get for free.
+
+
+# Where Next.js is the better pick
+
+- You need the React ecosystem: a specific component library, a charting or table library, React Native code sharing, or a large team already fluent in React.
+- You want managed edge deployment with zero configuration on Vercel, integrated image optimization, and first-party i18n. WebJs defers image optimization and i18n to libraries you layer on.
+- You are hiring against a deep React talent pool and that matters more than output size.
+
+
+# Where WebJs is the better pick
+
+- You want the source you read in `node_modules` to be the source that runs, with no compiled layer to debug through.
+- You are tired of tracking the server/client boundary on every component and want one clear RPC boundary instead.
+- You care about shipping little JavaScript and want progressive enhancement by default.
+- You build with AI agents and want a framework small enough (roughly 5 to 10 percent of Next.js by source) for an agent to read end to end, with conventions the tooling enforces.
+
+WebJs is the framework I wanted to exist: the good parts of the Next.js experience, rebuilt on the platform instead of on top of a compiler and a component runtime.

--- a/compare/webjs-vs-rails.md
+++ b/compare/webjs-vs-rails.md
@@ -1,0 +1,60 @@
+---
+title: "WebJs vs Rails: No Build, One Language, Web Components"
+date: 2026-07-09T10:00:00+05:30
+slug: webjs-vs-rails
+description: "An honest comparison of WebJs and Ruby on Rails. Both refuse a build step and lean on importmaps and sensible defaults, but WebJs is one TypeScript language across the stack with web components and typed server actions, where Rails is Ruby with Hotwire."
+competitor: "Rails"
+tagline: "The Rails no-build, sensible-defaults philosophy, in one TypeScript language."
+tags: comparison, rails, hotwire, importmap, no-build
+author: Vivek
+---
+
+WebJs owes Rails a direct debt. The no-build model, source files served as importmapped ES modules with production speed from HTTP/2 instead of a bundler, is the Rails 7 approach with `importmap-rails`, and WebJs says so openly. The "you should not make thirty decisions before your first feature" feeling, sensible defaults so you can start writing features immediately, is Rails philosophy too. Where the two part ways is how far the conventions reach: Rails is convention over configuration across the whole architecture, while WebJs is prescriptive only about file routing (the Next.js-style `app/` tree) and otherwise leaves the architecture to you, shipping its recommended conventions in the scaffold rather than enforcing them. So this is less a rivalry than an account of what changes when you take the no-build, sensible-defaults ideas to a single-language JavaScript and TypeScript stack built on web components.
+
+
+# What the two share
+
+- **No build step.** Rails 7 pins JavaScript dependencies with importmaps and serves them without Webpack or esbuild. WebJs serves your `.ts` files directly with types stripped in place. Same bet: skip the bundler, lean on the platform and HTTP/2.
+- **Sensible defaults out of the box.** Both let you write features instead of wiring integrations from scratch. The reach differs: Rails is convention over configuration across the framework, while WebJs prescribes the file-routing conventions (the `app/` tree) and ships recommended conventions for everything else in the scaffold without forcing them, so you can shape the rest of the architecture as your app needs.
+- **Server-rendered HTML first.** Both send real HTML and treat JavaScript as an enhancement, not the baseline that has to boot before anything renders.
+- **Batteries included.** Auth, sessions, caching, jobs in Rails; auth, sessions, caching, rate limiting, a data layer, and a client router in WebJs. Neither expects you to assemble the basics yourself.
+
+If you like how Rails feels, a lot of that feeling is deliberately present in WebJs.
+
+
+# Difference one: one language across the whole stack
+
+Rails is Ruby on the server and JavaScript in the browser. That split is fine, and Hotwire is designed to keep you mostly in Ruby, but the two halves are still two languages with two ecosystems.
+
+WebJs is TypeScript (or JavaScript) everywhere. The same language writes your pages, your components, and your server actions, and types flow across the network boundary: import a `.server.ts` function into a component and the client sees its real signature, with the wire serializer round-tripping `Date`, `Map`, `Set`, `BigInt`, `Blob`, `File`, and more without hand-written adapters. One language, one type system, from the database row to the rendered element.
+
+
+# Difference two: web components vs Hotwire
+
+Rails does interactivity with Hotwire: Turbo swaps HTML fragments over the wire, and Stimulus attaches modest JavaScript behavior to server-rendered markup. It is a mature, HTML-over-the-wire approach that keeps most logic on the server.
+
+WebJs does interactivity with native web components. An interactive island hydrates per element with a lit-shaped authoring API, reactive properties, and signals; a display-only component ships zero JavaScript because the framework strips its module from the download. WebJs also has a Turbo-style client router (it preserves layout DOM across navigations, with prefetch and no white flash), so the HTML-over-the-wire navigation feel is there too, but the unit of interactivity is a standards-based custom element rather than a Stimulus controller.
+
+
+# Difference three: data layer
+
+Rails ships Active Record, one of the most refined ORMs in any ecosystem, with a huge surface of associations, validations, and migrations built over years. It is a genuine strength and a reason people choose Rails.
+
+WebJs defaults to Drizzle with SQLite (or Postgres by swapping one file), a typed query builder rather than an Active Record style model layer. It is lighter and fully typed end to end, but it is not trying to match Active Record's depth, and it is a default rather than a lock-in; WebJs is bring-your-own on the data layer.
+
+
+# Where Rails is the better pick
+
+- Your team knows Ruby, or you want to hire into the deep Rails talent pool.
+- You want Active Record and the maturity of the Rails ecosystem: gems, generators, and a community with a decade-plus of accumulated answers.
+- You are happy with Hotwire's server-driven interactivity model and do not need a component runtime.
+
+
+# Where WebJs is the better pick
+
+- You want one language across the entire stack, with types that span the client and server boundary instead of a Ruby and JavaScript split.
+- You want native web components as the interactivity unit, with automatic zero-JavaScript elision for display-only elements.
+- You want the no-build, sensible-defaults Rails feeling but in the JavaScript and TypeScript ecosystem your frontend already lives in, without committing to conventions across the whole architecture.
+- You are building with AI agents and want a framework small enough to read end to end, with conventions the tooling enforces.
+
+WebJs took the parts of Rails it admired most, the no-build importmap model and the sensible defaults that let you start fast, and rebuilt them for a single-language TypeScript stack on web components, while staying flexible about the rest of the architecture. If you love how Rails thinks but want to stay in one language on web standards, that is the trade WebJs is offering.

--- a/compare/webjs-vs-remix.md
+++ b/compare/webjs-vs-remix.md
@@ -1,0 +1,68 @@
+---
+title: "WebJs vs Remix 3: No Build, Beyond React, Web Standards"
+date: 2026-07-09T10:00:00+05:30
+slug: webjs-vs-remix
+description: "An honest comparison of WebJs and Remix 3. Both drop the bundler, move beyond React, run on web standards, and are built for AI agents. They diverge on the view layer: WebJs uses native web components with a declarative reactive API, Remix 3 uses its own runtime-first virtual DOM with an imperative model."
+competitor: "Remix 3"
+tagline: "Two frameworks that dropped the bundler and moved beyond React, diverging on the view layer."
+tags: comparison, remix, remix-3, web-standards, no-build
+author: Vivek
+---
+
+This compares WebJs with **Remix 3**, the ground-up rewrite currently in beta, not Remix 1 or 2. That distinction matters, because Remix 3 is a different framework from the React-based Remix that came before. It drops React entirely, drops the bundler, and rebuilds on web standards. Where the older Remix was a React framework with a compiler, Remix 3 shares a surprising amount of philosophy with WebJs, so this is more a story of two frameworks reaching similar conclusions and then diverging on the view layer.
+
+
+# What the two share
+
+Remix 3 and WebJs agree on more than most framework pairs:
+
+- **No bundler.** Remix 3 is "religiously runtime": bundler-free, zero-dependency, running your source through a Node `--import` loader that strips TypeScript types and compiles JSX. WebJs is no-build too, through the same kind of Node loader, but its transform only strips types (its `html` templates are ordinary tagged template literals, so nothing else needs compiling). Neither has a Webpack or Vite step, and both treat pre-runtime static analysis as something to avoid designing around.
+- **Beyond React.** Remix 3 removed React and renders through its own lightweight virtual DOM (a few low-level pieces adapted from Preact), authored in JSX. WebJs uses native web components. Both concluded that the React runtime is not the thing to build the future on.
+- **Web standards at the core.** Remix 3 runs directly on the Fetch API with standard `Request` and `Response` objects. WebJs is built on native custom elements and the same web platform primitives.
+- **Built for AI agents.** Remix 3 aims for a model-first API surface optimized for humans and AI agents. WebJs is AI-first by design, small enough to read end to end, with conventions the tooling enforces.
+- **Progressive enhancement.** Both send real HTML and treat forms and the request/response cycle as first-class, not a fallback nobody tests.
+
+If you were drawn to Remix 3's direction, WebJs will feel philosophically adjacent. The differences are in how each one builds the view and the data layer.
+
+
+# Difference one: native web components vs a runtime-first VDOM
+
+This is the core divergence. Remix 3 renders through its own lightweight virtual DOM (with a reconciler, a `mix` composition system, JSX, and frame hydration) that it ships and controls. WebJs renders through native web components: `customElements.define`, shadow DOM when you want it, `<slot>` projection, no virtual DOM and no reconciler shipped to the browser.
+
+The consequence is what outlives the framework. A WebJs `<my-counter>` is a real custom element that the browser upgrades and runs on its own; it keeps working independent of the framework version. Remix 3's components live inside its VDOM runtime. One bets on the browser's own component model, the other on a small controlled virtual DOM. WebJs also elides display-only components entirely, so a component with no interactivity ships zero JavaScript, which a shipped VDOM runtime does not do by default.
+
+
+# Difference two: declarative reactivity vs an imperative model
+
+Remix 3 leans deliberately imperative. A component is a setup function that receives a `handle` and returns a render function: the outer function runs once, the inner one runs on each update. State is plain local variables, you trigger a re-render explicitly by calling `handle.update()`, and you compose reusable behavior with `mix` and mixins. It is a procedural style: first do this, then do that.
+
+WebJs is declarative and lit-shaped. State lives in signals or reactive properties, and reads inside `render()` re-render automatically when they change, through the lit lifecycle (`willUpdate`, `updated`, and the rest). You describe what the UI is for a given state rather than imperatively pushing updates. Neither is objectively better; it is a genuine taste split between an explicit imperative model and an automatic declarative one, and it is the clearest day-to-day difference in how the two feel to write.
+
+
+# Difference three: data and mutations
+
+Both keep data and mutations on the server, but the surface differs. Remix 3 is model-first: you start from a declarative schema, with first-class database drivers, and mutations are actions tied to form submissions.
+
+WebJs uses one server-action boundary. A `.server.ts` file with `'use server'` exports functions that a component imports and calls directly; the import is rewritten to a typed RPC stub, and the same mechanism carries both reads and writes, with the HTTP verb, caching, and validation declared through sibling config exports. Types flow across that boundary, so a component sees the real signature of a server function. A leaf component can also `await` its own data during SSR and have it in the first paint. WebJs keeps the Next.js-style nested `app/` routing (route groups, per-segment error and loading boundaries, catch-all segments) as its one strong convention, and leaves the rest of the architecture to you.
+
+
+# Difference four: stability today
+
+Remix 3 is in beta preview. Its ideas are compelling and its direction is close to WebJs's, but the API is still moving, and building on it today means building on a moving target. This is a factual note about where Remix 3 is in its cycle, worth weighing if you need to ship on a stable surface now.
+
+
+# Where Remix 3 is the better pick
+
+- You prefer JSX and an explicit imperative model (plain variables, `handle.update()`, `mix` composition) over a declarative reactive one.
+- You want the model-first, schema-driven approach where routes and components derive from a declarative data model.
+- You want to follow the Remix team's roadmap and ecosystem as Remix 3 matures.
+
+
+# Where WebJs is the better pick
+
+- You want native web components as the view layer: standards-based custom elements that render on their own and outlive the framework, with no virtual DOM shipped to the browser.
+- You prefer a declarative, lit-shaped reactive model over an imperative one, with signals and reactive properties that re-render automatically.
+- You want automatic zero-JavaScript elision for display-only components, so static parts of the page ship no script.
+- You want a single typed server-action boundary for reads and writes, with types spanning the client and server, and file-routing conventions you already know from the Next.js app router.
+
+WebJs and Remix 3 arrived at the same crossroads, no bundler, beyond React, web standards, built for agents, and then took different roads through the view layer. The choice is largely native web components with declarative reactivity, versus a runtime-first virtual DOM with an imperative model.

--- a/website/app/compare/[slug]/page.ts
+++ b/website/app/compare/[slug]/page.ts
@@ -1,0 +1,60 @@
+import { html, unsafeHTML, notFound } from '@webjsdev/core';
+import { getComparison } from '#modules/compare/queries/get-comparison.server.ts';
+import { renderPostBody } from '#modules/blog/utils/render-post.ts';
+
+/**
+ * /compare/[slug]
+ *
+ * Thin route adapter. File-reading and frontmatter parsing live in
+ * `modules/compare/`. The markdown body is rendered with the blog's
+ * `renderPostBody` (same typography, no need for a second renderer).
+ *
+ * `generateMetadata` gives each comparison its own title / description /
+ * og:* tags, with a canonical URL at `/compare/<slug>`, which is what
+ * makes these pages rank for "webjs vs <framework>" queries.
+ */
+
+export async function generateMetadata({ params }: { params: { slug: string } }) {
+  const c = await getComparison(params.slug);
+  if (!c) return { title: 'Comparison not found · webjs' };
+  return {
+    title: `${c.title} · webjs`,
+    description: c.description,
+    openGraph: {
+      title: c.title,
+      description: c.description,
+      type: 'article',
+      url: `https://webjs.dev/compare/${c.slug}`,
+      publishedTime: c.date,
+      authors: [c.author],
+      tags: c.tags,
+    },
+    twitter: { card: 'summary_large_image' },
+  };
+}
+
+export default async function ComparePage({ params }: { params: { slug: string } }) {
+  const c = await getComparison(params.slug);
+  if (!c) notFound();
+
+  return html`
+    <main id="main" tabindex="-1" class="max-w-[840px] mx-auto px-[24px] py-[64px] focus:outline-none">
+      <nav class="mb-[48px]">
+        <a href="/compare" class="font-mono text-[12px] text-fg-subtle no-underline hover:text-fg tracking-wide">← All comparisons</a>
+      </nav>
+
+      <header class="mb-[64px]">
+        <p class="font-mono text-[12px] uppercase tracking-[0.14em] text-accent font-semibold mb-[20px]">WebJs vs ${c.competitor}</p>
+        <h1 class="font-serif text-[clamp(36px,6vw,56px)] leading-[1.05] tracking-tight text-fg m-0 mb-[24px]">${c.title}</h1>
+        <p class="text-fg-muted text-[19px] leading-[1.55] m-0 font-serif italic">${c.tagline}</p>
+      </header>
+
+      <article class="mt-[16px]">${unsafeHTML(renderPostBody(c.body))}</article>
+
+      <footer class="mt-[104px] pt-[36px] border-t border-border flex flex-wrap gap-x-[24px] gap-y-[12px]">
+        <a href="/compare" class="font-mono text-[12px] text-fg-subtle no-underline hover:text-fg tracking-wide">← All comparisons</a>
+        <a href="/blog" class="font-mono text-[12px] text-fg-subtle no-underline hover:text-fg tracking-wide">Read the blog →</a>
+      </footer>
+    </main>
+  `;
+}

--- a/website/app/compare/page.ts
+++ b/website/app/compare/page.ts
@@ -1,0 +1,45 @@
+import { html } from '@webjsdev/core';
+import { listComparisons } from '#modules/compare/queries/list-comparisons.server.ts';
+
+/**
+ * /compare
+ *
+ * Thin route adapter. The file-reading and frontmatter parsing live in
+ * `modules/compare/queries/list-comparisons.server.ts`. This page maps
+ * the result to cards. Each card links to `/compare/<slug>`, the
+ * long-form head-to-head, which is where the SEO value sits.
+ */
+
+export const metadata = {
+  title: 'WebJs compared: vs Next.js, Lit, Remix, Astro, Rails · webjs',
+  description: 'Honest, head-to-head comparisons of WebJs with Next.js, Lit, Remix, Astro, and Rails. Where they agree, where they genuinely differ, and who should pick which.',
+};
+
+export default async function Compare() {
+  const comparisons = await listComparisons();
+  return html`
+    <main id="main" tabindex="-1" class="max-w-[840px] mx-auto px-6 py-12 focus:outline-none">
+      <header class="mb-10">
+        <p class="font-mono text-[11px] uppercase tracking-[0.15em] text-accent font-semibold mb-2">Compare</p>
+        <h1 class="font-serif text-[clamp(28px,4vw,40px)] leading-[1.05] tracking-tight text-fg mb-3">How WebJs compares</h1>
+        <p class="text-fg-muted text-[15px] leading-relaxed max-w-[640px]">
+          Honest head-to-head write-ups: where WebJs agrees with each framework, where it genuinely differs, and who should pick which. No trashing the alternative, and each one says where the other tool is the better call.
+        </p>
+      </header>
+
+      ${comparisons.length === 0
+        ? html`<p class="text-fg-subtle italic">No comparisons yet.</p>`
+        : comparisons.map((c) => html`
+            <article class="border border-border rounded-xl bg-bg-elev p-5 sm:p-6 mb-5 shadow-sm transition-colors hover:border-border-strong">
+              <a href=${'/compare/' + c.slug} class="block no-underline text-fg">
+                <header class="flex flex-wrap items-baseline gap-x-3 gap-y-1 mb-2">
+                  <span class="font-mono text-[11.5px] uppercase tracking-[0.12em] text-accent font-semibold">WebJs vs ${c.competitor}</span>
+                </header>
+                <h2 class="font-serif text-[clamp(20px,3vw,26px)] leading-[1.15] tracking-tight text-fg m-0 mb-2">${c.tagline}</h2>
+                <p class="text-fg-muted text-[14.5px] leading-relaxed m-0">${c.description}</p>
+              </a>
+            </article>
+          `)}
+    </main>
+  `;
+}

--- a/website/app/layout.ts
+++ b/website/app/layout.ts
@@ -24,6 +24,7 @@ const NAV = [
   { label: 'UI', href: UI_URL, ext: true },
   { label: 'Demo', href: EXAMPLE_BLOG_URL, ext: true },
   { label: 'Blog', href: '/blog', ext: false },
+  { label: 'Compare', href: '/compare', ext: false },
   { label: 'Changelog', href: '/changelog', ext: false },
   { label: 'GitHub', href: GH_URL, ext: true },
 ];

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -395,7 +395,7 @@ lib/session.server.ts</pre>
 
     <footer class="mt-24 border-t border-border py-16 px-6 bg-bg-subtle/30">
       <div class="max-w-[1080px] mx-auto">
-        <nav class="grid grid-cols-2 md:grid-cols-4 gap-8 mb-12" aria-label="Footer">
+        <nav class="grid grid-cols-2 md:grid-cols-5 gap-8 mb-12" aria-label="Footer">
           <div class="flex flex-col gap-3">
             <h4 class="text-xs font-bold uppercase tracking-wider text-fg">Product</h4>
             <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href=${DOCS_URL + '/docs/getting-started'} target="_blank" rel="noopener noreferrer">Docs${NEW_TAB}</a>
@@ -408,6 +408,14 @@ lib/session.server.ts</pre>
             <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href="/blog">Blog</a>
             <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href="/changelog">Changelog</a>
             <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href=${GH_URL + '/releases'} target="_blank" rel="noopener noreferrer">Releases${NEW_TAB}</a>
+          </div>
+          <div class="flex flex-col gap-3">
+            <h4 class="text-xs font-bold uppercase tracking-wider text-fg"><a class="no-underline text-fg hover:text-accent transition-colors" href="/compare">Compare</a></h4>
+            <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href="/compare/webjs-vs-nextjs">WebJs vs Next.js</a>
+            <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href="/compare/webjs-vs-lit">WebJs vs Lit</a>
+            <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href="/compare/webjs-vs-remix">WebJs vs Remix 3</a>
+            <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href="/compare/webjs-vs-astro">WebJs vs Astro</a>
+            <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href="/compare/webjs-vs-rails">WebJs vs Rails</a>
           </div>
           <div class="flex flex-col gap-3">
             <h4 class="text-xs font-bold uppercase tracking-wider text-fg">Community</h4>

--- a/website/app/sitemap.ts
+++ b/website/app/sitemap.ts
@@ -1,0 +1,42 @@
+import { sitemap } from '@webjsdev/server';
+import { listComparisons } from '#modules/compare/queries/list-comparisons.server.ts';
+import { listPosts } from '#modules/blog/queries/list-posts.server.ts';
+
+/**
+ * /sitemap.xml
+ *
+ * Serialized from the live content queries so newly added comparison and
+ * blog markdown is discoverable without touching this file. The compare
+ * pages are the SEO reason this exists: each `/compare/<slug>` is a
+ * canonical head-to-head we want search engines to crawl and index.
+ *
+ * `SITE_URL` falls back to the production origin; override it per
+ * deployment the same way the header/footer links are configured.
+ */
+const SITE_URL = ((globalThis as any).process?.env?.SITE_URL || 'https://webjs.dev').replace(/\/$/, '');
+
+export default async function Sitemap() {
+  const [comparisons, posts] = await Promise.all([listComparisons(), listPosts()]);
+
+  const staticRoutes = ['/', '/blog', '/compare', '/changelog'].map((path) => ({
+    url: `${SITE_URL}${path}`,
+    changeFrequency: 'weekly' as const,
+    priority: path === '/' ? 1.0 : 0.7,
+  }));
+
+  const compareRoutes = comparisons.map((c) => ({
+    url: `${SITE_URL}/compare/${c.slug}`,
+    lastModified: c.date || undefined,
+    changeFrequency: 'monthly' as const,
+    priority: 0.8,
+  }));
+
+  const blogRoutes = posts.map((p) => ({
+    url: `${SITE_URL}/blog/${p.slug}`,
+    lastModified: p.date || undefined,
+    changeFrequency: 'monthly' as const,
+    priority: 0.6,
+  }));
+
+  return sitemap([...staticRoutes, ...compareRoutes, ...blogRoutes]);
+}

--- a/website/modules/compare/queries/get-comparison.server.ts
+++ b/website/modules/compare/queries/get-comparison.server.ts
@@ -1,0 +1,47 @@
+'use server';
+
+import { readFile } from 'node:fs/promises';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseFrontmatter } from '#lib/frontmatter.ts';
+import type { ComparisonWithBody } from '#modules/compare/types.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..', '..', '..');
+const COMPARE_DIR = resolve(REPO_ROOT, 'compare');
+
+/**
+ * Read a single `compare/<slug>.md` and return its metadata + body.
+ * Returns `null` if the slug is invalid or the file does not exist;
+ * the route handler turns that into a 404 via `notFound()`.
+ *
+ * Slug validation is `[a-z0-9-]+`, which also blocks path traversal
+ * (`../../etc/passwd`) before touching the filesystem.
+ *
+ * A GET server action (#488): a public, cacheable per-slug read,
+ * identical for every visitor, so `public: true` is safe. The cache
+ * key includes the `slug` arg; the per-page `compare:` tag (plus the
+ * shared `compare` tag) lets a future write path evict it.
+ */
+export const method = 'GET';
+export const cache = { maxAge: 300, public: true };
+export const tags = (slug: string) => ['compare', `compare:${slug}`];
+export async function getComparison(slug: string): Promise<ComparisonWithBody | null> {
+  if (!/^[a-z0-9-]+$/.test(slug)) return null;
+  let raw: string;
+  try { raw = await readFile(join(COMPARE_DIR, slug + '.md'), 'utf8'); }
+  catch { return null; }
+  const { fm, body } = parseFrontmatter(raw);
+  if (!fm.title || !fm.competitor || !fm.tagline) return null;
+  return {
+    slug,
+    title: fm.title,
+    date: fm.date || '',
+    description: fm.description || '',
+    competitor: fm.competitor,
+    tagline: fm.tagline,
+    tags: (fm.tags || '').split(',').map((t) => t.trim()).filter(Boolean),
+    author: fm.author || 'Vivek',
+    body: body.trim(),
+  };
+}

--- a/website/modules/compare/queries/list-comparisons.server.ts
+++ b/website/modules/compare/queries/list-comparisons.server.ts
@@ -1,0 +1,54 @@
+'use server';
+
+import { readdir, readFile } from 'node:fs/promises';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseFrontmatter } from '#lib/frontmatter.ts';
+import type { Comparison } from '#modules/compare/types.ts';
+
+// website/modules/compare/queries/list-comparisons.server.ts is 4 levels
+// deep from the repo root (website/modules/compare/queries/...).
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..', '..', '..');
+const COMPARE_DIR = resolve(REPO_ROOT, 'compare');
+
+/**
+ * Read every `compare/<slug>.md` at the repo root, parse frontmatter,
+ * and return the metadata (not the body) so the index page can render
+ * compact cards. Sorted alphabetically by competitor so the list is
+ * stable regardless of file dates.
+ *
+ * Each file requires `title`, `competitor`, and `tagline`; files
+ * missing those are dropped silently (lets a draft sit in the dir).
+ *
+ * Declared as a GET server action (#488): a public, cacheable read of
+ * repo content identical for every visitor, so `public: true` is safe.
+ * Content only changes on redeploy, so a 5-minute max-age is fine; the
+ * `compare` tag lets a future write path evict it.
+ */
+export const method = 'GET';
+export const cache = { maxAge: 300, public: true };
+export const tags = () => ['compare'];
+export async function listComparisons(): Promise<Comparison[]> {
+  let files: string[];
+  try { files = await readdir(COMPARE_DIR); } catch { return []; }
+  const comparisons: Comparison[] = [];
+  for (const f of files) {
+    if (!f.endsWith('.md')) continue;
+    const raw = await readFile(join(COMPARE_DIR, f), 'utf8');
+    const { fm } = parseFrontmatter(raw);
+    if (!fm.title || !fm.competitor || !fm.tagline) continue;
+    comparisons.push({
+      slug: f.replace(/\.md$/, ''),
+      title: fm.title,
+      date: fm.date || '',
+      description: fm.description || '',
+      competitor: fm.competitor,
+      tagline: fm.tagline,
+      tags: (fm.tags || '').split(',').map((t) => t.trim()).filter(Boolean),
+      author: fm.author || 'Vivek',
+    });
+  }
+  comparisons.sort((a, b) => a.competitor.localeCompare(b.competitor));
+  return comparisons;
+}

--- a/website/modules/compare/types.ts
+++ b/website/modules/compare/types.ts
@@ -1,0 +1,16 @@
+export type Comparison = {
+  slug: string;
+  title: string;
+  date: string;
+  description: string;
+  /** The framework being compared against, e.g. "Next.js". */
+  competitor: string;
+  /** One-line hook shown on the index card. */
+  tagline: string;
+  tags: string[];
+  author: string;
+};
+
+export type ComparisonWithBody = Comparison & {
+  body: string;
+};


### PR DESCRIPTION
## What

Adds a `/compare` section to the marketing site with honest, head-to-head write-ups of WebJs vs **Next.js**, **Lit**, **Remix 3**, **Astro**, and **Rails**, for SEO on high-intent "webjs vs framework" queries.

Each essay follows the same honest structure: where the two agree, where WebJs genuinely differs, where the other tool is the better pick, and where WebJs is. The "where the competitor wins" sections lead with that framework's real strengths (ecosystem, language, specific features), never by disparaging WebJs.

## Comparisons

- **Next.js**: no build step, no RSC server/client split, web components instead of a React runtime.
- **Lit**: the same lit-shaped component API, wrapped in a full framework (routing, SSR, actions).
- **Remix 3**: targets the bundler-free, beyond-React rewrite specifically. Verified against the Remix 3 source. Its own runtime-first VDOM with an imperative `handle.update()` model, vs WebJs's native web components with declarative reactivity. Both converge on no-build, web standards, and being built for AI agents.
- **Astro**: islands and near-zero JS, but WebJs is a full-stack framework where Astro is a build-time content framework.
- **Rails**: the no-build importmap model and sensible defaults, in one TypeScript language on web components. Notes the honest distinction that Rails is convention-over-configuration across the whole architecture while WebJs prescribes only file routing.

## Surfaces

- **Content**: repo-root `compare/*.md` (mirrors the `blog/` pattern), shipped via a new `Dockerfile` `COPY compare` line.
- **Read layer**: `website/modules/compare/` (types plus GET `list`/`get` server-action queries, cacheable and public).
- **Pages**: `/compare` index and `/compare/[slug]`, reusing the blog's markdown renderer and per-page `generateMetadata` (canonical URLs, og/twitter tags).
- **Navigation**: a **Compare** column in the footer and a **Compare** item in the header nav.
- **Sitemap**: new `app/sitemap.ts` emitting every compare and blog URL.

## Conventions

- Prose capitalizes **WebJs** as a proper noun everywhere; code tokens (`webjs` CLI, `@webjsdev/*`, `*.webjs.dev`, URL slugs) stay lowercase.

## Verification

- `webjs check`: all checks pass.
- Booted the site: `/compare`, all five `/compare/<slug>`, and `/sitemap.xml` return 200; an unknown slug 404s; per-page titles and og tags render; footer and header links present.
