### PR TITLE
fix: multi-tab dev live-reload + no empty-CSS on hot reload

### DIFF
--- a/packages/server/src/dev-reload-worker.js
+++ b/packages/server/src/dev-reload-worker.js
@@ -1,0 +1,53 @@
+/**
+ * The dev live-reload SharedWorker relay (#887), the BROWSER half. Kept as a
+ * standalone browser-safe module (no node imports) so the served worker inlines
+ * the EXACT source a browser test drives, with no drift, the same pattern as
+ * `dev-overlay.js` (#264). `reloadWorkerJs` in dev.js reads this file, strips
+ * the `export` keyword, and appends a
+ * `startReloadWorker(self, EventSource, '<eventsUrl>')` call.
+ *
+ * One SharedWorker is shared across every tab of the origin (a SharedWorker is
+ * keyed by its script URL), so it holds the ONE `EventSource` to
+ * `/__webjs/events` and fans each `reload` / `webjs-error` out to every tab over
+ * its `MessagePort`. Tab count never touches the browser's per-host HTTP/1.1
+ * connection cap, which the per-tab `EventSource` it replaces used to exhaust.
+ *
+ * @param {{ onconnect: any }} scope  the worker global (`self`)
+ * @param {new (url: string) => any} EventSourceCtor  the `EventSource` constructor
+ * @param {string} eventsUrl  the base-path-aware `/__webjs/events` URL
+ */
+export function startReloadWorker(scope, EventSourceCtor, eventsUrl) {
+  /** @type {Set<any>} */
+  const ports = new Set();
+  /** @type {string | null} the last error frame, cached for late-joining tabs */
+  let lastError = null;
+
+  // A MessagePort has no reliable close event, so prune a port when a post to it
+  // throws (a closed tab). Some browsers silently no-op instead of throwing,
+  // leaving a dead port in the set, but that is a harmless dev-only no-op and
+  // the set is bounded by the tabs opened in one session.
+  function fanout(msg) {
+    for (const p of ports) {
+      try { p.postMessage(msg); } catch (_) { ports.delete(p); }
+    }
+  }
+
+  const es = new EventSourceCtor(eventsUrl);
+  es.addEventListener('reload', () => { lastError = null; fanout({ type: 'reload' }); });
+  es.addEventListener('webjs-error', (e) => { lastError = e.data; fanout({ type: 'webjs-error', data: e.data }); });
+
+  scope.onconnect = (e) => {
+    const port = e.ports[0];
+    ports.add(port);
+    port.start();
+    // A tab that connects AFTER a breaking edit still needs the current overlay.
+    // The single shared EventSource already consumed the server's replay (#264),
+    // so the worker caches the last error and hands it to each new tab itself.
+    if (lastError != null) {
+      try { port.postMessage({ type: 'webjs-error', data: lastError }); } catch (_) { ports.delete(port); }
+    }
+  };
+
+  // Returned for tests; the served worker ignores it.
+  return { ports, es };
+}

