### PR TITLE
fix: client router must not reconcile into hydrated components

### DIFF
--- a/packages/core/src/router-client.js
+++ b/packages/core/src/router-client.js
@@ -2666,10 +2666,40 @@ function diffElementInPlace(dst, src) {
   // The attribute version is skipped above; we deliberately do nothing
   // here so the user's typing / checking is never blown away.
 
+  // A hydrated component OWNS its rendered subtree. The client renderer
+  // stashes the live template instance (lit-html parts holding DIRECT
+  // references to the rendered nodes) on the host under
+  // `Symbol.for('webjs.instance')`. Recursing into those children would
+  // import/remove/reorder the very nodes the parts still point at, so the
+  // component's next reactive update would write into detached nodes and
+  // silently do nothing (a dead click after a soft nav, #906). Treat the
+  // component as opaque: the attribute sync above already drove any reactive
+  // property change through `attributeChangedCallback`, so the component
+  // re-renders ITSELF; the router must not touch its internals. This mirrors
+  // Turbo/morphdom, which leave custom elements alone by default.
+  if (isHydratedComponent(dst)) return;
+
   // Recurse into children: collect both sides, run reconcileSiblings on
   // them with synthetic boundary markers. Cheap implementation: use
   // virtual ranges instead of inserting real comment markers.
   reconcileChildren(dst, src);
+}
+
+/**
+ * True when `el` carries a live client-side render instance, i.e. a webjs
+ * component whose `render()` produced the current children and owns them via
+ * lit-html parts. The router must not reconcile INTO such an element (#906).
+ *
+ * Detected via the render-client instance symbol rather than a `customElements`
+ * lookup so it fires only for elements that have actually rendered client-side:
+ * a not-yet-upgraded or purely display-only custom element (no client render,
+ * no parts to corrupt) stays fully reconcilable.
+ *
+ * @param {Element} el
+ * @returns {boolean}
+ */
+function isHydratedComponent(el) {
+  return /** @type {any} */ (el)[Symbol.for('webjs.instance')] != null;
 }
 
 /**

--- a/packages/core/test/routing/browser/reconcile-hydrated-component.test.js
+++ b/packages/core/test/routing/browser/reconcile-hydrated-component.test.js
@@ -128,4 +128,40 @@ suite('Client router: reconcile does not corrupt a hydrated component (#906)', (
 
     parent.remove();
   });
+
+  test('an interactive component that projects slotted content still clicks after reconcile', async () => {
+    // A light-DOM interactive component with a <slot> keeps its live instance
+    // symbol on the HOST, so the guard fires and the router leaves its subtree
+    // alone. The primary guarantee (interactivity survives) must hold for a
+    // slotted component too. Known trade-off (see #906 follow-up): the router
+    // no longer re-projects page-authored slotted content of a REUSED
+    // interactive component across a soft nav; that is a separate slot-aware
+    // reconcile concern, and the pre-fix behaviour here was worse (dead click).
+    const tag = `rc-slotted-${counter++}`;
+    class RcSlotted extends WebComponent({ on: Boolean }) {
+      constructor() { super(); this.on = false; }
+      render() {
+        return html`<button @click=${() => { this.on = !this.on; }}>t</button><div><slot></slot></div>`;
+      }
+    }
+    customElements.define(tag, RcSlotted);
+
+    const live = document.createElement(tag);
+    live.innerHTML = 'SLOTTED';
+    document.body.appendChild(live);
+    await live.updateComplete;
+    assert.ok(live.querySelector('button'), 'renders a button + slot');
+
+    const incoming = document.createElement(tag);
+    incoming.innerHTML = 'SLOTTED';
+    _diffElementInPlace(live, incoming);
+
+    // Interactivity survives the reconcile: the reactive toggle still updates.
+    live.querySelector('button').click();
+    await live.updateComplete;
+    assert.equal(live.on, true, 'reactive state still updates after reconcile');
+    assert.ok(live.querySelector('button'), 'button still present and live');
+
+    live.remove();
+  });
 });

--- a/packages/core/test/routing/browser/reconcile-hydrated-component.test.js
+++ b/packages/core/test/routing/browser/reconcile-hydrated-component.test.js
@@ -1,0 +1,131 @@
+/**
+ * Real-browser regression for #906: the client-router reconciler must not
+ * recurse INTO a hydrated component's rendered subtree.
+ *
+ * The bug: a light-DOM component renders into its own host via the client
+ * renderer, which stashes the live template instance (lit-html parts holding
+ * DIRECT references to the rendered nodes) on the host under
+ * `Symbol.for('webjs.instance')`. On a same-layout soft navigation the router
+ * positionally/keyed-matches the live component to the incoming SSR one and
+ * calls `diffElementInPlace`, which used to recurse into the children and
+ * import/remove/reorder the very nodes the parts point at. After that, the
+ * component's next reactive update (a click -> `count++` -> re-render) writes
+ * into DETACHED nodes, so nothing reaches the screen: the button looks dead.
+ *
+ * MUST run in a real browser: the corruption only exists once the element is
+ * actually upgraded and has rendered through real lit-html parts, which
+ * linkedom does not model. The counterfactual is clean: revert the
+ * `isHydratedComponent` guard in `router-client.js` and this test goes red
+ * (the post-reconcile click no longer updates the DOM).
+ */
+import { html } from '../../../src/html.js';
+import { WebComponent } from '../../../src/component.js';
+import { _diffElementInPlace, _reconcileChildren } from '../../../src/router-client.js';
+
+const assert = {
+  ok: (v, msg) => { if (!v) throw new Error(msg || `Expected truthy, got ${v}`); },
+  equal: (a, b, msg) => { if (a !== b) throw new Error(msg || `Expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}`); },
+};
+
+let counter = 0;
+function defineLikeButton() {
+  const tag = `rc-like-button-${counter++}`;
+  class RcLikeButton extends WebComponent({ count: Number }) {
+    render() {
+      return html`<button @click=${() => this.count++}>heart ${this.count}</button>`;
+    }
+  }
+  customElements.define(tag, RcLikeButton);
+  return tag;
+}
+
+suite('Client router: reconcile does not corrupt a hydrated component (#906)', () => {
+  test('click still increments after the component is reconciled in place', async () => {
+    const tag = defineLikeButton();
+
+    // Hydrate a live component: upgrade it and let it render (this is what
+    // stashes the live instance + parts on the host).
+    const live = document.createElement(tag);
+    live.setAttribute('count', '2');
+    document.body.appendChild(live);
+    await live.updateComplete;
+    assert.equal(live.querySelector('button').textContent, 'heart 2', 'first paint');
+
+    // Sanity: the live instance symbol is present (this is what the guard reads).
+    assert.ok(live[Symbol.for('webjs.instance')] != null, 'component has a live render instance');
+
+    // Simulate the soft-nav reconcile: an incoming SSR copy of the same
+    // component in its initial state, matched against the live one.
+    const incoming = document.createElement(tag);
+    incoming.setAttribute('count', '2');
+    incoming.innerHTML = '<button>heart 2</button>';
+    _diffElementInPlace(live, incoming);
+
+    // THE ASSERTION THAT FAILS WITHOUT THE FIX: clicking after the reconcile
+    // must still drive the reactive update all the way to the DOM.
+    live.querySelector('button').click();
+    await live.updateComplete;
+    assert.equal(live.querySelector('button').textContent, 'heart 3',
+      'click after reconcile must still increment the rendered count');
+
+    live.remove();
+  });
+
+  test('reconcile leaves the live component subtree untouched (identity + content)', async () => {
+    const tag = defineLikeButton();
+    const live = document.createElement(tag);
+    live.setAttribute('count', '0');
+    document.body.appendChild(live);
+    await live.updateComplete;
+
+    // Drive the component's own state forward (user clicked to 5).
+    for (let i = 0; i < 5; i++) live.querySelector('button').click();
+    await live.updateComplete;
+    const liveButton = live.querySelector('button');
+    assert.equal(liveButton.textContent, 'heart 5', 'live client state');
+
+    // Incoming SSR still carries the initial state.
+    const incoming = document.createElement(tag);
+    incoming.setAttribute('count', '0');
+    incoming.innerHTML = '<button>heart 0</button>';
+    _diffElementInPlace(live, incoming);
+
+    // The router preserved the live subtree: same node identity, live content.
+    assert.equal(live.querySelector('button'), liveButton, 'button kept its identity');
+    assert.equal(live.querySelector('button').textContent, 'heart 5',
+      'live client state was not morphed back to the SSR initial state');
+
+    live.remove();
+  });
+
+  test('a hydrated component nested under a reconciled parent survives (#906)', async () => {
+    // The common shape: the component sits inside a page/children-slot region
+    // that the router reconciles. reconcileChildren -> diffElementInPlace on
+    // the component must still leave its internals alone.
+    const tag = defineLikeButton();
+    const parent = document.createElement('div');
+    const live = document.createElement(tag);
+    live.setAttribute('count', '1');
+    parent.appendChild(live);
+    document.body.appendChild(parent);
+    await live.updateComplete;
+
+    const src = document.createElement('div');
+    const incoming = document.createElement(tag);
+    incoming.setAttribute('count', '1');
+    incoming.innerHTML = '<button>heart 1</button>';
+    src.appendChild(incoming);
+
+    _reconcileChildren(parent, src);
+
+    // Same component instance kept, and it is still interactive.
+    const stillLive = parent.querySelector(tag);
+    assert.equal(stillLive, live, 'the component instance was reused, not recreated');
+    stillLive.querySelector('button').click();
+    await stillLive.updateComplete;
+    assert.equal(stillLive.querySelector('button').textContent, 'heart 2',
+      'nested component still interactive after parent reconcile');
+
+    parent.remove();
+  });
+});

