### PR TITLE
test: boot website/docs/ui-website in CI on Bun and Node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,14 @@ jobs:
       # a node:crypto digest, so it must be byte-identical on the Bun.serve path.
       - name: App-source deploy signal on Bun
         run: bun test/bun/app-source-signal.mjs
+      # Boot website + docs + ui-website on Bun and GET real routes (#542). All
+      # four in-repo apps deploy on Bun, but only examples/blog had a Bun boot in
+      # CI, so a per-route break only on Bun (the #526 ui-website 500) could reach
+      # production. The script runs each app's webjs.start.before presteps (the
+      # ui-website registry copy is the #526 root cause) and probes an ui-website
+      # component detail page. Node runs it too in the "In-repo app tests" job.
+      - name: App boot-check on Bun (website + docs + ui-website)
+        run: bun test/bun/app-boot.mjs
       # SSR action-result seeding on Bun (#529): seeding rode Node's
       # module.registerHooks, which Bun lacks; it now installs via a Bun.plugin
       # onLoad, so a shipping async component seeds during SSR (the __webjs-seeds
@@ -343,7 +351,7 @@ jobs:
       - run: npm run build:dist --workspace=@webjsdev/core
 
   apps:
-    name: In-repo app tests (website + blog)
+    name: In-repo app tests (all four apps)
     runs-on: ubuntu-latest
     # The framework jobs above cover packages/* and the root cross-package
     # suite. This job runs each IN-REPO app's OWN test suite (its `webjs test`
@@ -351,7 +359,10 @@ jobs:
     # app's tests gates the merge (issue #342). The website's `test` runs both
     # its node + browser suites (hence Playwright); the blog is node-only and
     # touches its SQLite DB (the same setup the unit + e2e jobs do). docs and
-    # the ui-website ship no test suite yet, so they are not listed.
+    # the ui-website ship no `webjs test` suite, so they are covered by the
+    # `node test/bun/app-boot.mjs` boot-check step below (#627), which boots all
+    # three via createRequestHandler and asserts each serves real routes with no
+    # broken modulepreload; the same script runs on Bun in the `bun` job (#542).
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -371,6 +382,12 @@ jobs:
         run: npm test --workspace=@webjsdev/website
       - name: blog tests (node)
         run: npm test --workspace=@webjsdev/example-blog
+      # docs + ui-website ship no `webjs test` suite (#627): boot all three
+      # non-blog apps on Node and assert each serves real routes with no broken
+      # modulepreload. Runs the apps' `webjs.start.before` presteps first (the
+      # ui-website registry copy). The blog is covered by the e2e job.
+      - name: App boot-check on Node (website + docs + ui-website)
+        run: node test/bun/app-boot.mjs
 
   docker:
     name: Docker image build (the deploy artifact)

