### PR TITLE
chore: release server 0.8.46, cli 0.10.36

### DIFF
--- a/changelog/cli/0.10.36.md
+++ b/changelog/cli/0.10.36.md
@@ -1,0 +1,17 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.36
+date: 2026-07-09T14:00:00.000Z
+commit_count: 4
+---
+## Features
+
+- **close coverage-gate deferred gaps with real scaffold demos** ([#870](https://github.com/webjsdev/webjs/pull/870)) [`e62d7e41`](https://github.com/webjsdev/webjs/commit/e62d7e41)
+- **add a tier-2 scaffold teaching-coverage gate for core exports** ([#861](https://github.com/webjsdev/webjs/pull/861)) [`35d180d2`](https://github.com/webjsdev/webjs/commit/35d180d2)
+- **add a boundaries gallery demo and harden the scaffold-sync skill** ([#854](https://github.com/webjsdev/webjs/pull/854)) [`5f7bd1f0`](https://github.com/webjsdev/webjs/commit/5f7bd1f0)
+
+## Fixes
+
+- **fresh saas scaffold passes typecheck and axe out of the box (#877, #878)** ([#879](https://github.com/webjsdev/webjs/pull/879)) [`72bb3611`](https://github.com/webjsdev/webjs/commit/72bb3611)
+  * Rewrite the `onBeforeCache` import to `#lib/utils/dom.ts` (it kept a registry-relative `../lib/dom.ts` and failed TS2307), and resolve `AUTH_SECRET` through a typed const with a production fail-fast guard (it was assigned as `string | undefined` to a required `string`).
+  * Give every generated page exactly one `<h1>`, raise the gallery label text to full `text-muted-foreground` contrast, and add accessible names to the file-upload and ref-focus inputs, so a fresh app returns zero axe violations.

--- a/changelog/server/0.8.46.md
+++ b/changelog/server/0.8.46.md
@@ -1,0 +1,11 @@
+---
+package: "@webjsdev/server"
+version: 0.8.46
+date: 2026-07-09T14:00:00.000Z
+commit_count: 1
+---
+## Fixes
+
+- **route(module) auto-applies an action's declared middleware and validate (#876)** ([#879](https://github.com/webjsdev/webjs/pull/879)) [`72bb3611`](https://github.com/webjsdev/webjs/commit/72bb3611)
+  * The `route()` REST adapter only ran the `middleware` / `validate` passed via its `opts`, so an action's declared `export const middleware` protected the RPC boundary but not the REST one (a function reference cannot reach its sibling config exports).
+  * `route()` now also accepts the action's module namespace (`import * as postActions from '...'; export const POST = route(postActions)`) and auto-applies the declared `middleware` and `validate`, so a guard declared once beside the action protects both boundaries. The bare-function form is unchanged, and an explicit `opts` value still overrides the declared config.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6975,7 +6975,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.33",
+      "version": "0.10.36",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -6991,7 +6991,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.30",
+      "version": "0.7.32",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.25.0"
@@ -7039,7 +7039,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.43",
+      "version": "0.8.46",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.35",
+  "version": "0.10.36",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.45",
+  "version": "0.8.46",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Release the accumulated unreleased work on `@webjsdev/server` and `@webjsdev/cli`. Merging this adds the `changelog/**.md` files to `main`, which triggers `release.yml` to `npm publish` both packages and cut GitHub Releases.

## @webjsdev/server 0.8.45 -> 0.8.46 (patch)
- **fix (#876):** `route()` now accepts the action's module namespace and auto-applies its declared `middleware` + `validate`, so a guard declared once protects the RPC and REST boundaries alike (from #879).

## @webjsdev/cli 0.10.35 -> 0.10.36 (patch)
- **fix (#877, #878):** fresh saas scaffold passes `webjs typecheck` and returns zero axe violations out of the box (from #879).
- **feat (#870):** close coverage-gate deferred gaps with real scaffold demos.
- **feat (#861):** tier-2 scaffold teaching-coverage gate for core exports.
- **feat (#854):** boundaries gallery demo + hardened scaffold-sync skill.

## Not bumped (checked all published packages)
- **core, mcp, intellisense:** only carry the cosmetic WebJs brand-casing prose change (#855) and a docs commit (#851); no behaviour change, so they ride to the next functional bump.
- **ui:** the one unreleased commit (#862) touched only `packages/ui/packages/website` (the nested website), not the published `@webjsdev/ui` surface.

## Notes
- Both bumps are patch and stay within the existing `^0.8.0` / `^0.10.0` dependent caret ranges, so no dependent range edits.
- `package-lock.json` resynced (it was stale on main). The diff is three workspace version lines: server -> 0.8.46 and cli -> 0.10.36 (the bumps), plus core 0.7.30 -> 0.7.32 correcting the lockfile to core's already-current package.json (core itself is NOT re-released; only the server and cli changelog files trigger a publish).
- The lockstep wrappers (create-webjs, webjsdev) are intentionally NOT bumped here; `release.yml` owns them.

Changelogs: `changelog/server/0.8.46.md`, `changelog/cli/0.10.36.md`.
