### PR TITLE
fix: keep parens in markdown link URLs instead of truncating

### DIFF
--- a/website/modules/blog/utils/render-post.ts
+++ b/website/modules/blog/utils/render-post.ts
@@ -24,7 +24,10 @@ function inline(s: string): string {
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
-  out = out.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_m, t, u) => {
+  // The URL group allows one level of balanced nested parens, so a link whose
+  // address contains a `(...)` (e.g. a Wikipedia `..._(programming_language)`
+  // URL) is captured whole instead of truncated at the first `)`.
+  out = out.replace(/\[([^\]]+)\]\(((?:[^()]|\([^()]*\))*)\)/g, (_m, t, u) => {
     // Absolute (off-site) links open in a new tab so the reader keeps the
     // article; internal links (starting with /) navigate in place. Escape any
     // `"` in the URL so it cannot break out of the href attribute.

--- a/website/modules/blog/utils/render-post.ts
+++ b/website/modules/blog/utils/render-post.ts
@@ -14,9 +14,10 @@
  *   - `> ` blockquotes
  *   - `- ` bulleted lists (custom-positioned markers via `before:` pseudo-element)
  *   - ```fenced``` code blocks
- *   - Inline: **bold**, *italic*, `code`, [text](url). An absolute or
- *     protocol-relative URL opens in a new tab (with a screen-reader cue);
- *     an internal `/path` link navigates in place.
+ *   - Inline: **bold**, *italic*, `code`, [text](url). The URL may contain
+ *     one level of balanced parens (e.g. a Wikipedia `..._(language)` link).
+ *     An absolute or protocol-relative URL opens in a new tab (with a
+ *     screen-reader cue); an internal `/path` link navigates in place.
  */
 
 function inline(s: string): string {
@@ -27,7 +28,7 @@ function inline(s: string): string {
   // The URL group allows one level of balanced nested parens, so a link whose
   // address contains a `(...)` (e.g. a Wikipedia `..._(programming_language)`
   // URL) is captured whole instead of truncated at the first `)`.
-  out = out.replace(/\[([^\]]+)\]\(((?:[^()]|\([^()]*\))*)\)/g, (_m, t, u) => {
+  out = out.replace(/\[([^\]]+)\]\(((?:[^()]|\([^()]*\))+)\)/g, (_m, t, u) => {
     // Absolute (off-site) links open in a new tab so the reader keeps the
     // article; internal links (starting with /) navigate in place. Escape any
     // `"` in the URL so it cannot break out of the href attribute.

--- a/website/test/ssr/compare-ssr.test.ts
+++ b/website/test/ssr/compare-ssr.test.ts
@@ -42,8 +42,15 @@ test('a link URL containing balanced parens is captured whole, not truncated', (
   // href lost its `)` tail. The full URL must survive.
   assert.match(out, /href="https:\/\/en\.wikipedia\.org\/wiki\/Ruby_\(programming_language\)"/, 'href keeps the full parenthesized URL');
   assert.match(out, /target="_blank"/, 'still classified as an external link');
-  // The stray trailing `)` from the truncated form must not leak as text.
-  assert.doesNotMatch(out, />Ruby<\/a>\)/, 'no orphaned closing paren after the link');
+  // Counterfactual: the truncated form left a stray `)` right after the closing
+  // </a>. The whole-URL form emits no such orphan.
+  assert.doesNotMatch(out, /<\/a>\)/, 'no orphaned closing paren after the link');
+});
+
+test('an empty link URL stays literal text (no empty-href anchor)', () => {
+  const out = renderPostBody('see [x]() here');
+  assert.doesNotMatch(out, /<a /, 'does not emit an anchor for an empty URL');
+  assert.match(out, /\[x\]\(\)/, 'leaves the malformed link as literal text');
 });
 
 test('the compare page shows a visible outbound link to the competitor site in a new tab', async () => {

--- a/website/test/ssr/compare-ssr.test.ts
+++ b/website/test/ssr/compare-ssr.test.ts
@@ -36,6 +36,16 @@ test('a double quote in a link URL cannot break out of the href attribute', () =
   assert.match(out, /%22/, 'the quote is percent-escaped in the href');
 });
 
+test('a link URL containing balanced parens is captured whole, not truncated', () => {
+  const out = renderPostBody('[Ruby](https://en.wikipedia.org/wiki/Ruby_(programming_language))');
+  // Counterfactual: the old `[^)]+` capture stopped at the first `)`, so the
+  // href lost its `)` tail. The full URL must survive.
+  assert.match(out, /href="https:\/\/en\.wikipedia\.org\/wiki\/Ruby_\(programming_language\)"/, 'href keeps the full parenthesized URL');
+  assert.match(out, /target="_blank"/, 'still classified as an external link');
+  // The stray trailing `)` from the truncated form must not leak as text.
+  assert.doesNotMatch(out, />Ruby<\/a>\)/, 'no orphaned closing paren after the link');
+});
+
 test('the compare page shows a visible outbound link to the competitor site in a new tab', async () => {
   const out = await renderToString(await ComparePage({ params: { slug: 'webjs-vs-nextjs' } }));
   // A visible, underlined "Visit the Next.js site" link (distinguishable while


### PR DESCRIPTION
Closes #860

## What

The shared blog/compare markdown renderer captured link URLs with `[^)]+`, which stops at the first `)`. A link whose address legitimately contains a paren (a Wikipedia `..._(programming_language)` URL, for example) was truncated, so its `href` pointed at a broken address and a stray `)` leaked as text. This widens the URL group to allow one level of balanced nested parens so the address is captured whole.

## Change

- `website/modules/blog/utils/render-post.ts`: the link regex URL group becomes `((?:[^()]|\([^()]*\))*)`, capturing a URL that contains a single level of balanced `(...)`.
- Test in `website/test/ssr/compare-ssr.test.ts` for a paren-containing URL, with a counterfactual (fails against the old `[^)]+`).

## Scope note

Handles one level of nesting (the realistic case). Deeper nesting (`a_(b_(c))`) is still not supported, which matches how many lightweight markdown renderers behave; not worth a full parser here.

## Docs / surfaces

- N/A for framework docs: website-local util, no `packages/*` public surface changed. The renderer header comment is updated to document balanced-paren URLs.
