### PR TITLE
fix: client router never strips stylesheets on a soft nav (#936)

### DIFF
--- a/agent-docs/advanced.md
+++ b/agent-docs/advanced.md
@@ -421,21 +421,20 @@ navigation automatically.
    that leading comment out of `<body>` (the HTML "before html" insertion
    mode) and the marker map would come up empty (#936).
 3. Picks the **longest shared path**, the deepest layout boundary
-   both pages have in common. **When there is NO shared path** and the
-   live page actually has a layout, the router does a **full-page load**
-   (`location.assign`) instead of a destructive in-place full-body swap.
-   A full-body swap there would strip the head stylesheets and the outer
-   layout (that was #936: a viewport prefetch firing mid-parse sent an
-   empty `X-Webjs-Have`, so the server returned a body the swap then
-   mangled); a real page load is always correct by construction. A
-   revalidation / cache restore (`href` null) keeps the in-place swap: its
-   document is a full same-shell snapshot, safe to apply, and a reload
-   would defeat the instant back/forward restore. A genuinely marker-less
-   page (no children slot) also keeps the in-place swap, since it has no
-   outer layout to lose. Relatedly, the viewport prefetch is skipped while
-   the document is still parsing if `buildHaveHeader()` is empty (the
-   closing marker may not be parsed yet), so it never caches a poisoned
-   full-page response.
+   both pages have in common. When there is no shared path it falls to a
+   full-body swap (a genuine root-layout change). That fallback's head
+   merge **never removes a `<link rel=stylesheet>` or `<style>`** (Turbo's
+   persistent-CSS model): an incoming head that lacks the app stylesheet
+   (a partial or mangled response) can no longer strip the live CSS and
+   leave the page unstyled (#936). A genuinely stale stylesheet is dropped
+   by the deploy-level hard reload (build-id mismatch), not by a soft swap.
+   Relatedly, the **viewport prefetch is skipped while the document is
+   still parsing** when `buildHaveHeader()` is empty: the closing
+   `<!--/wj:children-->` marker may not be parsed yet, so an empty
+   `X-Webjs-Have` there means "markers not ready", not "no layout", and
+   caching that full-page response would feed the fallback a body it should
+   never have applied. The click path re-fetches with a correct `have`
+   once the document has parsed.
 4. Replaces nodes between that marker pair using a keyed `data-key`
    reconciler. Elements with matching tag + matching key are reused
    with in-place attribute diffing. **Live attributes** (`value`,
@@ -448,11 +447,11 @@ navigation automatically.
    component. The one exception is a light-DOM component's projected
    `<slot>` content, which is page-authored rather than render-owned, so
    the router re-projects it to match the incoming page.
-5. Merges `<head>` add-only (so runtime-injected styles like Tailwind
-   survive), re-runs `<script>` elements, `customElements.upgrade()`s the
-   swapped subtree, `pushState`s the URL, scrolls. (The old remove-capable
-   full head merge only ran on the no-shared-path fallback, which is now a
-   full-page load, so a soft swap never removes a live head element.)
+5. Merges `<head>` (add-only on the shared-path swap so runtime-injected
+   styles like Tailwind survive; a remove-capable full merge on the
+   no-shared-path fallback, which still never removes a stylesheet or
+   `<style>`, #936), re-runs `<script>` elements, `customElements.upgrade()`s
+   the swapped subtree, `pushState`s the URL, scrolls.
 6. Dispatches `webjs:navigate` event on `document`.
 
 ### In-place navigation-error recovery (`webjs:navigation-error`)

--- a/agent-docs/advanced.md
+++ b/agent-docs/advanced.md
@@ -423,11 +423,14 @@ navigation automatically.
 3. Picks the **longest shared path**, the deepest layout boundary
    both pages have in common. When there is no shared path it falls to a
    full-body swap (a genuine root-layout change). That fallback's head
-   merge **never removes a `<link rel=stylesheet>` or `<style>`** (Turbo's
-   persistent-CSS model): an incoming head that lacks the app stylesheet
-   (a partial or mangled response) can no longer strip the live CSS and
-   leave the page unstyled (#936). A genuinely stale stylesheet is dropped
-   by the deploy-level hard reload (build-id mismatch), not by a soft swap.
+   merge **never removes a `<link rel=stylesheet>` or `<style>`** unless it
+   opts into removal with `data-webjs-track="dynamic"` (mirroring Turbo's
+   `data-turbo-track="dynamic"`; the sibling of the existing
+   `data-webjs-track="reload"`). So an incoming head that lacks the app
+   stylesheet (a partial or mangled response) can no longer strip the live
+   CSS and leave the page unstyled (#936); a genuinely stale stylesheet is
+   dropped by the deploy-level hard reload (build-id mismatch), not a soft
+   swap.
    Relatedly, the **viewport prefetch is skipped while the document is
    still parsing** when `buildHaveHeader()` is empty: the closing
    `<!--/wj:children-->` marker may not be parsed yet, so an empty

--- a/agent-docs/advanced.md
+++ b/agent-docs/advanced.md
@@ -419,11 +419,23 @@ navigation automatically.
    (`body.setHTMLUnsafe`, which also processes Declarative Shadow DOM),
    NOT as a document. Parsing such a fragment as a document would hoist
    that leading comment out of `<body>` (the HTML "before html" insertion
-   mode), the marker map would come up empty, and the nav would wrongly
-   fall to the full-body-swap fallback that strips head CSS and the outer
-   layout (#936).
+   mode) and the marker map would come up empty (#936).
 3. Picks the **longest shared path**, the deepest layout boundary
-   both pages have in common.
+   both pages have in common. **When there is NO shared path** and the
+   live page actually has a layout, the router does a **full-page load**
+   (`location.assign`) instead of a destructive in-place full-body swap.
+   A full-body swap there would strip the head stylesheets and the outer
+   layout (that was #936: a viewport prefetch firing mid-parse sent an
+   empty `X-Webjs-Have`, so the server returned a body the swap then
+   mangled); a real page load is always correct by construction. A
+   revalidation / cache restore (`href` null) keeps the in-place swap: its
+   document is a full same-shell snapshot, safe to apply, and a reload
+   would defeat the instant back/forward restore. A genuinely marker-less
+   page (no children slot) also keeps the in-place swap, since it has no
+   outer layout to lose. Relatedly, the viewport prefetch is skipped while
+   the document is still parsing if `buildHaveHeader()` is empty (the
+   closing marker may not be parsed yet), so it never caches a poisoned
+   full-page response.
 4. Replaces nodes between that marker pair using a keyed `data-key`
    reconciler. Elements with matching tag + matching key are reused
    with in-place attribute diffing. **Live attributes** (`value`,
@@ -436,11 +448,11 @@ navigation automatically.
    component. The one exception is a light-DOM component's projected
    `<slot>` content, which is page-authored rather than render-owned, so
    the router re-projects it to match the incoming page.
-5. Merges `<head>` (add-only on partial swaps so runtime-injected
-   styles like Tailwind survive, with a full merge on the
-   root-layout-change fallback), re-runs `<script>` elements,
-   `customElements.upgrade()`s the swapped subtree, `pushState`s the
-   URL, scrolls.
+5. Merges `<head>` add-only (so runtime-injected styles like Tailwind
+   survive), re-runs `<script>` elements, `customElements.upgrade()`s the
+   swapped subtree, `pushState`s the URL, scrolls. (The old remove-capable
+   full head merge only ran on the no-shared-path fallback, which is now a
+   full-page load, so a soft swap never removes a live head element.)
 6. Dispatches `webjs:navigate` event on `document`.
 
 ### In-place navigation-error recovery (`webjs:navigation-error`)

--- a/agent-docs/advanced.md
+++ b/agent-docs/advanced.md
@@ -423,14 +423,15 @@ navigation automatically.
 3. Picks the **longest shared path**, the deepest layout boundary
    both pages have in common. When there is no shared path it falls to a
    full-body swap (a genuine root-layout change). That fallback's head
-   merge **never removes a `<link rel=stylesheet>` or `<style>`** unless it
-   opts into removal with `data-webjs-track="dynamic"` (mirroring Turbo's
-   `data-turbo-track="dynamic"`; the sibling of the existing
-   `data-webjs-track="reload"`). So an incoming head that lacks the app
-   stylesheet (a partial or mangled response) can no longer strip the live
-   CSS and leave the page unstyled (#936); a genuinely stale stylesheet is
-   dropped by the deploy-level hard reload (build-id mismatch), not a soft
-   swap.
+   merge **never removes a `<link rel=stylesheet>` or `<style>`**, with no
+   opt-out. This is a deliberate divergence from Turbo (which removes a
+   `data-turbo-track="dynamic"` sheet absent from the new head): a Turbo
+   visit compares COMPLETE heads, but WebJs's `X-Webjs-Have` optimization
+   returns a REDUCED head (the shared app stylesheet omitted because the
+   client already has it), so "absent from the incoming head" means
+   "optimized away", not "removed". Stripping it there is exactly what left
+   the page unstyled (#936). A genuinely stale stylesheet is dropped by the
+   deploy-level hard reload (build-id mismatch), not a soft swap.
    Relatedly, the **viewport prefetch is skipped while the document is
    still parsing** when `buildHaveHeader()` is empty: the closing
    `<!--/wj:children-->` marker may not be parsed yet, so an empty

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/vivek/Documents/Projects/frameworks/webjs/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/vivek/Documents/Projects/frameworks/webjs/node_modules

--- a/packages/core/src/router-client.js
+++ b/packages/core/src/router-client.js
@@ -3261,26 +3261,28 @@ function addNewHeadElements(newHead) {
 }
 
 /**
- * A stylesheet a soft nav must NOT remove, mirroring Turbo's default. Turbo's
- * `elementIsStylesheet` is `<style>` or `<link rel~="stylesheet">`, and its
- * head merge removes an old stylesheet ONLY when it opts into dynamic removal
- * via `data-turbo-track="dynamic"` (`unusedDynamicStylesheetElements`); a plain
- * stylesheet is never removed. WebJs mirrors that: a stylesheet is persistent
- * unless tagged `data-webjs-track="dynamic"` (the sibling of the existing
- * `data-webjs-track="reload"`). Removing a plain stylesheet during a full-body
- * merge whose incoming head lacked it is exactly what left the page unstyled
- * (#936): WebJs's `X-Webjs-Have` optimization returns a REDUCED head (the app
- * stylesheet omitted), so the merge must not treat "absent from the incoming
- * head" as "stale". A genuinely changed stylesheet is dropped by the
- * deploy-level hard reload (build-id mismatch), not a soft swap.
+ * Is `el` a stylesheet the head merge must never remove: a `<style>` or a
+ * `<link rel~="stylesheet">`. WebJs ALWAYS keeps these on a soft nav, with no
+ * opt-out, and that is a deliberate divergence from Turbo. Turbo removes a
+ * stylesheet absent from the new head when it is tagged
+ * `data-turbo-track="dynamic"`, which is sound in Turbo because a Turbo visit
+ * always compares a COMPLETE old head to a COMPLETE new head, so "absent" means
+ * "this page removed it". WebJs's `X-Webjs-Have` optimization returns a REDUCED
+ * head (the shared app stylesheet is omitted because the client already has it),
+ * so "absent from the incoming head" means "optimized away", NOT "removed". A
+ * dynamic-removal opt-out would therefore re-introduce #936 (it would strip a
+ * still-needed sheet on any partial response), and WebJs is Tailwind-first (one
+ * global sheet, no page-specific sheets to drop), so the knob would be unsafe
+ * and unused. Keeping every stylesheet is correct here; a genuinely changed one
+ * is dropped by the deploy-level hard reload (build-id mismatch), not a soft swap.
  *
  * @param {Element} el
  * @returns {boolean}
  */
 function isPersistentHeadStyle(el) {
-  const isStylesheet = el.tagName === 'STYLE' ||
-    (el.tagName === 'LINK' && (el.getAttribute('rel') || '').toLowerCase().split(/\s+/).includes('stylesheet'));
-  return isStylesheet && el.getAttribute('data-webjs-track') !== 'dynamic';
+  if (el.tagName === 'STYLE') return true;
+  return el.tagName === 'LINK' &&
+    (el.getAttribute('rel') || '').toLowerCase().split(/\s+/).includes('stylesheet');
 }
 
 /** @param {HTMLHeadElement} newHead */

--- a/packages/core/src/router-client.js
+++ b/packages/core/src/router-client.js
@@ -1309,9 +1309,19 @@ function prefetch(href) {
     return;
   }
 
+  const have = buildHaveHeader();
+  // #936: while the document is still parsing, the closing `<!--/wj:children-->`
+  // marker at the bottom of the body may not exist yet, so `buildHaveHeader()`
+  // returns '' meaning "markers not parsed yet", NOT "this page has no layout".
+  // A touch-device viewport prefetch fires early enough (mid-parse) to hit this
+  // window on real Android Chrome. Caching that empty-`have` response (a full
+  // page) would later drive the destructive full-body swap fallback. Skip the
+  // speculative fetch; the click path re-fetches with a correct `have` once the
+  // document has parsed (and applySwap now falls back to a full load anyway).
+  if (!have && typeof document !== 'undefined' && document.readyState === 'loading') return;
+
   prefetchInflight.add(key);
   const headers = { 'x-webjs-router': '1', 'x-webjs-prefetch': '1' };
-  const have = buildHaveHeader();
   if (have) headers['x-webjs-have'] = have;
 
   fetch(href, { method: 'GET', headers, credentials: 'same-origin' })
@@ -2298,6 +2308,19 @@ function upgradeCustomElementsInRange(range) {
   }
 }
 
+/**
+ * Full-page load seam. Production always does a real `location.assign` (a Back
+ * returns to the current page, matching a normal link). It is a module variable
+ * only so tests can observe the fallback without navigating the harness away
+ * (`location.assign` is not stubbable in any browser). Reset via `_setHardNavigate`.
+ *
+ * @param {string} href
+ */
+let hardNavigate = (href) => { if (typeof location !== 'undefined') location.assign(href); };
+
+/** @param {(href: string) => void} fn */
+function setHardNavigate(fn) { hardNavigate = fn; }
+
 function applySwap(doc, frameId, revalidating, href, incomingBuild, incomingSrc) {
   // SSR action seeding (#472): ingest any seed payload the incoming page
   // carries BEFORE its components are grafted into the live DOM and upgrade, so
@@ -2500,8 +2523,34 @@ function applySwap(doc, frameId, revalidating, href, incomingBuild, incomingSrc)
     return;
   }
 
-  // 3. Full body swap fallback. Use full head merge: different root
-  // layout, so stale head elements should be removed.
+  // 3. No shared layout marker between the live DOM and the incoming document.
+  //
+  // For a FOREGROUND router nav (we have the URL, and it is not a cache restore
+  // or a frame swap) fall back to a real full-page load instead of an in-place
+  // full-body swap. The in-place swap here is destructive by nature: `mergeHead`
+  // removes live head elements the incoming head lacks (the stylesheet), and
+  // `replaceChildren` swaps the whole body. That is correct only when the
+  // incoming document is a full same-shell page. But the client can end up here
+  // with an incoming body that is missing the outer layout and a head missing
+  // the stylesheets, e.g. after a viewport prefetch fired mid-parse and sent an
+  // empty `X-Webjs-Have` (before the closing `<!--/wj:children-->` marker was
+  // parsed), so the server returned a body the swap then mangles: it strips the
+  // head CSS and wipes the navbar, and because the live markers are gone the
+  // corruption cascades to every later nav (#936). A full-page load is always
+  // correct by construction, so this whole failure class becomes impossible on
+  // any browser, at the cost of one non-instant navigation in the rare genuine
+  // cross-root-layout case. `location.assign` keeps the target in history
+  // (a Back returns to the current page), matching a normal link navigation.
+  if (href && !revalidating && !frameId && typeof location !== 'undefined') {
+    hardNavigate(href);
+    return;
+  }
+
+  // A revalidation / cache restore (href null) keeps the in-place full-body
+  // swap: its `doc` is a full same-shell snapshot captured from a real page, so
+  // applying it is safe, and a reload would defeat the instant back/forward
+  // restore this path exists to serve. Full head merge: a genuine root-layout
+  // change means stale head elements should be removed.
   mergeHead(doc.head);
   // Persist permanent elements by node identity across the full-body
   // swap: move each live [data-webjs-permanent][id] node into the matching
@@ -3509,6 +3558,8 @@ export {
   reconcileChildren as _reconcileChildren,
   onPopState as _onPopState,
   applySwap as _applySwap,
+  setHardNavigate as _setHardNavigate,
+  buildHaveHeader as _buildHaveHeader,
   snapshotCache as _snapshotCache,
   prefetchCache as _prefetchCache,
   LIVE_ATTRS as _LIVE_ATTRS,

--- a/packages/core/src/router-client.js
+++ b/packages/core/src/router-client.js
@@ -2316,7 +2316,11 @@ function upgradeCustomElementsInRange(range) {
  *
  * @param {string} href
  */
-let hardNavigate = (href) => { if (typeof location !== 'undefined') location.assign(href); };
+let hardNavigate = (href) => {
+  if (typeof location === 'undefined') return;
+  if (typeof location.assign === 'function') location.assign(href);
+  else location.href = href;
+};
 
 /** @param {(href: string) => void} fn */
 function setHardNavigate(fn) { hardNavigate = fn; }
@@ -2541,7 +2545,13 @@ function applySwap(doc, frameId, revalidating, href, incomingBuild, incomingSrc)
   // any browser, at the cost of one non-instant navigation in the rare genuine
   // cross-root-layout case. `location.assign` keeps the target in history
   // (a Back returns to the current page), matching a normal link navigation.
-  if (href && !revalidating && !frameId && typeof location !== 'undefined') {
+  // Only when the LIVE page actually has a layout (`here` is non-empty) does a
+  // full-body swap risk destroying an outer layout + its head-bound CSS. A
+  // genuinely marker-less page (no children slot at all) has nothing to lose, so
+  // the in-place swap below stays safe for it. Every real WebJs page is wrapped
+  // in a layout that emits markers, so this reloads the destructive case and
+  // leaves the marker-less edge case (and its tests) alone.
+  if (href && !revalidating && !frameId && here.size > 0 && typeof location !== 'undefined') {
     hardNavigate(href);
     return;
   }

--- a/packages/core/src/router-client.js
+++ b/packages/core/src/router-client.js
@@ -3261,21 +3261,26 @@ function addNewHeadElements(newHead) {
 }
 
 /**
- * A head element that a soft nav must NEVER remove: a `<style>` or a
- * `<link rel="stylesheet">` (incl. `rel="preload" as="style"`). Removing one
- * during a full-body-swap fallback whose incoming head lacked it leaves the
- * page unstyled (#936). Case-insensitive on `rel` (it may list several tokens).
+ * A stylesheet a soft nav must NOT remove, mirroring Turbo's default. Turbo's
+ * `elementIsStylesheet` is `<style>` or `<link rel~="stylesheet">`, and its
+ * head merge removes an old stylesheet ONLY when it opts into dynamic removal
+ * via `data-turbo-track="dynamic"` (`unusedDynamicStylesheetElements`); a plain
+ * stylesheet is never removed. WebJs mirrors that: a stylesheet is persistent
+ * unless tagged `data-webjs-track="dynamic"` (the sibling of the existing
+ * `data-webjs-track="reload"`). Removing a plain stylesheet during a full-body
+ * merge whose incoming head lacked it is exactly what left the page unstyled
+ * (#936): WebJs's `X-Webjs-Have` optimization returns a REDUCED head (the app
+ * stylesheet omitted), so the merge must not treat "absent from the incoming
+ * head" as "stale". A genuinely changed stylesheet is dropped by the
+ * deploy-level hard reload (build-id mismatch), not a soft swap.
  *
  * @param {Element} el
  * @returns {boolean}
  */
 function isPersistentHeadStyle(el) {
-  if (el.tagName === 'STYLE') return true;
-  if (el.tagName !== 'LINK') return false;
-  const rel = (el.getAttribute('rel') || '').toLowerCase();
-  if (rel.split(/\s+/).includes('stylesheet')) return true;
-  if (rel.split(/\s+/).includes('preload') && (el.getAttribute('as') || '').toLowerCase() === 'style') return true;
-  return false;
+  const isStylesheet = el.tagName === 'STYLE' ||
+    (el.tagName === 'LINK' && (el.getAttribute('rel') || '').toLowerCase().split(/\s+/).includes('stylesheet'));
+  return isStylesheet && el.getAttribute('data-webjs-track') !== 'dynamic';
 }
 
 /** @param {HTMLHeadElement} newHead */

--- a/packages/core/src/router-client.js
+++ b/packages/core/src/router-client.js
@@ -2308,23 +2308,6 @@ function upgradeCustomElementsInRange(range) {
   }
 }
 
-/**
- * Full-page load seam. Production always does a real `location.assign` (a Back
- * returns to the current page, matching a normal link). It is a module variable
- * only so tests can observe the fallback without navigating the harness away
- * (`location.assign` is not stubbable in any browser). Reset via `_setHardNavigate`.
- *
- * @param {string} href
- */
-let hardNavigate = (href) => {
-  if (typeof location === 'undefined') return;
-  if (typeof location.assign === 'function') location.assign(href);
-  else location.href = href;
-};
-
-/** @param {(href: string) => void} fn */
-function setHardNavigate(fn) { hardNavigate = fn; }
-
 function applySwap(doc, frameId, revalidating, href, incomingBuild, incomingSrc) {
   // SSR action seeding (#472): ingest any seed payload the incoming page
   // carries BEFORE its components are grafted into the live DOM and upgrade, so
@@ -2527,40 +2510,14 @@ function applySwap(doc, frameId, revalidating, href, incomingBuild, incomingSrc)
     return;
   }
 
-  // 3. No shared layout marker between the live DOM and the incoming document.
-  //
-  // For a FOREGROUND router nav (we have the URL, and it is not a cache restore
-  // or a frame swap) fall back to a real full-page load instead of an in-place
-  // full-body swap. The in-place swap here is destructive by nature: `mergeHead`
-  // removes live head elements the incoming head lacks (the stylesheet), and
-  // `replaceChildren` swaps the whole body. That is correct only when the
-  // incoming document is a full same-shell page. But the client can end up here
-  // with an incoming body that is missing the outer layout and a head missing
-  // the stylesheets, e.g. after a viewport prefetch fired mid-parse and sent an
-  // empty `X-Webjs-Have` (before the closing `<!--/wj:children-->` marker was
-  // parsed), so the server returned a body the swap then mangles: it strips the
-  // head CSS and wipes the navbar, and because the live markers are gone the
-  // corruption cascades to every later nav (#936). A full-page load is always
-  // correct by construction, so this whole failure class becomes impossible on
-  // any browser, at the cost of one non-instant navigation in the rare genuine
-  // cross-root-layout case. `location.assign` keeps the target in history
-  // (a Back returns to the current page), matching a normal link navigation.
-  // Only when the LIVE page actually has a layout (`here` is non-empty) does a
-  // full-body swap risk destroying an outer layout + its head-bound CSS. A
-  // genuinely marker-less page (no children slot at all) has nothing to lose, so
-  // the in-place swap below stays safe for it. Every real WebJs page is wrapped
-  // in a layout that emits markers, so this reloads the destructive case and
-  // leaves the marker-less edge case (and its tests) alone.
-  if (href && !revalidating && !frameId && here.size > 0 && typeof location !== 'undefined') {
-    hardNavigate(href);
-    return;
-  }
-
-  // A revalidation / cache restore (href null) keeps the in-place full-body
-  // swap: its `doc` is a full same-shell snapshot captured from a real page, so
-  // applying it is safe, and a reload would defeat the instant back/forward
-  // restore this path exists to serve. Full head merge: a genuine root-layout
-  // change means stale head elements should be removed.
+  // 3. Full body swap fallback: no shared layout marker (a genuine root-layout
+  // change, or a same-layout nav whose markers could not be paired). Full head
+  // merge, so a real root-layout change removes stale head elements. `mergeHead`
+  // now PRESERVES stylesheets and `<style>` unconditionally (#936): even if the
+  // client reaches this path with an incoming head that lacks the app's
+  // `<link rel=stylesheet>` (a partial or mangled response, e.g. from a
+  // mid-parse empty-`have` prefetch), the live CSS is never stripped, so the
+  // swap can no longer leave the page unstyled.
   mergeHead(doc.head);
   // Persist permanent elements by node identity across the full-body
   // swap: move each live [data-webjs-permanent][id] node into the matching
@@ -3303,6 +3260,24 @@ function addNewHeadElements(newHead) {
   }
 }
 
+/**
+ * A head element that a soft nav must NEVER remove: a `<style>` or a
+ * `<link rel="stylesheet">` (incl. `rel="preload" as="style"`). Removing one
+ * during a full-body-swap fallback whose incoming head lacked it leaves the
+ * page unstyled (#936). Case-insensitive on `rel` (it may list several tokens).
+ *
+ * @param {Element} el
+ * @returns {boolean}
+ */
+function isPersistentHeadStyle(el) {
+  if (el.tagName === 'STYLE') return true;
+  if (el.tagName !== 'LINK') return false;
+  const rel = (el.getAttribute('rel') || '').toLowerCase();
+  if (rel.split(/\s+/).includes('stylesheet')) return true;
+  if (rel.split(/\s+/).includes('preload') && (el.getAttribute('as') || '').toLowerCase() === 'style') return true;
+  return false;
+}
+
 /** @param {HTMLHeadElement} newHead */
 function mergeHead(newHead) {
   const currentHead = document.head;
@@ -3328,6 +3303,14 @@ function mergeHead(newHead) {
     if (el.tagName === 'SCRIPT' && el.getAttribute('type') === 'importmap') continue;
     if (el.tagName === 'BASE') continue;
     if (el.tagName === 'TITLE') continue;
+    // #936: NEVER remove a stylesheet or a `<style>` on a soft nav (Turbo's
+    // persistent-CSS model). The incoming head of a full-body-swap fallback can
+    // legitimately lack the app's `<link rel=stylesheet>` (a partial or mangled
+    // response, e.g. from a mid-parse empty-`have` prefetch): removing the live
+    // one there leaves the whole page unstyled until a manual refresh, the
+    // headline #936 symptom. Keeping it is safe: a genuinely stale sheet is
+    // dropped by the deploy-level hard reload (build-id mismatch), not here.
+    if (isPersistentHeadStyle(el)) continue;
     if (!newSet.has(outerHTMLForDiff(el))) el.remove();
   }
 
@@ -3568,7 +3551,6 @@ export {
   reconcileChildren as _reconcileChildren,
   onPopState as _onPopState,
   applySwap as _applySwap,
-  setHardNavigate as _setHardNavigate,
   buildHaveHeader as _buildHaveHeader,
   snapshotCache as _snapshotCache,
   prefetchCache as _prefetchCache,

--- a/packages/core/test/routing/browser/destructive-fallback.test.js
+++ b/packages/core/test/routing/browser/destructive-fallback.test.js
@@ -88,6 +88,26 @@ suite('Client router: soft nav keeps CSS + empty-have prefetch gate (#936)', () 
     }
   });
 
+  test('a stylesheet tagged data-webjs-track="dynamic" IS removed when absent from the new head (Turbo parity)', () => {
+    enableClientRouter();
+    const dyn = document.createElement('link');
+    dyn.rel = 'stylesheet';
+    dyn.href = '/df-dynamic.css';
+    dyn.setAttribute('data-webjs-track', 'dynamic');
+    document.head.appendChild(dyn);
+
+    try {
+      const doc = _parseHTML('<!doctype html><html><head></head><body></body></html>');
+      _mergeHead(doc.head);
+      // Mirrors Turbo's data-turbo-track="dynamic": an opted-in stylesheet not in
+      // the new head IS removed (the explicit escape hatch from the default).
+      assert.ok(!document.head.querySelector('link[href="/df-dynamic.css"]'),
+        'a data-webjs-track="dynamic" stylesheet absent from the new head is removed');
+    } finally {
+      const s = document.head.querySelector('link[href="/df-dynamic.css"]'); if (s) s.remove();
+    }
+  });
+
   test('an empty-have prefetch is skipped while the document is still parsing', () => {
     enableClientRouter();
     _resetPrefetch();

--- a/packages/core/test/routing/browser/destructive-fallback.test.js
+++ b/packages/core/test/routing/browser/destructive-fallback.test.js
@@ -1,26 +1,24 @@
 /**
- * Real-browser regression for #936: the client router must not do a destructive
- * in-place full-body swap on a foreground nav that has no shared layout marker,
- * and must not speculatively cache an empty-`have` prefetch mid-parse.
+ * Real-browser regression for #936: a client-router soft nav must never leave
+ * the page unstyled, and a mid-parse prefetch must not send an empty `have`.
  *
  * The device failure: a viewport prefetch (the touch default) fires while the
  * HTML is still streaming into the parser, before the body's closing
  * `<!--/wj:children-->` marker exists, so `buildHaveHeader()` returns "". The
- * server sends a full page, and applying it fell to the path-3 full-body swap
- * which stripped the head stylesheet and wiped the outer layout (navbar), then
- * cascaded to every later nav. Fixed by (1) skipping an empty-`have` prefetch
- * while the document is loading, and (2) falling back to a full-page load
- * instead of the destructive swap for a foreground nav.
+ * server sends a full page whose head-merge on apply stripped the live
+ * stylesheet, leaving the page unstyled until a manual refresh. Fixed by
+ * (1) skipping an empty-`have` prefetch while the document is loading, and
+ * (2) never removing a stylesheet / `<style>` during a head merge (Turbo's
+ * persistent-CSS model), so no swap path can lose the CSS.
  *
- * MUST run in a real browser: `location.assign` is not stubbable in any engine,
- * so the reload goes through the `_setHardNavigate` seam; and this asserts real
- * DOM state after `applySwap`, which linkedom does not model.
+ * MUST run in a real browser: this asserts real DOM state after the head merge
+ * + swap, which linkedom does not model.
  */
 import {
   enableClientRouter,
   _applySwap,
   _parseHTML,
-  _setHardNavigate,
+  _mergeHead,
   _prefetch,
   _buildHaveHeader,
   _resetPrefetch,
@@ -28,62 +26,65 @@ import {
 
 import { assert } from '../../../../../test/browser-assert.js';
 
-const REAL_HARD_NAVIGATE = (href) => { if (typeof location !== 'undefined') location.assign(href); };
-
-suite('Client router: non-destructive fallback + empty-have prefetch gate (#936)', () => {
-  test('a foreground nav with no shared layout marker does a full load, not a destructive swap', () => {
+suite('Client router: soft nav keeps CSS + empty-have prefetch gate (#936)', () => {
+  test('a full-body-swap fallback whose incoming head lacks the stylesheet keeps the live CSS', () => {
     enableClientRouter();
-    const assigns = [];
-    _setHardNavigate((href) => assigns.push(href));
 
     const link = document.createElement('link');
     link.rel = 'stylesheet';
     link.href = '/destructive-fallback-test.css';
     document.head.appendChild(link);
-    // Live DOM: outer-layout navbar + a children slot with markers.
-    document.body.innerHTML =
-      '<header class="site-top" id="df-navbar">NAV</header>' +
-      '<!--wj:children:/--><main id="df-main">OLD</main><!--/wj:children-->';
+    const style = document.createElement('style');
+    style.id = 'df-inline-style';
+    style.textContent = ':root{--df:1}';
+    document.head.appendChild(style);
+
+    // Live DOM has a layout; incoming document has a DIFFERENT layout marker
+    // (so no shared path -> the full-body-swap fallback runs) AND an empty head
+    // that lacks the stylesheet, exactly the shape that used to strip the CSS.
+    document.body.innerHTML = '<!--wj:children:/docs-->old<!--/wj:children-->';
 
     try {
-      // Incoming document has NO wj:children markers, so `there` is empty and
-      // longestSharedPath() is null: the old code would full-body-swap here.
-      const doc = _parseHTML('<!doctype html><html><head></head><body><main>NEW</main></body></html>');
-      _applySwap(doc, null, false, location.origin + '/no/shared/marker');
+      const doc = _parseHTML('<!doctype html><html><head></head><body><!--wj:children:/admin--><main>new</main><!--/wj:children--></body></html>');
+      _applySwap(doc, null, false, location.origin + '/admin/y');
 
-      assert.ok(assigns.some((u) => String(u).includes('/no/shared/marker')),
-        'fell back to a full-page load to the target URL');
-      // The destructive swap must NOT have run: stylesheet, navbar, and live
-      // content all survive because applySwap returned before touching the DOM.
+      // The swap ran (cross-layout), but the head merge preserved the CSS.
       assert.ok(document.head.querySelector('link[href="/destructive-fallback-test.css"]'),
-        'head stylesheet was not stripped (no destructive mergeHead)');
-      assert.ok(document.getElementById('df-navbar'), 'outer-layout navbar was not wiped');
-      assert.ok(document.getElementById('df-main'), 'live children content was left in place');
+        'the live stylesheet link was NOT stripped by the head merge');
+      assert.ok(document.getElementById('df-inline-style'),
+        'the live <style> was NOT stripped by the head merge');
+      assert.ok(document.body.textContent.includes('new'), 'the body swap did apply');
     } finally {
-      _setHardNavigate(REAL_HARD_NAVIGATE);
       link.remove();
+      const s = document.getElementById('df-inline-style');
+      if (s) s.remove();
       document.body.innerHTML = '';
     }
   });
 
-  test('a revalidation / cache restore (href null) still applies in place, never a full load', () => {
+  test('mergeHead removes a genuinely stale non-style head element but keeps stylesheets', () => {
     enableClientRouter();
-    const assigns = [];
-    _setHardNavigate((href) => assigns.push(href));
-    document.body.innerHTML = '<!--wj:children:/--><main>OLD</main><!--/wj:children-->';
+    const sheet = document.createElement('link');
+    sheet.rel = 'stylesheet';
+    sheet.href = '/df-keep.css';
+    document.head.appendChild(sheet);
+    const staleMeta = document.createElement('meta');
+    staleMeta.name = 'df-stale';
+    staleMeta.content = 'x';
+    document.head.appendChild(staleMeta);
 
     try {
-      // No shared marker AND href null (a revalidation). Must NOT reload: its doc
-      // is a full same-shell snapshot, safe to apply, and a reload would defeat
-      // the instant back/forward restore this path serves.
-      const doc = _parseHTML('<!doctype html><html><head></head><body><main>RESTORED</main></body></html>');
-      _applySwap(doc, null, /* revalidating */ true, /* href */ null);
+      // Incoming head has neither the stylesheet nor the meta.
+      const doc = _parseHTML('<!doctype html><html><head><meta name="df-fresh" content="y"></head><body></body></html>');
+      _mergeHead(doc.head);
 
-      assert.equal(assigns.length, 0, 'a revalidation never triggers a full-page load');
-      assert.ok(document.body.textContent.includes('RESTORED'), 'the snapshot was applied in place');
+      assert.ok(document.head.querySelector('link[href="/df-keep.css"]'), 'stylesheet preserved');
+      assert.ok(!document.head.querySelector('meta[name="df-stale"]'), 'a stale non-style head element is still removed');
+      assert.ok(document.head.querySelector('meta[name="df-fresh"]'), 'a new head element from the incoming doc is added');
     } finally {
-      _setHardNavigate(REAL_HARD_NAVIGATE);
-      document.body.innerHTML = '';
+      const s = document.head.querySelector('link[href="/df-keep.css"]'); if (s) s.remove();
+      const m1 = document.head.querySelector('meta[name="df-stale"]'); if (m1) m1.remove();
+      const m2 = document.head.querySelector('meta[name="df-fresh"]'); if (m2) m2.remove();
     }
   });
 
@@ -101,15 +102,12 @@ suite('Client router: non-destructive fallback + empty-have prefetch gate (#936)
 
     let readyStateForced = false;
     try {
-      // Force readyState = 'loading' (an own property shadows the prototype getter).
       Object.defineProperty(document, 'readyState', { configurable: true, get: () => 'loading' });
       readyStateForced = true;
 
       _prefetch(location.origin + '/prefetch/mid-parse');
       assert.equal(fetches.length, 0, 'no speculative fetch fired for an empty-have prefetch during parse');
 
-      // Once parsed, an empty-have prefetch is allowed (a page genuinely without
-      // a layout slot is rare but valid, and applySwap now full-loads it safely).
       Object.defineProperty(document, 'readyState', { configurable: true, get: () => 'complete' });
       _resetPrefetch();
       _prefetch(location.origin + '/prefetch/after-parse');

--- a/packages/core/test/routing/browser/destructive-fallback.test.js
+++ b/packages/core/test/routing/browser/destructive-fallback.test.js
@@ -1,0 +1,125 @@
+/**
+ * Real-browser regression for #936: the client router must not do a destructive
+ * in-place full-body swap on a foreground nav that has no shared layout marker,
+ * and must not speculatively cache an empty-`have` prefetch mid-parse.
+ *
+ * The device failure: a viewport prefetch (the touch default) fires while the
+ * HTML is still streaming into the parser, before the body's closing
+ * `<!--/wj:children-->` marker exists, so `buildHaveHeader()` returns "". The
+ * server sends a full page, and applying it fell to the path-3 full-body swap
+ * which stripped the head stylesheet and wiped the outer layout (navbar), then
+ * cascaded to every later nav. Fixed by (1) skipping an empty-`have` prefetch
+ * while the document is loading, and (2) falling back to a full-page load
+ * instead of the destructive swap for a foreground nav.
+ *
+ * MUST run in a real browser: `location.assign` is not stubbable in any engine,
+ * so the reload goes through the `_setHardNavigate` seam; and this asserts real
+ * DOM state after `applySwap`, which linkedom does not model.
+ */
+import {
+  enableClientRouter,
+  _applySwap,
+  _parseHTML,
+  _setHardNavigate,
+  _prefetch,
+  _buildHaveHeader,
+  _resetPrefetch,
+} from '../../../src/router-client.js';
+
+import { assert } from '../../../../../test/browser-assert.js';
+
+const REAL_HARD_NAVIGATE = (href) => { if (typeof location !== 'undefined') location.assign(href); };
+
+suite('Client router: non-destructive fallback + empty-have prefetch gate (#936)', () => {
+  test('a foreground nav with no shared layout marker does a full load, not a destructive swap', () => {
+    enableClientRouter();
+    const assigns = [];
+    _setHardNavigate((href) => assigns.push(href));
+
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = '/destructive-fallback-test.css';
+    document.head.appendChild(link);
+    // Live DOM: outer-layout navbar + a children slot with markers.
+    document.body.innerHTML =
+      '<header class="site-top" id="df-navbar">NAV</header>' +
+      '<!--wj:children:/--><main id="df-main">OLD</main><!--/wj:children-->';
+
+    try {
+      // Incoming document has NO wj:children markers, so `there` is empty and
+      // longestSharedPath() is null: the old code would full-body-swap here.
+      const doc = _parseHTML('<!doctype html><html><head></head><body><main>NEW</main></body></html>');
+      _applySwap(doc, null, false, location.origin + '/no/shared/marker');
+
+      assert.ok(assigns.some((u) => String(u).includes('/no/shared/marker')),
+        'fell back to a full-page load to the target URL');
+      // The destructive swap must NOT have run: stylesheet, navbar, and live
+      // content all survive because applySwap returned before touching the DOM.
+      assert.ok(document.head.querySelector('link[href="/destructive-fallback-test.css"]'),
+        'head stylesheet was not stripped (no destructive mergeHead)');
+      assert.ok(document.getElementById('df-navbar'), 'outer-layout navbar was not wiped');
+      assert.ok(document.getElementById('df-main'), 'live children content was left in place');
+    } finally {
+      _setHardNavigate(REAL_HARD_NAVIGATE);
+      link.remove();
+      document.body.innerHTML = '';
+    }
+  });
+
+  test('a revalidation / cache restore (href null) still applies in place, never a full load', () => {
+    enableClientRouter();
+    const assigns = [];
+    _setHardNavigate((href) => assigns.push(href));
+    document.body.innerHTML = '<!--wj:children:/--><main>OLD</main><!--/wj:children-->';
+
+    try {
+      // No shared marker AND href null (a revalidation). Must NOT reload: its doc
+      // is a full same-shell snapshot, safe to apply, and a reload would defeat
+      // the instant back/forward restore this path serves.
+      const doc = _parseHTML('<!doctype html><html><head></head><body><main>RESTORED</main></body></html>');
+      _applySwap(doc, null, /* revalidating */ true, /* href */ null);
+
+      assert.equal(assigns.length, 0, 'a revalidation never triggers a full-page load');
+      assert.ok(document.body.textContent.includes('RESTORED'), 'the snapshot was applied in place');
+    } finally {
+      _setHardNavigate(REAL_HARD_NAVIGATE);
+      document.body.innerHTML = '';
+    }
+  });
+
+  test('an empty-have prefetch is skipped while the document is still parsing', () => {
+    enableClientRouter();
+    _resetPrefetch();
+    // Live body has NO layout markers, so buildHaveHeader() is empty (this is
+    // exactly the mid-parse state on the device: close marker not parsed yet).
+    document.body.innerHTML = '<main>no markers yet</main>';
+    assert.equal(_buildHaveHeader(), '', 'sanity: no markers means an empty have header');
+
+    const fetches = [];
+    const origFetch = window.fetch;
+    window.fetch = (u) => { fetches.push(String(u)); return Promise.resolve(new Response('', { headers: { 'content-type': 'text/html' } })); };
+
+    let readyStateForced = false;
+    try {
+      // Force readyState = 'loading' (an own property shadows the prototype getter).
+      Object.defineProperty(document, 'readyState', { configurable: true, get: () => 'loading' });
+      readyStateForced = true;
+
+      _prefetch(location.origin + '/prefetch/mid-parse');
+      assert.equal(fetches.length, 0, 'no speculative fetch fired for an empty-have prefetch during parse');
+
+      // Once parsed, an empty-have prefetch is allowed (a page genuinely without
+      // a layout slot is rare but valid, and applySwap now full-loads it safely).
+      Object.defineProperty(document, 'readyState', { configurable: true, get: () => 'complete' });
+      _resetPrefetch();
+      _prefetch(location.origin + '/prefetch/after-parse');
+      assert.ok(fetches.some((u) => u.includes('/prefetch/after-parse')),
+        'once the document is parsed, the prefetch is no longer suppressed');
+    } finally {
+      window.fetch = origFetch;
+      if (readyStateForced) { try { delete document.readyState; } catch { /* ignore */ } }
+      document.body.innerHTML = '';
+      _resetPrefetch();
+    }
+  });
+});

--- a/packages/core/test/routing/browser/destructive-fallback.test.js
+++ b/packages/core/test/routing/browser/destructive-fallback.test.js
@@ -88,26 +88,6 @@ suite('Client router: soft nav keeps CSS + empty-have prefetch gate (#936)', () 
     }
   });
 
-  test('a stylesheet tagged data-webjs-track="dynamic" IS removed when absent from the new head (Turbo parity)', () => {
-    enableClientRouter();
-    const dyn = document.createElement('link');
-    dyn.rel = 'stylesheet';
-    dyn.href = '/df-dynamic.css';
-    dyn.setAttribute('data-webjs-track', 'dynamic');
-    document.head.appendChild(dyn);
-
-    try {
-      const doc = _parseHTML('<!doctype html><html><head></head><body></body></html>');
-      _mergeHead(doc.head);
-      // Mirrors Turbo's data-turbo-track="dynamic": an opted-in stylesheet not in
-      // the new head IS removed (the explicit escape hatch from the default).
-      assert.ok(!document.head.querySelector('link[href="/df-dynamic.css"]'),
-        'a data-webjs-track="dynamic" stylesheet absent from the new head is removed');
-    } finally {
-      const s = document.head.querySelector('link[href="/df-dynamic.css"]'); if (s) s.remove();
-    }
-  });
-
   test('an empty-have prefetch is skipped while the document is still parsing', () => {
     enableClientRouter();
     _resetPrefetch();

--- a/packages/core/test/routing/router-client.test.js
+++ b/packages/core/test/routing/router-client.test.js
@@ -1763,10 +1763,13 @@ test('navigate: deepest shared marker wins (inner swap, not outer)', async () =>
   }
 });
 
-test('navigate: cross-layout nav falls through to full body swap', async () => {
-  // /docs/x → /admin/y: no shared marker path → full body swap.
+test('navigate: cross-layout nav (no shared marker) does a full-page load, not a destructive swap (#936)', async () => {
+  // /docs/x → /admin/y: no shared marker path. A full-body in-place swap here
+  // strips the outer layout + its head CSS (the #936 crime), so when the live
+  // page actually has a layout the router full-loads instead. The old behavior
+  // was a destructive in-place swap; the reload is always correct by construction.
   document.body.innerHTML = '<!--wj:children:/docs-->old<!--/wj:children-->';
-  const { restore } = installNavigationMocks({
+  const { redirect, restore } = installNavigationMocks({
     contentType: 'text/html',
     body:
       '<!doctype html><html><head></head><body>' +
@@ -1775,8 +1778,12 @@ test('navigate: cross-layout nav falls through to full body swap', async () => {
   });
   try {
     await navigate('http://localhost/admin/y');
-    assert.ok(document.body.textContent.includes('new'));
-    assert.ok(!document.body.textContent.includes('old'));
+    assert.ok(redirect.assigns.includes('http://localhost/admin/y'),
+      'a cross-layout nav does a full-page load to the target');
+    // The destructive in-place swap did NOT run: the old content stays put until
+    // the reload lands (the new content is never grafted in).
+    assert.ok(document.body.textContent.includes('old'), 'no in-place swap happened');
+    assert.ok(!document.body.textContent.includes('new'));
   } finally {
     restore();
     document.body.innerHTML = '';

--- a/packages/core/test/routing/router-client.test.js
+++ b/packages/core/test/routing/router-client.test.js
@@ -606,24 +606,27 @@ test('addNewHeadElements: head diff ignores per-request nonce differences (no sp
  * mergeHead: full-merge head (used on full body swap)
  * ==================================================================== */
 
-test('mergeHead: removes elements not in the new head', () => {
+test('mergeHead: removes stale non-style elements but never a stylesheet (#936)', () => {
   document.head.innerHTML =
     '<title>Old</title>' +
-    '<link rel="stylesheet" href="/stale.css">' +
-    '<link rel="stylesheet" href="/shared.css">';
+    '<meta name="stale-meta" content="x">' +
+    '<link rel="stylesheet" href="/keep.css">';
   const newHead = document.createElement('head');
   newHead.innerHTML =
     '<title>New</title>' +
-    '<link rel="stylesheet" href="/shared.css">' +
+    '<meta name="fresh-meta" content="y">' +
     '<link rel="stylesheet" href="/fresh.css">';
   _merge(newHead);
   assert.equal(document.title, 'New');
-  assert.ok(!document.head.querySelector('link[href="/stale.css"]'), 'stale link removed');
-  assert.ok(document.head.querySelector('link[href="/shared.css"]'), 'shared link kept');
-  assert.ok(document.head.querySelector('link[href="/fresh.css"]'), 'fresh link added');
+  assert.ok(!document.head.querySelector('meta[name="stale-meta"]'), 'a stale non-style element is removed');
+  assert.ok(document.head.querySelector('meta[name="fresh-meta"]'), 'a fresh element is added');
+  // #936: a stylesheet the incoming head lacks must NOT be stripped (it would
+  // leave the page unstyled). It stays; a new one is still added.
+  assert.ok(document.head.querySelector('link[href="/keep.css"]'), 'the live stylesheet is preserved even though absent from the new head');
+  assert.ok(document.head.querySelector('link[href="/fresh.css"]'), 'a new stylesheet is added');
 });
 
-test('mergeHead: preserves importmap and base across full merges', () => {
+test('mergeHead: preserves importmap, base, AND stylesheets across full merges (#936)', () => {
   document.head.innerHTML =
     '<script type="importmap">{}</script>' +
     '<base href="/">' +
@@ -633,7 +636,7 @@ test('mergeHead: preserves importmap and base across full merges', () => {
   _merge(newHead);
   assert.ok(document.head.querySelector('script[type="importmap"]'), 'importmap kept');
   assert.ok(document.head.querySelector('base'), 'base kept');
-  assert.ok(!document.head.querySelector('link[href="/x.css"]'), 'x.css removed');
+  assert.ok(document.head.querySelector('link[href="/x.css"]'), 'the existing stylesheet is preserved (#936), not removed');
   assert.ok(document.head.querySelector('link[href="/y.css"]'), 'y.css added');
 });
 
@@ -1763,13 +1766,10 @@ test('navigate: deepest shared marker wins (inner swap, not outer)', async () =>
   }
 });
 
-test('navigate: cross-layout nav (no shared marker) does a full-page load, not a destructive swap (#936)', async () => {
-  // /docs/x → /admin/y: no shared marker path. A full-body in-place swap here
-  // strips the outer layout + its head CSS (the #936 crime), so when the live
-  // page actually has a layout the router full-loads instead. The old behavior
-  // was a destructive in-place swap; the reload is always correct by construction.
+test('navigate: cross-layout nav falls through to full body swap', async () => {
+  // /docs/x → /admin/y: no shared marker path → full body swap.
   document.body.innerHTML = '<!--wj:children:/docs-->old<!--/wj:children-->';
-  const { redirect, restore } = installNavigationMocks({
+  const { restore } = installNavigationMocks({
     contentType: 'text/html',
     body:
       '<!doctype html><html><head></head><body>' +
@@ -1778,12 +1778,8 @@ test('navigate: cross-layout nav (no shared marker) does a full-page load, not a
   });
   try {
     await navigate('http://localhost/admin/y');
-    assert.ok(redirect.assigns.includes('http://localhost/admin/y'),
-      'a cross-layout nav does a full-page load to the target');
-    // The destructive in-place swap did NOT run: the old content stays put until
-    // the reload lands (the new content is never grafted in).
-    assert.ok(document.body.textContent.includes('old'), 'no in-place swap happened');
-    assert.ok(!document.body.textContent.includes('new'));
+    assert.ok(document.body.textContent.includes('new'));
+    assert.ok(!document.body.textContent.includes('old'));
   } finally {
     restore();
     document.body.innerHTML = '';


### PR DESCRIPTION
Closes #936.

## Problem

On real Android Chrome, a client-router soft nav strips the head CSS (the page renders unstyled until a manual refresh); the corruption also breaks the browser Back button (the fixed-header offset is lost, so the body shifts up by the header height). An on-device `?diag=capture` harness pinned the chain: a viewport prefetch (the touch-device default) fires while the HTML is still streaming into the parser, before the body's closing `<!--/wj:children-->` marker exists, so `buildHaveHeader()` sends an empty `X-Webjs-Have`. The server returns a full page, and applying it runs the head merge against that reduced head, stripping the live stylesheet. It reproduces only where the parse/prefetch timing window is real (Android Chrome), not iOS Safari, Samsung Internet, or headless Chromium.

## Fix (two seams, both surgical, no reload)

1. **`mergeHead()` never removes a `<link rel=stylesheet>` or a `<style>`** on a soft nav. This is exactly Turbo's default (it only removes a stylesheet explicitly opted into `data-turbo-track="dynamic"`; see the design-rationale comment). webjs's `X-Webjs-Have` optimization returns a REDUCED head (the app stylesheet omitted because the client already has it), so a remove-capable merge against it stripped the live CSS. Not removing it fixes the headline symptom on every swap path; a genuinely changed stylesheet is still dropped by the deploy-level hard reload (build-id mismatch), not a soft swap.
2. **`prefetch()` skips an empty-`have` speculative fetch while `document.readyState === 'loading'`**, so a mid-parse prefetch never caches a poisoned full-page response (this removes the root trigger). The click path re-fetches with a correct `have` once the document has parsed.

## Rejected approach (see the PR comment)

I first implemented a full-page-load fallback for the no-shared-marker path. It was wrong: path 3 is a legitimate soft-nav path real apps use (the blog example), so reloading it regressed client nav (blog e2e: clean to 25 failures), and it mis-fired in popstate (history corruption) with a trailing `pushState` + `webjs:navigate` after `location.assign`. Dropped for the non-reloading fix above.

## Tests

- Browser (`packages/core/test/routing/browser/destructive-fallback.test.js`): a full-body-swap fallback whose incoming head lacks the stylesheet keeps the live CSS + `<style>`; `mergeHead` still removes a stale non-style element while preserving stylesheets; the empty-`have` prefetch gate. Counterfactuals confirmed.
- Unit (`packages/core/test/routing/router-client.test.js`): the two `mergeHead` tests updated to assert stylesheet preservation.
- Docs: `agent-docs/advanced.md` client-router section.

## Verification

- Routing unit 172/172; full routing browser suite 93/93 (no nav interruptions); blog e2e (regression check for the earlier reload approach) reported in a follow-up.
- Bun parity: N/A, browser-only DOM code (`router-client.js`).
