### PR TITLE
chore: release server 0.8.49

### DIFF
--- a/changelog/server/0.8.49.md
+++ b/changelog/server/0.8.49.md
@@ -1,0 +1,26 @@
+---
+package: "@webjsdev/server"
+version: 0.8.49
+date: 2026-07-12T11:58:39.879Z
+commit_count: 3
+---
+## Performance
+
+- **preload walk roots at the shipped module set, not raw route entries** ([#921](https://github.com/webjsdev/webjs/pull/921)) [`a345012f`](https://github.com/webjsdev/webjs/commit/a345012f)
+  * perf: preload walk roots at the shipped module set, not raw route entries
+  
+  deduplicatedPreloads (the app-module + component modulepreload walk) rooted
+  at the raw [route.file, ...route.layouts] route entries, so it walked a
+
+## Fixes
+
+- **capture a dynamic import() inside a template ${} hole** ([#919](https://github.com/webjsdev/webjs/pull/919)) [`e484202f`](https://github.com/webjsdev/webjs/commit/e484202f)
+  * fix: capture a dynamic import() inside a template ${} hole
+  
+  The module-graph edge scanner missed a dynamic import() whose
+  string-literal specifier sits inside a template-literal ${} hole
+- **stamp the trusted socket IP on a WebSocket upgrade (#778)** ([#923](https://github.com/webjsdev/webjs/pull/923)) [`bef996d7`](https://github.com/webjsdev/webjs/commit/bef996d7)
+  A WS(ws, req) handler calling clientIp(req) read the spoofable inbound
+  x-webjs-remote-ip header on BOTH runtimes: the upgrade path built the
+  handler's Request by copying all inbound headers and never (a) stripped
+  the inbound x-webjs-remote-ip copy nor (b) stamped the framework-trusted

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.48",
+  "version": "0.8.49",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Release `@webjsdev/server` 0.8.49 (patch).

## What lands

- **fix:** stamp the trusted socket IP on a WebSocket upgrade (#923, #778)
- **fix:** capture a dynamic `import()` inside a template `${}` hole (#919)
- **perf:** preload walk roots at the shipped module set, not raw route entries (#921)

Full notes in `changelog/server/0.8.49.md`. On merge, `release.yml` publishes to npm and creates the `server@0.8.49` GitHub Release from that file.

## Release debt survey (other packages)

Left out deliberately, no genuine debt:

- **core** (0.7.35): only `test:` commits since last release
- **cli** (0.10.38): nothing since last release
- **ui** (0.3.8): all commits touched only the non-published nested website sub-app
- **mcp** (0.1.7): one cosmetic brand-casing string recase (#855) that would read as a misleading `feat` changelog entry