### PR TITLE
chore: release core 0.7.35, cli 0.10.38

### DIFF
--- a/changelog/cli/0.10.38.md
+++ b/changelog/cli/0.10.38.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.38
+date: 2026-07-11T12:26:38.027Z
+commit_count: 1
+---
+## Features
+
+- **add saas logout control and login error feedback** ([#911](https://github.com/webjsdev/webjs/pull/911)) [`8d8c3892`](https://github.com/webjsdev/webjs/commit/8d8c3892)
+  * feat(scaffold): add saas logout control and login error feedback
+  
+  The generated saas app shipped no way to log out (signOut was exported but
+  unused) and swallowed a failed login: wrong credentials bounced silently to

--- a/changelog/core/0.7.35.md
+++ b/changelog/core/0.7.35.md
@@ -1,0 +1,16 @@
+---
+package: "@webjsdev/core"
+version: 0.7.35
+date: 2026-07-11T12:26:37.974Z
+commit_count: 2
+---
+## Fixes
+
+- **client router re-projects slotted content of a reused component** ([#910](https://github.com/webjsdev/webjs/pull/910)) [`b77194f4`](https://github.com/webjsdev/webjs/commit/b77194f4)
+  * test: add #908 acceptance test for slot re-projection on soft nav
+  
+  * fix: re-project slotted content of a reused hydrated component on soft nav
+- **re-project slot actual/fallback boundary transitions on soft nav** ([#914](https://github.com/webjsdev/webjs/pull/914)) [`e3538280`](https://github.com/webjsdev/webjs/commit/e3538280)
+  * test: add #912 acceptance tests for slot actual/fallback transitions
+  
+  * fix: re-project slot actual/fallback boundary transitions via the slot runtime

--- a/package-lock.json
+++ b/package-lock.json
@@ -6975,7 +6975,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.37",
+      "version": "0.10.38",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -6991,7 +6991,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.34",
+      "version": "0.7.35",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.25.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.37",
+  "version": "0.10.38",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.34",
+  "version": "0.7.35",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",


### PR DESCRIPTION
Release **@webjsdev/core 0.7.35** and **@webjsdev/cli 0.10.38**.

## What ships

**core 0.7.35** (2 fixes):
- #910 client router re-projects slotted content of a reused hydrated component on soft nav
- #914 client router re-projects the slot actual/fallback boundary transitions on soft nav

**cli 0.10.38** (1 feature):
- #911 scaffold: add saas logout control and login error feedback

## Release debt check (all published packages)

- core: owed (2 unreleased fixes since 0.7.34) -> 0.7.35
- cli: owed (1 unreleased feat since 0.10.37) -> 0.10.38
- server (0.8.48), ui (0.3.8), mcp (0.1.7), intellisense (0.5.3): no unreleased qualifying commits, no bump.

## Mechanics

- Patch bumps only; dependents pin `^0.7.0` / `^0.10.0`, so the new versions stay in range and no dependent ranges were widened.
- `package-lock.json` regenerated (`npm install --package-lock-only`).
- `changelog/core/0.7.35.md` + `changelog/cli/0.10.38.md` auto-generated by the pre-commit backfill from the conventional-commit squash subjects.
- Merging this adds the `changelog/**.md` files to `main`, which triggers `release.yml` to `npm publish` both packages and cut their GitHub Releases.