--- a/packages/core/test/routing/router-client.test.js
+++ b/packages/core/test/routing/router-client.test.js
@@ -401,6 +401,57 @@ test('diffElementInPlace: different tag → replaceWith (no in-place reuse)', ()
     'mismatched tags swap out the element');
 });
 
+test('diffElementInPlace: does NOT recurse into a hydrated component (#906)', () => {
+  // A hydrated component owns its rendered subtree: the client renderer
+  // stashes a live instance on the host under Symbol.for('webjs.instance'),
+  // whose lit-html parts hold direct references to these child nodes.
+  // Reconciling into them would swap the nodes out and orphan the parts, so
+  // the component's next reactive update writes to detached nodes (a dead
+  // click after a soft nav). The router must leave the subtree alone.
+  const dst = document.createElement('like-button');
+  dst.setAttribute('count', '3');
+  dst.innerHTML = '<button>heart 7</button>'; // live: user clicked up to 7
+  const liveButton = dst.firstChild;
+  /** @type {any} */ (dst)[Symbol.for('webjs.instance')] = { strings: [], parts: [] };
+
+  const src = document.createElement('like-button');
+  src.setAttribute('count', '3');
+  src.innerHTML = '<button>heart 3</button>'; // incoming SSR: initial state
+
+  _diffEl(dst, src);
+
+  // The live rendered node is preserved by identity, its content untouched.
+  assert.equal(dst.firstChild, liveButton, 'component child kept its identity');
+  assert.equal(dst.textContent, 'heart 7', 'live component content not morphed');
+});
+
+test('diffElementInPlace: hydrated component still gets its attributes synced (#906)', () => {
+  // Opacity is only about CHILDREN. Attributes must still sync, because a
+  // reactive-property attribute change is how the router drives the
+  // component to re-render itself.
+  const dst = document.createElement('my-widget');
+  dst.setAttribute('label', 'old');
+  /** @type {any} */ (dst)[Symbol.for('webjs.instance')] = { strings: [], parts: [] };
+  const src = document.createElement('my-widget');
+  src.setAttribute('label', 'new');
+  _diffEl(dst, src);
+  assert.equal(dst.getAttribute('label'), 'new',
+    'reactive-prop attribute must still sync so the component re-renders itself');
+});
+
+test('diffElementInPlace: a custom element with NO live instance IS reconciled (#906)', () => {
+  // The guard keys on the live-instance symbol, not on the tag name: a
+  // not-yet-upgraded or display-only custom element has no parts to corrupt
+  // and must still reconcile normally.
+  const dst = document.createElement('like-button');
+  dst.innerHTML = '<button>heart 7</button>';
+  const src = document.createElement('like-button');
+  src.innerHTML = '<button>heart 3</button>';
+  _diffEl(dst, src);
+  assert.equal(dst.textContent, 'heart 3',
+    'a custom element with no client render reconciles like any element');
+});
+
 /* ====================================================================
  * reconcileChildren: keyed reuse + positional reuse
  * ==================================================================== */


