### PR TITLE
docs: add 12 SEO blog posts for shipped-but-unblogged features

### DIFF
--- a/blog/bun-serve-vs-node-http.md
+++ b/blog/bun-serve-vs-node-http.md
@@ -1,0 +1,60 @@
+---
+title: "Why Bun.serve Beats the node:http Bridge (a ~1.9x Story)"
+date: 2026-06-07T10:00:00+05:30
+slug: bun-serve-vs-node-http
+description: "On Bun, WebJs serves through native Bun.serve instead of routing every request through Node's compatibility bridge. That is roughly 1.9x more requests per second on the listening path, at near-complete feature parity, with 103 Early Hints the one honest gap."
+tags: bun, nodejs, performance, runtime, throughput
+author: Vivek
+---
+
+You have a WebJs app in production. It is buildless, so the same `.ts` source runs on Node 24 and on Bun with nothing to recompile. One afternoon you try Bun under it, mostly because you have heard it is faster. You flip the runtime, run a load test, and the requests-per-second number on the listening path jumps by roughly 1.9x. You changed no code. That number is the whole subject of this post: where it comes from, what "the listening path" actually is, and the one feature you give up to get it.
+
+If you want the mechanics of how WebJs runs on two runtimes at all (the runtime-neutral seam, the two TypeScript strippers, the parity test matrix), that is a separate story in the companion post `node-and-bun-no-build`. This one is purely about throughput.
+
+# What "requests per second" and "the listening path" mean
+
+Let me define the pieces in plain terms, because the win lives in one specific place and it is easy to overstate.
+
+Every web server has a listening path, sometimes just called the listener. It is the code that accepts an incoming network connection, reads the raw HTTP bytes off the socket, hands a request object to your application, takes the response your app hands back, and writes it to the socket. It is the plumbing between the network and your code. Separate from it is your application work: the SSR, the routing, the queries, the actual WebJs logic.
+
+Requests per second (req/s) is simply how many of those accept-read-respond cycles the server turns through in one second under load. A leaner listening path means more req/s for the same application work, because less of each request's time is spent in the plumbing.
+
+So the 1.9x is a listening-path number. It is not 1.9x on your whole app end to end, because your SSR and queries cost the same on either runtime. It is 1.9x on the plumbing, which you get for free by choosing the runtime.
+
+# A compatibility bridge, and why it costs you
+
+Bun can run Node's built-in `node:http` module, which is a big reason so much of the Node ecosystem runs on Bun unmodified. But when Bun runs `node:http`, it runs a compatibility bridge (a compat bridge for short): a translation layer that emulates Node's HTTP request and response objects on top of Bun's own native machinery. Every single request pays that translation cost. You are asking Bun to pretend to be Node on the hottest path in the server.
+
+Bun also ships its own native HTTP server, `Bun.serve`, which speaks Bun's request and response objects directly with zero emulation. The catch is that `Bun.serve` is not shaped like `node:http`, so a framework that wants the native path cannot just flip a config value; it has to write a second listener that talks to `Bun.serve` on its own terms.
+
+WebJs writes that second listener. On Bun it serves through a native `Bun.serve` shell and skips the compat bridge entirely. On Node it serves through `node:http`. Your application code sits above that boundary and never knows which shell is underneath.
+
+```sh
+# same app, same source. the runtime is a command choice:
+npm run dev            # Node, node:http listener
+bun --bun run dev      # Bun, native Bun.serve listener
+```
+
+Skipping the bridge is where the 1.9x comes from. Nothing in your app changed. You stopped paying a per-request translation tax that existed only so Bun could look like Node.
+
+# The one honest gap: 103 Early Hints
+
+I will not pretend the native path is a perfect superset of the bridged one, because the missing piece is worth naming plainly.
+
+The one Node-only feature the Bun listener cannot match is 103 Early Hints. That is an informational HTTP response (a preliminary status the server can send before the real one) that lets the server tell the browser to start preloading assets while the actual response is still being produced. It is a first-paint latency optimization. `Bun.serve` has no informational-response API at all, so there is nothing for WebJs to build on, and on Bun that optimization is simply off.
+
+That is the entire tradeoff. You give up one preload-timing feature and you get 1.9x on the listener in exchange. For most apps that is a clear win, and I would rather document the gap honestly than paper over it with a shim that fakes an API Bun does not have.
+
+# Trimming the per-request cost on the Bun path
+
+The listener choice is the headline, but a buildless server has to earn throughput in the small places too, because there is no build step ahead of time to absorb overhead. So the Bun request path got its own passes.
+
+Brotli compression on the Bun listener runs through `node:zlib` (#518), so a Bun-served response gets the same compression a Node-served one does, no native gap there. And the per-request overhead got trimmed directly (#773): one pass removed a full request-object clone that existed only to stamp the client's IP address onto every request, and another removed an extra stream hop that every compressed response was being bridged through. Neither was large alone, but they are per-request costs, so they multiply by your traffic. On the hot path, a clone you do not need and a stream hop you can collapse are exactly the kind of thing worth cutting by hand.
+
+# You pick the runtime
+
+The runtime is your choice, not the framework's. You write one WebJs app. Run it on Node and you get the mature `node:http` listener and 103 Early Hints. Run it on Bun and you get the native `Bun.serve` listener and roughly 1.9x the listening-path throughput, minus that one Early Hints feature. Everything else behaves the same. Pass `--runtime bun` to `webjs create` and the generated app is wired for Bun from the first commit, or run `bun create webjs <name>` and it detects the runtime for you.
+
+# The takeaway
+
+The 1.9x is not magic and it is not the whole app; it is the listening path, the plumbing that accepts a connection and produces a response. On Bun, WebJs serves through native `Bun.serve` instead of running `node:http` over a compatibility bridge, and skipping that per-request translation tax is where the throughput comes from. The honest cost is 103 Early Hints, which Bun has no API to support. Brotli compression rides `node:zlib` and the per-request overhead has been trimmed to keep the Bun path lean. You pick the runtime, and if you pick Bun you get a real throughput win on the hot path with almost no change in behavior.

--- a/blog/cancel-server-actions-abortsignal.md
+++ b/blog/cancel-server-actions-abortsignal.md
@@ -1,0 +1,95 @@
+---
+title: "Cancelling Server Actions With AbortSignal (No Wasted Work on Disconnect)"
+date: 2026-06-15T10:00:00+05:30
+slug: cancel-server-actions-abortsignal
+description: "WebJs wires the platform's own AbortSignal through the server-action RPC boundary in both directions, so a client that navigates away actually cancels the in-flight request and the server stops paying for work nobody is waiting for."
+tags: server-actions, abortsignal, performance, cancellation, web-standards
+author: Vivek
+---
+
+Picture a typeahead search. The user types "web", you fire an action, they type "webj", you fire another, they type "webjs", you fire a third. By the time they stop, the first two requests are answers nobody wants. In most setups those first two still run to completion on the server, still hit the database, still serialize a result, and only then get thrown away on the client. You paid full price for two answers that were obsolete the moment they were requested.
+
+I did not want WebJs to pay for work nobody is waiting for. The web platform already has the primitive for this. It is `AbortSignal`, the same object `fetch` accepts to be cancelled. So WebJs wires that signal through the server-action RPC (remote procedure call) boundary, in both directions, and a cancelled request is actually cancelled on the wire.
+
+# The server side reads the request's signal
+
+Inside an action, you can read the current request's `AbortSignal` and stop working the moment the client goes away. It is one import.
+
+```ts
+// modules/search/queries/search.server.ts
+'use server';
+import { actionSignal } from '@webjsdev/server';
+
+export async function search(term: string) {
+  const signal = actionSignal();
+  const res = await fetch(`https://api.example.com/q?term=${term}`, { signal });
+  return res.json();
+}
+```
+
+`actionSignal()` returns the `AbortSignal` tied to the in-flight request. When the client disconnects or aborts, that signal fires, and anything you passed it to unwinds. You hand it to a `fetch`, or to a database query that accepts a signal, or you check `signal.aborted` yourself inside a loop.
+
+```ts
+export async function crunch(rows: Row[]) {
+  const signal = actionSignal();
+  const out = [];
+  for (const row of rows) {
+    if (signal.aborted) break;   // client left, stop chewing
+    out.push(expensiveTransform(row));
+  }
+  return out;
+}
+```
+
+There is a deliberate safety detail here. When you call an action directly server-to-server (not across an HTTP request, just one server function calling another), `actionSignal()` returns a signal that never aborts. So the pattern is always safe to write. Your action does not need to know whether it is being reached over the network or called inline, and it will never spuriously abort just because there was no request context around it.
+
+# The client side aborts the superseded render for you
+
+The server half is only useful if the client actually signals the abort, and this is where the RPC boundary earns its keep. When a component's `async render()` is superseded by a newer render (a prop changed, the user typed again), WebJs does not merely ignore the old render's result. It aborts the in-flight action fetch that render started.
+
+The generated RPC stub binds every fetch it issues to a per-render `AbortController`. When that render is superseded, its controller is aborted, the underlying HTTP request is torn down, and the `AbortSignal` you read on the server with `actionSignal()` fires. The whole chain connects. Client supersedes a render, the fetch is aborted on the wire, the server's signal trips, your action stops.
+
+```ts
+class Search extends WebComponent({ term: String }) {
+  async render() {
+    if (!this.term) return html`<ul></ul>`;
+    const hits = await search(this.term);   // superseded by the next keystroke
+    return html`<ul>${hits.map((h) => html`<li>${h.title}</li>`)}</ul>`;
+  }
+}
+Search.register('search-box');
+```
+
+Type fast into this and every keystroke supersedes the last render. Without cancellation, each stale request runs to completion server-side before its result is dropped. With it, the stale request is actually cancelled the moment the next keystroke lands, so the server stops the query it was running and moves on. Under a burst of typing that is the difference between one live query and five, and you wrote none of the plumbing. It falls out of `async render()` being cancellable and the stub binding each fetch to the render that issued it.
+
+# Streaming actions cancel their source too
+
+The same principle extends to streaming results. An action that returns a `ReadableStream`, an async iterable, or an async generator streams its chunks over the single RPC response instead of buffering them all first.
+
+```ts
+// modules/tokens/actions/stream-tokens.server.ts
+'use server';
+export async function* streamTokens(n: number) {
+  for (let i = 0; i < n; i++) {
+    yield { i, token: await nextToken() };
+  }
+}
+```
+
+```ts
+for await (const chunk of await streamTokens(8)) {
+  this.tokens = [...this.tokens, chunk.token];
+}
+```
+
+If the client disconnects, or the render that started the stream is superseded, WebJs cancels the source generator. The `for await` on the server stops advancing, so a long or infinite stream (think a token feed from a model) does not keep producing into a void. The producer is torn down at the source, not just ignored at the consumer. Back-pressure is respected the same way, so a slow reader does not force the generator to run ahead of what anyone is consuming.
+
+# Why this is the right shape
+
+The thing I like about this is that it is not a WebJs invention layered on top of the platform. `AbortSignal` and `AbortController` are the web's own cancellation primitives, the same ones `fetch` has accepted for years. WebJs just threads them through the one place they were previously missing, which is the RPC boundary between a client component and a server action. The server reads the platform signal, the client drives the platform controller, and the framework connects the two ends across the network so an abort on one side becomes an abort on the other.
+
+You get to write the ordinary, boring, correct thing. Pass a signal to your `fetch`, check `signal.aborted` in a hot loop, let a superseded render clean up after itself. No cancellation library, no request-ID bookkeeping, no manual "is this response still the latest" guard on the client.
+
+# The takeaway
+
+Work that nobody is waiting for is work you should not be doing. WebJs makes server actions cancellable by wiring the platform's own `AbortSignal` through the RPC boundary in both directions. On the server, `actionSignal()` gives you the request's signal to pass to a fetch, a DB query, or an `aborted` check, and it returns a never-aborting signal outside a request so server-to-server calls stay safe. On the client, a superseded `async render()` aborts the previous render's in-flight fetch through a per-render `AbortController`, so a fast typeahead cancels stale requests on the wire instead of letting them finish and drop. Streaming actions cancel their source generator on disconnect or supersession too. It is the platform's cancellation model, threaded through the one boundary that was missing it, so you stop paying for answers no one wants.

--- a/blog/component-suspense-streaming.md
+++ b/blog/component-suspense-streaming.md
@@ -1,0 +1,79 @@
+---
+title: "Streaming Slow Web Components With <webjs-suspense>"
+date: 2026-05-30T13:00:00+05:30
+slug: component-suspense-streaming
+description: "How WebJs streams slow web components with <webjs-suspense> so the first byte flushes immediately, the fallback shows, and the slow data streams in over plain HTML with no RSC or Flight protocol, all while keeping progressive enhancement."
+tags: streaming, suspense, web-components, ssr, performance
+author: Vivek
+---
+
+Picture a dashboard page. Most of it is instant. There is a header, a summary card, a nav. But one panel calls out to a slow analytics query that takes 400ms on a good day. In WebJs the default behavior is that `async render()` blocks server-side rendering (SSR), which means the framework awaits your data before sending a single byte of HTML. For the fast parts that is exactly what you want, because the resolved data lands in the first paint, a crawler indexes real content, and a reader with JavaScript off still sees everything. But that one slow panel would hold the entire page's first byte hostage for 400ms. Everything else is ready and the user sees a blank tab.
+
+That is the wrong trade for a slow region, and the fix is `<webjs-suspense>`.
+
+# Block by default, stream on purpose
+
+I want to be precise about the default first, because the streaming case only makes sense against it. When you write `await` inside a component's `render()`, WebJs blocks SSR for it and bakes the resolved data into the HTML. No spinner, no empty box, no hydration flicker. That is the right default. It is progressive-enhancement-safe (the page works before JavaScript runs) and it is good for search engine optimization (SEO) because the content is really in the document.
+
+The moment blocking the first byte on one query starts to hurt time-to-first-byte, you opt that region out of blocking and into streaming. You do it by wrapping the slow component in a `<webjs-suspense>` element with a fallback.
+
+```ts
+class SalesDashboard extends WebComponent {
+  render() {
+    return html`
+      <section class="grid gap-6">
+        <summary-card></summary-card>
+        <webjs-suspense .fallback=${html`<div class="skeleton h-48"></div>`}>
+          <slow-analytics></slow-analytics>
+        </webjs-suspense>
+      </section>
+    `;
+  }
+}
+SalesDashboard.register('sales-dashboard');
+```
+
+Here is what happens on the wire. The framework renders everything that is fast, flushes the first byte with the summary card already filled in, and in the hole where `<slow-analytics>` goes it emits the `.fallback` markup (the skeleton). The browser paints that immediately. Meanwhile the slow component keeps rendering on the server, and when its data resolves WebJs streams the real content down the same response and swaps it into place. The user sees the shell instantly, a skeleton where the slow panel will be, and then the panel fills in.
+
+One detail that matters and is easy to miss. The `.fallback` hole is a property hole, so it must be unquoted. Write `.fallback=${html`...`}`, never `.fallback="${...}"`. The leading dot tells WebJs to pass the template as a DOM property rather than stringify it into an attribute.
+
+# Multiple boundaries fetch concurrently
+
+The part that makes this genuinely fast is that boundaries do not queue. If a page has three `<webjs-suspense>` regions, each wrapping its own slow query, they all start on the server at once and stream in as they finish, in whatever order they resolve. There is no server-side waterfall where the second slow query waits for the first to flush. You get fast-content-first, and each slow region arrives independently the instant it is ready.
+
+```ts
+html`
+  <webjs-suspense .fallback=${html`<div class="skeleton h-32"></div>`}>
+    <revenue-chart></revenue-chart>
+  </webjs-suspense>
+  <webjs-suspense .fallback=${html`<div class="skeleton h-32"></div>`}>
+    <top-customers></top-customers>
+  </webjs-suspense>
+`
+```
+
+Revenue and customers fetch in parallel. If customers resolves first, it streams in first. Nothing about one boundary is coupled to another.
+
+# This is plain HTML streaming, not RSC
+
+If you come from React, the word "Suspense" carries baggage, so let me draw the line clearly. WebJs has no React Server Components, no Flight protocol, no serialized render tree traveling over a special wire format. `<webjs-suspense>` is HTML streaming and nothing more. The server flushes ordinary HTML in chunks, the fallback is real markup, and the streamed-in content is real markup too, rendered with Declarative Shadow DOM or light DOM exactly like every other WebJs component. There is no client runtime reconstructing a virtual tree from a binary protocol. The browser's own streaming HTML parser does the work, which is why it degrades so gracefully.
+
+# It streams on soft navigation too
+
+The streaming is not only a first-load trick. When the client router does a soft navigation (an in-app link click that swaps content without a full page reload), the same boundaries stream progressively into the new view. The fallback flushes into the swapped region, and the slow content streams in after, so a client-side navigation to a page with a slow panel behaves exactly like the initial server load. You author it once and it works both ways.
+
+# A thrown component is isolated
+
+Slow data is also flaky data, so failure handling matters. If a component inside a boundary throws while it renders, WebJs isolates it. That one component renders its own error state, and its siblings keep streaming as if nothing happened. A single broken panel does not blank the page and it does not tear down the other boundaries mid-stream. This is the same per-component error isolation WebJs gives you for a blocking `async render()`, carried through the streaming path.
+
+# When to reach for it, and when not to
+
+Do not reach for `<webjs-suspense>` reflexively. It is the exception, not the pattern. For request-time server data that resolves fast, block in `async render()` and bake it into the first paint. That is faster and simpler and it is the whole reason WebJs blocks by default. Reserve `<webjs-suspense>` for a region that is genuinely slow enough that holding the first byte for it hurts more than showing a fallback for it would.
+
+It is worth knowing this is the ONLY way to show a fallback on the first paint in WebJs. A blocking `async render()` never shows a first-paint fallback, by design, because it has real data instead. So if you find yourself wanting a first-paint skeleton, that want is the signal that the region is slow and belongs in a boundary. There is also a page-level and region-level `Suspense({ fallback, children })` (a value you drop into a template hole rather than an element you wrap), and a `loading.js` route file that wraps a whole page in Suspense with an immediately flushed fallback, for when the slow thing is the entire route rather than one island.
+
+One implementation note for the curious. A streamed component that uses `static shadow = true` always ships its JavaScript module, even when it would otherwise be elided. Declarative Shadow DOM only attaches during initial HTML parsing, so a component that arrives mid-stream needs its module to re-run `attachShadow` in the browser. Light-DOM streamed components have no such requirement.
+
+# The takeaway
+
+WebJs blocks SSR by default so your data is in the first paint, which is the right call for fast queries and keeps the page working without JavaScript. For the one slow panel that would otherwise stall the whole first byte, wrap it in `<webjs-suspense .fallback=${...}>`. The fallback flushes immediately, the slow content streams in when it resolves, multiple boundaries fetch concurrently with no server waterfall, a throwing component stays isolated, and it all works on soft navigation too. It is plain HTML streaming, no RSC and no Flight, so the browser's own parser carries it. Fast first byte for slow data, without giving up progressive enhancement. This shipped in #470 and #471.

--- a/blog/device-adaptive-link-prefetch.md
+++ b/blog/device-adaptive-link-prefetch.md
@@ -1,0 +1,76 @@
+---
+title: "Device-Adaptive Link Prefetch That Does Not Bloat the Network Tab"
+date: 2026-07-04T10:00:00+05:30
+slug: device-adaptive-link-prefetch
+description: "How WebJs's client router prefetches links with a device-adaptive default: intent-based prefetch on desktop hover, dwell-gated viewport prefetch on mobile. Instant navigation without a bandwidth tax, tuned to the device, no import required."
+tags: client-router, prefetch, performance, mobile, navigation
+author: Vivek
+---
+
+Prefetching is the trick that makes a link feel instant. Before you click, the browser has already fetched the page behind the link, so the moment you tap it, the content is just there. No spinner, no wait. It feels like the app read your mind.
+
+The naive way to do it is to prefetch every link on the page. Every card in a feed, every item in a nav, every footer link, all fetched the instant they render. On a fast desktop connection you might get away with it. On a phone on cellular data you are torching someone's bandwidth to prefetch forty pages they will never visit. Open the network tab on a fetch-everything prefetcher and it lights up like a christmas tree. That is not a feature. That is a bandwidth tax you are quietly charging your users.
+
+The rule I held while building this was simple. Snappy is the goal, but never at the cost of over-fetching. When in doubt, under-fetch. A prefetch you did not need is waste, and waste on mobile data is worse than a 100ms wait.
+
+# The device-adaptive default
+
+WebJs's client router prefetches, but the default strategy adapts to the device it is running on. The signal it uses is whether the pointer can hover.
+
+On a hover-capable pointer (a desktop with a mouse), the default is `intent` prefetch. The page behind a link is fetched when you hover over it. A hover is a strong signal. On desktop, moving the cursor onto a link and pausing there is most of the way to a click already. So the fetch fires on hover, and by the time your finger comes down on the mouse button, the page is usually ready. You prefetch exactly the links the user is actively considering, not the whole document.
+
+On a touch device (a phone or tablet, no hover), there is no hover to lean on. Your finger does not float over a link before tapping it. So the default switches to `viewport` prefetch, with two guards that keep it honest.
+
+The first guard is dwell-gating. A link is not prefetched the instant it scrolls into view. It has to STAY in view for a short moment first. If you are flicking through a long feed, links stream past the viewport constantly, and prefetching each one as it flashed by would be exactly the network-tab flood we are trying to avoid. The dwell timer says "prefetch this only if the user actually paused on it," which is the touch-device equivalent of a hover.
+
+The second guard is cancel-on-scroll-out. If a link enters the viewport, starts its dwell timer, but scrolls back out before the timer elapses, the prefetch never fires. You looked away in time, so nothing was fetched. Only a link you dwelt on long enough to plausibly tap gets warmed.
+
+Together those two guards mean a mobile user scrolling a feed prefetches a handful of links they lingered on, not the hundreds they scrolled past. The network tab stays quiet. The navigation still feels instant on the links that matter.
+
+# Per-link override
+
+The default is device-adaptive, but you can override any single link with `data-prefetch`.
+
+```ts
+import { html } from '@webjsdev/core';
+
+export default function Nav() {
+  return html`
+    <nav>
+      <a href="/dashboard">Dashboard</a>              <!-- device-adaptive default -->
+      <a href="/heavy-report" data-prefetch="none">Report</a>   <!-- never prefetch -->
+      <a href="/pricing" data-prefetch="intent">Pricing</a>     <!-- force intent on any device -->
+    </nav>
+  `;
+}
+```
+
+Set `data-prefetch="none"` on a link whose target is expensive to render or rarely visited, and it is never prefetched regardless of device. Force a strategy the other way when you know something the heuristic does not. The default is tuned for the common case, and the attribute is the escape hatch for the ones you understand better than the framework does.
+
+# You do not import anything to get this
+
+There is no prefetch library to install and no router to wire up. The client router auto-enables the moment `@webjsdev/core` loads in the browser, and core is the bundle every component pulls in. So any page that ships a single component gets client navigation, and with it device-adaptive prefetch, for free. Prefetch is on by default. You did not opt into it and you do not configure it to get sensible behaviour.
+
+```ts
+// a page with one interactive component. prefetch is already on, nothing to wire.
+import { html } from '@webjsdev/core';
+import '#components/like-button.ts';
+
+export default function Feed() {
+  return html`
+    <ul>
+      ${posts.map(p => html`
+        <li><a href="/posts/${p.id}">${p.title}</a> <like-button .id=${p.id}></like-button></li>
+      `)}
+    </ul>
+  `;
+}
+```
+
+# Prefetch is one piece of a larger router
+
+Prefetch is the front edge of a navigation, but the client router does more once you click. It swaps pages in place with no full-page reload, so there is no white flash between routes and your nested layouts stay mounted. It sends an `X-Webjs-Have` header listing the layout fragments it already holds, so the server returns only the divergent part of the next page instead of re-serializing the shared header, sidebar, and footer every time. It restores scroll position on back and forward. Prefetch and those pieces reinforce each other. Prefetch warms the divergent fragment early, `X-Webjs-Have` keeps that fragment small, and the in-place swap paints it without a flash. I will not go deep on those here (the client-router post covers them), but it is worth knowing prefetch is not a bolt-on. It is the leading edge of one coherent navigation pipeline.
+
+# The takeaway
+
+Prefetching the page behind a link is what makes navigation feel instant, but fetching every visible link is a bandwidth tax that hits mobile users hardest. WebJs's client router prefetches with a device-adaptive default. On a hover-capable desktop it uses `intent` prefetch (fetch on hover, since a hover is a strong click signal), and on touch it uses `viewport` prefetch that is dwell-gated and cancel-on-scroll-out, so only the links a user actually pauses on get warmed. Override any link with `data-prefetch`, and get all of it with no import because the router auto-enables when core loads. The guiding rule underneath it is the one worth stealing. Be snappy, but under-fetch when in doubt, because a prefetch you did not need is pure waste.

--- a/blog/file-uploads-and-storage.md
+++ b/blog/file-uploads-and-storage.md
@@ -1,0 +1,102 @@
+---
+title: "File Uploads and Storage in WebJs: FileStore, Signed URLs, S3-Ready"
+date: 2026-06-10T10:00:00+05:30
+slug: file-uploads-and-storage
+description: "How WebJs handles file uploads with a built-in FileStore and diskStore default: streaming multipart uploads, path-traversal-safe keys, signed URLs for private files, and an S3-ready swap that never touches your call sites."
+tags: file-upload, storage, s3, server-actions, security
+author: Vivek
+---
+
+Let me set the scene with the feature every app eventually grows: a user wants to upload an avatar. Or attach a PDF to a support ticket. Or drop an image into a post. It sounds like a five-minute job, and then you open your editor and remember why it never is.
+
+You have to parse the multipart request (the special encoding a browser uses to send a file plus form fields in one POST). You have to decide where the bytes actually land, because a file is not a row in your database. You have to serve it back later without letting one user read another user's private file. And you have to do all of that in a way you will not have to rewrite the day you outgrow the local disk and move to S3. Four separate problems wearing one innocent-looking trench coat.
+
+WebJs ships a built-in for this. It is small, it is streaming, and it is deliberately shaped so the local-disk version and the S3 version are the same code.
+
+
+# The upload half: a File that just arrives
+
+The first pleasant surprise is that you do not hand-parse anything. A WebJs server action (a function in a `*.server.ts` file marked `'use server'`) can receive a native `File`, a `Blob`, or a whole `FormData` as an argument, because the wire serializer round-trips them for you. You call the action from a client component with a normal import, and on the server you get a real `File` object.
+
+```ts
+// modules/uploads/actions/upload-avatar.server.ts
+'use server';
+import { getFileStore, generateKey } from '@webjsdev/server';
+
+export async function uploadAvatar(file: File) {
+  const store = getFileStore();
+  const key = generateKey(file.name);          // opaque, safe key
+  const { size, contentType } = await store.put(key, file);
+  return { success: true, data: { key, size, contentType } };
+}
+```
+
+The `store.put(key, file)` call streams the bytes to storage. Streaming matters more than it sounds. A naive upload reads the entire file into memory before writing it, so a handful of users sending 50 MB videos at once can knock your server over. WebJs pipes the file's stream straight to disk, so a large upload uses roughly constant memory no matter how big it is.
+
+You also want a guardrail on how big an upload is allowed to be in the first place. That lives in your `package.json` config, not in the action.
+
+```jsonc
+// package.json
+{
+  "webjs": {
+    "maxMultipartBytes": 10485760
+  }
+}
+```
+
+That cap (default 10 MiB) bounds the request before the bytes ever reach the store, so an oversized upload is rejected at the door. The store stays simple and just keeps streaming whatever it is handed.
+
+
+# Why you never use the filename as the key
+
+Notice I called `generateKey(file.name)` instead of storing the file under its original name. This is the part beginners get bitten by, so it is worth spelling out.
+
+A "key" is just the identifier the store files the bytes under. If you trust a user-supplied filename as the key, a malicious user names their file `../../etc/passwd` and now your write (or a later read) tries to escape your uploads folder and touch a system file. That escape trick is called path traversal, and it is one of the oldest holes in the book.
+
+WebJs closes it in two layers. Every key is resolved to an absolute path and rejected if it lands outside the store directory, so a key with `..`, a leading slash, a NUL byte, or a backslash throws before any filesystem operation runs. And `generateKey(filename)` hands you a random UUID-based key that keeps only a sanitized, whitelisted file extension from the original name. A hostile `'../../x.sh'` comes back as a bare opaque key with no path and no dangerous extension. Use it, and the traversal problem simply cannot exist in your app.
+
+
+# The diskStore default, and serving files back
+
+Out of the box the file store is a `diskStore` rooted at `<cwd>/.webjs/uploads`, served under `/uploads`. You add that directory to `.gitignore` (it holds user data, not source) and you are done for local development. Override the location at startup if you want:
+
+```ts
+import { setFileStore, diskStore } from '@webjsdev/server';
+setFileStore(diskStore({ dir: '/var/data/uploads', baseUrl: '/files' }));
+```
+
+Serving a file back is a `route.ts` handler that reads a streaming handle from the store and hands its body to a `Response`, so the file streams to the browser without being loaded into memory. One caveat that is genuinely important. The content-type recorded on an upload is the one the browser claimed at upload time, so it is attacker-controlled. A route that reflects it inline lets someone upload HTML dressed up as an image and run script on your origin (stored XSS). The fix is to send `X-Content-Type-Options: nosniff` and a `Content-Disposition: attachment` for anything a user uploaded, and only ever serve inline from a strict allowlist of inert types you have validated. Serving uploads from a separate cookieless origin is the strongest version of that mitigation.
+
+
+# Signed URLs: a private file without a session lookup
+
+Some files are public. Some are not, and you do not want the serving route doing a database session check on every image request. That is what a signed URL is for. It is a time-limited link that carries its own proof of permission.
+
+```ts
+import { signedUrl, verifySignedUrl } from '@webjsdev/server';
+
+// mint a link that is valid for one hour
+const url = signedUrl(key, { secret: process.env.AUTH_SECRET, expiresIn: 3600 });
+
+// in the serving route.ts
+const check = verifySignedUrl(new URL(request.url).searchParams, process.env.AUTH_SECRET);
+if (!check.valid) return new Response('Forbidden', { status: 403 });
+```
+
+Under the hood WebJs signs the exact key plus its expiry with HMAC-SHA256 (a keyed hash, so nobody without the secret can forge or tamper with the link), and the comparison is constant-time. Neither the key nor the expiry can be edited after the fact without the signature failing. A nice safety detail: passing `expiresIn: 0` or a negative number fails closed, so a "no access" intent never silently becomes a one-hour grant. The one-hour default only applies when you omit `expiresIn` entirely.
+
+
+# The day you move to S3
+
+Here is the payoff that makes all of the above worth it. Every method on the store operates on web-standard objects only: a `File` goes in, a streaming handle comes out. So an S3 (or R2, or GCS, or MinIO) adapter is a drop-in that implements the same `put`, `get`, `delete`, and `url` against the cloud SDK. Because the shape is identical, moving your whole app off local disk is one line at startup.
+
+```ts
+setFileStore(s3Store({ /* ... */ }));
+```
+
+Not one call site changes. Your `uploadAvatar` action, your serving route, your signed URLs all keep working. WebJs ships no S3 SDK itself (no dependency you did not ask for); the adapter is a thin wrapper you provide. That is the whole point of putting the interface first. The thing you build on a Friday afternoon with `diskStore` is the same thing you scale in production, minus the rewrite.
+
+
+# The takeaway
+
+File uploads feel like a rite of passage because most stacks make you assemble four things by hand: multipart parsing, a place for the bytes, safe serving, and an eventual cloud migration. WebJs folds them into one built-in. A server action receives a native `File` because the serializer round-trips it, `store.put` streams it so a big upload does not eat your memory, `generateKey` gives you a path-traversal-safe key so a malicious filename cannot escape, and `signedUrl` gates a private file without a session lookup. The `diskStore` default gets you running with zero config, and the web-standard interface means swapping to S3 is one `setFileStore` call with no change to a single call site. Write it once on disk, ship it to the cloud unchanged.

--- a/blog/import-only-pages-zero-js.md
+++ b/blog/import-only-pages-zero-js.md
@@ -1,0 +1,57 @@
+---
+title: "Your Page Module Should Not Be in the Network Tab"
+date: 2026-07-03T10:00:00+05:30
+slug: import-only-pages-zero-js
+description: "In WebJs, pages and layouts never hydrate, so their JavaScript has no job in the browser. An import-only page or layout is dropped entirely and the boot ships just the interactive component leaves it imported. How it works, when a page still ships whole, and how to check."
+tags: performance, elision, no-build, ssr, web-components
+author: Vivek
+---
+
+Open a WebJs blog post, pop the network tab, and look for `page.ts`. It is not there. Look for `layout.ts` either. Neither downloaded. The page rendered, the theme toggle in the corner works, the two files that describe the whole page never crossed the wire. Do the same on a typical React or Next app and you watch the page component and its layout come down as client JavaScript that then hydrates. That contrast is the whole point of this post.
+
+The reason those two files stayed home is not something you configured. It falls out of one fact about the framework, and once you see it, the empty network tab becomes the thing you check for.
+
+# Pages run on the server. Components run in the browser.
+
+The mental model to unlearn comes from React, where a page component is JavaScript you ship and then hydrate. In WebJs there is no server or client component split, and pages do not work that way.
+
+Pages and layouts are isomorphic modules, meaning the same source can run on both sides. But a page function runs only on the server. It executes once to produce HTML and is never invoked again in the browser. There is no second render, no client-side re-run, no event wiring at the page level. A layout is the same: it runs on the server to wrap its children and it is done.
+
+All the interactivity lives one level down, in components. A component is an island: its module loads in the browser, the custom element upgrades in place, and its `@click` handlers, signals, and reactive properties come alive. That client-side run is the entire reason a component's module ships at all. It hydrates; the page around it does not.
+
+So a page's own module usually has nothing to do on the client. It rendered its HTML on the server, the components inside it are the parts that come alive, and the page function finished the moment SSR did. Shipping that module to the browser buys you nothing, because no code in it runs there.
+
+# What "import-only" means
+
+Here is the subtle case, and the one this post is really about. It landed in #605 and #609.
+
+A page rarely sits there doing nothing. It imports things, in particular the interactive components it wants to render: a `<theme-toggle>`, a `<comment-box>`, a `<search-bar>`. Those components DO hydrate, so their modules genuinely need to reach the browser.
+
+The naive way to get them there is to ship the page module and let the browser follow its imports. But that drags the whole page module across the wire just to act as a pointer to its children. WebJs does better. A page or layout that is non-inert only because it imports interactive components is called import-only. Since the page never hydrates, the framework does not need it in the browser to reach its imports. The boot emits the component modules directly and drops the page or layout wrapper, so the browser fetches the interactive leaves and nothing else. The page module was the middleman, and the middleman gets cut out.
+
+You never annotated anything. No `"use client"` on the components, no marker on the page. You wrote a page that imports some components, and the browser received exactly the components that run there, not the page that listed them.
+
+The other module elision touches is the display-only component itself, the interactive-looking element whose JavaScript changes nothing so the framework strips it too. I wrote that side up separately in `ship-zero-javascript-display-only-components`; here I am staying on the page and layout half.
+
+# When a page still ships whole
+
+Import-only is a specific condition, and it is worth knowing when it fails, because that is when `page.ts` shows up in your network tab. A page or layout ships whole when it has a client side effect of its own, not just interactive imports. Any of these in the module's closure pins it to the browser:
+
+- An explicit client-router import.
+- A call at module scope, something that runs the instant the module loads.
+- A self-registering bare import, a module imported purely for its side effect.
+- Importing a client-effecting non-component utility. The classic offender is a `cn.ts` class-name helper that touches a browser global. Import that into your page and the page module now does client work, so it ships whole.
+
+That last one is sneaky, because a class-name helper looks innocent. But if it reads a browser global at module load, importing it makes your page module client-effecting, and a client-effecting page module ships. The fix is to keep client-only behavior inside a component and server-only work in a `.server.ts` file, and if a utility mixes a pure helper with client-global code, split the client part out so the pure helper does not pin every page that imports it.
+
+# The self-check, and the tool that names the reason
+
+The rule of thumb is short. `page.ts` and `layout.ts` should never appear in the network tab or in the boot `<script type="module">`. If one does, something in its closure is doing client-side work, and that is your signal to find the stray side effect and move it where it belongs.
+
+You do not have to squint at the network tab to figure out which one. `webjs doctor` includes a page and layout elision advisory (#646), and a later change (#666) added advisory naming of the specific reason a given page or layout ships, so the tool tells you which client side effect pinned the module to the browser.
+
+If you ever want everything shipped, for a debugging session or because you distrust the analysis, turn elision off with `"webjs": { "elide": false }` in the config or `WEBJS_ELIDE=0` in the environment, and every module ships as written. Dropping a page module can never change your first paint anyway, because the served HTML is identical with elision on or off.
+
+# The takeaway
+
+A React page component is client JavaScript you ship and hydrate. A WebJs page is not, because pages and layouts do not hydrate at all. Their functions run only on the server, so an import-only page or layout gets dropped entirely and the boot ships just the interactive component leaves it imported (#605, #609). A page ships whole only when it does client work of its own, and `webjs doctor` names the reason when it happens (#646, #666). The self-check is a glance at the network tab: if `page.ts` or `layout.ts` is in it, something in that module is doing browser work it should not. The result is a mostly-static page that ships almost no JavaScript, with not a single boundary marked by hand.

--- a/blog/native-sqlite-node-and-bun.md
+++ b/blog/native-sqlite-node-and-bun.md
@@ -1,0 +1,85 @@
+---
+title: "Dropping better-sqlite3 for Native SQLite on Node and Bun"
+date: 2026-06-03T11:00:00+05:30
+slug: native-sqlite-node-and-bun
+description: "WebJs dropped the better-sqlite3 native addon for the runtime's built-in SQLite: node:sqlite on Node 24+ and bun:sqlite on Bun. No node-gyp, no compile step, no prebuilt-binary roulette, and a pure Bun Docker image with no Node toolchain."
+tags: sqlite, drizzle, nodejs, bun, database
+author: Vivek
+---
+
+You clone a project, run the install, and it sits there compiling C++ for a while. Then you upgrade to a new Node major and the same package refuses to load, because the binary it built last month was compiled against a different version. You reinstall, it recompiles, and you have lost twenty minutes to a database driver that never ran a single query. If you have used SQLite in Node, you have met better-sqlite3, and you have probably met this exact afternoon.
+
+WebJs used to ship better-sqlite3 too. In #670 I pulled it out entirely and switched to the SQLite the runtime already includes. On Node that is `node:sqlite`, on Bun it is `bun:sqlite`. No native addon, no compile, nothing to rebuild when Node bumps a version.
+
+
+# What a native addon is, and why compiling at install is fragile
+
+better-sqlite3 is a native addon, which means it is not JavaScript. It is a wrapper around SQLite's C library, and that C code has to be turned into a machine binary your specific Node build can load. Two ways that happens, and both have sharp edges.
+
+The first is compiling on your machine at install time, using a toolchain called node-gyp. That needs a working C++ compiler, Python, and the right platform headers present on whatever machine runs `npm install`, your laptop, a teammate's laptop, a CI runner, a Docker image. When one of them is missing or the wrong version, the install fails with a wall of compiler output that has nothing to do with your app.
+
+The second is downloading a prebuilt binary that someone compiled ahead of time for your platform. That is faster, until a binary for your exact combination of operating system, CPU architecture, and Node version does not exist, and you silently fall back to the node-gyp path anyway. Worse, a native binary is pinned to a Node ABI (application binary interface), so a fresh Node major means a fresh compile. The driver works, then you upgrade Node, and it stops loading until it rebuilds. That coupling between your database driver and your runtime version is the whole class of pain.
+
+
+# Use the SQLite the runtime already has
+
+The fix is almost boring. Modern runtimes ship SQLite in the box, so there is no addon to compile at all.
+
+Node 24+ has `node:sqlite`, a stable built-in module. Bun has `bun:sqlite`, built into the binary. Both are C SQLite already compiled into the runtime you are running, so importing them costs nothing at install time. No node-gyp, no Python, no prebuilt-binary roulette, no recompile on a Node upgrade. WebJs picks the right one for whichever runtime you are on and hands it to the ORM.
+
+That ORM is Drizzle, the scaffold default. You do not touch `node:sqlite` or `bun:sqlite` directly. You write a plain TypeScript schema and Drizzle sits on top of the runtime's driver.
+
+```ts
+// db/schema.server.ts
+import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
+
+export const posts = sqliteTable('posts', {
+  id: text('id').primaryKey(),
+  title: text('title').notNull(),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+});
+```
+
+You query it from a server action or a query module, importing the shared `db` client:
+
+```ts
+// modules/posts/queries/list-posts.server.ts
+'use server';
+import { db } from '#db/connection.server.ts';
+
+export async function listPosts() {
+  return db.query.posts.findMany({ orderBy: { createdAt: 'desc' } });
+}
+```
+
+The migration loop is the usual Drizzle Kit flow through the WebJs CLI:
+
+```sh
+webjs db generate   # create a migration from the current schema
+webjs db migrate    # apply pending migrations
+```
+
+Nothing in that loop compiles a binary. The migration is a SQL file, and the driver underneath it is already part of the runtime.
+
+
+# It also works the other direction: Postgres, same code
+
+Because Drizzle is the layer you write against, the SQLite-vs-Postgres choice is one flag at scaffold time, and the schema, queries, and actions are identical across both dialects (the dialect-parity work landed in #563).
+
+```sh
+webjs create my-app --db postgres
+```
+
+SQLite is the default because a new app then runs with zero setup, no server to install, just a file on disk. When you outgrow that, you move to Postgres without rewriting your data layer.
+
+
+# The payoff shows up hardest in Docker
+
+The install-time compile is annoying on your laptop and genuinely expensive in a container image, where you would otherwise ship a C++ toolchain just so a database driver could build. Dropping the native addon is what let the Bun scaffold use a pure `oven/bun:1` Dockerfile (#595, #596) with no Node in it at all.
+
+That only works because two things are true at once. SQLite is built into Bun, so there is nothing to compile, and `webjs db migrate` became npx-free in #570, so the migration step needs no Node either. Remove the native addon and remove the npx dependency, and the image no longer needs a Node runtime or a compiler toolchain sitting in it. It is a smaller image that builds faster and has less to go wrong.
+
+
+# The takeaway
+
+SQLite in Node used to mean a native addon that compiled C++ at install time, with node-gyp failures, prebuilt-binary gaps, and a forced recompile on every Node major. WebJs dropped better-sqlite3 (#670) and uses the runtime's own SQLite instead, `node:sqlite` on Node 24+ and `bun:sqlite` on Bun, so there is no compile step and no binary pinned to your runtime version. Drizzle sits on top and keeps the same code across SQLite and Postgres. The lesson generalizes past this one driver. When the platform grows a capability you were pulling in a fragile dependency for, delete the dependency and use the platform.

--- a/blog/nextjs-16-file-routing-parity.md
+++ b/blog/nextjs-16-file-routing-parity.md
@@ -1,0 +1,113 @@
+---
+title: "Next.js 16 File-Routing Parity in WebJs: forbidden(), unauthorized(), and Nearest not-found"
+date: 2026-07-08T10:00:00+05:30
+slug: nextjs-16-file-routing-parity
+description: "WebJs closed the last Next.js 15/16 file-routing parity gaps. forbidden() and unauthorized() control-flow throws, nearest-wins not-found boundaries, sync-or-await params, and an instrumentation.js boot hook, explained for anyone migrating from Next.js."
+tags: nextjs, routing, web-standards, migration, auth
+author: Vivek
+---
+
+If you have built with Next.js, the routing primitives live in your muscle memory. You throw `notFound()` and a `not-found.tsx` renders. You reach for a boundary file and it just appears at the right place in the tree. WebJs has matched that file-routing model from early on, but a handful of the newer Next.js 15 and 16 primitives were still missing. Those are the ones that bite a migrator, because you write the call you have written a hundred times and nothing happens.
+
+This post is about the four gaps WebJs just closed. If you are coming from Next, these are the last routing pieces that were not there yet, and now they match.
+
+# forbidden() and unauthorized() are control-flow throws
+
+Next 15 added `forbidden()` and `unauthorized()` alongside the older `notFound()`. WebJs now has both, and they behave exactly the way the `notFound()` pattern already taught you. You throw them, and the framework catches the throw, sets the HTTP status, and renders the matching boundary file.
+
+```ts
+// app/dashboard/page.ts
+import { html, forbidden, unauthorized } from '@webjsdev/core';
+
+export default async function Dashboard() {
+  const session = await getSession();
+  if (!session) unauthorized();          // 401, not authenticated
+  if (!session.canSeeDashboard) forbidden(); // 403, authenticated but not allowed
+  return html`<h1>Dashboard</h1>`;
+}
+```
+
+The distinction is the useful part, and it is the same one HTTP has always drawn. `unauthorized()` returns a 401 and is for a request that is not authenticated at all (no session, nobody logged in). `forbidden()` returns a 403 and is for a user who IS logged in but lacks permission for this particular thing. Reaching for the right one gives you honest status codes for free.
+
+Each renders the nearest boundary file walking up from where you threw. A `forbidden()` renders the closest `forbidden.{js,ts}`, an `unauthorized()` renders the closest `unauthorized.{js,ts}`, innermost wins, and if you have not written one, WebJs renders a sensible default page. So you can put a single `app/forbidden.ts` at the root for the whole app, or drop a `app/admin/forbidden.ts` that is specific to the admin section, and the nearer one takes over inside its subtree.
+
+```ts
+// app/admin/forbidden.ts
+import { html } from '@webjsdev/core';
+export default function AdminForbidden() {
+  return html`<p>You need admin access for this area.</p>`;
+}
+```
+
+One thing to internalize, because it is where the throw model has edges. These work from a page or layout render, and from a page `action` (the no-JS write path, the function that handles a form POST to the page's own URL). They do NOT belong in a `route.ts` handler, which is a raw HTTP handler that should return a `Response` itself. And inside a `'use server'` RPC action, a raw `forbidden()` throw becomes a generic 500, because an action's job is to return a value. For an auth failure in an action, return an `ActionResult` instead.
+
+```ts
+// modules/posts/actions/delete-post.server.ts
+'use server';
+export async function deletePost(id: string) {
+  const session = await getSession();
+  if (!session) return { success: false, error: 'Sign in first.', status: 401 };
+  if (!session.isAdmin) return { success: false, error: 'Not allowed.', status: 403 };
+  // ...delete
+  return { success: true };
+}
+```
+
+The rule of thumb is the same one that governs `notFound()` and `redirect()`. Throw in a render path, return an envelope in an action, return a `Response` in a route.
+
+# not-found is now nearest-wins
+
+This is the fix that quietly matters most for a migrator (issue #848). Previously a thrown `notFound()` in WebJs always rendered the single root `not-found` page. In Next, a `not-found.tsx` is nearest-wins, so a `not-found` deep in your tree takes over for pages beneath it. WebJs now matches that.
+
+```
+app/
+  not-found.ts                 root 404
+  blog/
+    [slug]/
+      page.ts                  throws notFound() for a missing post
+    not-found.ts               renders THIS for a missing post
+```
+
+Throw `notFound()` from `app/blog/[slug]/page.ts` and you get `app/blog/not-found.ts`, the nearest one walking up from the throwing page. No blog-specific boundary in that subtree? It keeps walking and lands on the root. This means you can give a section its own styled 404 (a missing product looks different from a missing blog post) without any wiring beyond dropping the file in the right folder.
+
+There is also a root-only `global-not-found.{js,ts}`, which renders for a URL that matches nothing anywhere in your app. That is the catch-all for an address that never resolves to a route at all, as opposed to a route that ran and decided the thing it wanted does not exist.
+
+# params and searchParams are sync or awaited, your choice
+
+Next 15 made `params` and `searchParams` async (you `await params` before reading it). Plenty of existing code, and plenty of tutorials, still read them synchronously. WebJs supports both, so a migrating Next dev does not have to think about it.
+
+```ts
+// Both of these work, in the same codebase, on the same object.
+export default async function Post({ params }) {
+  const { slug } = await params;   // the Next 15/16 way
+  // ...
+}
+
+export default function Post2({ params }) {
+  const slug = params.slug;        // the synchronous way
+  // ...
+}
+```
+
+Paste your `await params` code from a Next project and it runs. Prefer the plainer synchronous read and that runs too. The object is awaitable AND directly subscriptable, so neither style is wrong and you never hit the confusing "params is a Promise now" error mid-migration.
+
+# instrumentation.js for boot-time wiring
+
+The last piece is the boot hook. WebJs now reads an optional `instrumentation.{js,ts}` at your app root, matching Next's file of the same name. It exports a `register()` function that runs once at server boot, which is where you wire up APM (application performance monitoring), tracing, or any one-time setup.
+
+```ts
+// instrumentation.ts
+import { setOnError } from '@webjsdev/server';
+
+export function register() {
+  setOnError((err, ctx) => {
+    myApm.captureException(err, { url: ctx.url });
+  });
+}
+```
+
+`setOnError` registers the hook the framework calls on an unhandled request error, so your monitoring tool sees every server-side failure with its request context. There is also an `instrumentation-client.{js,ts}` that runs first on the client, before your app modules, for the browser side of the same idea (a client error reporter, an analytics init).
+
+# The takeaway
+
+WebJs was already file-routing compatible with Next in shape, and these four changes (all shipped in #848 and #849) close the remaining gaps a migrator actually trips on. `forbidden()` and `unauthorized()` are control-flow throws that render the nearest boundary, with honest 403 and 401 status codes and the clear rule that you throw in a render, return an `ActionResult` in an action, and return a `Response` in a route. `not-found` is nearest-wins now, so sections get their own 404s. `params` and `searchParams` read either synchronously or awaited, so your Next code just works. And `instrumentation.js` gives you the boot hook for wiring monitoring. Bring your Next.js routing habits over, and the ones that used to fall through now land.

--- a/blog/per-action-middleware.md
+++ b/blog/per-action-middleware.md
@@ -2,7 +2,7 @@
 title: "Per-Action Middleware: Auth and Context Around a Single Server Action"
 date: 2026-06-17T10:00:00+05:30
 slug: per-action-middleware
-description: "How WebJs attaches per-action middleware to a single server action for auth, rate-limit checks, logging, and tenant resolution. Declarative middleware that runs on both the RPC and route.ts boundaries, short-circuits cleanly, and feeds context via actionContext()."
+description: "How WebJs attaches per-action middleware to a single server action for auth, rate-limit checks, logging, and tenant resolution. Declarative middleware that runs automatically on the RPC boundary, short-circuits cleanly, and feeds context via actionContext()."
 tags: server-actions, middleware, auth, rpc, composition
 author: Vivek
 ---
@@ -70,11 +70,22 @@ First, the middleware short-circuits by returning an `ActionResult` instead of c
 
 Second, it accumulates context. Anything the middleware writes onto `ctx` is readable inside the action via `actionContext()` (imported from `@webjsdev/server`). The action's own signature never changes. `deletePost(id)` still takes one argument. The user arrives out of band, through the context the middleware built, so the calling code stays exactly as clean as it was.
 
-# It runs on every entry point to the action, not just one
+# Where it runs, and the one place you wire it through by hand
 
 This is the part that made me want the feature. A WebJs action is reachable two ways. A client component imports it and the import becomes a typed RPC (Remote Procedure Call) stub. Or a `route.ts` REST endpoint imports and calls it, often through the `route()` adapter from `@webjsdev/server`.
 
-The middleware runs on BOTH boundaries. When the browser calls `deletePost` over RPC, `requireUser` runs. When a mobile client hits your `route.ts` wrapper for the same action, `requireUser` runs there too. You declare the guard once, next to the function, and it protects every way in. There is no "but did I remember to add auth to the REST route as well" gap, because the guard is a property of the action, not of a single transport.
+On the RPC boundary the declared middleware runs automatically. When the browser calls `deletePost` over RPC, `requireUser` runs first, because the framework reads the `export const middleware` config off the action and wraps the chain around it for you. That is the primary path for a WebJs app, since components import actions directly, and it needs no wiring at all.
+
+The `route()` adapter is deliberately lower level, and here you pass the same chain explicitly:
+
+```ts
+// app/api/posts/[id]/route.ts
+import { route } from '@webjsdev/server';
+import { deletePost, middleware } from '#modules/posts/actions/delete-post.server.ts';
+export const DELETE = route(deletePost, { middleware });
+```
+
+I would honestly prefer `route(deletePost)` to pick the action's own middleware up on its own, the way the RPC boundary does. Today it does not, so you re-export the `middleware` array and hand it to the adapter. It is one line, and the guard still lives next to the action as its single source of truth, but it is a real seam to remember rather than an automatic guarantee. Verified by dogfooding: `route(action)` with no `middleware` option runs the body without the declared guards.
 
 # Compose several, in order
 
@@ -100,4 +111,4 @@ One rule ties this together. A configured action file holds exactly one callable
 
 # The takeaway
 
-Auth, rate-limit checks, logging, and tenant resolution are cross-cutting, so they do not belong copy-pasted into the top of every action body. WebJs lets a `'use server'` action declare `export const middleware = [mw1, mw2]`, an array of `async (ctx, next) => result` functions that run around the action on both the RPC and `route.ts` boundaries. A middleware short-circuits by returning an `ActionResult` before the body runs, and feeds context the action reads through `actionContext()` with no change to its signature. You write the guard once, next to the function, and every path into that action inherits it. Next.js has no first-class primitive for this (you wrap manually or lean on route middleware that cannot even see the action), which is exactly the gap this closes.
+Auth, rate-limit checks, logging, and tenant resolution are cross-cutting, so they do not belong copy-pasted into the top of every action body. WebJs lets a `'use server'` action declare `export const middleware = [mw1, mw2]`, an array of `async (ctx, next) => result` functions that wrap the action. On the RPC boundary they run automatically; a `route.ts` REST endpoint built with the `route()` adapter takes the same array through its `middleware` option. A middleware short-circuits by returning an `ActionResult` before the body runs, and feeds context the action reads through `actionContext()` with no change to its signature. You write the guard once, next to the function, and reuse that one array on every path into the action. Next.js has no first-class primitive for this (you wrap manually or lean on route middleware that cannot even see the action), which is exactly the gap this closes.

--- a/blog/per-action-middleware.md
+++ b/blog/per-action-middleware.md
@@ -1,0 +1,103 @@
+---
+title: "Per-Action Middleware: Auth and Context Around a Single Server Action"
+date: 2026-06-17T10:00:00+05:30
+slug: per-action-middleware
+description: "How WebJs attaches per-action middleware to a single server action for auth, rate-limit checks, logging, and tenant resolution. Declarative middleware that runs on both the RPC and route.ts boundaries, short-circuits cleanly, and feeds context via actionContext()."
+tags: server-actions, middleware, auth, rpc, composition
+author: Vivek
+---
+
+Here is a shape I write in almost every app. An action that updates a profile, deletes a comment, or charges a card. Before the real work runs, the same three lines run first. Check the user is logged in. Check they are allowed to touch this record. Maybe log the attempt. Then, and only then, do the thing.
+
+The naive version copies those lines into the top of every action body. You have seen it. Fifteen actions, each opening with the same authentication dance, each one a place you could forget it. Miss the check on one action and you have shipped a hole.
+
+```ts
+// modules/posts/actions/delete-post.server.ts (the copy-paste way)
+'use server';
+export async function deletePost(id: string) {
+  const user = await auth();                  // repeated
+  if (!user) return { success: false, error: 'unauthorized' };   // repeated
+  await db.delete(posts).where(eq(posts.id, id));
+  return { success: true };
+}
+```
+
+The cross-cutting concern (auth) is tangled into the business logic (delete a post). Every action re-implements the same preamble, and the preamble is exactly the part you cannot afford to get wrong.
+
+# The WebJs way: declare middleware as a sibling export
+
+In WebJs a server action is a function in a `*.server.ts` file marked `'use server'`. Alongside that function you can declare a reserved export the framework reads statically, `export const middleware`, an array of functions to run around the action.
+
+```ts
+// modules/posts/actions/delete-post.server.ts
+'use server';
+import { requireUser } from '#lib/auth-middleware.server.ts';
+import { actionContext } from '@webjsdev/server';
+
+export const middleware = [requireUser];
+
+export async function deletePost(id: string) {
+  const user = actionContext().user;          // set by the middleware
+  await db.delete(posts).where(eq(posts.id, id)).where(eq(posts.authorId, user.id));
+  return { success: true };
+}
+```
+
+The action body no longer knows how auth works. It just reads the user the middleware put there. The auth logic lives in one place, and every action that lists `requireUser` gets it identically.
+
+# What a middleware function looks like
+
+Each middleware is `async (ctx, next) => result`. It receives a context object it can write to, and a `next` function that runs the rest of the chain (the next middleware, or finally the action itself). This is the same onion model you know from Express or Koa, scoped to a single action.
+
+```ts
+// lib/auth-middleware.server.ts
+import { getSession } from '#lib/session.server.ts';
+
+export async function requireUser(ctx, next) {
+  const user = await getSession();
+  if (!user) {
+    // short-circuit: the action body never runs
+    return { success: false, error: 'unauthorized', status: 401 };
+  }
+  ctx.user = user;        // hand data down to the action
+  return next();          // proceed to the action
+}
+```
+
+Two things are happening here, and both matter.
+
+First, the middleware short-circuits by returning an `ActionResult` instead of calling `next()`. When `requireUser` finds no session it returns `{ success: false, error: 'unauthorized' }` and the action body is never entered. No half-run mutation, no reaching the database with a null user. The chain simply stops and that result is what the caller receives.
+
+Second, it accumulates context. Anything the middleware writes onto `ctx` is readable inside the action via `actionContext()` (imported from `@webjsdev/server`). The action's own signature never changes. `deletePost(id)` still takes one argument. The user arrives out of band, through the context the middleware built, so the calling code stays exactly as clean as it was.
+
+# It runs on every entry point to the action, not just one
+
+This is the part that made me want the feature. A WebJs action is reachable two ways. A client component imports it and the import becomes a typed RPC (Remote Procedure Call) stub. Or a `route.ts` REST endpoint imports and calls it, often through the `route()` adapter from `@webjsdev/server`.
+
+The middleware runs on BOTH boundaries. When the browser calls `deletePost` over RPC, `requireUser` runs. When a mobile client hits your `route.ts` wrapper for the same action, `requireUser` runs there too. You declare the guard once, next to the function, and it protects every way in. There is no "but did I remember to add auth to the REST route as well" gap, because the guard is a property of the action, not of a single transport.
+
+# Compose several, in order
+
+Because it is an array, you compose. Middleware run left to right, each wrapping the next.
+
+```ts
+export const middleware = [requireUser, requireAdmin, auditLog];
+
+export async function banUser(id: string) {
+  const admin = actionContext().user;
+  await db.update(users).set({ banned: true }).where(eq(users.id, id));
+  return { success: true };
+}
+```
+
+`requireUser` runs first and sets `ctx.user`. `requireAdmin` reads that user and short-circuits with a `403` if they are not an admin. `auditLog` records the attempt and calls `next()`, which finally runs `banUser`. Each concern is one small function, testable on its own, reusable across every action that needs it.
+
+# The neighbours: the rest of the sibling config exports
+
+Middleware is one of a family of reserved exports a `'use server'` file can declare, all read statically by the framework. You already saw these if you have tuned an action's transport. `export const method` sets the HTTP verb (`'GET'`, `'PATCH'`, and so on). `export const cache` sets a GET's cache window. `export const tags` labels a read's cache entries and `export const invalidates` names the tags a mutation evicts. `export const validate` is the boundary validator. They all sit next to the function and describe how it should be treated, not what it does.
+
+One rule ties this together. A configured action file holds exactly one callable function. That is not an arbitrary limit. The config exports (`middleware`, `method`, `validate`) describe THE function in the file, so a second function would have nowhere to hang its own config. `webjs check` flags a configured file with more than one export as an error. One function, one file, one clear set of guards around it.
+
+# The takeaway
+
+Auth, rate-limit checks, logging, and tenant resolution are cross-cutting, so they do not belong copy-pasted into the top of every action body. WebJs lets a `'use server'` action declare `export const middleware = [mw1, mw2]`, an array of `async (ctx, next) => result` functions that run around the action on both the RPC and `route.ts` boundaries. A middleware short-circuits by returning an `ActionResult` before the body runs, and feeds context the action reads through `actionContext()` with no change to its signature. You write the guard once, next to the function, and every path into that action inherits it. Next.js has no first-class primitive for this (you wrap manually or lean on route middleware that cannot even see the action), which is exactly the gap this closes.

--- a/blog/sanitizing-server-action-errors.md
+++ b/blog/sanitizing-server-action-errors.md
@@ -1,0 +1,82 @@
+---
+title: "Leaky Error Messages: Sanitizing Production Server-Action Errors"
+date: 2026-07-07T10:00:00+05:30
+slug: sanitizing-server-action-errors
+description: "How WebJs sanitizes production server-action errors so a thrown action returns a generic message plus a digest instead of leaking a database string, internal IP, or filesystem path. Safe by default in prod, with a digest to keep debuggability."
+tags: security, server-actions, error-handling, production, observability
+author: Vivek
+---
+
+Let me show you the leak, because it is easy to ship without noticing.
+
+Your action opens a database connection and the connection fails. The driver throws an error, and the error message is something like `connect ECONNREFUSED 10.0.3.14:5432`. A naive framework catches that throw and sends the message straight to the browser, where it lands in the network tab of anyone who opens dev tools. You just told a stranger your internal database host, its port, and that you run Postgres. You never chose to say any of that. The database driver said it for you, and the framework relayed it.
+
+It is not always a driver. A thrown error can carry a filesystem path (`/home/app/src/lib/secrets.server.ts`), an internal IP, a stack frame, a raw SQL fragment. None of it is author-controlled, and all of it is exactly the reconnaissance an attacker wants. The mistake is treating an error message as safe to display. An error message is a debugging aid for you, not a user-facing string, and the two must not be the same channel.
+
+```ts
+// the leak: a raw throw whose message reaches the client verbatim
+'use server';
+export async function loadDashboard() {
+  const rows = await db.query.metrics.findMany();   // driver throws with the host in the message
+  return { success: true, data: rows };
+}
+```
+
+# What WebJs does instead
+
+In production, WebJs sanitizes the error before it leaves the server. A thrown action does not return its real message to the client. The browser receives a generic message plus a short `digest`, and nothing else.
+
+A digest is just a short hash id, a little fingerprint like `a1b9f4c2`. It carries no meaning on its own. Its whole job is to be a shared reference number between the user and your logs. The client sees the digest. The full error, message, stack, and all, is logged server-side keyed by that same digest. So when a user reports "I got an error, the id was a1b9f4c2," you grep your logs for `a1b9f4c2` and find the exact stack trace that produced it. You lose nothing for debugging. You just stop broadcasting the internals to the browser.
+
+```ts
+// what the browser receives from a thrown action in prod
+{
+  "error": "Something went wrong",
+  "digest": "a1b9f4c2"
+}
+// what your server log holds, keyed by a1b9f4c2:
+// the full "connect ECONNREFUSED 10.0.3.14:5432" and stack
+```
+
+The same sanitization applies to the streaming error frame. If an action returns a stream and throws mid-stream, the error that surfaces from the iterable is sanitized identically. There is no side door where the raw message slips out because the response happened to be a stream.
+
+# Control-flow throws still pass through
+
+There is one category of throw that is NOT an error, and WebJs is careful to let it through untouched. `redirect()`, `notFound()`, `forbidden()`, and `unauthorized()` are implemented as throws, but they are control flow, not failures. You throw `redirect('/login')` to mean "stop here and send the user to the login page," and that intent has to survive.
+
+So the sanitizer recognizes these control-flow throws and passes them through verbatim. A `redirect()` still redirects. A `notFound()` still renders your 404. Only an actual unexpected error, the kind that carries a driver string or a stack, gets collapsed into the generic message plus digest.
+
+# Where your real error messages belong
+
+If the generic message is all the client gets, how do you show a user "Email already taken"? You do not throw it. You return it.
+
+A user-facing message belongs on the `ActionResult` envelope, not on a throw.
+
+```ts
+'use server';
+export async function signup(input: { email: string }) {
+  const existing = await findByEmail(input.email);
+  if (existing) {
+    // a user-facing message: returned, not thrown, so it is intentional and safe
+    return { success: false, error: 'Email already taken' };
+  }
+  const user = await createUser(input);
+  return { success: true, data: user };
+}
+```
+
+This draws a clean line. A `return { success: false, error }` is a message you deliberately chose to show, so it reaches the client as written. A `throw` is for the unexpected, the thing you did not plan for, so it gets sanitized. The envelope is your intentional-message channel and the throw is your panic channel, and only the panic channel is redacted. Once you internalize that split, you stop reaching for `throw new Error('nice message')` and start returning the message on the envelope where it belongs.
+
+# The boundary this covers, and the one it does not
+
+This protection lives on the action RPC boundary, the path a client component's imported action takes. It does not automatically cover a hand-written `route.ts` REST endpoint, including one built with the `route()` adapter.
+
+A `route.ts` handler is a raw HTTP handler you wrote on purpose, and WebJs does not wrap your own error handling around it. So on a mutating REST endpoint the responsibility is yours. Authenticate it, validate the input, log without leaking secrets into the response, and rate-limit it. The framework hands you the pieces (`validate`, the auth helpers, `rateLimit()`), but it will not redact a message you chose to send from a route you chose to write. The rule of thumb holds from the CSRF story too. Reach for a server action for in-app work and get the safe defaults, reach for `route.ts` when you are exposing a real public API and own its security.
+
+# One more thing: dev still shows you the truth
+
+Sanitization is a production behaviour. In development the real error message still surfaces in the browser and the overlay, because when you are building you WANT the driver string and the stack right there in front of you. It would be miserable to debug a `connect ECONNREFUSED` as "Something went wrong (digest: a1b9f4c2)" on your own machine. Only prod redacts. Dev tells you everything.
+
+# The takeaway
+
+An error message is a debugging aid, not a user-facing string, and shipping the raw one to the browser leaks database hosts, internal IPs, and filesystem paths an attacker loves. WebJs sanitizes production server-action errors so a thrown action returns a generic message plus a short `digest`, logs the full error server-side under that same digest (so you correlate the two and lose no debuggability), and sanitizes the streaming error frame the same way. Control-flow throws (`redirect()`, `notFound()`, `forbidden()`, `unauthorized()`) pass through untouched, a genuinely user-facing message belongs on the `ActionResult` envelope rather than a throw, and dev still shows you the real message. Just remember this guards the action boundary, so a hand-written `route.ts` is yours to secure.

--- a/blog/ssr-action-seeding-no-refetch.md
+++ b/blog/ssr-action-seeding-no-refetch.md
@@ -1,0 +1,75 @@
+---
+title: "No Double Fetch: Seeding SSR Data So Hydration Does Not Re-Request"
+date: 2026-06-05T13:00:00+05:30
+slug: ssr-action-seeding-no-refetch
+description: "The classic SSR double-fetch problem, where the server renders with data and the client hydrates and fetches the same data again. How WebJs eliminates it with automatic SSR action-result seeding, no props to pass down and no query-cache hydration boundary."
+tags: ssr, hydration, server-actions, performance, no-build
+author: Vivek
+---
+
+There is a bug that almost every server-rendered app has shipped at least once, and most never fully fix. The server renders a component with real data, sends the HTML, the browser paints it, and then the component hydrates and immediately fetches the exact same data all over again. The user already had the data on screen. The server already did the query. And now the client throws a second request at the network to fetch a copy of what it is already showing. That is the double fetch, and it costs you a wasted round trip, a possible flicker when the second result swaps in, and load on a server that had no reason to answer twice.
+
+I did not want WebJs to have this problem at all, and the fix is a feature you never have to think about. It is called SSR action-result seeding, and it landed in #472 and #486.
+
+# The old way, in any framework
+
+Here is the shape of the workaround everyone writes. In React or Next you fetch on the server, then you have to physically carry that data into the client so hydration does not refetch. Either you thread it down as props through every layer between the fetch and the component that needs it, or you stand up a query-cache hydration boundary and dehydrate and rehydrate the cache across the wire.
+
+```tsx
+// the manual version: fetch on the server, then pass it down by hand
+export default async function Page() {
+  const user = await getUser(uid);          // server fetch
+  return <UserProfile initialUser={user} />; // now prop-drill it in
+}
+
+function UserProfile({ initialUser }) {
+  const { data } = useQuery(['user', uid], () => fetchUser(uid), {
+    initialData: initialUser,               // and remember to seed the cache
+  });
+  // ...
+}
+```
+
+Every one of those lines is glue. The `initialUser` prop exists only to stop the refetch. The `initialData` option exists only to stop the refetch. If you forget either, it still works, it just quietly fetches twice, which is why this bug ships so often. The framework did the server fetch and then made carrying the result the application's job.
+
+# The WebJs way, which is no way at all
+
+In WebJs you write the fetch inside the component and pass nothing.
+
+```ts
+class UserProfile extends WebComponent({ uid: String }) {
+  async render() {
+    const user = await getUser(this.uid);   // a 'use server' action
+    return html`<h3>${user.name}</h3>`;
+  }
+}
+UserProfile.register('user-profile');
+```
+
+`getUser` is a `'use server'` action, so during SSR it runs on the server as the real function and its result is baked into the HTML. When this component ships to the browser and hydrates, its first call to `getUser(this.uid)` does not hit the network. It reads a seed that the server already put in the page. The query ran once, on the server, and the client reuses the result on its first render. No prop, no `initialData`, no cache boundary, no code.
+
+# What the framework is doing under the hood
+
+The mechanism is simple to state. Every `'use server'` action result computed during a non-streamed SSR render is serialized into the page. The generated client RPC stub, the typed stub WebJs rewrites your action import into, reads that serialized seed on its FIRST call for a given set of arguments. So the first client invocation is answered from the seed instead of the network.
+
+A few properties make it safe to leave on and forget about:
+
+- It is keyed by the action hash, the function name, and the serialized arguments. So the seed for `getUser(7)` is never handed to `getUser(9)`. The arguments have to match.
+- It is consume-once. The seed answers the first call and then it is spent. A later refetch, or a call with changed arguments, goes to the network like normal. Seeding removes the redundant hydration fetch, not real subsequent fetches.
+- It fails open. If a seed is missing for any reason, the stub degrades to a normal RPC call. A miss costs you a network request, never wrong data. There is no failure mode where a stale or mismatched seed gets served.
+
+And the way the seed is captured is worth calling out, because it is where a build-based framework would reach for a transform. WebJs captures it through a transparent server-side `'use server'` facade. There is no source transform and no build step. The file on disk is unchanged, and the source you see in the browser's network tab is unchanged. Nothing rewrites your code to inject an initial-data payload. The facade sits at the action boundary at runtime and records what SSR computed. It runs on Bun too (#529 and #534), same as on Node.
+
+# It composes with elision
+
+Seeding is one half of a two-part story, and the other half is that most of these components do not even ship. A display-only component, one that just fetches and renders with no click handlers, no signals, no interactivity, is elided entirely. Its server-rendered HTML is already the complete and final output, so WebJs drops its JavaScript module from the page. There is nothing left to hydrate, so there is nothing to refetch. The data is in the HTML and the browser gets zero client JavaScript for it.
+
+So think of it as a clean split. A display-only async component ships no JavaScript, which means no hydration and no second fetch by construction. Seeding is the safety net for the components that DO ship, the ones that are also interactive and therefore have to hydrate. Those hydrate without re-requesting the data SSR already fetched. Between the two, the double fetch has nowhere to live.
+
+# Turning it off
+
+It is on by default and there is rarely a reason to change that, but you can. Set `"webjs": { "seed": false }` in `package.json`, or `WEBJS_SEED=0` in the environment, and the stub always goes to the network on its first call. You would only reach for this to debug the RPC path in isolation. In normal operation the default is what you want.
+
+# The takeaway
+
+The double fetch is a bug that ships constantly because the fix in most frameworks is manual, an `initialData` you have to remember or a prop you have to thread, and forgetting it fails silently. WebJs eliminates it with SSR action-result seeding. Every `'use server'` result computed during SSR is serialized into the page, the client stub reads it on its first call keyed by action hash and function name and arguments, it is consume-once and fails open, and it is captured through a runtime facade with no source transform and no build step. Combine it with elision dropping the display-only components entirely and the picture is clean. The server already did the work, so the client does not redo it, and you wrote zero glue to make that true.

--- a/blog/websockets-and-realtime.md
+++ b/blog/websockets-and-realtime.md
@@ -1,0 +1,102 @@
+---
+title: "Real-Time WebJs: WebSockets and Broadcast Without a Separate Server"
+date: 2026-06-27T15:00:00+05:30
+slug: websockets-and-realtime
+description: "How WebJs adds real-time features with WebSockets folded into the file router: a WS export in route.ts, connectWS with auto-reconnect and queued sends on the client, and a broadcast built-in for fan-out, no separate WebSocket server required."
+tags: websockets, realtime, broadcast, routing, web-standards
+author: Vivek
+---
+
+The moment your app needs to feel alive, the ground shifts under you. A live chat. A little green "3 people viewing" presence dot. A cursor gliding across a shared document. All of these need the server to push to the browser without the browser asking first, which a normal HTTP request cannot do. HTTP is a question-and-answer format: the client asks, the server answers, the line closes.
+
+A WebSocket is the fix. It is a connection that stays open in both directions, so the server can send you a message the instant something happens, and you can send one back, all over the same pipe. Great. Except in most stacks, adding one means standing up a second server.
+
+That is the part I always found deflating. You already have an app with routing and auth and sessions, and now you bolt a separate WebSocket process next to it and re-wire all of that by hand. Which user is this socket? What route does it belong to? Is it allowed to be here? You answer those questions once for HTTP and then answer them all over again, differently, for the socket server. WebJs skips the second server entirely.
+
+
+# The old way: a socket server living next door
+
+Here is the shape of the pain, roughly. You install a WebSocket library, create its server, and run it alongside your app, often on another port.
+
+```ts
+// a whole separate process, more or less
+import { WebSocketServer } from 'ws';
+
+const wss = new WebSocketServer({ port: 3001 });
+
+wss.on('connection', (socket, req) => {
+  // Which user is this? Your app knows. This server does not.
+  // Re-parse cookies, re-validate the session, re-check the route...
+  socket.on('message', (data) => {
+    // and now fan this out to everyone else, which you also build by hand
+  });
+});
+```
+
+Nothing here is exotic, but every line is a small re-implementation of something your app already does. The socket server does not share your routing, so a connection to `/chat/42` is just a string you parse yourself. It does not share your auth, so you re-derive the user. And it runs beside your app, so now you have two things to deploy, two things to scale, and two things to keep from drifting apart.
+
+
+# The WebJs way: a WS export in the same route file
+
+WebJs folds WebSockets into the file router you already use for pages and HTTP handlers. A `route.{js,ts}` file can export named HTTP methods like `GET` and `POST`, and it can also export a `WS` function. That function defines a WebSocket endpoint at exactly that path, sitting right next to (or instead of) the HTTP handlers.
+
+```js
+// app/api/chat/route.js
+export function WS(ws, req, { params }) {
+  ws.on('message', (data) => ws.send('echo:' + data));
+  ws.on('close', () => { /* cleanup */ });
+}
+```
+
+A socket at `/api/chat` is now a file at `app/api/chat/route.js`, the same way a page at `/about` is a file at `app/about/page.js`. The `params` argument is the same route-params object your dynamic routes get, so a socket at `app/room/[id]/route.js` reads `params.id` with no string parsing. There is no second server, no second port, no second deploy. The endpoint lives inside the app that already knows your routes.
+
+One dev-mode detail worth knowing. In development the module re-imports on each new connection so it picks up your edits without a restart. That means you cannot keep shared state (like the set of connected clients) in a module-level variable, because it would reset per connection. Park it on `globalThis` instead:
+
+```js
+const clients = globalThis.__chat_clients ?? (globalThis.__chat_clients = new Set());
+```
+
+
+# The client: connectWS, and why queued sends matter
+
+On the browser side you open the socket with `connectWS(url, handlers)` from `@webjsdev/core`.
+
+```ts
+import { connectWS } from '@webjsdev/core';
+
+const socket = connectWS('/api/chat', {
+  onOpen: () => console.log('connected'),
+  onMessage: (msg) => appendMessage(msg),
+  onClose: () => console.log('gone'),
+});
+```
+
+Two things it does for you that you would otherwise hand-roll. It auto-reconnects with exponential backoff, which means when the connection drops (a phone leaving a tunnel, a laptop lid closing, a flaky cafe network) it quietly tries again, waiting a little longer between each attempt so it does not hammer a struggling server. And it queues sends while disconnected. If your code calls send during that brief dead window, the message is not thrown away; it is held and flushed the instant the socket comes back. It also JSON-encodes and decodes for you, so you send and receive objects, not strings.
+
+Those two behaviors are exactly the fiddly bits people get wrong when they wire a raw socket by hand, which is why baking them in matters. Real networks are unreliable, and a chat that silently loses the message you sent at the wrong half-second is worse than no chat.
+
+
+# Fan-out: the broadcast built-in
+
+A live feature is rarely one client talking to the server. It is one client's action showing up on everyone else's screen. That is fan-out, or broadcast: take one message and push it to every connected client on a channel. WebJs ships a `broadcast` helper in `@webjsdev/server` so you do not build the "who else is connected" bookkeeping yourself.
+
+```js
+import { broadcast } from '@webjsdev/server';
+
+export function WS(ws, req) {
+  ws.on('message', (data) => {
+    broadcast('/api/chat', data);  // to every client connected on this path
+  });
+}
+```
+
+The first argument is the channel (here just the path), and everyone connected to it receives the message. This same primitive powers presence indicators and notifications, not just chat, because they are all the same shape underneath: something happened, tell everyone watching.
+
+It also composes with WebJs's server-push rendering. A route can build a `<webjs-stream>` HTML fragment and `broadcast` it, and every viewer's client applies the DOM update with no custom handler, the same applier the client router already uses. So "a new comment appears live for everyone reading the post" is a broadcast of a rendered fragment, not a bespoke client script.
+
+One honest limit. The built-in `broadcast` is single-instance: it fans out to the clients connected to this one server process. When you scale to multiple instances behind a load balancer, you add Redis pub/sub yourself to bridge them. WebJs does not hide that behind magic, and I would rather it be upfront about the boundary than pretend a single-process broadcast scales horizontally on its own.
+
+
+# The takeaway
+
+Real-time features usually mean a second server that re-implements your app's routing and auth just to hold an open connection. WebJs folds WebSockets into the same file router: a `WS(ws, req, { params })` export in a `route.{js,ts}` file defines a socket endpoint at that path, with the same route params your pages get and no separate process to deploy. On the client, `connectWS` gives you auto-reconnect and queued sends so a dropped connection does not lose a message, and `broadcast` fans one message out to every connected client for chat, presence, or live updates. It is single-instance out of the box (add Redis pub/sub when you scale past one process), but the everyday version, the one you build to make an app feel alive, is a file next to your pages instead of a server next to your app.


### PR DESCRIPTION
Adds 12 blog posts under `blog/` covering features that shipped without a post yet. Each is a distinct high search-intent topic, checked against the existing 29 posts to avoid direct or indirect duplication.

## Posts (12)
| Slug | Date | Backing |
|---|---|---|
| component-suspense-streaming | 2026-05-30 | #470/#471 |
| native-sqlite-node-and-bun | 2026-06-03 | #670 |
| ssr-action-seeding-no-refetch | 2026-06-05 | #472 |
| bun-serve-vs-node-http | 2026-06-07 | #512/#773 |
| file-uploads-and-storage | 2026-06-10 | #247 |
| cancel-server-actions-abortsignal | 2026-06-15 | #492 |
| per-action-middleware | 2026-06-17 | #490 |
| websockets-and-realtime | 2026-06-27 | advanced.md |
| import-only-pages-zero-js | 2026-07-03 | #605/#609 |
| device-adaptive-link-prefetch | 2026-07-04 | #594 |
| sanitizing-server-action-errors | 2026-07-07 | #749/#764 |
| nextjs-16-file-routing-parity | 2026-07-08 | #848 |

## De-duplication
Two initial drafts were dropped as duplicates of published posts and replaced:
- path-aliases (duplicate of `fix-relative-import-paths`) replaced by **file-uploads-and-storage**
- http-verb-server-actions (duplicate of `get-server-actions-caching`) replaced by **websockets-and-realtime**

`bun-serve-vs-node-http` and `import-only-pages-zero-js` were refocused to stay distinct from `node-and-bun-no-build` and `ship-zero-javascript-display-only-components` respectively (companion cross-links, no re-explaining).

## Notes
- Dates interleave into the existing timeline with an even cadence; no existing dates needed changing.
- All prose passes the em-dash / pause-punctuation invariant (hook-verified).
- Content-only (no `src`), so the doc/scaffold/test commit gates do not apply.

Closes #874

https://claude.ai/code/session_01A9agkAXwoKqXPY2DseWoA4