### PR TITLE
chore: release core 0.7.34

### DIFF
--- a/changelog/core/0.7.34.md
+++ b/changelog/core/0.7.34.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/core"
+version: 0.7.34
+date: 2026-07-11T03:54:14.783Z
+commit_count: 1
+---
+## Fixes
+
+- **client router must not reconcile into hydrated components** ([#907](https://github.com/webjsdev/webjs/pull/907)) [`c5c797f0`](https://github.com/webjsdev/webjs/commit/c5c797f0)
+  * fix: client router must not reconcile into hydrated components
+  
+  A light-DOM component renders into its own host via the client renderer,
+  which stashes the live template instance (lit-html parts holding direct

--- a/package-lock.json
+++ b/package-lock.json
@@ -6991,7 +6991,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.33",
+      "version": "0.7.34",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.25.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.33",
+  "version": "0.7.34",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",


### PR DESCRIPTION
Releases `@webjsdev/core` 0.7.34.

## What ships

- **Fix (#907):** the client router no longer reconciles into a hydrated component's rendered subtree, so interactivity (an `@click`, a reactive-property assignment) survives a same-layout soft navigation instead of dying (the dead like-button after navigating away and back). Closes #906.

## Mechanics

- Bumps `packages/core/package.json` 0.7.33 -> 0.7.34 (patch; a fix while core stays in the 0.7 line).
- Dependents all pin `^0.7.0` / `^0.7.1`, which 0.7.34 satisfies, so no dependent ranges change.
- `package-lock.json` regenerated (only the core version line).
- `changelog/core/0.7.34.md` generated by the pre-commit hook from the `fix:` squash subject.

Merging adds `changelog/core/0.7.34.md` to main, which triggers `release.yml` to `npm publish` core 0.7.34 and cut its GitHub Release (idempotent).