### PR TITLE
chore: release server 0.8.47

### DIFF
--- a/changelog/server/0.8.47.md
+++ b/changelog/server/0.8.47.md
@@ -1,0 +1,11 @@
+---
+package: "@webjsdev/server"
+version: 0.8.47
+date: 2026-07-10T12:00:00.000Z
+commit_count: 1
+---
+## Fixes
+
+- **multi-tab dev live-reload and no empty CSS on hot reload (#887, #891)** ([#890](https://github.com/webjsdev/webjs/pull/890)) [`7a950d81`](https://github.com/webjsdev/webjs/commit/7a950d81)
+  * The dev live-reload client opened one `EventSource` per tab, so on the HTTP/1.1 dev server a handful of open tabs exhausted the browser's ~6-connections-per-host cap and later tabs hung. It now shares one connection across all tabs via a SharedWorker (with a per-tab EventSource fallback), so tab count no longer touches the connection pool.
+  * A hot reload that landed while an external watcher (`tailwindcss --watch`) was rewriting `public/tailwind.css` served the 0-byte mid-rewrite file, so the page painted unstyled. In dev, a just-modified 0-byte static read is now re-read briefly so the truncated content never reaches the browser. Both fixes are dev-only.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7039,7 +7039,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.46",
+      "version": "0.8.47",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.46",
+  "version": "0.8.47",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Release the unreleased `@webjsdev/server` fix. Merging adds `changelog/server/0.8.47.md` to `main`, which triggers `release.yml` to `npm publish @webjsdev/server@0.8.47` and cut a GitHub Release.

## @webjsdev/server 0.8.46 -> 0.8.47 (patch)
- **fix (#887, #891):** multi-tab dev live-reload via a SharedWorker, and no empty CSS served during a hot reload (from #890). Both dev-only.

## Not bumped (checked all published packages)
- **core, cli, mcp, intellisense:** no unreleased commits since the last release.
- **ui:** the one unreleased commit (#889) touched only `packages/ui/packages/website` (the nested website), not the published `@webjsdev/ui` surface.

## Notes
- Patch bump stays within the existing `^0.8.0` dependent caret ranges, so no dependent edits.
- `package-lock.json` diff is the single server version line.
- Railway redeploy: N/A because #890 is a dev-only change (the reload client 404s in prod and the CSS retry is dev-guarded), so the deployed apps' production behavior is unaffected.