### PR DESCRIPTION
Closes #906

## Summary

Interactivity on a hydrated component (an `@click`, a reactive-property assignment) stopped working after soft-navigating away from its page and back. Found by dogfooding: the marketing site's `<like-button>` "click to count" demo goes dead after visiting a few pages via the client router and returning. Intermittent, only on some return navigations.

Root cause: the client router's DOM reconciler recursed INTO a hydrated component's rendered subtree and morphed the nodes out from under the component's live render bindings.

A light-DOM `WebComponent` renders into its own host (`_renderRoot === this`) via `clientRender(tpl, this._renderRoot)`. The client renderer stashes the live template instance, whose lit-html parts hold DIRECT references to the rendered `<button>` and text nodes, on the host under `Symbol.for('webjs.instance')`. On a same-layout soft nav, `reconcileSiblings` / `reconcileChildren` positionally- or key-match the live `<like-button>` to the incoming SSR one and call `diffElementInPlace(live, incoming)`, which recursed into the component's children, importing fresh nodes and removing/reinserting the live ones. The button + text nodes the parts still referenced got replaced by detached copies, so the next reactive update (`count++` then re-render) wrote into the ORPHANED nodes and never reached the DOM.

Intermittent because it only fired on the fetch+reconcile return path with the subtree matched-and-morphed; the popstate snapshot-restore path re-parses fresh HTML and re-upgrades cleanly, so that path always worked.

