### PR TITLE
chore: ?diag= badge reports wj:children marker + navbar state (#936)

### DIFF
--- a/website/app/layout.ts
+++ b/website/app/layout.ts
@@ -166,12 +166,27 @@ export default function RootLayout({ children, url }: { children: unknown; url?:
         // what background colour actually resolved. Read straight off the badge
         // on the phone, so we can tell a head-removal (css:GONE) apart from a
         // repaint failure (css:ok but the page looks unstyled).
+        function countMarkers() {
+          // Count wj:children open-comment markers in the live body. The client
+          // router needs these to do the scoped layout-marker swap; if they are
+          // missing (e.g. an on-device optimizing proxy stripped HTML comments),
+          // it falls back to a destructive full-body swap that wipes the head
+          // CSS and the outer layout. 0 here on the entry page is the smoking gun.
+          var n = 0;
+          try {
+            var w = document.createTreeWalker(document.body, NodeFilter.SHOW_COMMENT, null);
+            var c;
+            while ((c = w.nextNode())) { if (/^wj:children:/.test(c.data)) n++; }
+          } catch (_) { n = -1; }
+          return n;
+        }
         function probe() {
           var link = document.querySelector('link[rel="stylesheet"][href*="tailwind"]');
           var sheets = document.querySelectorAll('link[rel="stylesheet"]').length;
+          var nav = document.querySelector('.site-top') ? 'ok' : 'GONE';
           var bg = '';
           try { bg = getComputedStyle(document.body).backgroundColor; } catch (_) {}
-          return { css: link ? 'ok' : 'GONE', sheets: sheets, bg: bg };
+          return { css: link ? 'ok' : 'GONE', sheets: sheets, nav: nav, markers: countMarkers(), bg: bg };
         }
         function badge() {
           var b = document.getElementById('webjs-diag-badge');
@@ -182,7 +197,10 @@ export default function RootLayout({ children, url }: { children: unknown; url?:
             (document.body || document.documentElement).appendChild(b);
           }
           var p = probe();
-          b.textContent = 'diag:' + mode + ' ' + location.pathname + ' | css:' + p.css + ' sheets:' + p.sheets + ' | bg:' + p.bg;
+          b.textContent = 'diag:' + mode + ' ' + location.pathname
+            + ' | css:' + p.css + ' sheets:' + p.sheets
+            + ' | nav:' + p.nav + ' markers:' + p.markers
+            + ' | bg:' + p.bg;
         }
         function nudge() {
           try {


### PR DESCRIPTION
References #936 (third diagnostic iteration; pinpoints where the layout markers are lost before the framework fix).

## Established so far

- On-device `?diag=control` reports `css:GONE` after a soft nav: the stylesheet `<link>` is removed from `<head>`.
- Only the full-body-swap fallback removes head elements (the layout-marker swap is add-only), and it also wipes the outer layout, which matches the reported "navbar is also gone".
- `?diag=restore` re-adds the stylesheet and restores styling partly (the inline `<style>` tokens are still missing, and the wiped navbar DOM cannot come back).
- The server emits well-formed `wj:children` open+close markers on every response (verified by curl on home, blog, changelog, full and partial), and emulated Android Chrome takes the correct scoped swap. So the markers are lost on the real device.

## What this adds

`markers:<n>` (count of `wj:children` open comments in the live body) and `nav:ok|GONE` (`.site-top` present) in the badge. `markers:0` on the entry page is the smoking gun: an on-device optimizing proxy stripping HTML comments (Chrome Lite mode / data saver, or a carrier proxy) removes the markers, so the client cannot do the scoped swap and falls to the destructive full-body fallback. That is Android-only, every-time, and invisible to emulation, which fits every symptom.

## Test plan (real Android phone)

- Load `webjs.dev/?diag=control` and read the badge ON the home page (no nav yet): note `markers:` and `nav:`.
- Then tap Blog / Changelog and read it again.

If `markers:0` on the home page, HTML comments are being stripped in transit on the device (worth checking Chrome data-saver / Lite mode too). Either way the framework fix is the same: the client router must not strip stylesheets on a soft nav and must not apply a partial body through the full-body path when the markers are missing.

## Verification (local)
- `webjs check`: pass. `webjs typecheck`: clean. Boot: `/` no diag block, `/?diag=control` serves the marker counter; entry body has the `wj:children` marker server-side.
