### PR TITLE
fix: give the /why page title a clean hyphen form

### DIFF
--- a/website/app/why/page.ts
+++ b/website/app/why/page.ts
@@ -20,7 +20,7 @@ import { DOCS_URL, GH_URL, EXAMPLE_BLOG_URL, NEW_TAB } from '#lib/links.ts';
 export function generateMetadata(ctx: { url: string }) {
   const origin = new URL(ctx.url).origin;
   const image = `${origin}/public/og-why.png`;
-  const title = 'Why WebJs: the framework your AI agent already understands';
+  const title = 'Why WebJs - The Framework Your AI Agent Already Understands';
   const description =
     'WebJs serves the framework source and your app code exactly as written, so any AI model can read the whole stack from node_modules, reason about it, and debug it. No training data required, no single blessed model. Built on the web components, HTML, and JavaScript every model already knows.';
   return {

--- a/website/test/ssr/why-ssr.test.ts
+++ b/website/test/ssr/why-ssr.test.ts
@@ -33,3 +33,11 @@ test('why metadata is self-consistent and points at the dedicated /why social ca
   assert.match(m.openGraph.image, /\/public\/og-why\.png$/, 'og:image is the dedicated /why card');
   assert.equal(m.twitter.image, m.openGraph.image, 'twitter image matches the og image');
 });
+
+test('the /why title uses a clean hyphen form, not a colon', () => {
+  // Guards the regression that shipped the title as "Why WebJs: the framework
+  // ...". This is a marketing page, so it takes the brand-first hyphen title
+  // like the home page, not a colon-label form.
+  const { title } = generateMetadata({ url: 'https://webjs.dev/why' });
+  assert.ok(!title.includes(':'), 'title uses no colon-label form');
+});


### PR DESCRIPTION
Closes #929

## What

The `/why` page title shipped as `Why WebJs: the framework ...`, with a colon. `/why` is a marketing page (not docs/blog/changelog), so it takes a brand-first hyphen title in title case, like the home page:

```
WebJs - The Framework Your AI Agent Already Understands
```

No ` · WebJs` suffix: that middot suffix is only for the WebJs-owned docs/blog/changelog pages, not a marketing page like `/why`, and it is deliberately not touched here. This stays an internal WebJs-site branding concern and is NOT a framework/scaffold rule for end-user apps.

## Surfaces

- `website/app/why/page.ts` renames the title to the clean title-cased hyphen form.
- `website/test/ssr/why-ssr.test.ts` asserts the title uses no colon-label form, guarding the regression.
- Docs / scaffold / MCP / editor plugins / other apps: N/A because this is a one-line title string on the marketing site with no framework surface change.

## Verification

- SSR tests pass (3/3), `webjs check` clean.
- Booted locally, the rendered `<title>` is `WebJs - The Framework Your AI Agent Already Understands`.