## The fix

Treat a hydrated component as opaque in the reconciler (`diffElementInPlace` in `packages/core/src/router-client.js`): still sync its attributes (a reactive-prop attribute change is how the router drives the component to re-render ITSELF), but skip the child recursion when the element carries a live client-render instance. Detection is the render-client instance symbol (`isHydratedComponent`), so a not-yet-upgraded or display-only custom element (no parts to corrupt) still reconciles normally. This mirrors Turbo/morphdom, which leave custom elements alone by default. `diffElementInPlace` is the single choke point every in-place child-morph passes through (`reconcileSiblings`, `reconcileChildren`, the frame `diffChildren`, `swapMarkerRange`), so one guard covers them all.

## Tests

- **Unit** (`packages/core/test/routing/router-client.test.js`, linkedom): `diffElementInPlace` skips child recursion when the instance symbol is present, still syncs attributes, and a custom element with NO live instance still reconciles (guard is symbol-keyed, not tag-keyed). 671/671 core node tests pass.
- **Browser** (`packages/core/test/routing/browser/reconcile-hydrated-component.test.js`, WTR on Chromium + Firefox + WebKit): the headline case. Hydrate a real component, reconcile it in place, then click and assert the DOM still increments; plus live-state preservation, a nested-under-reconciled-parent case, and an interactive-slotted-component case. 4/4 on all three engines; full browser routing suite 69/69 on all three, no regressions.
- **Counterfactual (confirmed)**: disabling only the `isHydratedComponent` guard reds the headline browser test on all three engines (post-reconcile click no longer increments) and the `does NOT recurse` unit test; the guard-independent tests stay green. Restored, all green.
- **E2E** (`WEBJS_E2E=1`, blog in a real browser): 93/93, including `counter works after navigating away and back (same-layout swap)`, `... after multiple navigations with random delays`, `... after rapid back-and-forth navigation`, and `counter element is fully upgraded after client navigation`. That is the exact #906 scenario end to end.

## Known trade-off (filed as #908)

With the guard, the router no longer re-projects page-authored `<slot>` content of a REUSED interactive component across a soft nav (the guard skips the whole subtree, including projected children). Interactivity is preserved (covered by a test). This is strictly smaller than #906 (pre-fix, the same components had a dead click), and a proper slot-aware reconcile is separate work, filed as #908.

## Surfaces

- Docs / AGENTS.md: N/A, internal correctness fix, no public-surface or documented-behaviour change (the "components own their subtree" contract already held; this makes the router honour it).
- Scaffold: N/A, no generated-code change.
- Bun parity: N/A, `router-client.js` is browser-only (touches `document`), not on the listener/serializer/stream path.
- Elision analyser: N/A, no new interactivity signal.

## Dogfood

- Blog e2e: 93/93 in a real browser (dist mode; core dist built).
- website / docs / ui-website: boot 200 in prod mode (docs `/` is a 302 redirect), no `modulepreload` 404s.
- `webjs check` on the blog: all checks pass.
- SSR output is unchanged (browser-runtime-only fix).