### PR TITLE
chore: capture req-have + post-swap state for #936

### DIFF
--- a/website/app/layout.ts
+++ b/website/app/layout.ts
@@ -72,39 +72,34 @@ export default function RootLayout({ children, url }: { children: unknown; url?:
   return html`
     ${diagOn ? html`<script nonce="${nonce}">
       (function () {
-        var last = null;
+        var reqLine = 'tap a nav link';
+        var respLine = '';
+        var postLine = '';
+        var openTok = '<!--wj:children:';
+        var closeTok = '<!--' + '/wj:children-->';
+        function headerGet(h, k) {
+          if (!h) return '';
+          if (typeof h.get === 'function') return h.get(k) || '';
+          return h[k] || h[k.toUpperCase()] || '';
+        }
         var of = window.fetch;
         window.fetch = function (input, init) {
           init = init || {};
-          var isRouter = false;
-          try {
-            var h = init.headers;
-            if (h) {
-              if (typeof h.get === 'function') isRouter = !!h.get('x-webjs-router');
-              else isRouter = !!(h['x-webjs-router'] || h['X-Webjs-Router']);
-            }
-          } catch (_) {}
+          var h = init.headers;
+          var isRouter = !!headerGet(h, 'x-webjs-router');
           var p = of.apply(this, arguments);
           if (isRouter) {
+            var have = headerGet(h, 'x-webjs-have');
+            var pf = !!headerGet(h, 'x-webjs-prefetch');
+            reqLine = 'REQ ' + (pf ? '(prefetch) ' : '') + 'have="' + have + '"';
             p.then(function (resp) {
               try {
                 resp.clone().text().then(function (t) {
-                  // String methods only: a regex literal in this template-emitted
-                  // script has its backslashes cooked away, which corrupts it.
-                  var openTok = '<!--wj:children:';
-                  var closeTok = '<!--' + '/wj:children-->';
-                  var start = t.slice(0, 15).toLowerCase();
-                  last = {
-                    len: t.length,
-                    start: t.slice(0, 15),
-                    doctype: start.indexOf('<!doctype') !== -1,
-                    head: t.indexOf('<head') !== -1,
-                    o: t.split(openTok).length - 1,
-                    c: t.split(closeTok).length - 1,
-                    nav: t.indexOf('site-top') !== -1,
-                    sheet: t.indexOf('tailwind.css') !== -1,
-                    enc: resp.headers.get('content-encoding') || '-',
-                  };
+                  respLine = 'RESP o' + (t.split(openTok).length - 1) + '/c' + (t.split(closeTok).length - 1)
+                    + ' nav=' + (t.indexOf('site-top') !== -1)
+                    + ' sheet=' + (t.indexOf('tailwind.css') !== -1)
+                    + ' doctype=' + (t.slice(0, 15).toLowerCase().indexOf('<!doctype') !== -1)
+                    + ' len=' + t.length + ' enc=' + (resp.headers.get('content-encoding') || '-');
                   badge();
                 });
               } catch (_) {}
@@ -112,20 +107,34 @@ export default function RootLayout({ children, url }: { children: unknown; url?:
           }
           return p;
         };
+        function postProbe() {
+          var sheet = !!document.head.querySelector('link[rel="stylesheet"][href*="tailwind"]');
+          var navbar = !!document.querySelector('.site-top');
+          var o = 0, c = 0;
+          try {
+            var w = document.createTreeWalker(document.body, NodeFilter.SHOW_COMMENT, null), n;
+            while ((n = w.nextNode())) {
+              if (n.data.indexOf('wj:children:') === 0) o++;
+              else if (n.data.trim() === '/wj:children') c++;
+            }
+          } catch (_) {}
+          var bg = '';
+          try { bg = getComputedStyle(document.body).backgroundColor; } catch (_) {}
+          postLine = 'POST head-sheet=' + sheet + ' navbar=' + navbar + ' body-o' + o + '/c' + c + ' bg=' + bg;
+          badge();
+        }
+        document.addEventListener('webjs:navigate', function () {
+          requestAnimationFrame(function () { requestAnimationFrame(postProbe); });
+        });
         function badge() {
           var b = document.getElementById('wj-cap');
           if (!b) {
             b = document.createElement('div');
             b.id = 'wj-cap';
-            b.style.cssText = 'position:fixed;left:6px;bottom:6px;z-index:99999;background:#111;color:#fff;font:600 11px/1.4 system-ui,sans-serif;padding:6px 8px;border-radius:8px;opacity:.92;pointer-events:none;max-width:88vw';
+            b.style.cssText = 'position:fixed;left:6px;bottom:6px;z-index:99999;background:#111;color:#fff;font:600 11px/1.45 system-ui,sans-serif;padding:6px 8px;border-radius:8px;opacity:.94;pointer-events:none;max-width:92vw';
             (document.body || document.documentElement).appendChild(b);
           }
-          b.textContent = last
-            ? 'nav-fetch len=' + last.len + ' start="' + last.start + '"'
-              + ' | markers o' + last.o + '/c' + last.c
-              + ' | nav=' + last.nav + ' sheet=' + last.sheet + ' head=' + last.head
-              + ' enc=' + last.enc
-            : 'diag:capture ready. tap a nav link.';
+          b.textContent = [reqLine, respLine, postLine].filter(Boolean).join('  //  ');
         }
         if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', badge);
         else badge();


### PR DESCRIPTION
References #936. The device gets a response WITH navbar+stylesheet yet the page is still unstyled, so the swap itself destroys it. Expands ?diag=capture to three lines: REQ x-webjs-have header sent, RESP marker/nav/sheet state, POST-swap live DOM (head stylesheet, navbar, body markers, bg). Verified in a real browser against a local prod boot. Inert without ?diag=capture.