### PR TITLE
fix: client router re-projects slotted content of a reused component

### DIFF
--- a/agent-docs/advanced.md
+++ b/agent-docs/advanced.md
@@ -419,7 +419,14 @@ navigation automatically.
    reconciler. Elements with matching tag + matching key are reused
    with in-place attribute diffing. **Live attributes** (`value`,
    `checked`, `selected`, `indeterminate`, `disabled`, `open`,
-   `popover`) are NEVER overwritten by the server HTML.
+   `popover`) are NEVER overwritten by the server HTML. A **hydrated
+   component** (one whose client render owns its subtree via live
+   template parts) is reconciled attribute-only: the router syncs its
+   attributes (driving any reactive-property change) but never touches
+   its render-owned nodes, so a soft nav cannot corrupt a live
+   component. The one exception is a light-DOM component's projected
+   `<slot>` content, which is page-authored rather than render-owned, so
+   the router re-projects it to match the incoming page.
 5. Merges `<head>` (add-only on partial swaps so runtime-injected
    styles like Tailwind survive, with a full merge on the
    root-layout-change fallback), re-runs `<script>` elements,

--- a/packages/core/src/router-client.js
+++ b/packages/core/src/router-client.js
@@ -2764,6 +2764,13 @@ function ownActualLightSlots(host) {
  * the live DOM and the incoming SSR HTML carry the same slot markers
  * (render-server emits them), so slots pair up by name + document order.
  *
+ * Scope: this handles the actual->actual case (the projected content changed).
+ * The two boundary transitions where a slot crosses between actual and fallback
+ * (content fully REMOVED, or ADDED where there was none) are deferred to #912:
+ * a slot's fallback is render-owned, so restoring or replacing it must go
+ * through the slot runtime, not a raw reconcile. Both are skipped here (see the
+ * two `continue`/iteration guards below), so neither can touch a lit-html part.
+ *
  * @param {Element} dst  Live hydrated component host.
  * @param {Element} src  Incoming SSR copy of the same component.
  */
@@ -2775,15 +2782,19 @@ function reprojectSlottedContent(dst, src) {
   const state = /** @type {any} */ (dst)[SLOT_STATE];
   if (!state) return;
 
+  // Iterate the LIVE component's actual slots only. A slot the live component
+  // currently shows as FALLBACK is absent here, so the fallback->actual
+  // direction (incoming ADDED content) is skipped: filling it would replace
+  // render-owned fallback nodes, which is the #906 hazard (deferred to #912).
   const liveSlots = ownActualLightSlots(dst);
   if (liveSlots.size === 0) return;
   const incSlots = ownActualLightSlots(src);
 
   for (const [name, liveSlot] of liveSlots) {
     const incSlot = incSlots.get(name);
-    // Incoming has no actual content for this slot (content removed, now
-    // showing fallback): leave the live projection as-is rather than risk
-    // touching render-owned fallback nodes. Conservative, no #906 regression.
+    // The actual->fallback direction: incoming REMOVED this slot's content (now
+    // shows fallback), so leave the live projection as-is rather than touch
+    // render-owned fallback nodes. Conservative, no #906 regression (#912).
     if (!incSlot) continue;
 
     // The slot's children are page-authored, so reconcileChildren is safe:

--- a/packages/core/src/router-client.js
+++ b/packages/core/src/router-client.js
@@ -14,6 +14,9 @@ import './webjs-suspense.js';
 // Ingest SSR action seeds (#472) from an incoming soft-nav document before its
 // components hydrate, so a navigated async component resolves from the seed.
 import { scanSeeds } from './action-seed-client.js';
+// Slot-runtime constants for re-projecting page-authored slotted content of a
+// reused hydrated light-DOM component across a soft nav (#908).
+import { SLOT_STATE, LIGHT_SLOT_ATTR, PROJECTION_ATTR, PROJECTION_ACTUAL } from './slot.js';
 
 /** The content type a content-negotiated stream-action response carries (#248). */
 const STREAM_MIME = 'text/vnd.webjs-stream.html';
@@ -2677,7 +2680,16 @@ function diffElementInPlace(dst, src) {
   // property change through `attributeChangedCallback`, so the component
   // re-renders ITSELF; the router must not touch its internals. This mirrors
   // Turbo/morphdom, which leave custom elements alone by default.
-  if (isHydratedComponent(dst)) return;
+  //
+  // One carve-out (#908): a light-DOM component's projected <slot> content is
+  // page-authored (moved into the slot by the slot runtime), NOT render-owned,
+  // so a reused component would otherwise keep showing STALE slotted content
+  // when the nav supplies different content. Re-project ONLY those slot
+  // children; the render-owned nodes stay untouched, so #906 does not regress.
+  if (isHydratedComponent(dst)) {
+    reprojectSlottedContent(dst, src);
+    return;
+  }
 
   // Recurse into children: collect both sides, run reconcileSiblings on
   // them with synthetic boundary markers. Cheap implementation: use
@@ -2700,6 +2712,91 @@ function diffElementInPlace(dst, src) {
  */
 function isHydratedComponent(el) {
   return /** @type {any} */ (el)[Symbol.for('webjs.instance')] != null;
+}
+
+/**
+ * True when `slot` belongs directly to `host`, i.e. no OTHER custom element
+ * sits between them. A slot nested inside a child custom element belongs to
+ * THAT component (its own slot state owns it), so the host must not touch it.
+ *
+ * @param {Element} slot
+ * @param {Element} host
+ * @returns {boolean}
+ */
+function isOwnLightSlot(slot, host) {
+  for (let p = slot.parentElement; p && p !== host; p = p.parentElement) {
+    if (p.tagName.includes('-')) return false;
+  }
+  return true;
+}
+
+/**
+ * Group a component's own `data-projection="actual"` light slots by name,
+ * first-wins (mirroring the slot runtime + SSR first-wins rule). Slots nested
+ * inside a child custom element are excluded (they belong to that child).
+ *
+ * @param {Element} host
+ * @returns {Map<string|null, HTMLSlotElement>}
+ */
+function ownActualLightSlots(host) {
+  /** @type {Map<string|null, HTMLSlotElement>} */
+  const byName = new Map();
+  const sel = `slot[${LIGHT_SLOT_ATTR}][${PROJECTION_ATTR}="${PROJECTION_ACTUAL}"]`;
+  for (const slot of host.querySelectorAll(sel)) {
+    const s = /** @type {HTMLSlotElement} */ (slot);
+    if (!isOwnLightSlot(s, host)) continue;
+    const name = s.getAttribute('name') || null;
+    if (!byName.has(name)) byName.set(name, s);
+  }
+  return byName;
+}
+
+/**
+ * Re-project the page-authored slotted content of a REUSED hydrated light-DOM
+ * component across a soft nav (#908), without touching its render-owned
+ * subtree.
+ *
+ * The #906 guard treats a hydrated component as opaque so the router never
+ * corrupts its lit-html-owned nodes. But the projected children inside a
+ * light-DOM `<slot data-webjs-light data-projection="actual">` are
+ * page-authored (moved there by the slot runtime), NOT held by lit-html parts,
+ * so reconciling ONLY those children is safe and cannot reintroduce #906. Both
+ * the live DOM and the incoming SSR HTML carry the same slot markers
+ * (render-server emits them), so slots pair up by name + document order.
+ *
+ * @param {Element} dst  Live hydrated component host.
+ * @param {Element} src  Incoming SSR copy of the same component.
+ */
+function reprojectSlottedContent(dst, src) {
+  // Only a light-DOM component that tracks slot assignments has projected
+  // page-authored content to update. No slot state (no <slot>, or a shadow-DOM
+  // component whose slotted nodes are ordinary light children) means nothing
+  // to re-project here.
+  const state = /** @type {any} */ (dst)[SLOT_STATE];
+  if (!state) return;
+
+  const liveSlots = ownActualLightSlots(dst);
+  if (liveSlots.size === 0) return;
+  const incSlots = ownActualLightSlots(src);
+
+  for (const [name, liveSlot] of liveSlots) {
+    const incSlot = incSlots.get(name);
+    // Incoming has no actual content for this slot (content removed, now
+    // showing fallback): leave the live projection as-is rather than risk
+    // touching render-owned fallback nodes. Conservative, no #906 regression.
+    if (!incSlot) continue;
+
+    // The slot's children are page-authored, so reconcileChildren is safe:
+    // it preserves node identity where it can and never touches lit-html parts.
+    reconcileChildren(liveSlot, incSlot);
+
+    // Keep the slot runtime's assignment bookkeeping in sync with the new
+    // children so a later component re-render's projection pass materialises
+    // THESE nodes, not the stale ones it captured at hydration.
+    const children = [...liveSlot.childNodes];
+    state.assignedByName.set(name, children);
+    state.lastSnapshot.set(liveSlot, children.slice());
+  }
 }
 
 /**

--- a/packages/core/test/routing/browser/reconcile-hydrated-component.test.js
+++ b/packages/core/test/routing/browser/reconcile-hydrated-component.test.js
@@ -164,4 +164,56 @@ suite('Client router: reconcile does not corrupt a hydrated component (#906)', (
 
     live.remove();
   });
+
+  test('a reused interactive component re-projects changed slotted content on soft nav (#908)', async () => {
+    // The #908 acceptance bar: a light-DOM interactive component that projects
+    // page-authored <slot> content is REUSED (not recreated) across a soft nav
+    // that supplies DIFFERENT slotted content. The router must update the
+    // projected content AND keep the component interactive. Both assertions
+    // together are the bar: the pre-fix behaviour (blanket-skip the subtree)
+    // kept interactivity but left the STALE slotted content on screen.
+    const tag = `rc-slot-reproject-${counter++}`;
+    class RcSlotReproject extends WebComponent({ on: Boolean }) {
+      constructor() { super(); this.on = false; }
+      render() {
+        return html`<button @click=${() => { this.on = !this.on; }}>t</button><div><slot></slot></div>`;
+      }
+    }
+    customElements.define(tag, RcSlotReproject);
+
+    const live = document.createElement(tag);
+    live.innerHTML = 'FIRST';
+    document.body.appendChild(live);
+    await live.updateComplete;
+    // Wait a microtask for the slot runtime's batched projection to settle.
+    await Promise.resolve();
+    assert.equal(live.querySelector('slot').textContent, 'FIRST', 'initial projection');
+
+    // The incoming SSR copy mirrors what render-server emits for a light-DOM
+    // slot: `<slot data-webjs-light data-projection="actual">` carrying the
+    // NEW page-authored content.
+    const incoming = document.createElement(tag);
+    incoming.innerHTML =
+      '<button>t</button><div><slot data-webjs-light data-projection="actual">SECOND</slot></div>';
+    _diffElementInPlace(live, incoming);
+
+    // 1. The projected slotted content updated to the incoming page's content.
+    assert.equal(live.querySelector('slot').textContent, 'SECOND',
+      'reused component must re-project the incoming slotted content');
+
+    // 2. Interactivity is intact after the reproject (no #906 regression).
+    live.querySelector('button').click();
+    await live.updateComplete;
+    assert.equal(live.on, true, 'reactive state still updates after reproject');
+
+    // 3. A subsequent component re-render must NOT revert to the old content
+    //    (the slot runtime's assignment bookkeeping stayed in sync).
+    live.on = false;
+    await live.updateComplete;
+    await Promise.resolve();
+    assert.equal(live.querySelector('slot').textContent, 'SECOND',
+      're-render must keep the re-projected content, not revert to FIRST');
+
+    live.remove();
+  });
 });

--- a/packages/core/test/routing/browser/reconcile-hydrated-component.test.js
+++ b/packages/core/test/routing/browser/reconcile-hydrated-component.test.js
@@ -216,4 +216,108 @@ suite('Client router: reconcile does not corrupt a hydrated component (#906)', (
 
     live.remove();
   });
+
+  test('re-projects element-bearing slotted content and keeps a nested component live (#908)', async () => {
+    // The corruption-risk surface: the slotted content is not plain text but an
+    // ELEMENT list including a NESTED hydrated component. The reproject must
+    // update the changed sibling (real slot-level add/remove, exercising the
+    // slot runtime's childObserver + removeFromAssignments) AND leave the
+    // nested component's own render-owned subtree alone (no #906 regression
+    // through the nested path).
+    const innerTag = `rc-inner-${counter++}`;
+    class RcInner extends WebComponent({ count: Number }) {
+      render() {
+        return html`<button @click=${() => this.count++}>n ${this.count}</button>`;
+      }
+    }
+    customElements.define(innerTag, RcInner);
+
+    const outerTag = `rc-outer-${counter++}`;
+    class RcOuter extends WebComponent({ on: Boolean }) {
+      constructor() { super(); this.on = false; }
+      render() {
+        return html`<button @click=${() => { this.on = !this.on; }}>o</button><div><slot></slot></div>`;
+      }
+    }
+    customElements.define(outerTag, RcOuter);
+
+    const live = document.createElement(outerTag);
+    live.innerHTML =
+      `<${innerTag} data-key="i" count="1"></${innerTag}><span data-key="s">OLD</span>`;
+    document.body.appendChild(live);
+    await live.updateComplete;
+    await Promise.resolve();
+    const liveInner = live.querySelector(innerTag);
+    await liveInner.updateComplete;
+    // Drive the nested component's client state forward.
+    liveInner.querySelector('button').click();
+    await liveInner.updateComplete;
+    assert.equal(liveInner.querySelector('button').textContent, 'n 2', 'nested first paint + click');
+    assert.equal(live.querySelector('span').textContent, 'OLD', 'initial sibling content');
+
+    // Incoming SSR: same nested component (keyed), CHANGED sibling text.
+    const incoming = document.createElement(outerTag);
+    incoming.innerHTML =
+      `<button>o</button><div><slot data-webjs-light data-projection="actual">` +
+      `<${innerTag} data-key="i" count="1"></${innerTag}><span data-key="s">NEW</span></slot></div>`;
+    _diffElementInPlace(live, incoming);
+
+    // 1. The changed element sibling re-projected (red without the fix).
+    assert.equal(live.querySelector('span').textContent, 'NEW',
+      'element-bearing slotted content must re-project the changed sibling');
+
+    // 2. The nested hydrated component kept its identity and live client state
+    //    (its render-owned subtree was never reconciled: no #906 regression).
+    assert.equal(live.querySelector(innerTag), liveInner, 'nested component reused, not recreated');
+    assert.equal(liveInner.querySelector('button').textContent, 'n 2',
+      'nested client state (n 2) survived, not morphed back to the SSR count=1');
+
+    // 3. The nested component is still interactive after the reproject.
+    liveInner.querySelector('button').click();
+    await liveInner.updateComplete;
+    assert.equal(liveInner.querySelector('button').textContent, 'n 3',
+      'nested component still interactive after the parent reproject');
+
+    live.remove();
+  });
+
+  test('re-projects named and default slots independently, first-wins (#908)', async () => {
+    // Named + default slots must re-project by NAME without cross-contaminating.
+    const tag = `rc-named-${counter++}`;
+    class RcNamed extends WebComponent({ on: Boolean }) {
+      constructor() { super(); this.on = false; }
+      render() {
+        return html`<button @click=${() => { this.on = !this.on; }}>b</button>
+          <header><slot name="title"></slot></header><main><slot></slot></main>`;
+      }
+    }
+    customElements.define(tag, RcNamed);
+
+    const live = document.createElement(tag);
+    live.innerHTML = '<h1 slot="title">OLD TITLE</h1><p>OLD BODY</p>';
+    document.body.appendChild(live);
+    await live.updateComplete;
+    await Promise.resolve();
+    assert.equal(live.querySelector('slot[name="title"]').textContent, 'OLD TITLE', 'title slot');
+    assert.equal(live.querySelector('main slot').textContent, 'OLD BODY', 'default slot');
+
+    const incoming = document.createElement(tag);
+    incoming.innerHTML =
+      '<button>b</button>' +
+      '<header><slot data-webjs-light data-projection="actual" name="title"><h1 slot="title">NEW TITLE</h1></slot></header>' +
+      '<main><slot data-webjs-light data-projection="actual"><p>NEW BODY</p></slot></main>';
+    _diffElementInPlace(live, incoming);
+
+    assert.equal(live.querySelector('slot[name="title"]').textContent, 'NEW TITLE',
+      'named title slot re-projected');
+    assert.equal(live.querySelector('main slot').textContent, 'NEW BODY',
+      'default slot re-projected independently, no cross-contamination');
+
+    // Interactivity intact.
+    live.querySelector('button').click();
+    await live.updateComplete;
+    assert.equal(live.on, true, 'reactive state still updates after named-slot reproject');
+
+    live.remove();
+  });
 });

--- a/packages/core/test/routing/browser/reconcile-hydrated-component.test.js
+++ b/packages/core/test/routing/browser/reconcile-hydrated-component.test.js
@@ -219,11 +219,12 @@ suite('Client router: reconcile does not corrupt a hydrated component (#906)', (
 
   test('re-projects element-bearing slotted content and keeps a nested component live (#908)', async () => {
     // The corruption-risk surface: the slotted content is not plain text but an
-    // ELEMENT list including a NESTED hydrated component. The reproject must
-    // update the changed sibling (real slot-level add/remove, exercising the
-    // slot runtime's childObserver + removeFromAssignments) AND leave the
-    // nested component's own render-owned subtree alone (no #906 regression
-    // through the nested path).
+    // ELEMENT list including a NESTED hydrated component. Both children are
+    // keyed, so reconcileChildren reuses them by identity and only the changed
+    // sibling text is updated. The point of this test is the nested path: the
+    // reproject must update the sibling AND leave the nested component's own
+    // render-owned subtree alone (no #906 regression through the nested path).
+    // The real slot-level add/remove path is covered by the next test.
     const innerTag = `rc-inner-${counter++}`;
     class RcInner extends WebComponent({ count: Number }) {
       render() {
@@ -317,6 +318,52 @@ suite('Client router: reconcile does not corrupt a hydrated component (#906)', (
     live.querySelector('button').click();
     await live.updateComplete;
     assert.equal(live.on, true, 'reactive state still updates after named-slot reproject');
+
+    live.remove();
+  });
+
+  test('re-projects a real slot add/remove and does not stale-revert on re-render (#908)', async () => {
+    // This drives the exact path the fix adds bookkeeping for: keyed items that
+    // are genuinely ADDED and REMOVED at the slot level (not just reused), so
+    // reconcileChildren removes an old node and inserts a new one. The host's
+    // async childObserver fires for those mutations; the fix keeps
+    // assignedByName/lastSnapshot in sync SYNCHRONOUSLY, so a later component
+    // re-render's projection pass must materialise the NEW set, not stale-revert
+    // to the old one.
+    const tag = `rc-list-${counter++}`;
+    class RcList extends WebComponent({ on: Boolean }) {
+      constructor() { super(); this.on = false; }
+      render() {
+        return html`<button @click=${() => { this.on = !this.on; }}>b</button><ul><slot></slot></ul>`;
+      }
+    }
+    customElements.define(tag, RcList);
+
+    const live = document.createElement(tag);
+    live.innerHTML = '<li data-key="a">A</li><li data-key="b">B</li>';
+    document.body.appendChild(live);
+    await live.updateComplete;
+    await Promise.resolve();
+    assert.equal(live.querySelector('slot').textContent, 'AB', 'initial list projection');
+
+    // Incoming removes A, keeps B, adds C: a genuine slot-level add + remove.
+    const incoming = document.createElement(tag);
+    incoming.innerHTML =
+      '<button>b</button><ul><slot data-webjs-light data-projection="actual">' +
+      '<li data-key="b">B</li><li data-key="c">C</li></slot></ul>';
+    _diffElementInPlace(live, incoming);
+
+    assert.equal(live.querySelector('slot').textContent, 'BC',
+      'slot add/remove re-projected (A removed, C added)');
+
+    // The async childObserver has since fired; a re-render must keep BC, proving
+    // assignedByName was synced to the new set (not the stale [A,B]).
+    await Promise.resolve();
+    live.querySelector('button').click();
+    await live.updateComplete;
+    await Promise.resolve();
+    assert.equal(live.querySelector('slot').textContent, 'BC',
+      're-render after a slot add/remove must not stale-revert to the old items');
 
     live.remove();
   });


### PR DESCRIPTION
Closes #908

## Summary

Follow-up to #906 / PR #907. That fix made the client-router reconciler treat a hydrated component as opaque (`diffElementInPlace` returns early when the host carries the `Symbol.for('webjs.instance')` live-render symbol), so the router can never corrupt the component's lit-html-owned subtree.

The blanket skip has a narrower cost: for a LIGHT-DOM interactive component that projects page-authored `<slot>` content, the live-instance symbol sits on the host, so the guard skips the entire subtree, including the projected (page-authored, not render-owned) children. When a same-layout soft nav positionally reuses that component but the incoming page supplies DIFFERENT slotted content, the router discards the incoming content and the component keeps showing the stale slotted content until a full reload.

This PR makes the guard slot-aware: it re-projects ONLY the page-authored children of each live `data-projection="actual"` light slot, matched against the incoming component's slot of the same name, and leaves every render-owned node untouched. Slot-runtime bookkeeping (`assignedByName` / `lastSnapshot`) is kept in sync so a later component re-render does not revert to the old content.

## Approach

- Render-owned nodes are held by lit-html parts; page-authored projected nodes live inside `<slot data-webjs-light data-projection="actual">` and are moved there by the light-DOM slot runtime, never by lit-html. Reconciling only those slot children is safe and cannot reintroduce the #906 corruption.
- Both the live DOM and the incoming SSR HTML carry identical slot markers (render-server emits `<slot data-webjs-light data-projection="actual" name="...">`), so matching by name + document order is reliable.

## Test plan

- [ ] `packages/core/test/routing/browser/reconcile-hydrated-component.test.js`: reused slotted component re-projects changed content AND stays interactive AND a later re-render keeps the new content (three assertions).
- [ ] Counterfactual: reverting the slot-aware logic fails the "slot content updated" assertion while the #906 tests stay green.
- [ ] Existing #906/#907 browser tests still pass (no regression).


## Deliberately out of scope

The two boundary transitions where a slot crosses between the actual and fallback projection states are left stale on purpose and filed as #912: content fully REMOVED (incoming shows the slot as `data-projection="fallback"`) and content ADDED where the live component was showing fallback. Both cross a render-owned boundary (a slot's fallback is the compiled fallback template), so restoring or replacing it must go through the slot runtime, not a raw reconcile, and folding either in here would risk the #906 corruption. `reprojectSlottedContent` skips both with explanatory comments and this PR only fixes the actual->actual case (the projected content changed).

## Verification

- Browser tests (Chromium + Firefox + WebKit): 7/7 in `reconcile-hydrated-component.test.js` (4 #906 + 3 #908), all 14 routing browser files and 3 slots browser files green.
- Counterfactual: reverting the reproject call turns exactly the 3 #908 tests red; the 4 #906 tests stay green.
- 172 slot + routing node unit tests pass.
- Bun parity: N/A (browser-only client-router DOM code, not a runtime-sensitive server surface).
- Dogfood four-app boot: N/A (no SSR / importmap / served-module change; the fix is confined to the browser client router).