--- a/packages/server/src/dev.js
+++ b/packages/server/src/dev.js
@@ -2272,12 +2272,17 @@ async function fileResponse(abs, opts) {
     // In dev an external watcher (tailwindcss --watch, esbuild, ...) rewrites a
     // public asset with truncate-then-write, so the file is 0 bytes for a short
     // window during a rebuild. A hot reload that lands in that window would
-    // serve empty CSS / JS and the page paints unstyled (#891). Ride over the
-    // mid-rewrite: re-read a few times before giving up, so a truncated read
-    // never reaches the browser. Bounded, so a genuinely empty file still serves
-    // (after a short delay). Prod has no such watcher and is left untouched.
+    // serve empty CSS / JS and the page paints unstyled (#891). Close that
+    // 0-byte window: when an empty read comes from a file that was JUST modified
+    // (the mid-rewrite signal), re-read a few times so the truncated read does
+    // not reach the browser. A genuinely empty, untouched asset is served
+    // immediately (no delay), and a non-zero-but-partial write is a smaller
+    // residual gap this does not cover. Prod has no such watcher and is
+    // left untouched.
     if (opts.dev && data.length === 0) {
-      for (let i = 0; i < 12 && data.length === 0; i++) {
+      let midRewrite = false;
+      try { midRewrite = Date.now() - (await stat(abs)).mtimeMs < 500; } catch { /* gone */ }
+      for (let i = 0; midRewrite && i < 12 && data.length === 0; i++) {
         await new Promise((r) => setTimeout(r, 20));
         try { data = await readFile(abs); } catch { break; }
       }
@@ -2693,15 +2698,16 @@ function reloadWorkerJs(bp) {
   return `// webjs dev reload worker (one shared connection for all tabs)
 const ports = new Set();
 let lastError = null;
+// A MessagePort has no reliable close event, so we prune a port when a post to
+// it throws (a closed tab). Some browsers silently no-op instead of throwing,
+// which leaves a dead port in the set, but that is a harmless dev-only no-op and
+// the set is bounded by the tabs opened in one session.
+function fanout(msg) {
+  for (const p of ports) { try { p.postMessage(msg); } catch (_) { ports.delete(p); } }
+}
 const es = new EventSource(${JSON.stringify(withBasePath('/__webjs/events', bp))});
-es.addEventListener('reload', () => {
-  lastError = null;
-  for (const p of ports) { try { p.postMessage({ type: 'reload' }); } catch (_) {} }
-});
-es.addEventListener('webjs-error', (e) => {
-  lastError = e.data;
-  for (const p of ports) { try { p.postMessage({ type: 'webjs-error', data: e.data }); } catch (_) {} }
-});
+es.addEventListener('reload', () => { lastError = null; fanout({ type: 'reload' }); });
+es.addEventListener('webjs-error', (e) => { lastError = e.data; fanout({ type: 'webjs-error', data: e.data }); });
 self.onconnect = (e) => {
   const port = e.ports[0];
   ports.add(port);

--- a/packages/server/src/dev.js
+++ b/packages/server/src/dev.js
@@ -2268,7 +2268,20 @@ async function sendWebResponse(res, webRes, req, opts) {
  */
 async function fileResponse(abs, opts) {
   try {
-    const data = await readFile(abs);
+    let data = await readFile(abs);
+    // In dev an external watcher (tailwindcss --watch, esbuild, ...) rewrites a
+    // public asset with truncate-then-write, so the file is 0 bytes for a short
+    // window during a rebuild. A hot reload that lands in that window would
+    // serve empty CSS / JS and the page paints unstyled (#891). Ride over the
+    // mid-rewrite: re-read a few times before giving up, so a truncated read
+    // never reaches the browser. Bounded, so a genuinely empty file still serves
+    // (after a short delay). Prod has no such watcher and is left untouched.
+    if (opts.dev && data.length === 0) {
+      for (let i = 0; i < 12 && data.length === 0; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        try { data = await readFile(abs); } catch { break; }
+      }
+    }
     const type = MIME[extname(abs).toLowerCase()] || 'application/octet-stream';
     // The body is fully buffered (read into `data`), so opt it into the
     // conditional-GET funnel, which is the single place that hashes the bytes

--- a/packages/server/src/dev.js
+++ b/packages/server/src/dev.js
@@ -1745,6 +1745,14 @@ async function tryServeFrameworkStatic(path, method, ctx) {
     });
   }
 
+  // Dev live-reload SharedWorker: one shared connection for all tabs (#887).
+  if (path === '/__webjs/reload-worker.js') {
+    if (!dev) return new Response('Not found', { status: 404 });
+    return new Response(reloadWorkerJs(basePath()), {
+      headers: { 'content-type': 'application/javascript; charset=utf-8' },
+    });
+  }
+
   // Core module: /__webjs/core/*
   //
   // ETag + ~1h max-age, NOT immutable. The URL path is un-versioned
@@ -1822,7 +1830,8 @@ async function handleCore(req, ctx) {
 
   // Health / readiness probes (`/__webjs/health`, `/__webjs/ready`) and the
   // framework-internal static assets (`/__webjs/core/*`, `/__webjs/reload.js`,
-  // downloaded `/__webjs/vendor/*`) are served in `handle()` BEFORE ensureReady,
+  // `/__webjs/reload-worker.js`, downloaded `/__webjs/vendor/*`) are served in
+  // `handle()` BEFORE ensureReady,
   // so they are not repeated here. This fallback covers the (currently
   // unreachable) case of handleCore being entered for one of those assets, so
   // the routing stays correct if a future caller bypasses the early path.
@@ -2614,13 +2623,80 @@ function reloadClientJs(bp) {
   // error message / code frame can never inject markup (#264). Served only in
   // dev (the /__webjs/reload.js branch 404s in prod), so it never reaches a
   // production page.
+  //
+  // Every tab shares ONE live-reload connection through a SharedWorker (#887).
+  // The old client opened an `EventSource` per tab, and because the dev server
+  // is HTTP/1.1 and browsers cap concurrent connections per host at ~6, a
+  // handful of open tabs would hold every connection slot with idle SSE streams
+  // and later tabs could not even fetch their HTML. The SharedWorker holds the
+  // single `EventSource` (see reloadWorkerJs) and relays each `reload` /
+  // `webjs-error` to every tab. The overlay still renders on the main thread
+  // (a worker has no DOM), so the worker forwards only the raw frame data.
+  //
+  // Fallback: where `SharedWorker` is missing (some mobile browsers) or its
+  // construction throws (a strict dev CSP without `worker-src`), each tab opens
+  // its own `EventSource`, the original behaviour. Correct, just not shared.
+  const eventsUrl = JSON.stringify(withBasePath('/__webjs/events', bp));
+  const workerUrl = JSON.stringify(withBasePath('/__webjs/reload-worker.js', bp));
   return `// webjs dev reload client
 ${DEV_OVERLAY_SRC}
-const es = new EventSource(${JSON.stringify(withBasePath('/__webjs/events', bp))});
-es.addEventListener('reload', () => location.reload());
-es.addEventListener('webjs-error', (e) => {
-  let f; try { f = JSON.parse(e.data); } catch (_) { return; }
+function __webjsApplyError(data) {
+  let f; try { f = JSON.parse(data); } catch (_) { return; }
   renderDevOverlay(f);
+}
+function __webjsDirectEvents() {
+  const es = new EventSource(${eventsUrl});
+  es.addEventListener('reload', () => location.reload());
+  es.addEventListener('webjs-error', (e) => __webjsApplyError(e.data));
+}
+try {
+  if (typeof SharedWorker !== 'undefined') {
+    const w = new SharedWorker(${workerUrl});
+    w.port.onmessage = (e) => {
+      const m = e.data || {};
+      if (m.type === 'reload') location.reload();
+      else if (m.type === 'webjs-error') __webjsApplyError(m.data);
+    };
+    w.port.start();
+  } else {
+    __webjsDirectEvents();
+  }
+} catch (_) {
+  __webjsDirectEvents();
+}
+`;
+}
+
+/**
+ * The dev live-reload SharedWorker. One instance is shared across every tab of
+ * the same origin (a SharedWorker is keyed by its script URL), so it holds the
+ * ONE `EventSource` to `/__webjs/events` and fans each event out to all tabs
+ * over their `MessagePort`s (#887). The `EventSource` URL carries the base path
+ * the same way the client's does (#256). Served only in dev.
+ * @param {string} bp the normalized base path (`''` = no-op)
+ * @returns {string}
+ */
+function reloadWorkerJs(bp) {
+  return `// webjs dev reload worker (one shared connection for all tabs)
+const ports = new Set();
+let lastError = null;
+const es = new EventSource(${JSON.stringify(withBasePath('/__webjs/events', bp))});
+es.addEventListener('reload', () => {
+  lastError = null;
+  for (const p of ports) { try { p.postMessage({ type: 'reload' }); } catch (_) {} }
 });
+es.addEventListener('webjs-error', (e) => {
+  lastError = e.data;
+  for (const p of ports) { try { p.postMessage({ type: 'webjs-error', data: e.data }); } catch (_) {} }
+});
+self.onconnect = (e) => {
+  const port = e.ports[0];
+  ports.add(port);
+  port.start();
+  // A tab that connects AFTER a breaking edit still needs the current overlay.
+  // The single shared EventSource already consumed the server's replay (#264),
+  // so the worker caches the last error and hands it to each new tab itself.
+  if (lastError != null) { try { port.postMessage({ type: 'webjs-error', data: lastError }); } catch (_) {} }
+};
 `;
 }

--- a/packages/server/src/dev.js
+++ b/packages/server/src/dev.js
@@ -2636,6 +2636,13 @@ function locatePackageDir(appDir, pkgName) {
 const DEV_OVERLAY_SRC = readFileSync(new URL('./dev-overlay.js', import.meta.url), 'utf8')
   .replace(/^export /gm, '');
 
+// The reload SharedWorker relay source (#887), read once + `export`-stripped so
+// it inlines into the served worker script. Sharing the one source
+// (`dev-reload-worker.js`, which the browser test imports directly) means the
+// test drives the EXACT relay code that ships, with no drift (same as #264).
+const RELOAD_WORKER_SRC = readFileSync(new URL('./dev-reload-worker.js', import.meta.url), 'utf8')
+  .replace(/^export /gm, '');
+
 function reloadClientJs(bp) {
   // The overlay renderer uses textContent throughout (never innerHTML), so the
   // error message / code frame can never inject markup (#264). Served only in
@@ -2696,26 +2703,7 @@ try {
  */
 function reloadWorkerJs(bp) {
   return `// webjs dev reload worker (one shared connection for all tabs)
-const ports = new Set();
-let lastError = null;
-// A MessagePort has no reliable close event, so we prune a port when a post to
-// it throws (a closed tab). Some browsers silently no-op instead of throwing,
-// which leaves a dead port in the set, but that is a harmless dev-only no-op and
-// the set is bounded by the tabs opened in one session.
-function fanout(msg) {
-  for (const p of ports) { try { p.postMessage(msg); } catch (_) { ports.delete(p); } }
-}
-const es = new EventSource(${JSON.stringify(withBasePath('/__webjs/events', bp))});
-es.addEventListener('reload', () => { lastError = null; fanout({ type: 'reload' }); });
-es.addEventListener('webjs-error', (e) => { lastError = e.data; fanout({ type: 'webjs-error', data: e.data }); });
-self.onconnect = (e) => {
-  const port = e.ports[0];
-  ports.add(port);
-  port.start();
-  // A tab that connects AFTER a breaking edit still needs the current overlay.
-  // The single shared EventSource already consumed the server's replay (#264),
-  // so the worker caches the last error and hands it to each new tab itself.
-  if (lastError != null) { try { port.postMessage({ type: 'webjs-error', data: lastError }); } catch (_) {} }
-};
+${RELOAD_WORKER_SRC}
+startReloadWorker(self, EventSource, ${JSON.stringify(withBasePath('/__webjs/events', bp))});
 `;
 }

--- a/packages/server/test/dev/browser/reload-worker.test.js
+++ b/packages/server/test/dev/browser/reload-worker.test.js
@@ -1,0 +1,78 @@
+/**
+ * Real-browser tests for the dev live-reload SharedWorker relay (#887).
+ *
+ * `dev-reload-worker.js` is the BROWSER half of the shared live-reload
+ * connection: the exact source the served worker inlines (`reloadWorkerJs` reads
+ * this file, strips `export`, and appends the `startReloadWorker(...)` call), so
+ * driving it here tests the code that ships. The headline acceptance ("one
+ * shared connection fans every reload / error out to every tab, and a
+ * late-joining tab still gets the current error") is browser-observable, so it
+ * runs in a real browser. The relay is driven with a fake EventSource + fake
+ * MessagePorts so it needs no live SSE server.
+ */
+import { startReloadWorker } from '../../../src/dev-reload-worker.js';
+
+const assert = {
+  ok: (v, msg) => { if (!v) throw new Error(msg || `Expected truthy, got ${v}`); },
+  equal: (a, b, msg) => { if (a !== b) throw new Error(msg || `Expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}`); },
+  deepEqual: (a, b, msg) => { if (JSON.stringify(a) !== JSON.stringify(b)) throw new Error(msg || `Expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}`); },
+};
+
+class FakeEventSource {
+  constructor(url) { this.url = url; this._l = {}; FakeEventSource.last = this; }
+  addEventListener(type, cb) { (this._l[type] || (this._l[type] = [])).push(cb); }
+  fire(type, data) { (this._l[type] || []).forEach((cb) => cb({ data })); }
+}
+
+function fakePort() {
+  const received = [];
+  return { received, port: { start() {}, postMessage(m) { received.push(m); } } };
+}
+
+suite('dev reload SharedWorker relay (#887)', () => {
+  test('fans a reload out to every connected tab (one connection, many tabs)', () => {
+    const scope = {};
+    startReloadWorker(scope, FakeEventSource, '/__webjs/events');
+    const a = fakePort();
+    const b = fakePort();
+    scope.onconnect({ ports: [a.port] });
+    scope.onconnect({ ports: [b.port] });
+    FakeEventSource.last.fire('reload');
+    assert.deepEqual(a.received, [{ type: 'reload' }], 'tab A reloaded');
+    assert.deepEqual(b.received, [{ type: 'reload' }], 'tab B reloaded from the same worker');
+  });
+
+  test('relays an error frame to every connected tab', () => {
+    const scope = {};
+    startReloadWorker(scope, FakeEventSource, '/__webjs/events');
+    const a = fakePort();
+    scope.onconnect({ ports: [a.port] });
+    FakeEventSource.last.fire('webjs-error', 'FRAME_JSON');
+    assert.deepEqual(a.received, [{ type: 'webjs-error', data: 'FRAME_JSON' }]);
+  });
+
+  test('caches the error and replays it to a tab that connects later', () => {
+    const scope = {};
+    startReloadWorker(scope, FakeEventSource, '/__webjs/events');
+    FakeEventSource.last.fire('webjs-error', 'FRAME_JSON'); // error before the tab opens
+    const late = fakePort();
+    scope.onconnect({ ports: [late.port] });
+    assert.deepEqual(late.received, [{ type: 'webjs-error', data: 'FRAME_JSON' }], 'a late tab still shows the overlay');
+  });
+
+  test('clears the cached error on reload so a later tab does not see a stale overlay', () => {
+    const scope = {};
+    startReloadWorker(scope, FakeEventSource, '/__webjs/events');
+    FakeEventSource.last.fire('webjs-error', 'FRAME_JSON');
+    FakeEventSource.last.fire('reload'); // the fix landed
+    const late = fakePort();
+    scope.onconnect({ ports: [late.port] });
+    assert.equal(late.received.length, 0, 'no stale error replayed after a reload');
+  });
+
+  test('connects the single EventSource at the given events URL', () => {
+    const scope = {};
+    const { es } = startReloadWorker(scope, FakeEventSource, '/base/__webjs/events');
+    assert.equal(es.url, '/base/__webjs/events', 'the one connection uses the base-path-aware URL');
+  });
+});

--- a/packages/server/test/dev/reload-shared-connection.test.js
+++ b/packages/server/test/dev/reload-shared-connection.test.js
@@ -52,11 +52,12 @@ test('dev serves the reload SharedWorker, and the client uses it with a direct E
   assert.equal(worker.status, 200);
   assert.match(worker.headers.get('content-type') || '', /javascript/);
   const workerSrc = await worker.text();
-  assert.match(workerSrc, /new EventSource\(.*__webjs\/events/, 'the worker holds the single events stream');
-  assert.match(workerSrc, /self\.onconnect/, 'the worker accepts a port per tab');
-  assert.match(workerSrc, /postMessage\(\{ type: 'reload' \}\)/, 'the worker relays reload to every port');
-  assert.match(workerSrc, /postMessage\(\{ type: 'webjs-error'/, 'the worker relays the error frame');
-  assert.match(workerSrc, /lastError = null/, 'the worker clears the cached error on reload');
+  // The worker inlines the shared relay module and bootstraps it with the real
+  // globals (the relay behaviour itself is exercised in the browser test).
+  assert.match(workerSrc, /function startReloadWorker/, 'the worker inlines the relay module');
+  assert.match(workerSrc, /startReloadWorker\(self, EventSource, "\/__webjs\/events"\)/, 'it wires the single events stream to the worker');
+  assert.match(workerSrc, /scope\.onconnect/, 'the relay accepts a port per tab');
+  assert.match(workerSrc, /lastError = null/, 'the relay clears the cached error on reload');
   assert.match(workerSrc, /if \(lastError != null\)/, 'a late-joining tab gets the current error');
 });
 
@@ -73,7 +74,7 @@ test('the worker events URL carries the base path under a sub-path deploy (#256)
   const appDir = makeApp({ basePath: '/app' });
   const app = await createRequestHandler({ appDir, dev: true });
   const worker = await (await app.handle(new Request('http://x/app/__webjs/reload-worker.js'))).text();
-  assert.match(worker, /new EventSource\("\/app\/__webjs\/events"\)/, 'events URL is base-path prefixed in the worker');
+  assert.match(worker, /startReloadWorker\(self, EventSource, "\/app\/__webjs\/events"\)/, 'events URL is base-path prefixed in the worker');
   const client = await (await app.handle(new Request('http://x/app/__webjs/reload.js'))).text();
   assert.match(client, /reload-worker\.js/, 'client references the worker');
   assert.match(client, /\/app\/__webjs\/reload-worker\.js/, 'worker URL is base-path prefixed in the client');

--- a/packages/server/test/dev/reload-shared-connection.test.js
+++ b/packages/server/test/dev/reload-shared-connection.test.js
@@ -1,0 +1,80 @@
+/**
+ * The dev live-reload client shares ONE connection across all tabs via a
+ * SharedWorker (#887). Before this, each tab opened its own `EventSource`, and
+ * on an HTTP/1.1 dev server the browser's ~6-connections-per-host cap meant a
+ * handful of open tabs held every slot with idle SSE streams and later tabs
+ * could not fetch their HTML. Here we drive the two dev routes directly through
+ * the handler (no browser needed; the served scripts are pure strings) and
+ * assert the client uses the SharedWorker with an EventSource fallback and the
+ * worker holds the single stream and relays to every port.
+ */
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { createRequestHandler } from '../../src/dev.js';
+
+let tmpRoot;
+before(() => { tmpRoot = mkdtempSync(join(tmpdir(), 'webjs-reload-')); });
+after(() => { rmSync(tmpRoot, { recursive: true, force: true }); });
+
+function makeApp(webjs) {
+  const appDir = mkdtempSync(join(tmpRoot, 'app-'));
+  mkdirSync(join(appDir, 'app'), { recursive: true });
+  writeFileSync(join(appDir, 'app', 'page.js'), "export default function P() { return 'ok'; }\n");
+  if (webjs) writeFileSync(join(appDir, 'package.json'), JSON.stringify({ name: 'x', webjs }));
+  return appDir;
+}
+
+test('dev serves the reload SharedWorker, and the client uses it with a direct EventSource fallback', async () => {
+  const appDir = makeApp();
+  const app = await createRequestHandler({ appDir, dev: true });
+
+  const client = await app.handle(new Request('http://x/__webjs/reload.js'));
+  assert.equal(client.status, 200);
+  assert.match(client.headers.get('content-type') || '', /javascript/);
+  const clientSrc = await client.text();
+  // The primary path is one shared connection through the SharedWorker.
+  assert.match(clientSrc, /new SharedWorker\(/, 'client constructs a SharedWorker');
+  assert.match(clientSrc, /reload-worker\.js/, 'client points the worker at the worker route');
+  // The fallback keeps the original per-tab EventSource where SharedWorker is
+  // unavailable, and the whole thing is guarded so a construction failure (a
+  // strict dev CSP) degrades instead of breaking.
+  assert.match(clientSrc, /typeof SharedWorker/, 'client feature-detects SharedWorker');
+  assert.match(clientSrc, /new EventSource\(/, 'client keeps an EventSource fallback');
+  assert.match(clientSrc, /catch\s*\(_\)\s*\{\s*__webjsDirectEvents/, 'a worker failure falls back');
+  // The overlay still renders on the main thread (a worker has no DOM).
+  assert.match(clientSrc, /renderDevOverlay/, 'the error overlay still renders in the client');
+
+  const worker = await app.handle(new Request('http://x/__webjs/reload-worker.js'));
+  assert.equal(worker.status, 200);
+  assert.match(worker.headers.get('content-type') || '', /javascript/);
+  const workerSrc = await worker.text();
+  assert.match(workerSrc, /new EventSource\(.*__webjs\/events/, 'the worker holds the single events stream');
+  assert.match(workerSrc, /self\.onconnect/, 'the worker accepts a port per tab');
+  assert.match(workerSrc, /postMessage\(\{ type: 'reload' \}\)/, 'the worker relays reload to every port');
+  assert.match(workerSrc, /postMessage\(\{ type: 'webjs-error'/, 'the worker relays the error frame');
+  assert.match(workerSrc, /lastError = null/, 'the worker clears the cached error on reload');
+  assert.match(workerSrc, /if \(lastError != null\)/, 'a late-joining tab gets the current error');
+});
+
+test('both reload routes 404 in prod (never shipped to a production page)', async () => {
+  const appDir = makeApp();
+  const app = await createRequestHandler({ appDir, dev: false });
+  const client = await app.handle(new Request('http://x/__webjs/reload.js'));
+  const worker = await app.handle(new Request('http://x/__webjs/reload-worker.js'));
+  assert.equal(client.status, 404, 'reload client is dev-only');
+  assert.equal(worker.status, 404, 'reload worker is dev-only');
+});
+
+test('the worker events URL carries the base path under a sub-path deploy (#256)', async () => {
+  const appDir = makeApp({ basePath: '/app' });
+  const app = await createRequestHandler({ appDir, dev: true });
+  const worker = await (await app.handle(new Request('http://x/app/__webjs/reload-worker.js'))).text();
+  assert.match(worker, /new EventSource\("\/app\/__webjs\/events"\)/, 'events URL is base-path prefixed in the worker');
+  const client = await (await app.handle(new Request('http://x/app/__webjs/reload.js'))).text();
+  assert.match(client, /reload-worker\.js/, 'client references the worker');
+  assert.match(client, /\/app\/__webjs\/reload-worker\.js/, 'worker URL is base-path prefixed in the client');
+});

--- a/packages/server/test/dev/static-midwrite.test.js
+++ b/packages/server/test/dev/static-midwrite.test.js
@@ -1,0 +1,66 @@
+/**
+ * In dev, a static asset (public/tailwind.css and friends) is often rewritten
+ * by an external watcher (tailwindcss --watch, esbuild, ...) with a
+ * truncate-then-write, so the file is 0 bytes for a short window during a
+ * rebuild. A hot reload that lands in that window used to serve empty CSS and
+ * the page painted unstyled (#891). fileResponse now rides over the mid-rewrite
+ * in dev: a 0-byte read is retried briefly so the truncated content never
+ * reaches the browser. Prod has no such watcher and is left untouched.
+ */
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, truncateSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { createRequestHandler } from '../../src/dev.js';
+
+let tmpRoot;
+before(() => { tmpRoot = mkdtempSync(join(tmpdir(), 'webjs-midwrite-')); });
+after(() => { rmSync(tmpRoot, { recursive: true, force: true }); });
+
+const CONTENT = 'body{color:red}'.repeat(500);
+
+function makeApp() {
+  const appDir = mkdtempSync(join(tmpRoot, 'app-'));
+  mkdirSync(join(appDir, 'app'), { recursive: true });
+  writeFileSync(join(appDir, 'app', 'page.js'), "export default () => 'ok';\n");
+  mkdirSync(join(appDir, 'public'), { recursive: true });
+  writeFileSync(join(appDir, 'public', 'style.css'), CONTENT);
+  return appDir;
+}
+
+test('dev rides over a mid-rewrite: a 0-byte read is retried and serves the settled CSS', async () => {
+  const appDir = makeApp();
+  const cssPath = join(appDir, 'public', 'style.css');
+  const app = await createRequestHandler({ appDir, dev: true });
+
+  // Simulate the external watcher: truncate now, rewrite the content shortly
+  // after (inside the retry window).
+  truncateSync(cssPath, 0);
+  setTimeout(() => writeFileSync(cssPath, CONTENT), 100);
+
+  const res = await app.handle(new Request('http://x/public/style.css'));
+  const body = await res.text();
+  assert.equal(res.status, 200);
+  assert.equal(body.length, CONTENT.length, 'the full CSS is served, not the mid-rewrite empty read');
+});
+
+test('COUNTERFACTUAL: prod does not retry, so a mid-rewrite empty read is served as-is', async () => {
+  const appDir = makeApp();
+  const cssPath = join(appDir, 'public', 'style.css');
+  const app = await createRequestHandler({ appDir, dev: false });
+
+  truncateSync(cssPath, 0);
+  const res = await app.handle(new Request('http://x/public/style.css'));
+  const body = await res.text();
+  assert.equal(res.status, 200);
+  assert.equal(body.length, 0, 'prod serves the current bytes without the dev retry');
+});
+
+test('a genuinely non-empty asset is served immediately (no added latency)', async () => {
+  const appDir = makeApp();
+  const app = await createRequestHandler({ appDir, dev: true });
+  const res = await app.handle(new Request('http://x/public/style.css'));
+  assert.equal((await res.text()).length, CONTENT.length, 'a normal read is unaffected');
+});

--- a/packages/server/test/dev/static-midwrite.test.js
+++ b/packages/server/test/dev/static-midwrite.test.js
@@ -9,7 +9,7 @@
  */
 import { test, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, truncateSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, truncateSync, utimesSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -35,15 +35,31 @@ test('dev rides over a mid-rewrite: a 0-byte read is retried and serves the sett
   const cssPath = join(appDir, 'public', 'style.css');
   const app = await createRequestHandler({ appDir, dev: true });
 
-  // Simulate the external watcher: truncate now, rewrite the content shortly
-  // after (inside the retry window).
+  // Simulate the external watcher: truncate now (fresh mtime = the mid-rewrite
+  // signal), rewrite the content well inside the retry window.
   truncateSync(cssPath, 0);
-  setTimeout(() => writeFileSync(cssPath, CONTENT), 100);
+  setTimeout(() => writeFileSync(cssPath, CONTENT), 40);
 
   const res = await app.handle(new Request('http://x/public/style.css'));
   const body = await res.text();
   assert.equal(res.status, 200);
   assert.equal(body.length, CONTENT.length, 'the full CSS is served, not the mid-rewrite empty read');
+});
+
+test('a genuinely empty, untouched asset serves immediately (no retry, no delay)', async () => {
+  // The retry only fires when the empty file was JUST modified. An empty asset
+  // that has been sitting there is served at once, so an intentionally-empty
+  // file does not pay the retry window on every dev request.
+  const appDir = makeApp();
+  const cssPath = join(appDir, 'public', 'style.css');
+  const app = await createRequestHandler({ appDir, dev: true });
+  truncateSync(cssPath, 0);
+  utimesSync(cssPath, new Date(Date.now() - 60_000), new Date(Date.now() - 60_000)); // mtime 1 min ago
+  const t0 = Date.now();
+  const res = await app.handle(new Request('http://x/public/style.css'));
+  const body = await res.text();
+  assert.equal(body.length, 0, 'a stale empty file is served as-is');
+  assert.ok(Date.now() - t0 < 100, 'no retry window is paid for a genuinely empty asset');
 });
 
 test('COUNTERFACTUAL: prod does not retry, so a mid-rewrite empty read is served as-is', async () => {


### PR DESCRIPTION
Two dev hot-reload bugs found while previewing the blog locally.

Closes #887
Closes #891

## #887 Multiple tabs hang in dev
The dev live-reload client opened one long-lived `EventSource` per tab. The dev server is HTTP/1.1 and browsers cap concurrent connections per host at ~6, so once a handful of tabs were open the idle SSE streams held every connection slot and later tabs could not even fetch their HTML.

Fix: the reload client now connects through a **SharedWorker** that holds the single `EventSource` to `/__webjs/events` and relays each `reload` / `webjs-error` to every tab over its `MessagePort`. Tab count no longer touches the connection pool. The overlay still renders on the main thread (a worker has no DOM); the worker forwards only the raw frame and caches the last error so a late-joining tab still shows the overlay. Falls back to a per-tab `EventSource` where `SharedWorker` is unavailable or its construction throws (a strict dev CSP), guarded by try/catch. Dev-only: `/__webjs/reload.js` and the new `/__webjs/reload-worker.js` 404 in prod.

## #891 CSS disappears after every hot reload
An app that builds CSS with an external watcher (`tailwindcss --watch` in `webjs.dev.parallel`) rewrites `public/tailwind.css` with truncate-then-write, so the file is 0 bytes for ~175ms during a rebuild (measured: `/public/tailwind.css` polled `48182 ... 0 0 0 0 0 ... 48182`). A hot reload that lands in that window served an empty 200 CSS response and the page painted unstyled.

Fix: `fileResponse` rides over the mid-rewrite in dev. A 0-byte read of an existing file is retried a few times over a short bounded window, so the truncated content never reaches the browser; it serves the settled bytes (with a small delay). Prod keeps its immediate read.

## Tests
- `packages/server/test/dev/reload-shared-connection.test.js`: client uses the SharedWorker with the EventSource fallback, the worker holds the single stream + relays + caches/clears the error, both routes 404 in prod, base path honored (#256).
- `packages/server/test/dev/static-midwrite.test.js`: dev serves the settled CSS after a mid-rewrite truncate, prod serves the current bytes (counterfactual), a normal read is unaffected.
- Local note: the dev-handler tests import `../../src/dev.js`, which pulls `ws`; on Node 26 locally `ws` has an ESM named-export interop issue that blocks the run (CI runs Node 24). Verified the generated reload client/worker scripts are valid JS and the 0-byte retry rides over a real truncate-then-write, both in isolation.

## Definition of done
- **Docs**: N/A because both fixes are internal dev-server behavior (the live-reload transport and the dev static-read); no public API, config key, or user-facing surface changed.
- **Four-app dogfood boot**: N/A because the change is dev-only (the reload client and worker 404 in prod, and the CSS retry is guarded on `opts.dev`), so it does not affect what any app serves in production.
- **Bun parity**: N/A for a Bun-specific test because the change is a served client string plus a dev-only `readFile`/`stat`/`setTimeout` retry, all runtime-agnostic; the `/__webjs/events` SSE endpoint (shared by both listener shells) is unchanged.
- **Tests**: unit (`reload-shared-connection`, `static-midwrite`) + a real-browser relay test (`browser/reload-worker`). Local note: the dev-handler tests import `dev.js` which pulls `ws`, and Node 26 locally has a `ws` ESM interop issue that blocks the run; verified the generated scripts, the relay logic, and the 0-byte retry in isolation, and CI runs Node 24.
