### PR TITLE
fix: sync llms.txt H1 test and docs to WebJs brand casing

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md for the docs site
 
-The webjs documentation site, built on webjs itself (eating our own
+The WebJs documentation site, built on WebJs itself (eating our own
 dogfood). All framework-wide rules (file conventions, public API,
 workflow, scaffold rules, persistence rules, autonomous-mode behaviour)
 live in the **framework root [`../AGENTS.md`](../AGENTS.md)** and apply
@@ -51,7 +51,7 @@ automatically):
 
 | URL | What it serves |
 |---|---|
-| `/llms.txt` | A structured INDEX. An `# webjs documentation` H1, a one-line blurb, then a markdown bullet list of every doc page (title, blurb, absolute link). Ordered to match the sidebar nav. |
+| `/llms.txt` | A structured INDEX. An `# WebJs documentation` H1, a one-line blurb, then a markdown bullet list of every doc page (title, blurb, absolute link). Ordered to match the sidebar nav. |
 | `/llms-full.txt` | The full prose CORPUS. Every doc page concatenated as lightweight markdown. In the monorepo it also folds in `agent-docs/*.md`; a standalone deploy that lacks the repo root simply skips that (try/catch read). |
 | `/docs/<topic>/llms.txt` | One page's raw markdown. Every topic gets one via the `app/docs/[topic]/llms.txt/route.ts` dynamic route. |
 

--- a/test/docs/llms.test.mjs
+++ b/test/docs/llms.test.mjs
@@ -52,7 +52,7 @@ describe('docs /llms.txt (the index)', () => {
     assert.match(r.headers.get('content-type') || '', /text\/plain/);
     const body = await r.text();
     assert.ok(body.startsWith('# '), 'body should start with a markdown H1');
-    assert.match(body, /^# webjs documentation/);
+    assert.match(body, /^# WebJs documentation/);
   });
 
   test('index lists known doc topics with absolute https URLs', async () => {


### PR DESCRIPTION
Closes #868

## What

`main` is red. #855 correctly capitalized the llms.txt index H1 in `docs/lib/llms.server.ts` to `# WebJs documentation` (the brand), but left two spots pinning the old lowercase form:
- `test/docs/llms.test.mjs:55` asserted `/^# webjs documentation/`
- `docs/AGENTS.md` documented the H1 (and a prose line) as lowercase (`docs/*.md` was not swept by the one-time fix)

This updates both to `WebJs` to match the emitted output. Source is unchanged (already correct).

## Root cause

The failing "Unit + integration" check was present on #855 and got bypassed by an `--admin` merge (which skips failing checks, not only the review gate). Fixing forward here; the process lesson (never admin-merge past a red check) is noted on #868 and is a candidate for the start-work guard.

## Tests

`node --test test/docs/llms.test.mjs`: all green (10 assertions incl. the H1 test).

https://claude.ai/code/session_016RNAZ8EfZYE8ZBpKUCzUao