### PR TITLE
chore: release core 0.7.33, server 0.8.48, cli 0.10.37

### DIFF
--- a/changelog/cli/0.10.37.md
+++ b/changelog/cli/0.10.37.md
@@ -1,0 +1,10 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.37
+date: 2026-07-10T18:00:00.000Z
+commit_count: 1
+---
+## Features
+
+- **close the scaffold coverage-gate deferred gaps with real demos (#859)** ([#901](https://github.com/webjsdev/webjs/pull/901)) [`9df1af33`](https://github.com/webjsdev/webjs/commit/9df1af33)
+  * Every `@webjsdev/core` and `@webjsdev/server` export and routing-convention stem that the scaffold teaching-coverage gate had marked `deferred` now ships a real, runnable, commented demo in the generated gallery (or an honest `internal:` reclassification). New surfaces the scaffold now teaches: the context API and `Task`, the remaining lit directives (`guard`, `cache`, `templateContent`, `asyncAppend`, `asyncReplace`), `Suspense` streaming, `redirect`, `disable`/`enableClientRouter`, `richFetch` with `json()` request accessors, `renderStream`, `render` / `renderToString`, `cspNonce`, a new sessions feature, cache eviction, file-store config, OAuth provider presets, per-action context/signal, `sitemapIndex`, the documented test helpers, and `setOnError` via a shipped `instrumentation.ts`. Also adds the root-only `global-error` / `global-not-found` boundaries and the `icon` / `apple-icon` / `opengraph-image` / `twitter-image` metadata routes.

--- a/changelog/core/0.7.33.md
+++ b/changelog/core/0.7.33.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/core"
+version: 0.7.33
+date: 2026-07-10T18:00:00.000Z
+commit_count: 2
+---
+## Fixes
+
+- **first-class dev hot-reload, with no restart flash and watching outside the appDir (#893, #894)** ([#896](https://github.com/webjsdev/webjs/pull/896)) [`4fc7446b`](https://github.com/webjsdev/webjs/commit/4fc7446b)
+  * The dev watcher only followed the appDir, so an app reading content from a sibling directory (a repo-root `blog/` beside the app) got no reload when that content changed. The watcher now also follows configured paths outside the appDir.
+  * On Node, `webjs dev` re-execs under `node --watch`, which restarted the whole process on an app edit and dropped the open dev connection, so an edit needed a manual refresh. Hot reload is now applied in place without the restart flash.
+- **reflect app and framework deploys on client navigation via content signals (#899)** ([#900](https://github.com/webjsdev/webjs/pull/900)) [`9902b1bd`](https://github.com/webjsdev/webjs/commit/9902b1bd)
+  * After a deploy, the client router kept serving its in-memory prefetch/snapshot copy of a page, so a soft navigation showed the pre-deploy version until a hard refresh. The router now detects a changed app or framework build via content signals and refetches instead of serving the stale snapshot.

--- a/changelog/server/0.8.48.md
+++ b/changelog/server/0.8.48.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/server"
+version: 0.8.48
+date: 2026-07-10T18:00:00.000Z
+commit_count: 2
+---
+## Fixes
+
+- **first-class dev hot-reload, with no restart flash and watching outside the appDir (#893, #894)** ([#896](https://github.com/webjsdev/webjs/pull/896)) [`4fc7446b`](https://github.com/webjsdev/webjs/commit/4fc7446b)
+  * The dev watcher only followed the appDir, so an app reading content from a sibling directory (a repo-root `blog/` beside the app) got no reload when that content changed. The watcher now also follows configured paths outside the appDir.
+  * On Node, `webjs dev` re-execs under `node --watch`, which restarted the whole process on an app edit and dropped the open dev connection, so an edit needed a manual refresh. Hot reload is now applied in place without the restart flash.
+- **reflect app and framework deploys on client navigation via content signals (#899)** ([#900](https://github.com/webjsdev/webjs/pull/900)) [`9902b1bd`](https://github.com/webjsdev/webjs/commit/9902b1bd)
+  * After a deploy, the client router kept serving its in-memory prefetch/snapshot copy of a page, so a soft navigation showed the pre-deploy version until a hard refresh. The server now emits a content signal on its responses so the client refetches instead of serving the stale snapshot.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6975,7 +6975,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.36",
+      "version": "0.10.37",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -6991,7 +6991,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.32",
+      "version": "0.7.33",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.25.0"
@@ -7039,7 +7039,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.47",
+      "version": "0.8.48",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.36",
+  "version": "0.10.37",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.32",
+  "version": "0.7.33",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.47",
+  "version": "0.8.48",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Releases three packages with accumulated unreleased work on `main`.

| Package | Bump | For |
|---|---|---|
| `@webjsdev/core` | 0.7.32 → 0.7.33 | `fix:` dev hot-reload (#896), client-nav content signals (#900) |
| `@webjsdev/server` | 0.8.47 → 0.8.48 | same two `fix:` commits (both touch core + server) |
| `@webjsdev/cli` | 0.10.36 → 0.10.37 | `feat:` scaffold coverage-gate demos (#859 / #901) |

Hand-written changelogs (`changelog/{core/0.7.33,server/0.8.48,cli/0.10.37}.md`) since the squash subjects on `main` are not conventional-commit prefixed, so the auto-generator finds nothing. All bumps are patch within the existing minor line, so every dependent caret range (`@webjsdev/core: ^0.7.1`, `@webjsdev/server: ^0.8.0`) still satisfies with no edits; `package-lock.json` regenerated.

Merging this adds the `changelog/**.md` files to `main`, which triggers `release.yml` to `npm publish` the three packages and cut their GitHub Releases (idempotent).

## Test plan
- Version-only + changelog + lockfile change; source is byte-identical to what already passed on `main`.
- Fast checks (Conventions + Build + Unit) cover the only release-specific failure modes (lockfile desync, changelog/convention format).
