### PR TITLE
fix: rebrand user-facing page head titles to WebJs casing

### DIFF
--- a/docs/app/docs/ai-first/page.ts
+++ b/docs/app/docs/ai-first/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'AI-First Development | webjs' };
+export const metadata = { title: 'AI-First Development | WebJs' };
 
 export default function AIFirst() {
   return html`

--- a/docs/app/docs/api-routes/page.ts
+++ b/docs/app/docs/api-routes/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'API Routes | webjs' };
+export const metadata = { title: 'API Routes | WebJs' };
 
 export default function ApiRoutes() {
   return html`

--- a/docs/app/docs/architecture/page.ts
+++ b/docs/app/docs/architecture/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Architecture | webjs' };
+export const metadata = { title: 'Architecture | WebJs' };
 
 export default function Architecture() {
   return html`

--- a/docs/app/docs/auth/page.ts
+++ b/docs/app/docs/auth/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Authentication | webjs' };
+export const metadata = { title: 'Authentication | WebJs' };
 
 export default function Auth() {
   return html`

--- a/docs/app/docs/authentication/page.ts
+++ b/docs/app/docs/authentication/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Authentication | webjs' };
+export const metadata = { title: 'Authentication | WebJs' };
 
 export default function Authentication() {
   return html`

--- a/docs/app/docs/backend-only/page.ts
+++ b/docs/app/docs/backend-only/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Backend-Only Mode | webjs' };
+export const metadata = { title: 'Backend-Only Mode | WebJs' };
 
 export default function BackendOnly() {
   return html`

--- a/docs/app/docs/cache/page.ts
+++ b/docs/app/docs/cache/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Caching | webjs' };
+export const metadata = { title: 'Caching | WebJs' };
 
 export default function Cache() {
   return html`

--- a/docs/app/docs/client-router/page.ts
+++ b/docs/app/docs/client-router/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Client Router | webjs' };
+export const metadata = { title: 'Client Router | WebJs' };
 
 export default function ClientRouter() {
   return html`

--- a/docs/app/docs/components/page.ts
+++ b/docs/app/docs/components/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Components | webjs' };
+export const metadata = { title: 'Components | WebJs' };
 
 export default function Components() {
   return html`

--- a/docs/app/docs/configuration/page.ts
+++ b/docs/app/docs/configuration/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Configuration | webjs' };
+export const metadata = { title: 'Configuration | WebJs' };
 
 export default function Configuration() {
   return html`

--- a/docs/app/docs/context/page.ts
+++ b/docs/app/docs/context/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Context Protocol | webjs' };
+export const metadata = { title: 'Context Protocol | WebJs' };
 
 export default function Context() {
   return html`

--- a/docs/app/docs/controllers/page.ts
+++ b/docs/app/docs/controllers/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Reactive Controllers | webjs' };
+export const metadata = { title: 'Reactive Controllers | WebJs' };
 
 export default function Controllers() {
   return html`

--- a/docs/app/docs/conventions/page.ts
+++ b/docs/app/docs/conventions/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Conventions & AI Workflow | webjs' };
+export const metadata = { title: 'Conventions & AI Workflow | WebJs' };
 
 export default function Conventions() {
   return html`

--- a/docs/app/docs/data-fetching/page.ts
+++ b/docs/app/docs/data-fetching/page.ts
@@ -1,7 +1,7 @@
 import { html } from '@webjsdev/core';
 
 export const metadata = {
-  title: 'Data Fetching | webjs',
+  title: 'Data Fetching | WebJs',
   description: 'When to reach for async render(), webjs-suspense streaming, Task and signals, or webjs-frame. The decision guide and anti-patterns.',
 };
 

--- a/docs/app/docs/database/page.ts
+++ b/docs/app/docs/database/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Database (Drizzle) | webjs' };
+export const metadata = { title: 'Database (Drizzle) | WebJs' };
 
 export default function Database() {
   return html`

--- a/docs/app/docs/deployment/page.ts
+++ b/docs/app/docs/deployment/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Deployment | webjs' };
+export const metadata = { title: 'Deployment | WebJs' };
 
 export default function Deployment() {
   return html`

--- a/docs/app/docs/directives/page.ts
+++ b/docs/app/docs/directives/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Directives | webjs' };
+export const metadata = { title: 'Directives | WebJs' };
 
 export default function Directives() {
   return html`

--- a/docs/app/docs/editor-setup/page.ts
+++ b/docs/app/docs/editor-setup/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Editor Setup | webjs' };
+export const metadata = { title: 'Editor Setup | WebJs' };
 
 export default function EditorSetup() {
   return html`

--- a/docs/app/docs/error-handling/page.ts
+++ b/docs/app/docs/error-handling/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Error Handling | webjs' };
+export const metadata = { title: 'Error Handling | WebJs' };
 
 export default function ErrorHandling() {
   return html`

--- a/docs/app/docs/file-storage/page.ts
+++ b/docs/app/docs/file-storage/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'File Storage | webjs' };
+export const metadata = { title: 'File Storage | WebJs' };
 
 export default function FileStorage() {
   return html`

--- a/docs/app/docs/getting-started/page.ts
+++ b/docs/app/docs/getting-started/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Getting Started | webjs' };
+export const metadata = { title: 'Getting Started | WebJs' };
 
 export default function GettingStarted() {
   return html`

--- a/docs/app/docs/lazy-loading/page.ts
+++ b/docs/app/docs/lazy-loading/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Lazy Loading | webjs' };
+export const metadata = { title: 'Lazy Loading | WebJs' };
 
 export default function LazyLoading() {
   return html`

--- a/docs/app/docs/lifecycle/page.ts
+++ b/docs/app/docs/lifecycle/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Lifecycle Hooks | webjs' };
+export const metadata = { title: 'Lifecycle Hooks | WebJs' };
 
 export default function Lifecycle() {
   return html`

--- a/docs/app/docs/loading-states/page.ts
+++ b/docs/app/docs/loading-states/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Loading States | webjs' };
+export const metadata = { title: 'Loading States | WebJs' };
 
 export default function LoadingStates() {
   return html`

--- a/docs/app/docs/metadata-routes/page.ts
+++ b/docs/app/docs/metadata-routes/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Metadata Routes | webjs' };
+export const metadata = { title: 'Metadata Routes | WebJs' };
 
 export default function MetadataRoutes() {
   return html`

--- a/docs/app/docs/middleware/page.ts
+++ b/docs/app/docs/middleware/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Middleware | webjs' };
+export const metadata = { title: 'Middleware | WebJs' };
 
 export default function Middleware() {
   return html`

--- a/docs/app/docs/migrating-from-nextjs/page.ts
+++ b/docs/app/docs/migrating-from-nextjs/page.ts
@@ -1,7 +1,7 @@
 import { html } from '@webjsdev/core';
 
 export const metadata = {
-  title: 'Migrating from Next.js | webjs',
+  title: 'Migrating from Next.js | WebJs',
   description:
     'A concept map from Next.js to webjs: the no-RSC execution model, isomorphic modules and the .server boundary instead of Server/Client Components, plain <a> instead of next/link, an async page function instead of getServerSideProps, and a before/after example.',
 };

--- a/docs/app/docs/no-build/page.ts
+++ b/docs/app/docs/no-build/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'No-Build Model | webjs' };
+export const metadata = { title: 'No-Build Model | WebJs' };
 
 export default function NoBuild() {
   return html`

--- a/docs/app/docs/progressive-enhancement/page.ts
+++ b/docs/app/docs/progressive-enhancement/page.ts
@@ -1,7 +1,7 @@
 import { html } from '@webjsdev/core';
 
 export const metadata = {
-  title: 'Progressive Enhancement | webjs',
+  title: 'Progressive Enhancement | WebJs',
   description:
     'WebJs pages and components are SSR\'d to real HTML. Read-paths, navigation, and form submissions work without JavaScript. JS is opt-in per interactive behavior: only the click / signal / focus handlers require scripts, not the component\'s first paint.',
 };

--- a/docs/app/docs/rate-limiting/page.ts
+++ b/docs/app/docs/rate-limiting/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Rate Limiting | webjs' };
+export const metadata = { title: 'Rate Limiting | WebJs' };
 
 export default function RateLimiting() {
   return html`

--- a/docs/app/docs/routing/page.ts
+++ b/docs/app/docs/routing/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Routing | webjs' };
+export const metadata = { title: 'Routing | WebJs' };
 
 export default function Routing() {
   return html`

--- a/docs/app/docs/runtime/page.ts
+++ b/docs/app/docs/runtime/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Runtime (Node & Bun) | webjs' };
+export const metadata = { title: 'Runtime (Node & Bun) | WebJs' };
 
 export default function Runtime() {
   return html`

--- a/docs/app/docs/security/page.ts
+++ b/docs/app/docs/security/page.ts
@@ -1,7 +1,7 @@
 import { html } from '@webjsdev/core';
 
 export const metadata = {
-  title: 'Security | webjs',
+  title: 'Security | WebJs',
   description:
     'The WebJs threat model and hardening surface: CSRF, CSP, secure headers, CORS, body limits, SRI, the .server boundary, sessions, and rate limiting, with which protections are automatic and which are opt-in.',
 };

--- a/docs/app/docs/server-actions/page.ts
+++ b/docs/app/docs/server-actions/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Server Actions | webjs' };
+export const metadata = { title: 'Server Actions | WebJs' };
 
 export default function ServerActions() {
   return html`

--- a/docs/app/docs/sessions/page.ts
+++ b/docs/app/docs/sessions/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Sessions | webjs' };
+export const metadata = { title: 'Sessions | WebJs' };
 
 export default function Sessions() {
   return html`

--- a/docs/app/docs/ssr/page.ts
+++ b/docs/app/docs/ssr/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Server-Side Rendering | webjs' };
+export const metadata = { title: 'Server-Side Rendering | WebJs' };
 
 export default function SSR() {
   return html`

--- a/docs/app/docs/styling/page.ts
+++ b/docs/app/docs/styling/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Styling | webjs' };
+export const metadata = { title: 'Styling | WebJs' };
 
 export default function Styling() {
   return html`

--- a/docs/app/docs/suspense/page.ts
+++ b/docs/app/docs/suspense/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Streaming & Suspense | webjs' };
+export const metadata = { title: 'Streaming & Suspense | WebJs' };
 
 export default function SuspensePage() {
   return html`

--- a/docs/app/docs/task/page.ts
+++ b/docs/app/docs/task/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Task Controller | webjs' };
+export const metadata = { title: 'Task Controller | WebJs' };
 
 export default function TaskPage() {
   return html`

--- a/docs/app/docs/testing/page.ts
+++ b/docs/app/docs/testing/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Testing | webjs' };
+export const metadata = { title: 'Testing | WebJs' };
 
 export default function Testing() {
   return html`

--- a/docs/app/docs/troubleshooting/page.ts
+++ b/docs/app/docs/troubleshooting/page.ts
@@ -1,7 +1,7 @@
 import { html } from '@webjsdev/core';
 
 export const metadata = {
-  title: 'Troubleshooting | webjs',
+  title: 'Troubleshooting | WebJs',
   description:
     'Symptom-keyed fixes for the distinctive WebJs error signatures: throw-at-load server imports, backtick-in-template 500s, TypeScript strip failures, SSR browser-global crashes, the missing-frame swap, and more, each linked to the webjs check rule and the invariant behind it.',
 };

--- a/docs/app/docs/typescript/page.ts
+++ b/docs/app/docs/typescript/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'TypeScript | webjs' };
+export const metadata = { title: 'TypeScript | WebJs' };
 
 export default function TypeScript() {
   return html`

--- a/docs/app/docs/websockets/page.ts
+++ b/docs/app/docs/websockets/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'WebSockets | webjs' };
+export const metadata = { title: 'WebSockets | WebJs' };
 
 export default function WebSockets() {
   return html`

--- a/docs/app/layout.ts
+++ b/docs/app/layout.ts
@@ -7,7 +7,7 @@ import { html, cspNonce } from '@webjsdev/core';
  * documentation pages.
  */
 
-const TITLE = 'webjs: Documentation';
+const TITLE = 'WebJs - Documentation';
 const DESCRIPTION = 'Getting started, routing, components, server actions, deployment, and more.';
 
 export function generateMetadata(ctx: { url: string }) {
@@ -28,7 +28,7 @@ export function generateMetadata(ctx: { url: string }) {
       'image:width': '1200',
       'image:height': '630',
       'image:alt': 'WebJs documentation',
-      'site_name': 'webjs · docs',
+      'site_name': 'WebJs · docs',
     },
     twitter: {
       card: 'summary_large_image',

--- a/examples/blog/app/(marketing)/about/page.ts
+++ b/examples/blog/app/(marketing)/about/page.ts
@@ -1,7 +1,7 @@
 import { html, type Metadata } from '@webjsdev/core';
 import { rubric, displayH1, codeChip } from '#lib/utils/ui.ts';
 
-export const metadata: Metadata = { title: 'About: webjs blog' };
+export const metadata: Metadata = { title: 'About - WebJs Blog' };
 
 const FEATURES = [
   { label: 'SSR + DSD',            note: 'Real server HTML; shadow DOM upgrades on connect.' },

--- a/examples/blog/app/abort/page.ts
+++ b/examples/blog/app/abort/page.ts
@@ -2,7 +2,7 @@ import { html } from '@webjsdev/core';
 import '#components/abort-demo.ts';
 
 export const metadata = {
-  title: 'Abort demo · webjs blog',
+  title: 'Abort demo · WebJs Blog',
   description: 'A superseded async-render fetch is aborted (#492).',
 };
 

--- a/examples/blog/app/async-leaf/page.ts
+++ b/examples/blog/app/async-leaf/page.ts
@@ -2,7 +2,7 @@ import { html } from '@webjsdev/core';
 import '#components/inline-quote.ts';
 
 export const metadata = {
-  title: 'Async leaf · webjs blog',
+  title: 'Async leaf · WebJs Blog',
   description: 'A bare async-render leaf, elided yet present in the first paint.',
 };
 

--- a/examples/blog/app/blog/[slug]/page.ts
+++ b/examples/blog/app/blog/[slug]/page.ts
@@ -15,8 +15,8 @@ import { rubric, backLink, displayH1, stat } from '#lib/utils/ui.ts';
 export async function generateMetadata({ params }: PageProps<'/blog/[slug]'>): Promise<Metadata> {
   const post = await getPost({ slug: params.slug });
   return post
-    ? { title: `${post.title}: webjs blog` }
-    : { title: 'Not found: webjs blog' };
+    ? { title: `${post.title} - WebJs Blog` }
+    : { title: 'Not found - WebJs Blog' };
 }
 
 export default async function PostPage({ params }: PageProps<'/blog/[slug]'>) {

--- a/examples/blog/app/dashboard/page.ts
+++ b/examples/blog/app/dashboard/page.ts
@@ -11,7 +11,7 @@ import { currentUser } from '#modules/auth/queries/current-user.server.ts';
 import { listPosts } from '#modules/posts/queries/list-posts.server.ts';
 import { rubric, clampH1, stat, accentLink } from '#lib/utils/ui.ts';
 
-export const metadata = { title: 'Dashboard: webjs blog' };
+export const metadata = { title: 'Dashboard - WebJs Blog' };
 
 export default async function Dashboard() {
   // Per-segment middleware.ts guarantees an authed user here.

--- a/examples/blog/app/dashboard/posts/new/page.ts
+++ b/examples/blog/app/dashboard/posts/new/page.ts
@@ -2,7 +2,7 @@ import { html } from '@webjsdev/core';
 import '#modules/posts/components/new-post.ts';
 import { backLink, rubric, clampH1 } from '#lib/utils/ui.ts';
 
-export const metadata = { title: 'New post: webjs blog' };
+export const metadata = { title: 'New post - WebJs Blog' };
 
 export default function NewPostPage() {
   return html`

--- a/examples/blog/app/feedback/page.ts
+++ b/examples/blog/app/feedback/page.ts
@@ -36,7 +36,7 @@ type PageCtx = {
   actionData?: { fieldErrors?: Record<string, string>; values?: Record<string, string> };
 };
 
-export const metadata = { title: 'Feedback: webjs blog' };
+export const metadata = { title: 'Feedback - WebJs Blog' };
 
 export default function FeedbackPage({ actionData }: PageCtx) {
   const err = actionData?.fieldErrors?.email;

--- a/examples/blog/app/feedback/thanks/page.ts
+++ b/examples/blog/app/feedback/thanks/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Thanks: webjs blog' };
+export const metadata = { title: 'Thanks - WebJs Blog' };
 
 // PRG target for a successful /feedback submission (#244 e2e fixture).
 export default function ThanksPage() {

--- a/examples/blog/app/frame-demo/deferred/page.ts
+++ b/examples/blog/app/frame-demo/deferred/page.ts
@@ -1,7 +1,7 @@
 import { html } from '@webjsdev/core';
 
 export const metadata = {
-  title: 'Deferred frame content · webjs blog',
+  title: 'Deferred frame content · WebJs Blog',
 };
 
 /**

--- a/examples/blog/app/frame-demo/page.ts
+++ b/examples/blog/app/frame-demo/page.ts
@@ -1,7 +1,7 @@
 import { html, type PageProps } from '@webjsdev/core';
 
 export const metadata = {
-  title: 'Frame demo · webjs blog',
+  title: 'Frame demo · WebJs Blog',
   description: 'A <webjs-frame> driven by external links (data-webjs-frame) and a _top breakout.',
 };
 

--- a/examples/blog/app/layout.ts
+++ b/examples/blog/app/layout.ts
@@ -9,7 +9,7 @@ const footerLink = (href: string, label: string) => html`
   <a href=${href} class="text-inherit no-underline transition-colors duration-fast hover:text-fg-muted">${label}</a>
 `;
 
-const TITLE = 'webjs blog: live demo';
+const TITLE = 'WebJs Blog - Live Demo';
 const DESCRIPTION = 'A live, full-stack webjs example: posts, comments, auth, and WebSocket chat.';
 
 // NOTE: no `cacheControl` here on purpose. This app is per-user (pages read
@@ -31,8 +31,8 @@ export function generateMetadata(ctx: { url: string }): Metadata {
       image,
       'image:width': '1200',
       'image:height': '630',
-      'image:alt': 'webjs blog: live demo',
-      'site_name': 'webjs · blog',
+      'image:alt': 'WebJs Blog - Live Demo',
+      'site_name': 'WebJs · blog',
     },
     twitter: {
       card: 'summary_large_image',

--- a/examples/blog/app/login/page.ts
+++ b/examples/blog/app/login/page.ts
@@ -6,7 +6,7 @@ import { rubric } from '#lib/utils/ui.ts';
 type Ctx = { searchParams?: Record<string, string> };
 
 export function generateMetadata({ searchParams }: Ctx) {
-  return { title: searchParams?.tab === 'signup' ? 'Create account: webjs blog' : 'Sign in: webjs blog' };
+  return { title: searchParams?.tab === 'signup' ? 'Create account - WebJs Blog' : 'Sign in - WebJs Blog' };
 }
 
 export default async function LoginPage({ searchParams }: Ctx) {

--- a/examples/blog/app/observed/page.ts
+++ b/examples/blog/app/observed/page.ts
@@ -4,7 +4,7 @@ import '#components/observe-badge.ts';
 import '#components/ssr-derived-badge.ts';
 
 export const metadata = {
-  title: 'Observed badge · webjs blog',
+  title: 'Observed badge · WebJs Blog',
   description: 'Pins the cross-module-registration elision fix (#169).',
 };
 

--- a/examples/blog/app/page.ts
+++ b/examples/blog/app/page.ts
@@ -10,9 +10,9 @@ import { currentUser } from '#modules/auth/queries/current-user.server.ts';
 import { rubric, stat, banner, accentLink, sectionH2 } from '#lib/utils/ui.ts';
 
 export const metadata = {
-  title: 'webjs blog',
+  title: 'WebJs Blog',
   description: 'A tiny full-feature demo of the webjs framework',
-  openGraph: { title: 'webjs blog', type: 'website' },
+  openGraph: { title: 'WebJs Blog', type: 'website' },
 };
 
 async function slowStat() {

--- a/examples/blog/app/rpc-stream/page.ts
+++ b/examples/blog/app/rpc-stream/page.ts
@@ -2,7 +2,7 @@ import { html } from '@webjsdev/core';
 import '#components/token-stream.ts';
 
 export const metadata = {
-  title: 'Streaming RPC · webjs blog',
+  title: 'Streaming RPC · WebJs Blog',
   description: 'An async-generator server action streams tokens over RPC (#489).',
 };
 

--- a/examples/blog/app/seeded/page.ts
+++ b/examples/blog/app/seeded/page.ts
@@ -2,7 +2,7 @@ import { html } from '@webjsdev/core';
 import '#components/seeded-user.ts';
 
 export const metadata = {
-  title: 'Seeded user · webjs blog',
+  title: 'Seeded user · WebJs Blog',
   description: 'SSR action-seeding fixture: async render data is seeded so hydration does not re-fetch (#472).',
 };
 

--- a/examples/blog/app/static-info/page.ts
+++ b/examples/blog/app/static-info/page.ts
@@ -1,7 +1,7 @@
 import { html } from '@webjsdev/core';
 
 export const metadata = {
-  title: 'Static info · webjs blog',
+  title: 'Static info · WebJs Blog',
   description: 'A fully-static route that ships zero application JS.',
 };
 

--- a/examples/blog/app/stream-demo/page.ts
+++ b/examples/blog/app/stream-demo/page.ts
@@ -3,7 +3,7 @@ import '#components/async-greeting.ts';
 import '#components/slow-fact.ts';
 
 export const metadata = {
-  title: 'Stream demo · webjs blog',
+  title: 'Stream demo · WebJs Blog',
   description: 'async render() + <webjs-suspense> streaming, end to end.',
 };
 

--- a/examples/blog/app/ui-demo/page.ts
+++ b/examples/blog/app/ui-demo/page.ts
@@ -20,7 +20,7 @@ import { labelClass } from '#components/ui/label.ts';
 import '#components/ui/dialog.ts';
 
 export const metadata = {
-  title: 'UI Demo · webjs',
+  title: 'UI Demo · WebJs',
   description: 'A showcase of the Webjs UI two-tier composition: class helpers on native elements + custom elements where state matters.',
 };
 

--- a/examples/blog/app/verbs/page.ts
+++ b/examples/blog/app/verbs/page.ts
@@ -2,7 +2,7 @@ import { html } from '@webjsdev/core';
 import '#components/verb-greeting.ts';
 
 export const metadata = {
-  title: 'HTTP-verb actions · webjs blog',
+  title: 'HTTP-verb actions · WebJs Blog',
   description: 'A GET action read (cached + seeded) and a POST mutation that invalidates it (#488).',
 };
 

--- a/packages/ui/packages/website/app/docs/components/[name]/page.ts
+++ b/packages/ui/packages/website/app/docs/components/[name]/page.ts
@@ -58,7 +58,7 @@ import '#components/ui/toggle-group.ts';
 import '#components/ui/tooltip.ts';
 
 export function generateMetadata({ params }: { params: { name: string } }) {
-  return { title: `${params.name}: Webjs UI` };
+  return { title: `${params.name}: WebJs UI` };
 }
 
 // Helper: renders a single preview pane around an example snippet.

--- a/packages/ui/packages/website/app/docs/page.ts
+++ b/packages/ui/packages/website/app/docs/page.ts
@@ -1,6 +1,6 @@
 import { html } from '@webjsdev/core';
 
-export const metadata = { title: 'Docs, Webjs UI' };
+export const metadata = { title: 'Docs, WebJs UI' };
 
 export default function Docs() {
   return html`

--- a/packages/ui/packages/website/app/layout.ts
+++ b/packages/ui/packages/website/app/layout.ts
@@ -16,7 +16,7 @@ const env = (globalThis as any).process?.env ?? {};
 const WEBSITE_URL = env.WEBSITE_URL || 'http://localhost:5001';
 const DOCS_URL = env.DOCS_URL || 'http://localhost:5002';
 
-const TITLE = 'Webjs UI: the AI-first component library for WebJs';
+const TITLE = 'WebJs UI - The AI-First Component Library for WebJs';
 const DESCRIPTION =
   'The AI-first component library for WebJs. Two-tier composition: class-helper functions for visuals, custom elements only where state matters. Source-copied into your project, styled with Tailwind v4.';
 
@@ -41,8 +41,8 @@ export function generateMetadata(ctx: { url: string }) {
       image,
       'image:width': '1200',
       'image:height': '630',
-      'image:alt': 'Webjs UI: AI-first component library',
-      'site_name': 'Webjs UI',
+      'image:alt': 'WebJs UI - AI-First Component Library',
+      'site_name': 'WebJs UI',
     },
     twitter: {
       card: 'summary_large_image',

--- a/website/app/blog/[slug]/page.ts
+++ b/website/app/blog/[slug]/page.ts
@@ -15,9 +15,9 @@ import { renderPostBody } from '#modules/blog/utils/render-post.ts';
 
 export async function generateMetadata({ params }: { params: { slug: string } }) {
   const post = await getPost(params.slug);
-  if (!post) return { title: 'Post not found · webjs' };
+  if (!post) return { title: 'Post not found · WebJs' };
   return {
-    title: `${post.title} · WebJs blog`,
+    title: `${post.title} · WebJs Blog`,
     description: post.description,
     openGraph: {
       title: post.title,

--- a/website/app/blog/page.ts
+++ b/website/app/blog/page.ts
@@ -10,7 +10,7 @@ import { listPosts } from '#modules/blog/queries/list-posts.server.ts';
  */
 
 export const metadata = {
-  title: 'Blog · webjs',
+  title: 'Blog · WebJs',
   description: 'Long-form notes from building webjs: the design decisions, the trade-offs, the things that did not work, and what the framework looks like in production.',
 };
 

--- a/website/app/changelog/page.ts
+++ b/website/app/changelog/page.ts
@@ -12,7 +12,7 @@ import { pkgBadge } from '#modules/changelog/utils/pkg-badge.ts';
  */
 
 export const metadata = {
-  title: 'Changelog · webjs',
+  title: 'Changelog · WebJs',
   description: 'Per-package, per-version release notes for the WebJs framework (@webjsdev/core, server, cli, intellisense, ui, mcp) plus the WebJs editor extensions for VS Code and Neovim.',
 };
 

--- a/website/app/compare/[slug]/page.ts
+++ b/website/app/compare/[slug]/page.ts
@@ -17,9 +17,9 @@ import { NEW_TAB } from '#lib/links.ts';
 
 export async function generateMetadata({ params }: { params: { slug: string } }) {
   const c = await getComparison(params.slug);
-  if (!c) return { title: 'Comparison not found · webjs' };
+  if (!c) return { title: 'Comparison not found · WebJs' };
   return {
-    title: `${c.title} · webjs`,
+    title: `${c.title} · WebJs`,
     description: c.description,
     openGraph: {
       title: c.title,

--- a/website/app/compare/page.ts
+++ b/website/app/compare/page.ts
@@ -11,7 +11,7 @@ import { listComparisons } from '#modules/compare/queries/list-comparisons.serve
  */
 
 export const metadata = {
-  title: 'WebJs compared: vs Next.js, Lit, Remix, Astro, Rails · webjs',
+  title: 'WebJs compared: vs Next.js, Lit, Remix, Astro, Rails · WebJs',
   description: 'Honest, head-to-head comparisons of WebJs with Next.js, Lit, Remix, Astro, and Rails. Where they agree, where they genuinely differ, and who should pick which.',
 };
 

--- a/website/app/layout.ts
+++ b/website/app/layout.ts
@@ -16,7 +16,7 @@ import { DOCS_URL, UI_URL, EXAMPLE_BLOG_URL, GH_URL, NEW_TAB } from '#lib/links.
  * lib/links.ts, imported here and by app/page.ts.
  */
 
-const TITLE = 'webjs: the web framework for AI agents';
+const TITLE = 'WebJs - The Web Framework for AI Agents';
 const DESCRIPTION = 'A full-stack web framework built on web components, SSR, and progressive enhancement, with zero build step. Lean enough for AI agents to read end to end. File-based routing, server actions, and streaming SSR on web standards. Runs on Node 24+ or Bun.';
 
 const NAV = [
@@ -50,7 +50,7 @@ export function generateMetadata(ctx: { url: string }) {
       'image:width': '1200',
       'image:height': '630',
       'image:alt': TITLE,
-      'site_name': 'webjs',
+      'site_name': 'WebJs',
     },
     twitter: { card: 'summary_large_image', title: TITLE, description: DESCRIPTION, image },
   };


### PR DESCRIPTION
## What

Rebrand every user-facing page `<head>` / metadata title (page `<title>`,
OpenGraph title, Twitter title, `image:alt`, `site_name`) that names the project
to proper `WebJs` casing, across the four apps: `website`, `docs`,
`packages/ui/packages/website`, and `examples/blog`.

Per AGENTS.md invariant 11 the brand is a proper noun; a browser-tab / social-card
title is prose, so `webjs` there should read `WebJs`.

## Rules applied

- Root/hero colon-tagline titles: `:` becomes ` - `, Title Case the tagline.
  `webjs: the web framework for AI agents` -> `WebJs - The Web Framework for AI Agents`.
- Per-page titles: preserve the separator (`|`, `·`), fix brand only
  (`Server Actions | webjs` -> `Server Actions | WebJs`); a `: webjs blog` colon
  suffix becomes ` - WebJs Blog`.
- Literal code tokens stay lowercase (`@webjsdev/ui` package names untouched).

## Out of scope

- Visible body copy (the marketing hero/footer `The web framework for AI agents`).
- The scaffold generator's `'${displayName}: built with webjs'` title in
  `packages/cli/lib/create.js` (needs the scaffold-sync surface, tracked separately).

## Testing

- Each touched app boots and renders (smoke).
- `webjs check` clean.

Closes #902
