### PR TITLE
fix: parse client-router partial-nav fragments in body context (#936)

### DIFF
--- a/agent-docs/advanced.md
+++ b/agent-docs/advanced.md
@@ -412,7 +412,16 @@ navigation automatically.
    one pair per layout in the chain. Auto-derived from folder
    structure. Layout authors write nothing extra.
 2. On click, the router walks both the live DOM and the incoming HTML
-   for these markers and builds `Map<path, {start, end}>`.
+   for these markers and builds `Map<path, {start, end}>`. The incoming
+   response for a same-layout nav is an INNER fragment that begins with
+   the `<!--wj:children:...-->` marker and carries no `<!doctype>`/`<html>`,
+   so the router parses it in a `<body>` fragment context
+   (`body.setHTMLUnsafe`, which also processes Declarative Shadow DOM),
+   NOT as a document. Parsing such a fragment as a document would hoist
+   that leading comment out of `<body>` (the HTML "before html" insertion
+   mode), the marker map would come up empty, and the nav would wrongly
+   fall to the full-body-swap fallback that strips head CSS and the outer
+   layout (#936).
 3. Picks the **longest shared path**, the deepest layout boundary
    both pages have in common.
 4. Replaces nodes between that marker pair using a keyed `data-key`

--- a/packages/core/src/router-client.js
+++ b/packages/core/src/router-client.js
@@ -82,10 +82,40 @@ const STREAM_MIME = 'text/vnd.webjs-stream.html';
  * Parse HTML into a Document. Prefers Document.parseHTMLUnsafe (processes
  * Declarative Shadow DOM) over DOMParser (does NOT process DSD).
  *
+ * A partial-nav response (#936) is an INNER fragment that BEGINS with the
+ * `<!--wj:children:<path>-->` layout marker and carries no `<!doctype>`/`<html>`.
+ * Parsing such a fragment as a DOCUMENT hoists that leading comment OUT of
+ * `<body>` (the HTML parser's "before html" insertion mode makes a leading
+ * comment a child of the document, before `<html>`), so
+ * `collectChildrenSlots(doc.body)` never sees the opening marker, finds no
+ * shared slot, and `applySwap` falls to the destructive full-body swap that
+ * strips the head stylesheets and the outer layout. So a fragment is parsed in
+ * BODY (fragment) context instead, keeping the marker with its content.
+ * `body.setHTMLUnsafe` also processes Declarative Shadow DOM, so a shadow
+ * component inside the swapped content still re-attaches its root; the
+ * `<template>` path is the fallback for browsers without it (markers preserved,
+ * DSD not, which matches the pre-`setHTMLUnsafe` baseline).
+ *
  * @param {string} html
  * @returns {Document | null}
  */
 function parseHTML(html) {
+  const isFragment = !/^\s*(?:<!doctype|<html)/i.test(html);
+  if (isFragment && typeof document !== 'undefined' && document.implementation) {
+    try {
+      const doc = document.implementation.createHTMLDocument();
+      if (typeof doc.body.setHTMLUnsafe === 'function') {
+        doc.body.setHTMLUnsafe(html);
+      } else {
+        const t = doc.createElement('template');
+        t.innerHTML = html;
+        doc.body.appendChild(t.content);
+      }
+      return doc;
+    } catch {
+      // Fall through to a document parse (still functional, just the #936 path).
+    }
+  }
   if (typeof Document !== 'undefined' && typeof Document.parseHTMLUnsafe === 'function') {
     return Document.parseHTMLUnsafe(html);
   }
@@ -3473,6 +3503,7 @@ export {
   clearFormBusy as _clearFormBusy,
   collectChildrenSlots as _collectChildrenSlots,
   longestSharedPath as _longestSharedPath,
+  parseHTML as _parseHTML,
   keyOf as _keyOf,
   diffElementInPlace as _diffElementInPlace,
   reconcileChildren as _reconcileChildren,

--- a/packages/core/test/routing/browser/partial-fragment-css.test.js
+++ b/packages/core/test/routing/browser/partial-fragment-css.test.js
@@ -1,0 +1,98 @@
+/**
+ * Real-browser regression for #936: a same-layout client-router nav must keep
+ * the head stylesheets and the outer layout, not wipe them.
+ *
+ * The server's X-Webjs-Have partial response for a same-layout nav is an INNER
+ * fragment that BEGINS with the `<!--wj:children:/-->` marker and carries no
+ * `<!doctype>`/`<html>` (see packages/server/src/ssr.js `wrapWithChildrenMarker`
+ * + the `have.has(segmentPath)` short-circuit). Parsing that fragment as a
+ * DOCUMENT hoists the leading comment OUT of `<body>` (the HTML "before html"
+ * insertion mode), so `collectChildrenSlots(doc.body)` finds no slot and the
+ * router falls to the destructive full-body swap: `mergeHead` strips the
+ * stylesheet the fragment head lacks and the outer layout (navbar) is wiped.
+ * On a real Android phone this showed as unstyled pages after every nav that a
+ * refresh fixed (css:GONE, nav:GONE, markers o0/c0).
+ *
+ * MUST run in a real browser: linkedom (the unit DOM) does not reproduce the
+ * "before html" comment-hoisting parse, so the bug is invisible there. The
+ * router's fetch is stubbed to return the exact marker-first fragment the
+ * server sends. The counterfactual is direct: revert the `parseHTML` fragment
+ * branch and both the direct-parse assertion and the full-nav assertion fail.
+ */
+import {
+  enableClientRouter,
+  navigate,
+  _parseHTML,
+  _collectChildrenSlots,
+} from '../../../src/router-client.js';
+
+import { assert } from '../../../../../test/browser-assert.js';
+
+const tick = () => new Promise((r) => setTimeout(r, 25));
+
+/** The inner fragment a same-layout partial nav returns: marker-first, no
+ *  <!doctype>/<html>/<head>, no outer layout. Exactly what the server sends. */
+const FRAGMENT = '<!--wj:children:/--><main id="inner">AFTER</main><!--/wj:children-->';
+
+suite('Client router: same-layout nav keeps head CSS + outer layout (#936)', () => {
+  test('parseHTML keeps the leading wj:children marker inside <body> for a bare fragment', () => {
+    const doc = _parseHTML(FRAGMENT);
+    const slots = _collectChildrenSlots(doc.body);
+    // The open marker must be IN body (a document-context parse hoists it out,
+    // leaving slots empty), so the slot map has the '/' path.
+    assert.ok(slots.has('/'), 'the "/" children slot is found in the parsed fragment body');
+    assert.ok(doc.querySelector('#inner'), 'the inner content parsed into the body');
+    // A full document still parses as before (regression guard).
+    const full = _parseHTML('<!doctype html><html><head><link rel="stylesheet" href="/x.css"></head><body><!--wj:children:/-->x<!--/wj:children--></body></html>');
+    assert.ok(_collectChildrenSlots(full.body).has('/'), 'a full document body still yields the slot');
+    assert.ok(full.querySelector('link[rel="stylesheet"]'), 'a full document keeps its head stylesheet');
+  });
+
+  test('a same-layout nav preserves the head stylesheet and the outer-layout navbar', async () => {
+    enableClientRouter(); // idempotent
+
+    // Head: a stylesheet the nav must NOT strip.
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = '/partial-fragment-css-test.css';
+    document.head.appendChild(link);
+    const hasSheet = () => !!document.head.querySelector('link[href="/partial-fragment-css-test.css"]');
+
+    // Body: an outer-layout element (navbar) OUTSIDE the children markers, plus
+    // the children slot the nav should swap. Mirrors the SSR layout structure.
+    document.body.innerHTML =
+      '<header class="site-top" id="navbar">NAV</header>' +
+      '<!--wj:children:/--><main id="inner">BEFORE</main><!--/wj:children-->';
+
+    const before = location.href;
+    const origFetch = window.fetch;
+    window.fetch = (url, init) => {
+      // The server's same-layout partial: the marker-first inner fragment.
+      return Promise.resolve(new Response(FRAGMENT, {
+        headers: { 'content-type': 'text/html', 'x-webjs-build': '' },
+      }));
+    };
+
+    try {
+      assert.ok(hasSheet(), 'stylesheet present before nav (sanity)');
+      await navigate(location.origin + '/some/same-layout/page');
+      // Give the swap a beat to settle.
+      await tick();
+
+      // The whole point: a soft nav must not strip the stylesheet...
+      assert.ok(hasSheet(), 'head stylesheet survived the soft nav (not stripped by a full-body swap)');
+      // ...nor wipe the outer layout...
+      assert.ok(document.getElementById('navbar'), 'outer-layout navbar survived the soft nav');
+      // ...while the children slot DID swap to the new content.
+      const inner = document.getElementById('inner');
+      assert.ok(inner && inner.textContent === 'AFTER', 'the children slot swapped to the new content');
+      // And the layout markers are still in the body (a scoped swap keeps them).
+      assert.ok(_collectChildrenSlots(document.body).has('/'), 'the layout markers are intact after the swap');
+    } finally {
+      window.fetch = origFetch;
+      try { history.replaceState(null, '', before); } catch { /* ignore */ }
+      link.remove();
+      document.body.innerHTML = '';
+    }
+  });
+});

--- a/website/app/layout.ts
+++ b/website/app/layout.ts
@@ -60,19 +60,8 @@ export function generateMetadata(ctx: { url: string }) {
 const navLink = 'text-fg-muted no-underline font-medium text-sm px-[11px] py-2 rounded-lg transition-colors duration-[140ms] hover:text-fg hover:bg-bg-subtle';
 const panelLink = 'text-fg-muted no-underline font-medium text-sm px-3 py-[10px] rounded-[9px] hover:text-fg hover:bg-bg-subtle';
 
-export default function RootLayout({ children, url }: { children: unknown; url?: string | URL }) {
+export default function RootLayout({ children }: { children: unknown }) {
   const nonce = cspNonce();
-  // #936 on-device A/B diagnostic. Inert unless the ENTRY page is loaded with
-  // ?diag=<mode>. The mode is baked into a head script that persists across
-  // client-router soft navs (add-only head merge keeps it), so loading
-  // /?diag=nudge once governs the whole session. Whitelisted so the value that
-  // reaches the inline script is always a known literal.
-  const DIAG_MODES = new Set(['control', 'reflow', 'repaint', 'recolor', 'nudge', 'restore']);
-  let diagMode = '';
-  try {
-    const raw = new URL(String(url ?? ''), 'http://x').searchParams.get('diag') || '';
-    if (DIAG_MODES.has(raw)) diagMode = raw;
-  } catch { /* no url in this context */ }
   return html`
     <link rel="icon" href="/public/favicon.svg" type="image/svg+xml" sizes="any">
     <link rel="icon" href="/public/favicon.png" type="image/png" sizes="32x32">
@@ -151,99 +140,6 @@ export default function RootLayout({ children, url }: { children: unknown; url?:
         }
       });
     </script>
-
-    <!-- #936 on-device soft-nav CSS diagnostic. Emitted only when the entry
-         load carried ?diag=<mode>; otherwise diagMode is '' and this whole
-         block is absent, so production is untouched. Applies a repaint/recalc
-         nudge to the swapped DOM after each client-router nav to see which one
-         (if any) restores styling on real Android Chrome. -->
-    ${diagMode ? html`<script nonce="${nonce}" data-webjs-diag="${diagMode}">
-      (function () {
-        var mode = "${diagMode}";
-        var tick = 0;
-        // Live probe of the state that actually matters: did the stylesheet
-        // <link> survive the soft nav, how many stylesheets are attached, and
-        // what background colour actually resolved. Read straight off the badge
-        // on the phone, so we can tell a head-removal (css:GONE) apart from a
-        // repaint failure (css:ok but the page looks unstyled).
-        function countMarkers() {
-          // Count wj:children OPEN and CLOSE comment markers in the live body.
-          // The client router's collectChildrenSlots only registers a layout
-          // slot when it sees BOTH the open (wj:children:<path>) AND the close
-          // (/wj:children) comment. If the device's HTML parser drops the close
-          // comment, the slot map is empty and the router falls to a destructive
-          // full-body swap that wipes the head CSS and the outer layout. Reading
-          // open vs close separately shows exactly which comment is lost.
-          var open = 0, close = 0;
-          try {
-            var w = document.createTreeWalker(document.body, NodeFilter.SHOW_COMMENT, null);
-            var c;
-            while ((c = w.nextNode())) {
-              if (/^wj:children:/.test(c.data)) open++;
-              else if (c.data.trim() === '/wj:children') close++;
-            }
-          } catch (_) { open = -1; close = -1; }
-          return 'o' + open + '/c' + close;
-        }
-        function probe() {
-          var link = document.querySelector('link[rel="stylesheet"][href*="tailwind"]');
-          var sheets = document.querySelectorAll('link[rel="stylesheet"]').length;
-          var nav = document.querySelector('.site-top') ? 'ok' : 'GONE';
-          var bg = '';
-          try { bg = getComputedStyle(document.body).backgroundColor; } catch (_) {}
-          return { css: link ? 'ok' : 'GONE', sheets: sheets, nav: nav, markers: countMarkers(), bg: bg };
-        }
-        function badge() {
-          var b = document.getElementById('webjs-diag-badge');
-          if (!b) {
-            b = document.createElement('div');
-            b.id = 'webjs-diag-badge';
-            b.style.cssText = 'position:fixed;left:8px;bottom:8px;z-index:99999;background:#111;color:#fff;font:600 11px/1.35 system-ui,sans-serif;padding:6px 9px;border-radius:8px;opacity:0.9;pointer-events:none;max-width:82vw';
-            (document.body || document.documentElement).appendChild(b);
-          }
-          var p = probe();
-          b.textContent = 'diag:' + mode + ' ' + location.pathname
-            + ' | css:' + p.css + ' sheets:' + p.sheets
-            + ' | nav:' + p.nav + ' markers:' + p.markers
-            + ' | bg:' + p.bg;
-        }
-        function nudge() {
-          try {
-            if (mode === 'reflow') { void document.body.offsetHeight; }
-            else if (mode === 'repaint') {
-              var el = document.body;
-              el.style.transform = 'translateZ(0)';
-              requestAnimationFrame(function () { requestAnimationFrame(function () { el.style.transform = ''; }); });
-            }
-            else if (mode === 'recolor') { document.documentElement.style.setProperty('--webjs-diag-tick', String(tick++)); }
-            else if (mode === 'nudge') {
-              var h = document.documentElement, prev = h.style.display;
-              h.style.display = 'none'; void h.offsetHeight; h.style.display = prev;
-            }
-            else if (mode === 'restore') {
-              // Head-removal hypothesis: if the stylesheet <link> is gone after
-              // the swap, re-add it. If this restores styling, the cause is the
-              // head merge stripping the sheet, not a repaint issue.
-              if (!document.querySelector('link[rel="stylesheet"][href*="tailwind"]')) {
-                var l = document.createElement('link');
-                l.rel = 'stylesheet'; l.href = '/public/tailwind.css';
-                document.head.appendChild(l);
-              }
-            }
-            /* mode 'control' does nothing: badge/probe only, to confirm the bug
-               still reproduces with the diagnostic present. */
-          } catch (_) {}
-        }
-        document.addEventListener('webjs:navigate', function () {
-          // nudge on the next frame (after the swap), then read the probe one
-          // more frame later so any nudge/restore has landed before we report.
-          requestAnimationFrame(function () { nudge(); requestAnimationFrame(badge); });
-        });
-        if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', badge);
-        else badge();
-        try { console.log('[webjs-diag] active mode:', mode); } catch (_) {}
-      })();
-    </script>` : ''}
 
     <link rel="stylesheet" href="/public/tailwind.css">
     <style>


### PR DESCRIPTION
Closes #936.

## The bug

On a real Android phone, every client-router nav within webjs.dev (home to blog/changelog) rendered the destination unstyled; a manual refresh fixed it. On-device `?diag=` probes showed the post-nav body at `css:GONE`, `nav:GONE`, `markers:o0/c0`: the whole body was replaced with a bare inner fragment and the head lost its stylesheets.

## Root cause (confirmed deterministically in Chromium)

For a same-layout nav the server returns only the inner children fragment wrapped in markers, `<!--wj:children:/-->...<!--/wj:children-->`, with no `<!doctype>`/`<html>`/`<head>` (`packages/server/src/ssr.js` `wrapWithChildrenMarker` + the `have.has(segmentPath)` short-circuit). `router-client.js` parsed that fragment with `parseHTML`, which parses as a **document**. The HTML parser's "before html" insertion mode places the LEADING `<!--wj:children:/-->` comment as a child of the document, **outside `<body>`**. So `collectChildrenSlots(doc.body)` never saw the opening marker, `longestSharedPath` returned null, and `applySwap` fell to the full-body-swap fallback: `mergeHead` stripped the stylesheet the fragment head lacks, and `replaceChildren` wiped the outer layout (navbar).

`Document.parseHTMLUnsafe(frag).body` yields open/close markers `0/1`; the open marker is the first document child. This is general to same-layout client navs, not Android-specific in the parser; the phone is just where it surfaced.

## Fix

Parse a partial fragment (no leading `<!doctype>`/`<html>`) in `<body>` fragment context via `body.setHTMLUnsafe`, which keeps the leading marker with its content AND processes Declarative Shadow DOM (a shadow component in the swapped content re-attaches its root). A `<template>` parse is the fallback where `setHTMLUnsafe` is absent (markers preserved, DSD not, matching the pre-`setHTMLUnsafe` baseline). Full-page responses (snapshot restore, cross-layout fallback, error pages) keep the document parse unchanged.

## Tests

- **Browser (headline)**, `packages/core/test/routing/browser/partial-fragment-css.test.js`: drives a real same-layout nav with the exact marker-first fragment the server sends and asserts the head stylesheet and the outer-layout navbar survive while the children slot swaps; plus a direct `parseHTML` assertion that the leading marker lands in `<body>`. Counterfactual verified: reverting the fragment branch fails both assertions.
- All 16 routing browser test files pass (90 tests) on Chromium, so frame / streaming / prefetch / query-string paths are unaffected.
- Unit: routing 172/172, ssr 185/185.

## Verification

- Dogfood: website / docs / ui-website boot 200 in prod mode with no broken modulepreload; blog e2e passes on a clean checkout; two page-action submit tests time out locally ONLY in the symlinked review worktree (they fail at the initial full-page `page.goto`, before any client nav, so the client-only change cannot be the cause, and they pass on a clean main checkout in ~2s). CI e2e (clean checkout, a required check) is the authority.
- Bun parity: N/A, this is browser-only DOM code (`router-client.js`), no server-runtime surface.

## Also in this PR

Removes the `?diag=` on-device diagnostic harness (PRs #937-#940) from `website/app/layout.ts`, restoring the root layout to its pre-harness state.