### PR TITLE
docs: reference render-server pre-render pass by symbol, not line number

### DIFF
--- a/agent-docs/lit-muscle-memory-gotchas.md
+++ b/agent-docs/lit-muscle-memory-gotchas.md
@@ -138,8 +138,9 @@ then controllers' `hostUpdate`), reflects `reflect: true` properties,
 and calls `instance.render()`. Nothing past render fires server-side.
 Not `connectedCallback`, not `shouldUpdate`, not the `update` DOM
 commit, not `firstUpdated`, not `updated`, not controllers'
-`hostConnected` / `hostUpdated`. See
-`packages/core/src/render-server.js` around line 357.
+`hostConnected` / `hostUpdated`. See the `performServerUpdate()`
+pre-render pass in `packages/core/src/render-server.js` (called from
+`injectDSD`).
 
 The mental model is one sentence. Code in the constructor, `willUpdate`,
 and `render()` must avoid the genuinely browser-only surface (`document`,


### PR DESCRIPTION
Closes #458

`agent-docs/lit-muscle-memory-gotchas.md` cited `render-server.js` "around line 357", but the pre-render lifecycle code it points to drifted to ~line 419 (the claim itself was still accurate, only the line number rotted). Replaced the line number with the `performServerUpdate()` symbol (called from `injectDSD`), which survives a refactor.

A sweep of every `agent-docs/*.md` and `AGENTS.md` for `around line N` / `.js:N` / `~LN` style hard references confirms this was the ONLY one, so the acceptance criterion ("other hard line refs replaced OR confirmed none remain") is satisfied by that sweep.

## Surfaces
- **Docs:** `agent-docs/lit-muscle-memory-gotchas.md` (the one reference). No other doc surface references this.
- **Tests / scaffold / MCP / editors / dogfood:** N/A because this is a docs-only prose change (no code, no behaviour, no generated-app or editor-projection change). The MCP bundles `agent-docs/*.md` at prepack, so it picks up the corrected text automatically.
- **Changelog:** none (docs-only, no version bump).

## Test plan
- [ ] Symbols `performServerUpdate` + `injectDSD` exist in `packages/core/src/render-server.js` (verified)
- [ ] Sweep finds no remaining hard line-number references in agent-docs / AGENTS.md