--- a/agent-docs/testing.md
+++ b/agent-docs/testing.md
@@ -178,9 +178,22 @@ script already covers the surface AND you ran it under Bun).
   failure, which fails the job). Set `WEBJS_BUN_TESTS=<substr,…>` to scope a
   local run.
 - CI runs it in the `bun` job alongside `test/bun/smoke.mjs` (#508),
-  `test/bun/listener.mjs` (#511, the listener-shell parity), and
+  `test/bun/listener.mjs` (#511, the listener-shell parity),
   `test/bun/timeouts.mjs` (#663, the `Bun.serve` `idleTimeout` wiring; the pure
-  ms-to-seconds mapping is unit-tested under the matrix too).
+  ms-to-seconds mapping is unit-tested under the matrix too), and
+  `test/bun/app-boot.mjs` (#542, the in-repo-app boot-check below).
+- **In-repo app boot-check (`test/bun/app-boot.mjs`, #542 / #627).** Boots
+  `website`, `docs`, and `packages/ui/packages/website` (ui-website) via
+  `createRequestHandler({ dev: false })`, runs each app's `webjs.start.before`
+  presteps first (the ui-website registry copy + the Tailwind build, exactly
+  what `webjs start` runs), GETs real routes (incl. a ui-website component detail
+  page, the #526 route class), and asserts status < 400 with no broken same-origin
+  `modulepreload`. A plain assert script (not `node:test`), so it runs identically
+  on BOTH runtimes: on Bun in the `bun` job (#542, since all four apps deploy on
+  Bun and only the blog had Bun coverage) and on Node in the "In-repo app tests"
+  job (#627, since docs + ui-website ship no `webjs test` suite). `examples/blog`
+  is not included (its own Bun e2e covers it). This automates the manual "boot
+  all four dogfood apps every framework PR" discipline.
 - Two cross-runtime test scripts also run under BOTH runtimes: `test/bun/smoke.mjs`
   (boot + SSR + TS strip + a server-action RPC) and `test/bun/listener.mjs`
   (`startServer` over a real socket: SSR + route + SSE + WebSocket). Plain assert

--- a/test/bun/app-boot.mjs
+++ b/test/bun/app-boot.mjs
@@ -1,0 +1,87 @@
+/**
+ * Cross-runtime app boot-check for the three in-repo apps that ship no test
+ * suite: `website`, `docs`, and `packages/ui/packages/website` (ui-website).
+ * All four in-repo apps DEPLOY on Bun in production (#541), but only
+ * `examples/blog` had Bun coverage in CI (the blog-on-bun e2e), so a per-route
+ * break that occurs only on Bun could reach production undetected. The #526
+ * incident was exactly this: ui.webjs.dev served 500s on its component detail
+ * pages because the prod start bypassed the registry copy, and Railway's
+ * liveness-only healthcheck never probed an individual route.
+ *
+ * This runs under WHICHEVER runtime executes it (Bun in the CI `bun` job, and
+ * Node via `scripts/run-bun-tests.js`): it runs each app's `webjs.start.before`
+ * presteps (the ui-website registry copy + each app's Tailwind build, exactly
+ * what `webjs start` runs), boots the app via `createRequestHandler({ dev:
+ * false })`, GETs real routes (including a ui-website component detail page, the
+ * #526 route class), and asserts status < 400 plus no broken same-origin
+ * `modulepreload` hint (the #158 / #159 probe). Fails LOUD with a non-zero exit.
+ *
+ * Left as-is: `examples/blog` already has its own Bun e2e (#523 / #525), so it
+ * is not duplicated here.
+ */
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequestHandler } from '@webjsdev/server';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const runtime = process.versions.bun ? `bun ${process.versions.bun}` : `node ${process.versions.node}`;
+
+/** The three apps + the real routes to probe. ui-website includes a component
+ *  detail page (`/docs/components/[name]`), the exact route class that 500'd in
+ *  #526 when the registry copy was skipped. */
+const APPS = [
+  { name: 'website', dir: 'website', routes: ['/'] },
+  { name: 'docs', dir: 'docs', routes: ['/', '/docs/no-build'] },
+  { name: 'ui-website', dir: 'packages/ui/packages/website', routes: ['/', '/docs/components/button'] },
+];
+
+/** Run an app's `webjs.start.before` steps (registry copy, Tailwind build) the
+ *  same way `webjs start` does, so the boot sees the assets a prod start bakes.
+ *  These are Node-tooling steps (tailwindcss, the copy-registry script); the CI
+ *  `bun` job has Node + `npm ci` available before it, and they run identically
+ *  under a local Node invocation. */
+function runStartBefore(appDir) {
+  let pkg;
+  try { pkg = JSON.parse(readFileSync(join(appDir, 'package.json'), 'utf8')); }
+  catch { return; }
+  const before = pkg?.webjs?.start?.before || [];
+  for (const cmd of before) execSync(cmd, { cwd: appDir, stdio: 'inherit' });
+}
+
+let failed = false;
+for (const app of APPS) {
+  const appDir = resolve(REPO_ROOT, app.dir);
+  try {
+    runStartBefore(appDir);
+    const h = await createRequestHandler({ appDir, dev: false });
+    if (h.warmup) await h.warmup();
+    for (const route of app.routes) {
+      const resp = await h.handle(new Request('http://localhost' + route));
+      const html = resp.status < 400 ? await resp.text() : '';
+      // Every same-origin modulepreload hint must resolve through the SAME
+      // in-process handler (a preload the auth gate then 404s is the #158/#159
+      // bug class). Probe method-agnostic, so no GET-vs-HEAD trap.
+      const preloads = [...html.matchAll(/<link[^>]+rel=["']modulepreload["'][^>]*href=["']([^"']+)["']/g)]
+        .map((m) => m[1]).filter((href) => href.startsWith('/'));
+      const broken = [];
+      for (const p of preloads) {
+        const pr = await h.handle(new Request('http://localhost' + p));
+        if (pr.status >= 400) broken.push(`${p}->${pr.status}`);
+      }
+      const ok = resp.status < 400 && broken.length === 0;
+      console.log(`${ok ? 'OK  ' : 'FAIL'} ${app.name} ${route} -> ${resp.status}, preloads=${preloads.length}, broken=[${broken.join(', ')}]`);
+      if (!ok) failed = true;
+    }
+  } catch (e) {
+    console.log(`FAIL ${app.name} boot threw: ${String(e && e.message ? e.message : e).split('\n')[0]}`);
+    failed = true;
+  }
+}
+
+if (failed) {
+  console.error(`FAIL  app boot-check on ${runtime}`);
+  process.exit(1);
+}
+console.log(`OK  app boot-check passed on ${runtime} (website + docs + ui-website serve real routes, no broken preloads)`);


### PR DESCRIPTION
Closes #542
Closes #627

All four in-repo apps deploy on Bun in production (#541), but only `examples/blog` had a Bun boot-check in CI, so a per-route break that occurs only on Bun could reach production undetected. The #526 incident was exactly this class: `ui.webjs.dev` served 500s on its component detail pages because the prod start bypassed the registry copy, and Railway's liveness-only healthcheck never probed an individual route.

## What this adds

`test/bun/app-boot.mjs`: boots `website`, `docs`, and `packages/ui/packages/website` (ui-website) via `createRequestHandler({ dev: false })`, runs each app's `webjs.start.before` presteps first (the ui-website registry copy + each app's Tailwind build, exactly what `webjs start` runs), GETs real routes (including a ui-website `/docs/components/[name]` page, the exact #526 route class), and asserts status < 400 with no broken same-origin `modulepreload`. Fails loud with a non-zero exit.

It is a plain assert script (not `node:test`, like `smoke.mjs` / `listener.mjs`), so it runs identically on both runtimes and is NOT double-run by the matrix (which globs `*.test.mjs`):
- **Bun** (`bun test/bun/app-boot.mjs` in the `bun` job) closes #542.
- **Node** (`node test/bun/app-boot.mjs` in the "In-repo app tests" job) closes #627, since docs + ui-website ship no `webjs test` suite.

`examples/blog` is left as-is (its own Bun e2e covers it, no duplication).

## Why #627 is folded in

#627 is the Node analog of the same gap (boot docs + ui-website in the apps job). It is the same script plus one `node ...` step and a job comment/name update, so I did both here rather than a near-duplicate second PR (this is the consolidation I flagged when we triaged the Todos). If you would rather ship #542 alone, say so and I will split the Node step out.

## Verification

- Counterfactual for the #526 class: with the ui-website registry absent (a fresh deploy before `copy-registry`), `/docs/components/button` returns 500, so the check FAILS. Running the prestep (as the script does) makes it 200, so the check PASSES. Confirmed locally.
- Boot result on both runtimes locally: `website /` 200, `docs /` 302 + `/docs/no-build` 200, `ui-website /` 200 + `/docs/components/button` 200 (40 preloads, none broken), on node 26 AND bun 1.3.14.

## Definition-of-done surfaces

- **Tests:** this IS test/CI infra (the boot-check + its two CI wirings); no app-runtime code changed.
- **Docs:** `agent-docs/testing.md` documents the new app boot-check layer (#542 / #627).
- **Everything else (AGENTS.md src rows, scaffold, MCP, editors, marketing, docs-site):** N/A because no framework `packages/*/src`, scaffold, or public API changed.

## Test plan
- [ ] `bun test/bun/app-boot.mjs` and `node test/bun/app-boot.mjs` both pass
- [ ] The #526 counterfactual (registry absent) reds the ui-website route
- [ ] `ci.yml` parses; the `bun` job and the renamed "In-repo app tests (all four apps)" job each run the boot-check
