### PR TITLE
chore: on-device diag A/B harness for Android soft-nav CSS (#936)

### DIFF
--- a/website/app/layout.ts
+++ b/website/app/layout.ts
@@ -60,8 +60,19 @@ export function generateMetadata(ctx: { url: string }) {
 const navLink = 'text-fg-muted no-underline font-medium text-sm px-[11px] py-2 rounded-lg transition-colors duration-[140ms] hover:text-fg hover:bg-bg-subtle';
 const panelLink = 'text-fg-muted no-underline font-medium text-sm px-3 py-[10px] rounded-[9px] hover:text-fg hover:bg-bg-subtle';
 
-export default function RootLayout({ children }: { children: unknown }) {
+export default function RootLayout({ children, url }: { children: unknown; url?: string | URL }) {
   const nonce = cspNonce();
+  // #936 on-device A/B diagnostic. Inert unless the ENTRY page is loaded with
+  // ?diag=<mode>. The mode is baked into a head script that persists across
+  // client-router soft navs (add-only head merge keeps it), so loading
+  // /?diag=nudge once governs the whole session. Whitelisted so the value that
+  // reaches the inline script is always a known literal.
+  const DIAG_MODES = new Set(['control', 'reflow', 'repaint', 'recolor', 'nudge']);
+  let diagMode = '';
+  try {
+    const raw = new URL(String(url ?? ''), 'http://x').searchParams.get('diag') || '';
+    if (DIAG_MODES.has(raw)) diagMode = raw;
+  } catch { /* no url in this context */ }
   return html`
     <link rel="icon" href="/public/favicon.svg" type="image/svg+xml" sizes="any">
     <link rel="icon" href="/public/favicon.png" type="image/png" sizes="32x32">
@@ -140,6 +151,51 @@ export default function RootLayout({ children }: { children: unknown }) {
         }
       });
     </script>
+
+    <!-- #936 on-device soft-nav CSS diagnostic. Emitted only when the entry
+         load carried ?diag=<mode>; otherwise diagMode is '' and this whole
+         block is absent, so production is untouched. Applies a repaint/recalc
+         nudge to the swapped DOM after each client-router nav to see which one
+         (if any) restores styling on real Android Chrome. -->
+    ${diagMode ? html`<script nonce="${nonce}" data-webjs-diag="${diagMode}">
+      (function () {
+        var mode = "${diagMode}";
+        var tick = 0;
+        function badge() {
+          var b = document.getElementById('webjs-diag-badge');
+          if (!b) {
+            b = document.createElement('div');
+            b.id = 'webjs-diag-badge';
+            b.style.cssText = 'position:fixed;left:8px;bottom:8px;z-index:99999;background:#111;color:#fff;font:600 12px/1.2 system-ui,sans-serif;padding:6px 9px;border-radius:8px;opacity:0.85;pointer-events:none;max-width:70vw';
+            (document.body || document.documentElement).appendChild(b);
+          }
+          b.textContent = 'diag: ' + mode + ' @ ' + location.pathname;
+        }
+        function nudge() {
+          try {
+            if (mode === 'reflow') { void document.body.offsetHeight; }
+            else if (mode === 'repaint') {
+              var el = document.body;
+              el.style.transform = 'translateZ(0)';
+              requestAnimationFrame(function () { requestAnimationFrame(function () { el.style.transform = ''; }); });
+            }
+            else if (mode === 'recolor') { document.documentElement.style.setProperty('--webjs-diag-tick', String(tick++)); }
+            else if (mode === 'nudge') {
+              var h = document.documentElement, prev = h.style.display;
+              h.style.display = 'none'; void h.offsetHeight; h.style.display = prev;
+            }
+            /* mode 'control' does nothing: it only shows the badge, to confirm the
+               bug still reproduces with the diagnostic script present. */
+          } catch (_) {}
+        }
+        document.addEventListener('webjs:navigate', function () {
+          requestAnimationFrame(function () { nudge(); badge(); });
+        });
+        if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', badge);
+        else badge();
+        try { console.log('[webjs-diag] active mode:', mode); } catch (_) {}
+      })();
+    </script>` : ''}
 
     <link rel="stylesheet" href="/public/tailwind.css">
     <style>


### PR DESCRIPTION
References #936 (diagnostic step, not a close: the framework fix follows once the on-device A/B identifies which nudge restores styling).

## Why

The Android-Chrome soft-nav CSS loss in #936 (styled on refresh, unstyled after a client-router nav, every time, Android Chrome only) does not reproduce in headless Blink. I drove the exact flow in emulated Android Chrome (Pixel 7) across home to blog to changelog, direct deep-link entry, chained navs, back/forward, throttled slow network, and dark mode: the stylesheet stays in `<head>` and styles apply in every case. That device-only shape matches the iOS oklch repaint bug (#610), which also needed an on-device query-param A/B to pin down. The site's theme is entirely oklch custom properties.

## What this adds

A `?diag=<mode>` harness in `website/app/layout.ts`, inert unless the entry load carries the param (verified: plain `/` is byte-unchanged, the block is absent). Loading `/?diag=nudge` bakes a small head script that persists across soft navs (add-only head merge keeps it) and, after each `webjs:navigate`, applies one repaint/recalc nudge to the swapped DOM, plus an on-screen badge showing the active mode and path so the tester knows which arm they are on.

Modes (whitelisted, so only a known literal reaches the inline script):

- `control`: badge only, no nudge (confirm the bug still reproduces with the harness present)
- `reflow`: force layout (`offsetHeight`)
- `repaint`: force a paint invalidation (transform toggle over a double rAF)
- `recolor`: re-assert a `:root` custom property (targets the oklch custom-property-resolution hypothesis)
- `nudge`: `<html>` display toggle (the full recalc plus repaint hammer)

## Test plan (on a real Android phone, against the deployed site)

Load each URL, then tap Blog / Changelog in the header and note whether the destination is styled:

- `https://webjs.dev/?diag=control` (expect broken, confirms repro)
- `https://webjs.dev/?diag=reflow`
- `https://webjs.dev/?diag=repaint`
- `https://webjs.dev/?diag=recolor`
- `https://webjs.dev/?diag=nudge`

Whichever mode restores styling identifies the minimal framework fix (moves into the client router in `packages/core/src/router-client.js`, guarded against re-introducing the iOS #610 flash). This harness is removed in the fix PR.

## Verification (local)

- `webjs check`: pass. `webjs typecheck`: clean.
- Boot (`createRequestHandler`, prod): `/` 200 with no diag block; `/?diag=nudge` 200 with the block; `/?diag=evil` (non-whitelisted) has no block; tailwind link present in all.
