### PR TITLE
chore: release server 0.8.49

### DIFF
--- a/changelog/server/0.8.49.md
+++ b/changelog/server/0.8.49.md
@@ -1,0 +1,12 @@
+---
+package: "@webjsdev/server"
+version: 0.8.49
+date: 2026-07-12T00:00:00.000Z
+commit_count: 2
+---
+## Fixes
+
+- **capture a dynamic import() inside a template `${}` hole (#918)** ([#919](https://github.com/webjsdev/webjs/pull/919)) [`e484202f`](https://github.com/webjsdev/webjs/commit/e484202f)
+  * The module-graph edge scanner missed a dynamic `import('./x.ts')` whose specifier sits inside a template-literal `${}` interpolation hole, because the dynamic scan ran over the fully-blanked mask, which blanks hole code along with template text. The browser-bound authorization gate derives from that graph, so the module was not admitted and could 404 if actually loaded. The dynamic scan now runs over the placeholder redaction, which keeps `${}` hole code readable while still treating a dynamic import written as literal text (in a string, comment, regex, or template text) as a non-edge. The static import / re-export scan stays on the blanked mask.
+- **harden the module-graph import scanner against literal-embedded keywords (#917)** ([#917](https://github.com/webjsdev/webjs/pull/917)) [`e18227dd`](https://github.com/webjsdev/webjs/commit/e18227dd)
+  * A stray `import` or `export` word written inside a comment, string, template, or regex literal could anchor a lazy regex match that spanned the literal's closing delimiter and consumed the next real `from '<spec>'`, silently dropping that edge so the gate 404'd a legitimately imported module. The scanner now runs its static regexes over a fully-blanked mask so no keyword can anchor inside any literal, closing the comment / template / regex swallow class at once (found by a new lexer-vs-AST differential harness that also covers generic component classes).

--- a/package-lock.json
+++ b/package-lock.json
@@ -7039,7 +7039,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.48",
+      "version": "0.8.49",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.48",
+  "version": "0.8.49",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Release `@webjsdev/server@0.8.49`. Merging this adds `changelog/server/0.8.49.md` to `main`, which triggers `release.yml` to `npm publish` and cut the GitHub Release (idempotent).

## Contents

- **#918** (`fix`, PR #919): capture a dynamic `import()` inside a template `${}` hole so the authorization gate admits it instead of 404ing.
- **#917** (landed under a `test:` subject, so the changelog is hand-written): harden the static import scanner against a stray `import`/`export` keyword inside a comment / string / template / regex literal swallowing the next real edge.

## Notes

- Patch bump; every dependent pins `^0.8.0`, so no dependent range edits. `package-lock.json` regenerated (one line: the server version).
- Changelog hand-written because #917's squash subject is `test:` (the backfill only picks up #919's `fix:`), so the auto-generated entry would omit the gate-hardening fix.

## Fast-check merge

Release-only diff (version + changelog + lockfile), so once **Conventions + Build + Unit** are green it is safe to squash-merge; E2E/Browser re-test source byte-identical to `main`.