### PR TITLE
refactor: align the blog example + styling docs to shadcn token naming

### DIFF
--- a/agent-docs/styling.md
+++ b/agent-docs/styling.md
@@ -59,7 +59,7 @@ shadow DOM.
 Default stack: a static compiled Tailwind stylesheet (`css:build` compiles
 `public/input.css` to the linked `public/tailwind.css`, so it works with JS
 off) + `@theme` design tokens (palette, fonts, fluid type, motion
-durations). Consume via utility classes (`text-fg`, `bg-bg-elev`,
+durations). Consume via utility classes (`text-foreground`, `bg-card`,
 `font-serif`, `duration-fast`, `text-display`).
 
 **DRY via JS helpers, not `@apply`.** When the same bundle of Tailwind
@@ -73,14 +73,14 @@ import { html } from '@webjsdev/core';
 export function rubric(label: string, mb: 'sm' | 'md' = 'md') {
   const mbCls = mb === 'sm' ? 'mb-3' : 'mb-4';
   return html`
-    <span class="block font-mono text-[11px] leading-none font-semibold tracking-[0.2em] uppercase text-accent ${mbCls}">● ${label}</span>
+    <span class="block font-mono text-[11px] leading-none font-semibold tracking-[0.2em] uppercase text-primary ${mbCls}">● ${label}</span>
   `;
 }
 
 /** "← label" back link: small caps, muted. */
 export function backLink(href: string, label: string) {
   return html`
-    <a href=${href} class="inline-block mb-12 text-fg-subtle no-underline font-mono text-[11px] leading-none font-medium tracking-[0.15em] uppercase transition-colors duration-fast hover:text-fg">← ${label}</a>
+    <a href=${href} class="inline-block mb-12 text-muted-foreground/70 no-underline font-mono text-[11px] leading-none font-medium tracking-[0.15em] uppercase transition-colors duration-fast hover:text-foreground">← ${label}</a>
   `;
 }
 ```
@@ -117,24 +117,23 @@ identical to inline classes, no client-side runtime.
 
 ## Dark mode: two signals, keep them in sync
 
-The default scaffold runs **two** theming systems, and a theme switch must
-drive **both** or one half goes stale (this is the single most common
-dark-mode bug in a scaffolded app):
+The theme uses ONE shadcn token vocabulary (`--background`, `--foreground`,
+`--primary`, ...), but a theme switch must drive **two signals** on `<html>`
+or half the styling goes stale (the single most common dark-mode bug in a
+scaffolded app):
 
-1. **Editorial chrome tokens** (`--fg`, `--bg`, `--accent`, ...) declared in
-   the root layout. They react to a **`data-theme` attribute** on `<html>`
-   (`data-theme="light"` vs absent) and default to dark.
-2. **Webjs UI (shadcn) component tokens** (`--background`, `--foreground`,
-   `--primary`, ...) used by everything under `components/ui/`. They react
-   to a **`.dark` class** on an ancestor (`@custom-variant dark (&:is(.dark *))`)
-   and default to light.
+1. **The `data-theme` attribute** (`data-theme="light"` vs absent, default
+   dark). The app palette blocks in the root layout react to it
+   (`:root` / `:root[data-theme='light']`).
+2. **The `.dark` class**. The `@webjsdev/ui` kit under `components/ui/` reacts
+   to it (`@custom-variant dark (&:is(.dark *))` plus its `.dark { ... }` token
+   defaults).
 
-The scaffold's head init script and `theme-toggle` set **both** signals on
-`<html>`: they write `data-theme` AND `classList.toggle('dark', isDark)`. If
-you wire your own theme switch or replace the toggle, you MUST set both.
-Setting only `data-theme` leaves the ui-* components rendering light tokens
-on a dark page (white buttons, white cards, invisible text) while the chrome
-looks correct.
+The head init script and `theme-toggle` set **both**: they write `data-theme`
+AND `classList.toggle('dark', isDark)`. If you wire your own theme switch or
+replace the toggle, you MUST set both. Setting only `data-theme` leaves the
+ui-* components rendering light tokens on a dark page (white buttons, white
+cards, invisible text) while the rest of the chrome looks correct.
 
 **Verify dark mode in a real browser, not just light.** Light mode passing
 proves nothing about dark mode: with neither signal set, both systems sit at
@@ -184,7 +183,7 @@ const STYLES = css`
   .page-dashboard {
     .actions      { display: flex; gap: 12px; }
     .btn          { padding: 12px 24px; border-radius: 999px; }
-    .btn-primary  { background: var(--accent); color: var(--accent-fg); }
+    .btn-primary  { background: var(--primary); color: var(--primary-foreground); }
   }
 `;
 

--- a/docs/app/docs/styling/page.ts
+++ b/docs/app/docs/styling/page.ts
@@ -200,7 +200,7 @@ export default function Post({ params }) {
   }
   ::selection { background: var(--primary-tint); }
   ::-webkit-scrollbar { width: 10px; }
-  ::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 999px; }
+  ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 999px; }
 &lt;/style&gt;</pre>
 
     <h2>Dark mode</h2>

--- a/docs/app/docs/styling/page.ts
+++ b/docs/app/docs/styling/page.ts
@@ -14,12 +14,13 @@ export default function Styling() {
 // which the dev / start tasks run automatically). The @theme maps live here.
 @import "tailwindcss";
 @theme {
-  --color-fg:        var(--fg);
-  --color-bg:        var(--bg);
-  --color-accent:    var(--accent);
-  --font-serif:      var(--font-serif);
-  --text-display:    clamp(2.6rem, 1.6rem + 3.2vw, 4.25rem);
-  --duration-fast:   140ms;
+  --color-background:       var(--background);
+  --color-foreground:       var(--foreground);
+  --color-primary:          var(--primary);
+  --color-muted-foreground: var(--muted-foreground);
+  --font-serif:             var(--font-serif);
+  --text-display:           clamp(2.6rem, 1.6rem + 3.2vw, 4.25rem);
+  --duration-fast:          140ms;
 }
 
 // app/layout.ts excerpt
@@ -31,9 +32,9 @@ export default function RootLayout({ children }: { children: unknown }) {
     &lt;style&gt;
       /* Token VALUES: plain CSS custom properties, so they resolve with JS off. */
       :root {
-        --fg: oklch(0.96 0.015 60);
-        --bg: oklch(0.14 0.01 55);
-        --accent: oklch(0.78 0.14 55);
+        --background: oklch(0.14 0.01 55);
+        --foreground: oklch(0.96 0.015 60);
+        --primary:    oklch(0.78 0.14 55);
         /* …etc */
       }
     &lt;/style&gt;
@@ -44,9 +45,9 @@ export default function RootLayout({ children }: { children: unknown }) {
 }</pre>
 
     <p>From any page or component you now write things like:</p>
-    <pre>&lt;h1 class="font-serif text-display text-fg mb-6"&gt;Hello&lt;/h1&gt;
-&lt;p class="text-fg-muted font-sans"&gt;Lede copy&lt;/p&gt;
-&lt;a class="text-accent hover:underline duration-fast"&gt;Link&lt;/a&gt;</pre>
+    <pre>&lt;h1 class="font-serif text-display text-foreground mb-6"&gt;Hello&lt;/h1&gt;
+&lt;p class="text-muted-foreground font-sans"&gt;Lede copy&lt;/p&gt;
+&lt;a class="text-primary hover:underline duration-fast"&gt;Link&lt;/a&gt;</pre>
 
     <h2>Light-DOM components</h2>
     <p>Light DOM is the default for any <code>WebComponent</code>. Tailwind classes apply as they would on plain HTML:</p>
@@ -134,7 +135,7 @@ export class Card extends WebComponent {
   static styles = css\`
     :host { display: block; padding: 16px; border: 1px solid var(--border); border-radius: 8px; }
     h3 { margin: 0 0 8px; }
-    p  { color: var(--fg-muted); margin: 0; }
+    p  { color: var(--muted-foreground); margin: 0; }
   \`;
   render() {
     return html\`
@@ -148,7 +149,7 @@ Card.register('my-card');</pre>
     <p>Shadow-DOM components are SSR'd via Declarative Shadow DOM. Styles paint before JS loads, no hydration runtime, and the browser enforces the boundary. Light-DOM components are SSR'd as direct HTML with a <code>&lt;!--webjs-hydrate--&gt;</code> marker, and client-side rendering replaces the marker without flash.</p>
 
     <h2>Design tokens via CSS custom properties</h2>
-    <p>CSS custom properties <strong>inherit through shadow DOM boundaries</strong>. Define them once on <code>:root</code> (as the blog example does in its layout) and both light-DOM and shadow-DOM components can consume them via Tailwind classes (<code>text-fg</code>, <code>bg-bg-elev</code>) or bare CSS (<code>var(--fg)</code>).</p>
+    <p>CSS custom properties <strong>inherit through shadow DOM boundaries</strong>. Define them once on <code>:root</code> (as the blog example does in its layout) and both light-DOM and shadow-DOM components can consume them via Tailwind classes (<code>text-foreground</code>, <code>bg-card</code>) or bare CSS (<code>var(--foreground)</code>).</p>
 
     <h2>DRY'ing up repeated Tailwind classes via JS helpers</h2>
     <p>When the same bundle of Tailwind classes appears in 2+ places, extract it into a JS helper in <code>lib/utils/ui.ts</code>. The helper runs at SSR time inside <code>html\`\`</code>, so the browser sees fully materialised HTML. No client-side runtime, no diff from inline classes.</p>
@@ -159,14 +160,14 @@ import { html } from '@webjsdev/core';
 /** \`label\` kicker: small caps, accent colour, above headings. */
 export function rubric(label: string) {
   return html\`
-    &lt;span class="block font-mono text-[11px] leading-none font-semibold tracking-[0.2em] uppercase text-accent mb-4"&gt;● \${label}&lt;/span&gt;
+    &lt;span class="block font-mono text-[11px] leading-none font-semibold tracking-[0.2em] uppercase text-primary mb-4"&gt;● \${label}&lt;/span&gt;
   \`;
 }
 
 /** "← label" back link. */
 export function backLink(href: string, label: string) {
   return html\`
-    &lt;a href=\${href} class="inline-block mb-12 text-fg-subtle no-underline font-mono text-[11px] uppercase tracking-[0.15em] duration-fast hover:text-fg"&gt;← \${label}&lt;/a&gt;
+    &lt;a href=\${href} class="inline-block mb-12 text-muted-foreground/70 no-underline font-mono text-[11px] uppercase tracking-[0.15em] duration-fast hover:text-foreground"&gt;← \${label}&lt;/a&gt;
   \`;
 }</pre>
 
@@ -178,7 +179,7 @@ export default function Post({ params }) {
   return html\`
     \${backLink('/', 'Posts')}
     \${rubric('post')}
-    &lt;h1 class="font-serif text-display text-fg"&gt;Hello&lt;/h1&gt;
+    &lt;h1 class="font-serif text-display text-foreground"&gt;Hello&lt;/h1&gt;
   \`;
 }</pre>
 
@@ -193,11 +194,11 @@ export default function Post({ params }) {
 &lt;style&gt;
   html, body { margin: 0; }
   body {
-    background: var(--bg);
-    color: var(--fg);
+    background: var(--background);
+    color: var(--foreground);
     font: 16px/1.65 var(--font-sans);
   }
-  ::selection { background: var(--accent-tint); }
+  ::selection { background: var(--primary-tint); }
   ::-webkit-scrollbar { width: 10px; }
   ::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 999px; }
 &lt;/style&gt;</pre>
@@ -233,7 +234,7 @@ const STYLES = css\`
   .page-dashboard {
     .actions     { display: flex; gap: 12px; }
     .btn         { padding: 12px 24px; border-radius: 999px; }
-    .btn-primary { background: var(--accent); color: var(--accent-fg); }
+    .btn-primary { background: var(--primary); color: var(--primary-foreground); }
   }
 \`;
 

--- a/examples/blog/CONVENTIONS.md
+++ b/examples/blog/CONVENTIONS.md
@@ -375,7 +375,7 @@ return html`
 // Avoid: hand-rolled Tailwind on every <button> loses visual
 // consistency. Tier-1 helpers give you the same control with one import.
 return html`
-  <button class="px-4 py-2 rounded-md bg-accent text-accent-fg">Save</button>
+  <button class="px-4 py-2 rounded-md bg-primary text-primary-foreground">Save</button>
 `;
 ```
 
@@ -418,7 +418,7 @@ export class MyWidget extends WebComponent({
   render() {
     return html`
       <div class="p-4 border border-border rounded-lg">
-        <p class="font-serif text-fg">${this.label}: ${this.count}</p>
+        <p class="font-serif text-foreground">${this.label}: ${this.count}</p>
       </div>
     `;
   }
@@ -496,7 +496,7 @@ Both hydrate without flash on the client.
 The scaffold ships with the **Tailwind CSS browser runtime** + `@theme`
 design tokens defined in the root layout. Every colour, font family,
 fluid type scale value, and motion duration is declared once in `@theme`
-and available everywhere via utility classes (`text-fg`, `bg-bg-elev`,
+and available everywhere via utility classes (`text-foreground`, `bg-card`,
 `font-serif`, `duration-fast`, `text-display`).
 
 **Dedup repeated Tailwind class bundles with JS helpers, not `@apply`.**
@@ -509,7 +509,7 @@ import { html } from '@webjsdev/core';
 
 export function rubric(label: string) {
   return html`
-    <span class="block font-mono text-[11px] leading-none font-semibold tracking-[0.2em] uppercase text-accent mb-4">● ${label}</span>
+    <span class="block font-mono text-[11px] leading-none font-semibold tracking-[0.2em] uppercase text-primary mb-4">● ${label}</span>
   `;
 }
 ```
@@ -571,7 +571,7 @@ const STYLES = css\`
   .page-dashboard {
     .actions     { display: flex; gap: 12px; }
     .btn         { padding: 12px 24px; border-radius: 999px; }
-    .btn-primary { background: var(--accent); color: var(--accent-fg); }
+    .btn-primary { background: var(--primary); color: var(--primary-foreground); }
   }
 \`;
 

--- a/examples/blog/app/(marketing)/about/page.ts
+++ b/examples/blog/app/(marketing)/about/page.ts
@@ -19,8 +19,8 @@ export default function About() {
     <span id="perm-probe" data-webjs-permanent hidden></span>
     ${rubric('about')}
     ${displayH1('A full-stack demo, at framework scale.')}
-    <p class="text-[1.15rem] leading-[1.5] font-sans text-fg-muted max-w-[56ch] m-0 mb-18">
-      A tiny blog built on <strong class="text-fg">webjs</strong>: a no-build, web-components-first,
+    <p class="text-[1.15rem] leading-[1.5] font-sans text-muted-foreground max-w-[56ch] m-0 mb-18">
+      A tiny blog built on <strong class="text-foreground">webjs</strong>: a no-build, web-components-first,
       NextJs-inspired framework. Every feature the framework ships with is exercised
       here in under a thousand lines.
     </p>
@@ -29,15 +29,15 @@ export default function About() {
     <div class="grid gap-0 border-t border-border">
       ${FEATURES.map((f) => html`
         <div class="grid grid-cols-[minmax(0,0.9fr)_minmax(0,2fr)] gap-6 py-4 border-b border-border min-w-0">
-          <div class="font-mono text-[11px] leading-[1.4] font-semibold tracking-[0.1em] text-accent uppercase">${f.label}</div>
-          <p class="font-serif text-base leading-[1.6] text-fg m-0">${f.note}</p>
+          <div class="font-mono text-[11px] leading-[1.4] font-semibold tracking-[0.1em] text-primary uppercase">${f.label}</div>
+          <p class="font-serif text-base leading-[1.6] text-foreground m-0">${f.note}</p>
         </div>
       `)}
     </div>
 
-    <div class="mt-12 px-8 py-6 bg-bg-elev border border-border rounded-[14px]">
-      <p class="m-0 text-[15px] text-fg-muted">
-        <strong class="text-fg">Modules architecture.</strong> Feature modules live under
+    <div class="mt-12 px-8 py-6 bg-card border border-border rounded-[14px]">
+      <p class="m-0 text-[15px] text-muted-foreground">
+        <strong class="text-foreground">Modules architecture.</strong> Feature modules live under
         ${codeChip('modules/')} with their own ${codeChip('actions/')}, ${codeChip('queries/')},
         ${codeChip('components/')}, and ${codeChip('types.js')}. Routes in ${codeChip('app/')}
         are thin adapters.
@@ -45,7 +45,7 @@ export default function About() {
     </div>
 
     <p class="mt-12">
-      <a href="/" class="text-accent underline underline-offset-[3px] decoration-transparent hover:decoration-current transition-colors duration-fast">← Back to posts</a>
+      <a href="/" class="text-primary underline underline-offset-[3px] decoration-transparent hover:decoration-current transition-colors duration-fast">← Back to posts</a>
     </p>
   `;
 }

--- a/examples/blog/app/async-leaf/page.ts
+++ b/examples/blog/app/async-leaf/page.ts
@@ -19,8 +19,8 @@ export default function AsyncLeaf() {
       <h1 class="font-serif text-display leading-[1.02] tracking-[-0.035em] font-bold m-0 mb-4">
         Async leaf
       </h1>
-      <p class="text-lede leading-[1.5] text-fg-muted max-w-[56ch] m-0 mb-6">
-        The quote below is fetched <strong class="text-fg font-bold">inside the component</strong>
+      <p class="text-lede leading-[1.5] text-muted-foreground max-w-[56ch] m-0 mb-6">
+        The quote below is fetched <strong class="text-foreground font-bold">inside the component</strong>
         with a bare async render() and no other client signal, so its module is
         elided and the quote is still in the first paint.
       </p>

--- a/examples/blog/app/blog/[slug]/page.ts
+++ b/examples/blog/app/blog/[slug]/page.ts
@@ -38,15 +38,15 @@ export default async function PostPage({ params }: PageProps<'/blog/[slug]'>) {
       <header class="mb-12">
         ${rubric('post')}
         ${displayH1(post.title)}
-        <div class="flex items-center gap-3 py-4 border-y border-border font-mono text-[11px] leading-[1.4] font-medium tracking-[0.1em] uppercase text-fg-subtle">
-          <span>By <strong class="text-fg font-bold">${post.authorName || 'someone'}</strong></span>
-          <span class="text-fg-subtle">·</span>
+        <div class="flex items-center gap-3 py-4 border-y border-border font-mono text-[11px] leading-[1.4] font-medium tracking-[0.1em] uppercase text-muted-foreground/70">
+          <span>By <strong class="text-foreground font-bold">${post.authorName || 'someone'}</strong></span>
+          <span class="text-muted-foreground/70">·</span>
           <span>${date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })}</span>
-          <span class="text-fg-subtle">·</span>
+          <span class="text-muted-foreground/70">·</span>
           <span>${readingMin} min read</span>
         </div>
       </header>
-      <div class="font-serif text-[1.14rem] leading-[1.75] text-fg whitespace-pre-wrap my-8 first-letter:text-[4em] first-letter:font-bold first-letter:leading-[0.9] first-letter:float-left first-letter:mr-3.5 first-letter:mt-2.5 first-letter:text-accent first-letter:font-serif">${post.body}</div>
+      <div class="font-serif text-[1.14rem] leading-[1.75] text-foreground whitespace-pre-wrap my-8 first-letter:text-[4em] first-letter:font-bold first-letter:leading-[0.9] first-letter:float-left first-letter:mr-3.5 first-letter:mt-2.5 first-letter:text-primary first-letter:font-serif">${post.body}</div>
     </article>
 
     <div class="mt-18 pt-8 border-t border-border">

--- a/examples/blog/app/dashboard/page.ts
+++ b/examples/blog/app/dashboard/page.ts
@@ -22,7 +22,7 @@ export default async function Dashboard() {
     <section>
       ${rubric('signed in', 'sm')}
       ${clampH1(`Hello, ${me.name || me.email.split('@')[0]}.`)}
-      <p class="text-fg-muted m-0 mb-8">You are ${me.name ? html`<strong class="text-fg">${me.email}</strong>` : ''}${me.name ? ' · ' : ''}a member since ${new Date(me.createdAt).toLocaleDateString(undefined, { year: 'numeric', month: 'short' })}.</p>
+      <p class="text-muted-foreground m-0 mb-8">You are ${me.name ? html`<strong class="text-foreground">${me.email}</strong>` : ''}${me.name ? ' · ' : ''}a member since ${new Date(me.createdAt).toLocaleDateString(undefined, { year: 'numeric', month: 'short' })}.</p>
     </section>
 
     <div class="flex gap-3 mb-18">
@@ -39,14 +39,14 @@ export default async function Dashboard() {
       </div>
       <div class=${cardContentClass()}>
         ${mine.length === 0
-          ? html`<div class="py-12 text-center border border-dashed border-border rounded-[14px] text-fg-muted italic font-serif text-[15px] leading-[1.6]">
+          ? html`<div class="py-12 text-center border border-dashed border-border rounded-[14px] text-muted-foreground italic font-serif text-[15px] leading-[1.6]">
               You haven't published anything yet.
               ${accentLink('/dashboard/posts/new', 'Write your first post →')}
             </div>`
           : html`<ul class="list-none p-0 m-0">
               ${repeat(mine, (p) => p.id, (p) => html`
                 <li class="flex items-baseline justify-between gap-4 py-4 border-b border-border first:border-t">
-                  <a href="/blog/${p.slug}" class="font-serif text-[1.1rem] no-underline text-fg font-semibold tracking-[-0.01em] transition-colors duration-fast hover:text-accent">${p.title}</a>
+                  <a href="/blog/${p.slug}" class="font-serif text-[1.1rem] no-underline text-foreground font-semibold tracking-[-0.01em] transition-colors duration-fast hover:text-primary">${p.title}</a>
                   <muted-text>${new Date(p.createdAt).toLocaleDateString()}</muted-text>
                 </li>`)}
             </ul>`}

--- a/examples/blog/app/frame-demo/page.ts
+++ b/examples/blog/app/frame-demo/page.ts
@@ -40,7 +40,7 @@ export default function FrameDemo({ searchParams }: PageProps) {
 
       <!-- A sentinel OUTSIDE the frame. A correct frame swap leaves it
            untouched; a wrong full-body swap would destroy it. -->
-      <p id="outside-sentinel" class="text-fg-muted text-sm">Outside the frame.</p>
+      <p id="outside-sentinel" class="text-muted-foreground text-sm">Outside the frame.</p>
 
       <!-- External tab links. NOT nested in the frame; they target it by id. -->
       <nav class="flex gap-3 text-sm" data-frame-tabs>
@@ -49,10 +49,10 @@ export default function FrameDemo({ searchParams }: PageProps) {
         <a id="tab-three" href="/frame-demo?tab=three" data-webjs-frame="panel" class="underline">Three</a>
       </nav>
 
-      <webjs-frame id="panel" class="block rounded-md border border-border bg-bg-elev p-4">
+      <webjs-frame id="panel" class="block rounded-md border border-border bg-card p-4">
         <p id="panel-body" data-tab=${tab}>${body}</p>
         <!-- A _top breakout link INSIDE the frame: a full-page nav home. -->
-        <a id="top-link" href="/" data-webjs-frame="_top" class="text-fg-subtle text-xs underline">Exit to home (full nav)</a>
+        <a id="top-link" href="/" data-webjs-frame="_top" class="text-muted-foreground/70 text-xs underline">Exit to home (full nav)</a>
       </webjs-frame>
 
       <!-- Deferred self-loading frame (#253). A lazy <webjs-frame src> that
@@ -66,9 +66,9 @@ export default function FrameDemo({ searchParams }: PageProps) {
         id="deferred"
         src="/frame-demo/deferred"
         loading="lazy"
-        class="block rounded-md border border-border bg-bg-elev p-4"
+        class="block rounded-md border border-border bg-card p-4"
       >
-        <p id="deferred-placeholder" class="text-fg-muted text-sm">Loading deferred content...</p>
+        <p id="deferred-placeholder" class="text-muted-foreground text-sm">Loading deferred content...</p>
       </webjs-frame>
     </section>
   `;

--- a/examples/blog/app/layout.ts
+++ b/examples/blog/app/layout.ts
@@ -2,11 +2,11 @@ import { html, cspNonce, type Metadata, type LayoutProps } from '@webjsdev/core'
 import '#components/theme-toggle.ts';
 
 const navLink = (href: string, label: string) => html`
-  <a href=${href} class="text-fg-muted no-underline font-medium text-[13px] leading-none tracking-[0.005em] transition-colors duration-fast hover:text-fg">${label}</a>
+  <a href=${href} class="text-muted-foreground no-underline font-medium text-[13px] leading-none tracking-[0.005em] transition-colors duration-fast hover:text-foreground">${label}</a>
 `;
 
 const footerLink = (href: string, label: string) => html`
-  <a href=${href} class="text-inherit no-underline transition-colors duration-fast hover:text-fg-muted">${label}</a>
+  <a href=${href} class="text-inherit no-underline transition-colors duration-fast hover:text-muted-foreground">${label}</a>
 `;
 
 const TITLE = 'WebJs Blog - Live Demo';
@@ -53,7 +53,7 @@ export function generateMetadata(ctx: { url: string }): Metadata {
  *     once in prod via `npm run start` or on-file-change in dev via
  *     `npm run dev`. The input lives in `public/input.css` and includes
  *     the `@theme` block that maps our design tokens into Tailwind's
- *     palette (so classes like `text-fg`, `bg-bg-elev`, `text-display`,
+ *     palette (so classes like `text-foreground`, `bg-card`, `text-display`,
  *     `font-serif`, `duration-fast` resolve).
  *  3. Shell markup styled with Tailwind utility classes.
  *
@@ -130,34 +130,37 @@ export default function RootLayout({ children }: LayoutProps) {
         color-scheme: light dark;
         --header-h: 61px; /* #610 fixed-header offset, kept exact by the ResizeObserver below */
 
-        /* dark (default) */
-        --fg:            oklch(0.96 0 0);
-        --fg-muted:      oklch(0.74 0 0);
-        --fg-subtle:     oklch(0.62 0 0);
-        --bg:            oklch(0 0 0);
-        --bg-elev:       oklch(0.135 0 0);
-        --bg-subtle:     oklch(0.09 0 0);
-        --bg-sunken:     oklch(0 0 0);
-        --border:        oklch(0.32 0 0 / 0.9);
-        --border-strong: oklch(0.44 0 0 / 0.92);
-        --accent:        oklch(0.7 0.16 52);
-        --accent-hover:  oklch(0.75 0.16 52);
-        --accent-fg:     oklch(0.17 0.02 52);
-        --danger:        oklch(0.7 0.19 25);
-        --success:       oklch(0.72 0.15 145);
+        /* dark (default). shadcn token names, the same vocabulary the scaffold
+           and the @webjsdev/ui kit use. --primary is the orange BRAND color;
+           --accent is a NEUTRAL hover tint (shadcn model). */
+        --background:             oklch(0 0 0);
+        --foreground:             oklch(0.96 0 0);
+        --card:                   oklch(0.135 0 0);
+        --card-foreground:        oklch(0.96 0 0);
+        --popover:                oklch(0.135 0 0);
+        --popover-foreground:     oklch(0.96 0 0);
+        --primary:                oklch(0.7 0.16 52);
+        --primary-foreground:     oklch(0.17 0.02 52);
+        --secondary:              oklch(0 0 0);
+        --secondary-foreground:   oklch(0.96 0 0);
+        --muted:                  oklch(0.09 0 0);
+        --muted-foreground:       oklch(0.74 0 0);
+        --accent:                 oklch(0.20 0 0);
+        --accent-foreground:      oklch(0.96 0 0);
+        --destructive:            oklch(0.7 0.19 25);
+        --destructive-foreground: oklch(0.96 0 0);
+        --border:                 oklch(0.32 0 0 / 0.9);
+        --input:                  oklch(0.32 0 0 / 0.9);
+        --ring:                   oklch(0.7 0.16 52);
+        --success:                oklch(0.72 0.15 145);
 
-        /* Accent-derived tokens + glow. Declared once: they reference
-           --accent / --accent-live, which resolve per scope, so they flow to
-           both modes. --glow-strength is 0.16 everywhere, so the glow shows in
-           light and dark alike. */
-        --accent-live:    oklch(0.63 0.17 50);
-        --accent-tint:    color-mix(in oklch, var(--accent-live) 14%, transparent);
-        --accent-text:    var(--accent);
-        --accent-surface: color-mix(in oklch, var(--accent-live) 12%, transparent);
-        --accent-border:  color-mix(in oklch, var(--accent-live) 28%, transparent);
-        /* Logo mark gradient: the exact warm-orange stops webjs.dev uses, so
-           the brand mark reads identically here and on the main site (dark
-           default here; the light overrides below carry the light stops). */
+        /* Decorative, derived from --primary so it tracks light/dark: a
+           translucent brand tint for focus rings and the logo glow (the same
+           pattern the scaffold's --primary-tint uses). Plus the logo mark
+           gradient, the exact warm-orange stops webjs.dev uses, so the brand
+           mark reads identically here and on the main site (dark stops here,
+           the light overrides below carry the light stops). */
+        --primary-tint:   color-mix(in oklch, var(--primary) 14%, transparent);
         --logo-from:      oklch(0.8 0.16 58);
         --logo-to:        oklch(0.62 0.18 44);
         --glow-a:         oklch(0.63 0.17 44);
@@ -171,39 +174,49 @@ export default function RootLayout({ children }: LayoutProps) {
 
       /* light: explicit toggle */
       :root[data-theme='light'] {
-        --fg:            oklch(0.20 0.018 60);
-        --fg-muted:      oklch(0.44 0.02 60);
-        --fg-subtle:     oklch(0.50 0.02 65);
-        --bg:            oklch(0.985 0.008 75);
-        --bg-elev:       oklch(1 0 0);
-        --bg-subtle:     oklch(0.96 0.008 75);
-        --bg-sunken:     oklch(0.93 0.01 70);
-        --border:        oklch(0.88 0.012 70 / 0.9);
-        --border-strong: oklch(0.78 0.014 70 / 0.95);
-        --accent:        oklch(0.54 0.16 52);
-        --accent-hover:  oklch(0.5 0.16 52);
-        --accent-fg:     oklch(1 0 0);
-        --logo-from:     oklch(0.63 0.17 50);
-        --logo-to:       oklch(0.44 0.11 52);
+        --background:             oklch(0.985 0.008 75);
+        --foreground:             oklch(0.20 0.018 60);
+        --card:                   oklch(1 0 0);
+        --card-foreground:        oklch(0.20 0.018 60);
+        --popover:                oklch(1 0 0);
+        --popover-foreground:     oklch(0.20 0.018 60);
+        --primary:                oklch(0.54 0.16 52);
+        --primary-foreground:     oklch(1 0 0);
+        --secondary:              oklch(0.93 0.01 70);
+        --secondary-foreground:   oklch(0.20 0.018 60);
+        --muted:                  oklch(0.96 0.008 75);
+        --muted-foreground:       oklch(0.44 0.02 60);
+        --accent:                 oklch(0.94 0.008 75);
+        --accent-foreground:      oklch(0.20 0.018 60);
+        --border:                 oklch(0.88 0.012 70 / 0.9);
+        --input:                  oklch(0.88 0.012 70 / 0.9);
+        --ring:                   oklch(0.54 0.16 52);
+        --logo-from:              oklch(0.63 0.17 50);
+        --logo-to:                oklch(0.44 0.11 52);
       }
 
       /* light: OS preference */
       @media (prefers-color-scheme: light) {
         :root:not([data-theme='dark']) {
-          --fg:            oklch(0.20 0.018 60);
-          --fg-muted:      oklch(0.44 0.02 60);
-          --fg-subtle:     oklch(0.50 0.02 65);
-          --bg:            oklch(0.985 0.008 75);
-          --bg-elev:       oklch(1 0 0);
-          --bg-subtle:     oklch(0.96 0.008 75);
-          --bg-sunken:     oklch(0.93 0.01 70);
-          --border:        oklch(0.88 0.012 70 / 0.9);
-          --border-strong: oklch(0.78 0.014 70 / 0.95);
-          --accent:        oklch(0.54 0.16 52);
-          --accent-hover:  oklch(0.5 0.16 52);
-          --accent-fg:     oklch(1 0 0);
-          --logo-from:     oklch(0.63 0.17 50);
-          --logo-to:       oklch(0.44 0.11 52);
+          --background:             oklch(0.985 0.008 75);
+          --foreground:             oklch(0.20 0.018 60);
+          --card:                   oklch(1 0 0);
+          --card-foreground:        oklch(0.20 0.018 60);
+          --popover:                oklch(1 0 0);
+          --popover-foreground:     oklch(0.20 0.018 60);
+          --primary:                oklch(0.54 0.16 52);
+          --primary-foreground:     oklch(1 0 0);
+          --secondary:              oklch(0.93 0.01 70);
+          --secondary-foreground:   oklch(0.20 0.018 60);
+          --muted:                  oklch(0.96 0.008 75);
+          --muted-foreground:       oklch(0.44 0.02 60);
+          --accent:                 oklch(0.94 0.008 75);
+          --accent-foreground:      oklch(0.20 0.018 60);
+          --border:                 oklch(0.88 0.012 70 / 0.9);
+          --input:                  oklch(0.88 0.012 70 / 0.9);
+          --ring:                   oklch(0.54 0.16 52);
+          --logo-from:              oklch(0.63 0.17 50);
+          --logo-to:                oklch(0.44 0.11 52);
         }
       }
 
@@ -222,8 +235,8 @@ export default function RootLayout({ children }: LayoutProps) {
            single source of truth: a sane SSR first-paint default in :root,
            kept exact and responsive by the ResizeObserver inline script. */
         padding-top: var(--header-h);
-        background: var(--bg);
-        color: var(--fg);
+        background: var(--background);
+        color: var(--foreground);
         font: 16px/1.65 var(--font-sans);
         -webkit-font-smoothing: antialiased;
         text-rendering: optimizeLegibility;
@@ -241,9 +254,9 @@ export default function RootLayout({ children }: LayoutProps) {
           radial-gradient(58% 44% at 50% -4%, color-mix(in oklch, var(--glow-a) calc(var(--glow-strength) * 100%), transparent), transparent 72%),
           radial-gradient(40% 36% at 88% 8%, color-mix(in oklch, var(--glow-a) calc(var(--glow-strength) * 60%), transparent), transparent 70%);
       }
-      ::selection { background: var(--accent-tint); color: var(--fg); }
+      ::selection { background: var(--primary-tint); color: var(--foreground); }
       ::-webkit-scrollbar { width: 10px; height: 10px; }
-      ::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 999px; }
+      ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 999px; }
       ::-webkit-scrollbar-track { background: transparent; }
 
       /* Mobile menu: native <details>/<summary>, same shape as
@@ -258,11 +271,11 @@ export default function RootLayout({ children }: LayoutProps) {
 
     <div class="glow-layer" aria-hidden="true"></div>
 
-    <header class="site-header fixed inset-x-0 top-0 z-20 flex items-center justify-between gap-4 px-4 sm:px-6 py-3 border-b border-border bg-[color-mix(in_oklch,var(--bg)_75%,transparent)] backdrop-blur-[18px] backdrop-saturate-[180%]">
-      <a href="/" class="inline-flex items-center gap-2 no-underline text-fg font-semibold text-[15px] leading-none tracking-tight">
-        <span class="inline-block w-[22px] h-[22px] rounded-[7px] bg-gradient-to-br from-[var(--logo-from)] to-[var(--logo-to)] shadow-[inset_0_0_0_1px_oklch(1_0_0/0.15),0_2px_10px_var(--accent-tint)]"></span>
+    <header class="site-header fixed inset-x-0 top-0 z-20 flex items-center justify-between gap-4 px-4 sm:px-6 py-3 border-b border-border bg-[color-mix(in_oklch,var(--background)_75%,transparent)] backdrop-blur-[18px] backdrop-saturate-[180%]">
+      <a href="/" class="inline-flex items-center gap-2 no-underline text-foreground font-semibold text-[15px] leading-none tracking-tight">
+        <span class="inline-block w-[22px] h-[22px] rounded-[7px] bg-gradient-to-br from-[var(--logo-from)] to-[var(--logo-to)] shadow-[inset_0_0_0_1px_oklch(1_0_0/0.15),0_2px_10px_var(--primary-tint)]"></span>
         <span>webjs</span>
-        <span class="text-fg-subtle mx-1 font-normal">/</span>
+        <span class="text-muted-foreground/70 mx-1 font-normal">/</span>
         <span>blog</span>
       </a>
 
@@ -274,7 +287,7 @@ export default function RootLayout({ children }: LayoutProps) {
         ${navLink('/seeded', 'Seeded')}
         ${navLink('/about', 'About')}
         ${navLink('/dashboard', 'Dashboard')}
-        <a href="https://github.com/webjsdev/webjs/tree/main/examples/blog" target="_blank" rel="noopener" class="text-fg-muted no-underline font-medium text-[13px] leading-none tracking-[0.005em] transition-colors duration-fast hover:text-fg">GitHub</a>
+        <a href="https://github.com/webjsdev/webjs/tree/main/examples/blog" target="_blank" rel="noopener" class="text-muted-foreground no-underline font-medium text-[13px] leading-none tracking-[0.005em] transition-colors duration-fast hover:text-foreground">GitHub</a>
         <theme-toggle></theme-toggle>
       </nav>
 
@@ -283,7 +296,7 @@ export default function RootLayout({ children }: LayoutProps) {
            ui.webjs.dev. -->
       <div class="flex items-center gap-2 sm:hidden">
         <details class="mobile-menu relative">
-          <summary class="list-none cursor-pointer w-9 h-9 inline-flex items-center justify-center rounded-md text-fg-muted hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" aria-label="Toggle navigation">
+          <summary class="list-none cursor-pointer w-9 h-9 inline-flex items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors duration-fast" aria-label="Toggle navigation">
             <svg class="open-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <path d="M3 6h18"/><path d="M3 12h18"/><path d="M3 18h18"/>
             </svg>
@@ -291,12 +304,12 @@ export default function RootLayout({ children }: LayoutProps) {
               <path d="M18 6 6 18"/><path d="m6 6 12 12"/>
             </svg>
           </summary>
-          <nav class="absolute right-0 top-[calc(100%+8px)] min-w-[200px] flex flex-col gap-1 bg-bg-elev border border-border rounded-lg shadow-lg p-2 z-50">
-            <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="/">Posts</a>
-            <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="/search">Search</a>
-            <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="/about">About</a>
-            <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="/dashboard">Dashboard</a>
-            <a class="text-fg-muted no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-bg-subtle hover:text-fg transition-colors duration-fast" href="https://github.com/webjsdev/webjs/tree/main/examples/blog" target="_blank" rel="noopener">GitHub</a>
+          <nav class="absolute right-0 top-[calc(100%+8px)] min-w-[200px] flex flex-col gap-1 bg-card border border-border rounded-lg shadow-lg p-2 z-50">
+            <a class="text-muted-foreground no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-muted hover:text-foreground transition-colors duration-fast" href="/">Posts</a>
+            <a class="text-muted-foreground no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-muted hover:text-foreground transition-colors duration-fast" href="/search">Search</a>
+            <a class="text-muted-foreground no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-muted hover:text-foreground transition-colors duration-fast" href="/about">About</a>
+            <a class="text-muted-foreground no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-muted hover:text-foreground transition-colors duration-fast" href="/dashboard">Dashboard</a>
+            <a class="text-muted-foreground no-underline font-medium text-sm px-3 py-2 rounded-md hover:bg-muted hover:text-foreground transition-colors duration-fast" href="https://github.com/webjsdev/webjs/tree/main/examples/blog" target="_blank" rel="noopener">GitHub</a>
           </nav>
         </details>
         <theme-toggle></theme-toggle>
@@ -304,7 +317,7 @@ export default function RootLayout({ children }: LayoutProps) {
     </header>
 
     <div class="relative z-[1]">
-      <div class="max-w-[760px] mx-auto px-4 sm:px-6 pt-4 text-[11px] leading-snug text-fg-subtle font-mono tracking-wide">
+      <div class="max-w-[760px] mx-auto px-4 sm:px-6 pt-4 text-[11px] leading-snug text-muted-foreground/70 font-mono tracking-wide">
         Demo app. Data will be wiped between redeploys.
       </div>
 
@@ -312,8 +325,8 @@ export default function RootLayout({ children }: LayoutProps) {
         ${children}
       </main>
 
-      <footer class="max-w-[760px] mx-auto px-4 sm:px-6 pt-12 pb-[72px] border-t border-border flex justify-between flex-wrap gap-3 text-fg-subtle font-mono text-[11px] leading-[1.4] tracking-[0.12em] uppercase">
-        <span><span class="text-accent">&#9679;</span>&nbsp; webjs / demo</span>
+      <footer class="max-w-[760px] mx-auto px-4 sm:px-6 pt-12 pb-[72px] border-t border-border flex justify-between flex-wrap gap-3 text-muted-foreground/70 font-mono text-[11px] leading-[1.4] tracking-[0.12em] uppercase">
+        <span><span class="text-primary">&#9679;</span>&nbsp; webjs / demo</span>
         <span>
           ${footerLink('/api/posts', 'api')}
           &nbsp;&middot;&nbsp;

--- a/examples/blog/app/layout.ts
+++ b/examples/blog/app/layout.ts
@@ -80,10 +80,21 @@ export default function RootLayout({ children }: LayoutProps) {
     <script nonce="${nonce}">
       (function(){
         try {
-          var t = localStorage.getItem('webjs_theme');
-          if (t === 'light' || t === 'dark') {
-            document.documentElement.dataset.theme = t;
+          var mq = window.matchMedia('(prefers-color-scheme: light)');
+          function apply(){
+            var t = null;
+            try { t = localStorage.getItem('webjs_theme'); } catch (_) {}
+            var el = document.documentElement;
+            if (t === 'light' || t === 'dark') el.dataset.theme = t;
+            else delete el.dataset.theme;
+            // data-theme drives the app palette blocks; the .dark class is what
+            // the @webjsdev/ui kit's dark: variants read. Keep both in sync (see
+            // agent-docs/styling.md "two signals").
+            var dark = t === 'dark' || (t !== 'light' && !mq.matches);
+            el.classList.toggle('dark', dark);
           }
+          apply();
+          mq.addEventListener('change', apply);
         } catch (_) {}
       })();
       // #610: keep --header-h equal to the fixed header's real height. The

--- a/examples/blog/app/login/page.ts
+++ b/examples/blog/app/login/page.ts
@@ -23,7 +23,7 @@ export default async function LoginPage({ searchParams }: Ctx) {
     <div class="max-w-[460px] mt-6 mx-auto text-center">
       ${rubric('access', 'sm')}
       <h1 class="font-serif text-[clamp(2rem,1.5rem+1.6vw,2.6rem)] leading-[1.1] tracking-[-0.03em] font-bold m-0 mb-3">${heading}</h1>
-      <p class="text-fg-muted m-0 mb-8 text-base">${subheading}</p>
+      <p class="text-muted-foreground m-0 mb-8 text-base">${subheading}</p>
       <auth-forms mode=${mode} then=${searchParams?.then || '/dashboard'}></auth-forms>
     </div>
   `;

--- a/examples/blog/app/not-found.ts
+++ b/examples/blog/app/not-found.ts
@@ -4,7 +4,7 @@ import { displayH1 } from '#lib/utils/ui.ts';
 export default function NotFound() {
   return html`
     ${displayH1('404')}
-    <p class="text-lede text-fg-muted m-0 mb-4">Page not found.</p>
-    <p class="m-0"><a href="/" class="text-accent underline underline-offset-[3px] decoration-transparent hover:decoration-current transition-colors duration-fast">← Home</a></p>
+    <p class="text-lede text-muted-foreground m-0 mb-4">Page not found.</p>
+    <p class="m-0"><a href="/" class="text-primary underline underline-offset-[3px] decoration-transparent hover:decoration-current transition-colors duration-fast">← Home</a></p>
   `;
 }

--- a/examples/blog/app/observed/page.ts
+++ b/examples/blog/app/observed/page.ts
@@ -20,7 +20,7 @@ export default function Observed() {
       <h1 class="font-serif text-display leading-[1.02] tracking-[-0.035em] font-bold m-0 mb-4">
         Observed badge
       </h1>
-      <p class="text-lede leading-[1.5] text-fg-muted max-w-[56ch] m-0 mb-6">
+      <p class="text-lede leading-[1.5] text-muted-foreground max-w-[56ch] m-0 mb-6">
         This page waits for the badge to upgrade, so the framework keeps its
         module on the wire even though the badge itself only renders static
         markup.

--- a/examples/blog/app/page.ts
+++ b/examples/blog/app/page.ts
@@ -27,9 +27,9 @@ export default async function HomePage() {
     <section class="mb-18">
       ${rubric('the webjs demo')}
       <h1 class="font-serif text-display leading-[1.02] tracking-[-0.035em] font-bold m-0 mb-4 text-balance">
-        Full-stack in <span class="text-accent italic">zero</span> build steps.
+        Full-stack in <span class="text-primary italic">zero</span> build steps.
       </h1>
-      <p class="text-lede leading-[1.5] text-fg-muted max-w-[56ch] m-0">
+      <p class="text-lede leading-[1.5] text-muted-foreground max-w-[56ch] m-0">
         Every line of this page runs on webjs: server-rendered web components, file-based routes,
         server actions, streaming Suspense, live WebSockets. Zero bundler. Authored in plain JavaScript
         with JSDoc.
@@ -37,16 +37,16 @@ export default async function HomePage() {
     </section>
 
     ${me
-      ? banner(html`Welcome back, <strong class="text-fg font-bold">${me.name || me.email}</strong>. ${accentLink('/dashboard', 'Your dashboard →')}`)
+      ? banner(html`Welcome back, <strong class="text-foreground font-bold">${me.name || me.email}</strong>. ${accentLink('/dashboard', 'Your dashboard →')}`)
       : banner(html`${accentLink('/login', 'Sign in')} or ${accentLink('/login?tab=signup&then=/dashboard/posts/new', 'create an account')} to write posts and comment.`)}
 
     <div class="flex items-baseline justify-between mt-8 mb-2">
-      <span class="block font-mono text-[11px] leading-none font-semibold tracking-[0.2em] uppercase text-accent">Latest posts</span>
+      <span class="block font-mono text-[11px] leading-none font-semibold tracking-[0.2em] uppercase text-primary">Latest posts</span>
       ${stat(`${posts.length.toString().padStart(2, '0')} total`)}
     </div>
 
     ${posts.length === 0
-      ? html`<div class="py-18 text-center text-fg-muted border-y border-border">
+      ? html`<div class="py-18 text-center text-muted-foreground border-y border-border">
           <p class="m-0 mb-4">No posts yet.</p>
           <p class="m-0">${accentLink('/dashboard/posts/new', 'Write the first one →')}</p>
         </div>`
@@ -54,13 +54,13 @@ export default async function HomePage() {
           ${repeat(posts, (p) => p.id, (p, i) => html`
             <li class="border-t border-border last:border-b">
               <a href="/blog/${p.slug}" class="grid grid-cols-[44px_1fr_auto] gap-4 items-baseline py-6 text-inherit no-underline transition-[padding] duration-[220ms] hover:pl-2 group">
-                <span class="font-mono text-[11px] leading-none font-medium tracking-[0.1em] text-fg-subtle pt-1.5">${(i + 1).toString().padStart(2, '0')}</span>
+                <span class="font-mono text-[11px] leading-none font-medium tracking-[0.1em] text-muted-foreground/70 pt-1.5">${(i + 1).toString().padStart(2, '0')}</span>
                 <div class="grid gap-1 min-w-0">
-                  <h3 class="font-serif text-[1.45rem] leading-[1.2] tracking-[-0.02em] font-semibold m-0 text-fg transition-colors duration-fast group-hover:text-accent">${p.title}</h3>
-                  <p class="text-sm leading-[1.55] text-fg-muted m-0 line-clamp-1">${p.body}</p>
+                  <h3 class="font-serif text-[1.45rem] leading-[1.2] tracking-[-0.02em] font-semibold m-0 text-foreground transition-colors duration-fast group-hover:text-primary">${p.title}</h3>
+                  <p class="text-sm leading-[1.55] text-muted-foreground m-0 line-clamp-1">${p.body}</p>
                   <muted-text>${p.authorName || 'someone'} · ${new Date(p.createdAt).toLocaleDateString()}</muted-text>
                 </div>
-                <span class="font-mono text-fg-subtle transition-[color,transform] duration-[220ms] group-hover:text-accent group-hover:translate-x-1">→</span>
+                <span class="font-mono text-muted-foreground/70 transition-[color,transform] duration-[220ms] group-hover:text-primary group-hover:translate-x-1">→</span>
               </a>
             </li>`)}
         </ul>`}
@@ -73,14 +73,14 @@ export default async function HomePage() {
     <section class="mt-18 pt-6 border-t border-border">
       ${rubric('client-side state')}
       ${sectionH2('Interactive counter')}
-      <p class="text-fg-muted m-0 mb-4 text-sm">Pure client-side state in a web component. SSR'd with the initial value, hydrated on connect, clicks don't lose focus.</p>
+      <p class="text-muted-foreground m-0 mb-4 text-sm">Pure client-side state in a web component. SSR'd with the initial value, hydrated on connect, clicks don't lose focus.</p>
       <my-counter count="3"></my-counter>
     </section>
 
     <section class="mt-18 pt-6 border-t border-border">
       ${rubric('real-time · websocket')}
       ${sectionH2('Live chat')}
-      <p class="text-fg-muted m-0 mb-4 text-sm">Open this page in two windows. Messages broadcast across every connected client.</p>
+      <p class="text-muted-foreground m-0 mb-4 text-sm">Open this page in two windows. Messages broadcast across every connected client.</p>
       <chat-box></chat-box>
     </section>
 

--- a/examples/blog/app/rpc-stream/page.ts
+++ b/examples/blog/app/rpc-stream/page.ts
@@ -17,8 +17,8 @@ export default function RpcStream() {
       <h1 class="font-serif text-display leading-[1.02] tracking-[-0.035em] font-bold m-0 mb-4">
         Streaming RPC
       </h1>
-      <p class="text-lede leading-[1.5] text-fg-muted max-w-[56ch] m-0 mb-6">
-        The button below calls an <strong class="text-fg font-bold">async-generator</strong>
+      <p class="text-lede leading-[1.5] text-muted-foreground max-w-[56ch] m-0 mb-6">
+        The button below calls an <strong class="text-foreground font-bold">async-generator</strong>
         server action. Each yielded token streams over the single RPC response and
         is appended as it arrives.
       </p>

--- a/examples/blog/app/search/page.ts
+++ b/examples/blog/app/search/page.ts
@@ -32,15 +32,15 @@ export default async function Search({ searchParams }: PageProps<'/search'>) {
           value=${q}
           placeholder="Search by title"
           aria-label="Search posts"
-          class="flex-1 px-3 py-2 rounded-md border border-border bg-bg-elev text-fg"
+          class="flex-1 px-3 py-2 rounded-md border border-border bg-card text-foreground"
         >
-        <button type="submit" class="px-4 py-2 rounded-md bg-accent text-bg font-medium">Search</button>
+        <button type="submit" class="px-4 py-2 rounded-md bg-primary text-primary-foreground font-medium">Search</button>
       </form>
       ${q
-        ? html`<p data-search-summary class="text-fg-muted text-sm">Found ${results.length} result${results.length === 1 ? '' : 's'} for "${q}".</p>`
-        : html`<p data-search-summary class="text-fg-muted text-sm">Type a query and submit to search post titles.</p>`}
+        ? html`<p data-search-summary class="text-muted-foreground text-sm">Found ${results.length} result${results.length === 1 ? '' : 's'} for "${q}".</p>`
+        : html`<p data-search-summary class="text-muted-foreground text-sm">Type a query and submit to search post titles.</p>`}
       <ul class="grid gap-2">
-        ${results.map((p) => html`<li class="search-result"><a href="/blog/${p.slug}" class="text-accent no-underline hover:underline">${p.title}</a></li>`)}
+        ${results.map((p) => html`<li class="search-result"><a href="/blog/${p.slug}" class="text-primary no-underline hover:underline">${p.title}</a></li>`)}
       </ul>
     </section>
   `;

--- a/examples/blog/app/seeded/page.ts
+++ b/examples/blog/app/seeded/page.ts
@@ -17,12 +17,12 @@ export default function Seeded() {
       <h1 class="font-serif text-display leading-[1.02] tracking-[-0.035em] font-bold m-0 mb-4">
         Seeded user
       </h1>
-      <p class="text-lede leading-[1.5] text-fg-muted max-w-[56ch] m-0 mb-6">
+      <p class="text-lede leading-[1.5] text-muted-foreground max-w-[56ch] m-0 mb-6">
         <code>&lt;seeded-user&gt;</code> fetches its data with a bare
-        <strong class="text-fg font-bold">async render()</strong> that awaits a
+        <strong class="text-foreground font-bold">async render()</strong> that awaits a
         <code>'use server'</code> action. The result is baked into the first paint
         AND seeded into the page (#472), so on hydration the component does
-        <strong class="text-fg font-bold">not</strong> re-issue the action over RPC.
+        <strong class="text-foreground font-bold">not</strong> re-issue the action over RPC.
         Bump the id to fetch a fresh (unseeded) user, which does hit the network.
       </p>
       <seeded-user uid="1"></seeded-user>

--- a/examples/blog/app/slot-demo/page.ts
+++ b/examples/blog/app/slot-demo/page.ts
@@ -33,11 +33,11 @@ export default function SlotDemo() {
         <h2 slot="header">Form survival</h2>
         <p>Type into the input then navigate away and back. The value
         should be preserved through hydration via DOM identity.</p>
-        <input id="survive-input" type="text" class="mt-2 rounded border border-border bg-bg-subtle px-2 py-1" />
+        <input id="survive-input" type="text" class="mt-2 rounded border border-border bg-muted px-2 py-1" />
       </slot-card>
 
       <h2 class="mt-8 text-xl font-semibold">Shadow-DOM parity</h2>
-      <p class="text-sm text-fg-muted">Identical render templates, just with <code>static shadow = true</code>.</p>
+      <p class="text-sm text-muted-foreground">Identical render templates, just with <code>static shadow = true</code>.</p>
 
       <slot-card-shadow id="card-shadow-full" data-testid="shadow-full">
         <h2 slot="header">Shadow full card</h2>

--- a/examples/blog/app/static-info/page.ts
+++ b/examples/blog/app/static-info/page.ts
@@ -22,8 +22,8 @@ export default function StaticInfo() {
       <h1 class="font-serif text-display leading-[1.02] tracking-[-0.035em] font-bold m-0 mb-4">
         Static info
       </h1>
-      <p class="text-lede leading-[1.5] text-fg-muted max-w-[56ch] m-0">
-        This route ships <strong class="text-fg font-bold">zero application JS</strong>.
+      <p class="text-lede leading-[1.5] text-muted-foreground max-w-[56ch] m-0">
+        This route ships <strong class="text-foreground font-bold">zero application JS</strong>.
         Its page module is inert, so the framework drops it from the boot
         script. What you see is the complete server-rendered output.
       </p>

--- a/examples/blog/app/stream-demo/page.ts
+++ b/examples/blog/app/stream-demo/page.ts
@@ -20,8 +20,8 @@ export default function StreamDemo() {
       <h1 class="font-serif text-display leading-[1.02] tracking-[-0.035em] font-bold m-0 mb-4">
         Stream demo
       </h1>
-      <p class="text-lede leading-[1.5] text-fg-muted max-w-[56ch] m-0 mb-6">
-        The greeting below is fetched <strong class="text-fg font-bold">inside the component</strong>
+      <p class="text-lede leading-[1.5] text-muted-foreground max-w-[56ch] m-0 mb-6">
+        The greeting below is fetched <strong class="text-foreground font-bold">inside the component</strong>
         with an async render(), so it is in the first paint with no fallback. The
         slow fact is wrapped in <code>&lt;webjs-suspense&gt;</code>, so its fallback
         shows immediately and the content streams in.

--- a/examples/blog/app/ui-demo/page.ts
+++ b/examples/blog/app/ui-demo/page.ts
@@ -28,12 +28,12 @@ export default function UiDemo() {
   return html`
     <section class="mx-auto max-w-3xl py-16 px-6">
       <h1 class="text-4xl font-bold tracking-tight mb-2">Webjs UI demo</h1>
-      <p class="text-fg-muted mb-8">
+      <p class="text-muted-foreground mb-8">
         The component kit is split into two tiers. Tier-1 components
         (button, card, input, label, alert, badge, separator) are
         <strong>class-helper functions</strong> you apply to raw native
         elements. Tier-2 components (dialog, popover, tabs, …) are real
-        <code class="font-mono text-sm bg-bg-subtle px-1.5 py-0.5 rounded">&lt;ui-X&gt;</code>
+        <code class="font-mono text-sm bg-muted px-1.5 py-0.5 rounded">&lt;ui-X&gt;</code>
         custom elements for state the browser doesn't give you natively.
       </p>
 
@@ -85,7 +85,7 @@ export default function UiDemo() {
         </ui-dialog-content>
       </ui-dialog>
 
-      <p class="mt-12 text-sm text-fg-subtle">
+      <p class="mt-12 text-sm text-muted-foreground/70">
         Tier-1 helpers compile to plain Tailwind class strings at SSR time -
         no client-side runtime. Tier-2 elements register with
         <code class="font-mono text-xs">customElements.define</code> and

--- a/examples/blog/app/verbs/page.ts
+++ b/examples/blog/app/verbs/page.ts
@@ -10,9 +10,9 @@ export default function Verbs() {
   return html`
     <section class="mb-8">
       <h1 class="font-serif text-display leading-[1.02] tracking-[-0.035em] font-bold m-0 mb-4">HTTP-verb actions</h1>
-      <p class="text-lede leading-[1.5] text-fg-muted max-w-[56ch] m-0 mb-6">
-        The greeting is read with a <strong class="text-fg font-bold">GET action</strong> (cacheable, seeded into
-        the first paint). The button runs a <strong class="text-fg font-bold">POST mutation</strong> that
+      <p class="text-lede leading-[1.5] text-muted-foreground max-w-[56ch] m-0 mb-6">
+        The greeting is read with a <strong class="text-foreground font-bold">GET action</strong> (cacheable, seeded into
+        the first paint). The button runs a <strong class="text-foreground font-bold">POST mutation</strong> that
         invalidates the read's tag, so the next read fetches fresh (#488).
       </p>
       <verb-greeting></verb-greeting>

--- a/examples/blog/components/build-stamp.ts
+++ b/examples/blog/components/build-stamp.ts
@@ -14,7 +14,7 @@ import { WebComponent, html } from '@webjsdev/core';
 export class BuildStamp extends WebComponent {
   render() {
     return html`<span
-      class="font-mono text-[11px] tracking-[0.12em] uppercase text-fg-subtle"
+      class="font-mono text-[11px] tracking-[0.12em] uppercase text-muted-foreground/70"
       >no-build · zero JS shipped for this badge</span
     >`;
   }

--- a/examples/blog/components/counter.ts
+++ b/examples/blog/components/counter.ts
@@ -25,13 +25,13 @@ export class Counter extends WebComponent({ count: Number }) {
     const v = this.count;
     return html`
       <button
-        class="w-8 h-8 rounded-full border-0 bg-transparent text-fg-muted font-sans font-semibold text-base leading-none cursor-pointer transition-all duration-150 hover:bg-bg-subtle hover:text-fg active:scale-[0.92] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-accent-tint"
+        class="w-8 h-8 rounded-full border-0 bg-transparent text-muted-foreground font-sans font-semibold text-base leading-none cursor-pointer transition-all duration-150 hover:bg-muted hover:text-foreground active:scale-[0.92] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-primary-tint"
         aria-label="Decrement"
         @click=${() => this._bump(-1)}
       >−</button>
-      <output class="min-w-[3ch] px-2 text-center font-mono font-semibold text-[15px] leading-none tabular-nums text-accent">${v}</output>
+      <output class="min-w-[3ch] px-2 text-center font-mono font-semibold text-[15px] leading-none tabular-nums text-primary">${v}</output>
       <button
-        class="w-8 h-8 rounded-full border-0 bg-transparent text-fg-muted font-sans font-semibold text-base leading-none cursor-pointer transition-all duration-150 hover:bg-bg-subtle hover:text-fg active:scale-[0.92] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-accent-tint"
+        class="w-8 h-8 rounded-full border-0 bg-transparent text-muted-foreground font-sans font-semibold text-base leading-none cursor-pointer transition-all duration-150 hover:bg-muted hover:text-foreground active:scale-[0.92] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-primary-tint"
         aria-label="Increment"
         @click=${() => this._bump(1)}
       >+</button>

--- a/examples/blog/components/error-card.ts
+++ b/examples/blog/components/error-card.ts
@@ -7,11 +7,11 @@ import { WebComponent, html } from '@webjsdev/core';
 export class ErrorCard extends WebComponent({ message: String }) {
   render() {
     return html`
-      <div class="block p-5 px-6 rounded-lg bg-bg-elev/85 border border-border-strong/50 text-fg shadow">
-        <div class="font-mono font-semibold text-[11px] leading-none tracking-[0.15em] uppercase text-accent mb-2">Error</div>
+      <div class="block p-5 px-6 rounded-lg bg-card/85 border border-border/50 text-foreground shadow">
+        <div class="font-mono font-semibold text-[11px] leading-none tracking-[0.15em] uppercase text-primary mb-2">Error</div>
         <h2 class="font-serif text-[1.4rem] font-bold tracking-tight m-0 mb-3">Something went wrong</h2>
-        <p class="m-0 mb-3 text-fg-muted"><code class="font-mono text-[0.9em] text-fg">${this.message}</code></p>
-        <p class="m-0 mb-3"><a class="text-accent underline underline-offset-[3px] decoration-accent/40 transition-colors duration-150 hover:decoration-current" href="/">← Back home</a></p>
+        <p class="m-0 mb-3 text-muted-foreground"><code class="font-mono text-[0.9em] text-foreground">${this.message}</code></p>
+        <p class="m-0 mb-3"><a class="text-primary underline underline-offset-[3px] decoration-primary/40 transition-colors duration-150 hover:decoration-current" href="/">← Back home</a></p>
       </div>
     `;
   }

--- a/examples/blog/components/muted-text.ts
+++ b/examples/blog/components/muted-text.ts
@@ -10,7 +10,7 @@ import { WebComponent, html } from '@webjsdev/core';
 export class MutedText extends WebComponent {
   constructor() {
     super();
-    this.className = 'text-fg-subtle font-mono text-[11px] font-medium leading-snug tracking-[0.12em] uppercase';
+    this.className = 'text-muted-foreground/70 font-mono text-[11px] font-medium leading-snug tracking-[0.12em] uppercase';
   }
 
   render() {

--- a/examples/blog/components/observed-badge.ts
+++ b/examples/blog/components/observed-badge.ts
@@ -23,7 +23,7 @@ import { WebComponent, html } from '@webjsdev/core';
 export class ObservedBadge extends WebComponent {
   render() {
     return html`<span
-      class="font-mono text-[11px] tracking-[0.12em] uppercase text-fg-subtle"
+      class="font-mono text-[11px] tracking-[0.12em] uppercase text-muted-foreground/70"
       >observed badge · registers because something waits for it</span
     >`;
   }

--- a/examples/blog/components/slot-card.ts
+++ b/examples/blog/components/slot-card.ts
@@ -19,14 +19,14 @@ import { WebComponent, html } from '@webjsdev/core';
 export class SlotCard extends WebComponent {
   render() {
     return html`
-      <article class="rounded-lg border border-border bg-bg-elev p-6">
+      <article class="rounded-lg border border-border bg-card p-6">
         <header class="mb-4 border-b border-border pb-3 text-lg font-semibold" data-region="header">
           <slot name="header"></slot>
         </header>
-        <div class="text-sm text-fg" data-region="body">
+        <div class="text-sm text-foreground" data-region="body">
           <slot></slot>
         </div>
-        <footer class="mt-4 border-t border-border pt-3 text-xs text-fg-muted" data-region="footer">
+        <footer class="mt-4 border-t border-border pt-3 text-xs text-muted-foreground" data-region="footer">
           <slot name="footer">no actions</slot>
         </footer>
       </article>

--- a/examples/blog/components/ssr-derived-badge.ts
+++ b/examples/blog/components/ssr-derived-badge.ts
@@ -33,7 +33,7 @@ export class SsrDerivedBadge extends WebComponent({
 
   render() {
     return html`<span
-      class="font-mono text-[11px] tracking-[0.12em] uppercase text-fg-subtle"
+      class="font-mono text-[11px] tracking-[0.12em] uppercase text-muted-foreground/70"
       data-label=${this.label}
       >${this.label}</span
     >`;

--- a/examples/blog/components/test/shadow-inner.ts
+++ b/examples/blog/components/test/shadow-inner.ts
@@ -5,7 +5,7 @@ export class ShadowInner extends WebComponent {
   static shadow = true;
   static styles = css`
     :host { display: inline-flex; align-items: center; gap: 4px; }
-    span { font: 600 14px/1 monospace; color: var(--accent, #e66); }
+    span { font: 600 14px/1 monospace; color: var(--primary, #e66); }
   `;
   render() {
     return html`<span data-testid="shadow-inner">shadow-inner OK</span>`;

--- a/examples/blog/components/theme-toggle.ts
+++ b/examples/blog/components/theme-toggle.ts
@@ -39,7 +39,7 @@ export class ThemeToggle extends WebComponent {
     const icon = t === 'light' ? ICONS.sun : t === 'dark' ? ICONS.moon : ICONS.system;
     return html`
       <button
-        class="inline-flex items-center justify-center w-9 h-9 p-0 border border-border rounded-full bg-bg-elev text-fg-muted cursor-pointer transition-all duration-150 hover:text-fg hover:border-border-strong active:scale-[0.94] focus-visible:outline-none focus-visible:border-accent focus-visible:ring-[3px] focus-visible:ring-accent-tint"
+        class="inline-flex items-center justify-center w-9 h-9 p-0 border border-border rounded-full bg-card text-muted-foreground cursor-pointer transition-all duration-150 hover:text-foreground hover:border-border active:scale-[0.94] focus-visible:outline-none focus-visible:border-primary focus-visible:ring-[3px] focus-visible:ring-primary-tint"
         @click=${() => this.cycle()}
         aria-label="Cycle theme (currently ${label})"
         title="Theme: ${label.toLowerCase()}"

--- a/examples/blog/components/theme-toggle.ts
+++ b/examples/blog/components/theme-toggle.ts
@@ -31,6 +31,12 @@ export class ThemeToggle extends WebComponent {
     } catch {}
     if (next === 'system') delete document.documentElement.dataset.theme;
     else document.documentElement.dataset.theme = next;
+    // Mirror the effective theme onto the .dark class too. data-theme drives the
+    // app palette blocks; the .dark class is what the @webjsdev/ui kit's dark:
+    // variants read, so both signals must move together (see agent-docs/styling.md).
+    const osLight = window.matchMedia('(prefers-color-scheme: light)').matches;
+    const dark = next === 'dark' || (next === 'system' && !osLight);
+    document.documentElement.classList.toggle('dark', dark);
   }
 
   render() {

--- a/examples/blog/components/vendor-badge.ts
+++ b/examples/blog/components/vendor-badge.ts
@@ -28,7 +28,7 @@ export class VendorBadge extends WebComponent {
   render() {
     const formatted = dayjs(RELEASED_AT).format('MMM D, YYYY');
     return html`<span
-      class="font-mono text-[11px] tracking-[0.12em] uppercase text-fg-subtle"
+      class="font-mono text-[11px] tracking-[0.12em] uppercase text-muted-foreground/70"
       >released ${formatted} · zero JS for this badge</span
     >`;
   }

--- a/examples/blog/lib/utils/ui.ts
+++ b/examples/blog/lib/utils/ui.ts
@@ -17,14 +17,14 @@ import { html } from '@webjsdev/core';
 export function rubric(label: string, mb: 'sm' | 'md' = 'md') {
   const mbCls = mb === 'sm' ? 'mb-3' : 'mb-4';
   return html`
-    <span class="block font-mono text-[11px] leading-none font-semibold tracking-[0.2em] uppercase text-accent ${mbCls}">● ${label}</span>
+    <span class="block font-mono text-[11px] leading-none font-semibold tracking-[0.2em] uppercase text-primary ${mbCls}">● ${label}</span>
   `;
 }
 
 /** Tiny monospaced small-caps label. Used for stats, counts, bylines. */
 export function stat(content: unknown, extraCls = '') {
   return html`
-    <span class="font-mono text-[11px] leading-none font-medium tracking-[0.15em] uppercase text-fg-subtle ${extraCls}">${content}</span>
+    <span class="font-mono text-[11px] leading-none font-medium tracking-[0.15em] uppercase text-muted-foreground/70 ${extraCls}">${content}</span>
   `;
 }
 
@@ -32,7 +32,7 @@ export function stat(content: unknown, extraCls = '') {
 export function backLink(href: string, label: string, mb: 'sm' | 'md' = 'md') {
   const mbCls = mb === 'sm' ? 'mb-6' : 'mb-12';
   return html`
-    <a href=${href} class="inline-block ${mbCls} text-fg-subtle no-underline font-mono text-[11px] leading-none font-medium tracking-[0.15em] uppercase transition-colors duration-fast hover:text-fg">← ${label}</a>
+    <a href=${href} class="inline-block ${mbCls} text-muted-foreground/70 no-underline font-mono text-[11px] leading-none font-medium tracking-[0.15em] uppercase transition-colors duration-fast hover:text-foreground">← ${label}</a>
   `;
 }
 
@@ -61,20 +61,20 @@ export function sectionH2(content: unknown, mb: 'sm' | 'md' = 'sm') {
 /** Notice/banner paragraph: soft card above the primary content. */
 export function banner(content: unknown) {
   return html`
-    <p class="p-6 bg-[color-mix(in_oklch,var(--bg-elev)_50%,transparent)] border border-border rounded-[10px] text-sm my-6 mb-12 text-fg-muted">${content}</p>
+    <p class="p-6 bg-[color-mix(in_oklch,var(--card)_50%,transparent)] border border-border rounded-[10px] text-sm my-6 mb-12 text-muted-foreground">${content}</p>
   `;
 }
 
 /** Inline accent link: used inside banners and body copy. */
 export function accentLink(href: string, label: unknown) {
   return html`
-    <a href=${href} class="text-accent font-semibold no-underline hover:underline hover:underline-offset-[3px]">${label}</a>
+    <a href=${href} class="text-primary font-semibold no-underline hover:underline hover:underline-offset-[3px]">${label}</a>
   `;
 }
 
 /** Small code chip: inline monospaced token with a tinted surface. */
 export function codeChip(text: string) {
   return html`
-    <code class="font-mono text-[0.88em] px-1.5 py-0.5 rounded-md bg-bg-subtle border border-border break-words [overflow-wrap:anywhere]">${text}</code>
+    <code class="font-mono text-[0.88em] px-1.5 py-0.5 rounded-md bg-muted border border-border break-words [overflow-wrap:anywhere]">${text}</code>
   `;
 }

--- a/examples/blog/modules/auth/components/auth-forms.ts
+++ b/examples/blog/modules/auth/components/auth-forms.ts
@@ -66,12 +66,12 @@ export class AuthForms extends WebComponent({
     const submitLabel = busy ? '…' : (mode === 'login' ? 'Sign in' : 'Create account');
     const pillBase =
       'py-2.5 px-3 font-sans text-xs font-semibold tracking-[0.02em] border-0 rounded-full cursor-pointer transition-all duration-150';
-    const pillActive = `${pillBase} bg-bg-elev text-fg shadow-sm`;
-    const pillInactive = `${pillBase} bg-transparent text-fg-muted`;
+    const pillActive = `${pillBase} bg-card text-foreground shadow-sm`;
+    const pillInactive = `${pillBase} bg-transparent text-muted-foreground`;
     return html`
       <div class=${cardClass()}>
         <div class=${cardHeaderClass()}>
-          <div class="grid grid-cols-2 p-1 rounded-full bg-bg-subtle border border-border" role="tablist">
+          <div class="grid grid-cols-2 p-1 rounded-full bg-muted border border-border" role="tablist">
             <button role="tab"
                     class=${mode === 'login' ? pillActive : pillInactive}
                     @click=${() => { this.mode = 'login'; this.error.set(null); }}>Sign in</button>

--- a/examples/blog/modules/chat/components/chat-box.ts
+++ b/examples/blog/modules/chat/components/chat-box.ts
@@ -73,8 +73,8 @@ export class ChatBox extends WebComponent {
       status === 'live'
         ? 'w-[7px] h-[7px] rounded-full bg-success shadow-[0_0_0_3px_color-mix(in_oklch,var(--success)_30%,transparent)]'
         : status === 'reconnecting'
-          ? 'w-[7px] h-[7px] rounded-full bg-accent'
-          : 'w-[7px] h-[7px] rounded-full bg-fg-subtle/40 animate-pulse';
+          ? 'w-[7px] h-[7px] rounded-full bg-primary'
+          : 'w-[7px] h-[7px] rounded-full bg-muted-foreground/40 animate-pulse';
     const statusText =
       status === 'live'
         ? html`Live · ${Math.max(0, count - 1)} other${count - 1 !== 1 ? 's' : ''} online`
@@ -84,20 +84,20 @@ export class ChatBox extends WebComponent {
     const placeholder =
       status === 'live' ? 'Say hi…' : status === 'reconnecting' ? 'Disconnected' : 'Connecting…';
     return html`
-      <div class="block border border-border rounded-xl bg-bg-elev shadow overflow-hidden font-sans">
-        <div class="flex items-center gap-2 px-4 py-3 border-b border-border bg-bg-subtle font-mono text-[10px] font-semibold uppercase tracking-[0.15em] text-fg-subtle">
+      <div class="block border border-border rounded-xl bg-card shadow overflow-hidden font-sans">
+        <div class="flex items-center gap-2 px-4 py-3 border-b border-border bg-muted font-mono text-[10px] font-semibold uppercase tracking-[0.15em] text-muted-foreground/70">
           <span class=${dotClass}></span>
           ${statusText}
         </div>
-        <div class="h-[220px] overflow-y-auto p-4 text-sm leading-relaxed font-sans scroll-smooth bg-bg-sunken">
+        <div class="h-[220px] overflow-y-auto p-4 text-sm leading-relaxed font-sans scroll-smooth bg-secondary">
           ${lines.length === 0
-            ? html`<p class="m-0 text-fg-subtle italic">No messages yet: say something.</p>`
+            ? html`<p class="m-0 text-muted-foreground/70 italic">No messages yet: say something.</p>`
             : lines.map((l) =>
                 l.kind === 'meta'
-                  ? html`<p class="m-0 mb-2 text-fg"><em class="font-mono text-[10px] font-medium uppercase tracking-[0.15em] text-fg-subtle not-italic">${l.text}</em></p>`
-                  : html`<p class="m-0 mb-2 text-fg">${l.text}</p>`)}
+                  ? html`<p class="m-0 mb-2 text-foreground"><em class="font-mono text-[10px] font-medium uppercase tracking-[0.15em] text-muted-foreground/70 not-italic">${l.text}</em></p>`
+                  : html`<p class="m-0 mb-2 text-foreground">${l.text}</p>`)}
         </div>
-        <form class="flex gap-2 px-4 py-3 border-t border-border bg-bg-subtle" @submit=${(e) => this.onSubmit(e)}>
+        <form class="flex gap-2 px-4 py-3 border-t border-border bg-muted" @submit=${(e) => this.onSubmit(e)}>
           <input name="message" class="${inputClass()} flex-1"
                  placeholder=${placeholder}
                  ?disabled=${!live} autocomplete="off">

--- a/examples/blog/modules/comments/components/comments-thread.ts
+++ b/examples/blog/modules/comments/components/comments-thread.ts
@@ -91,27 +91,27 @@ export class CommentsThread extends WebComponent({
     const error = this.error.get();
     return html`
       ${comments.length === 0
-        ? html`<div class="p-6 text-center text-fg-subtle font-serif text-sm leading-relaxed italic border border-dashed border-border rounded-xl mb-5">No comments yet: be the first.</div>`
+        ? html`<div class="p-6 text-center text-muted-foreground/70 font-serif text-sm leading-relaxed italic border border-dashed border-border rounded-xl mb-5">No comments yet: be the first.</div>`
         : html`<ul class="list-none p-0 m-0 mb-5 grid gap-4">${repeat(comments, (c) => c.id, (c) => html`
-            <li class="p-4 px-5 bg-bg-elev border border-border rounded">
-              <div class="flex gap-2 items-baseline font-mono text-[10px] font-semibold uppercase tracking-[0.15em] text-fg-subtle mb-1.5">
-                <strong class="text-fg font-bold tracking-[0.08em]">${c.authorName}</strong>
-                <span class="text-fg-subtle">·</span>
+            <li class="p-4 px-5 bg-card border border-border rounded">
+              <div class="flex gap-2 items-baseline font-mono text-[10px] font-semibold uppercase tracking-[0.15em] text-muted-foreground/70 mb-1.5">
+                <strong class="text-foreground font-bold tracking-[0.08em]">${c.authorName}</strong>
+                <span class="text-muted-foreground/70">·</span>
                 <span>${new Date(c.createdAt).toLocaleString()}</span>
               </div>
-              <div class="font-serif text-[15px] leading-relaxed text-fg">${c.body}</div>
+              <div class="font-serif text-[15px] leading-relaxed text-foreground">${c.body}</div>
             </li>`)}
           </ul>`}
 
       ${this.signedIn
-        ? html`<form class="flex gap-2 p-3 bg-bg-elev border border-border rounded" @submit=${(e: SubmitEvent) => this.onSubmit(e)}>
+        ? html`<form class="flex gap-2 p-3 bg-card border border-border rounded" @submit=${(e: SubmitEvent) => this.onSubmit(e)}>
             <input name="body" class="${inputClass()} flex-1"
                    placeholder="Add a comment…" ?disabled=${busy} autocomplete="off">
             <button class=${buttonClass({ size: 'sm' })} type="submit" ?disabled=${busy}>Post</button>
           </form>
-          ${error ? html`<p class="mt-2 text-accent font-mono text-xs leading-snug">${error}</p>` : ''}`
-        : html`<p class="p-5 text-fg-muted bg-bg-subtle border border-dashed border-border rounded text-center font-serif text-sm leading-relaxed italic">
-            <a class="text-accent font-semibold no-underline not-italic hover:underline hover:underline-offset-[3px]" href=${signinHref()}>Sign in</a> to comment.
+          ${error ? html`<p class="mt-2 text-primary font-mono text-xs leading-snug">${error}</p>` : ''}`
+        : html`<p class="p-5 text-muted-foreground bg-muted border border-dashed border-border rounded text-center font-serif text-sm leading-relaxed italic">
+            <a class="text-primary font-semibold no-underline not-italic hover:underline hover:underline-offset-[3px]" href=${signinHref()}>Sign in</a> to comment.
           </p>`}
     `;
   }

--- a/examples/blog/modules/posts/components/new-post.ts
+++ b/examples/blog/modules/posts/components/new-post.ts
@@ -66,7 +66,7 @@ export class NewPost extends WebComponent {
             <div class="grid gap-2">
               <label class=${labelClass()} for="new-post-body">Body</label>
               <textarea id="new-post-body"
-                        class="font-serif text-base leading-relaxed resize-y min-h-[220px] text-fg bg-transparent border border-border-strong rounded p-4 transition-all duration-150 focus:outline-none focus:border-accent focus:shadow-[0_0_0_3px_var(--accent-tint)]"
+                        class="font-serif text-base leading-relaxed resize-y min-h-[220px] text-foreground bg-transparent border border-border rounded p-4 transition-all duration-150 focus:outline-none focus:border-primary focus:shadow-[0_0_0_3px_var(--primary-tint)]"
                         name="body"
                         placeholder="Write your post: markdown not required."
                         required></textarea>

--- a/examples/blog/public/input.css
+++ b/examples/blog/public/input.css
@@ -1,51 +1,61 @@
-/* Tailwind CSS v4 input file - compiled to public/tailwind.css by the
+/* Tailwind CSS v4 input file, compiled to public/tailwind.css by the
  * `css:watch` / `css:build` npm scripts. Authors shouldn't edit
  * public/tailwind.css directly; it's generated and gitignored. */
 @import "tailwindcss";
 
-/* Scan the new shadcn-style component sources so their utility classes
- * make it into the generated bundle. (Tailwind v4 already scans the
- * project tree by default - this @source is belt-and-braces.) */
+/* Scan the shadcn-style component sources so their utility classes make it
+ * into the generated bundle. (Tailwind v4 already scans the project tree by
+ * default; this @source is belt-and-braces.) */
 @source "../components/ui/*.ts";
 
-/* @theme maps our design-token CSS custom properties (defined on
- * :root in app/layout.ts for light/dark switching) into Tailwind's
- * palette so utility classes like `text-fg`, `bg-bg-elev`,
- * `text-display`, `font-serif`, `duration-fast` resolve. */
+/* @theme maps the shadcn design-token CSS custom properties (defined on :root
+ * in app/layout.ts for light/dark switching) into Tailwind's palette, so
+ * utility classes like `text-foreground`, `bg-card`, `bg-primary`,
+ * `text-muted-foreground`, `border-border`, `text-display`, `font-serif`,
+ * `duration-fast` resolve. Same shadcn vocabulary the scaffold and the
+ * @webjsdev/ui kit use, so the ui-* components read one source of truth. */
 @theme {
-  --color-fg:            var(--fg);
-  --color-fg-muted:      var(--fg-muted);
-  --color-fg-subtle:     var(--fg-subtle);
+  --color-background:             var(--background);
+  --color-foreground:             var(--foreground);
+  --color-card:                   var(--card);
+  --color-card-foreground:        var(--card-foreground);
+  --color-popover:                var(--popover);
+  --color-popover-foreground:     var(--popover-foreground);
+  --color-primary:                var(--primary);
+  --color-primary-foreground:     var(--primary-foreground);
+  --color-secondary:              var(--secondary);
+  --color-secondary-foreground:   var(--secondary-foreground);
+  --color-muted:                  var(--muted);
+  --color-muted-foreground:       var(--muted-foreground);
+  --color-accent:                 var(--accent);
+  --color-accent-foreground:      var(--accent-foreground);
+  --color-destructive:            var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border:                 var(--border);
+  --color-input:                  var(--input);
+  --color-ring:                   var(--ring);
 
-  --color-bg:            var(--bg);
-  --color-bg-elev:       var(--bg-elev);
-  --color-bg-subtle:     var(--bg-subtle);
-  --color-bg-sunken:     var(--bg-sunken);
+  /* A translucent brand tint derived from --primary (the same pattern the
+     scaffold's --primary-tint uses), for focus rings and the logo glow. */
+  --color-primary-tint:           var(--primary-tint);
 
-  --color-border:        var(--border);
-  --color-border-strong: var(--border-strong);
-
-  --color-accent:        var(--accent);
-  --color-accent-hover:  var(--accent-hover);
-  --color-accent-fg:     var(--accent-fg);
-  --color-accent-tint:   var(--accent-tint);
-  --color-accent-live:   var(--accent-live);
-
-  --color-success:       var(--success);
-  --color-danger:        var(--danger);
+  /* One extra semantic shadcn does not ship: success (a couple of status
+     affordances use it). Added the canonical @theme way, not a parallel
+     vocabulary. */
+  --color-success:                var(--success);
 
   --font-display: var(--font-display);
   --font-sans:  var(--font-sans);
   --font-serif: var(--font-serif);
   --font-mono:  var(--font-mono);
 
-  /* Fluid type scale - used via text-display, text-h1, text-h2, text-lede. */
+  /* Fluid type scale (text-display, text-h1, text-h2, text-lede). */
   --text-display: clamp(2.6rem, 1.6rem + 3.2vw, 4.25rem);
   --text-h1:      clamp(2rem, 1.5rem + 1.6vw, 2.85rem);
   --text-h2:      clamp(1.35rem, 1.15rem + 0.7vw, 1.7rem);
   --text-lede:    clamp(1.05rem, 0.95rem + 0.3vw, 1.2rem);
 
-  /* Custom motion durations - used via duration-fast / duration-slow. */
+  /* Custom motion durations (duration-fast / duration-slow). */
   --duration-fast: 140ms;
   --duration-slow: 380ms;
 }


### PR DESCRIPTION
Closes #951

## Problem

`examples/blog` uses a custom token vocabulary (`--fg`, `--bg`, `--bg-elev`, `--accent` as the BRAND color, …) while the scaffold and the `@webjsdev/ui` kit use shadcn tokens (`--foreground`, `--background`, `--card`, `--primary` as brand, `--accent` as a NEUTRAL tint). The blog even ships shadcn `components/ui/*` that expect the shadcn names, so the two collide, and the framework's own convention says never to invent a parallel `--fg`/`--bg` vocabulary. The styling docs teach the blog's divergent names.

## Approach

Adopt the full shadcn token set in the blog (matching the scaffold), carrying the blog's tuned VALUES onto the shadcn tokens so the look is unchanged, then rename every custom utility. Mapping:

| blog | shadcn |
|---|---|
| `--fg` | `--foreground` |
| `--fg-muted` | `--muted-foreground` |
| `--fg-subtle` | `--muted-foreground` (with an opacity modifier for the subtler sites) |
| `--bg` | `--background` |
| `--bg-elev` | `--card` |
| `--bg-subtle` | `--muted` |
| `--bg-sunken` | `--secondary` |
| `--border` / `--border-strong` | `--border` |
| `--accent` (brand) | `--primary` |
| `--accent-fg` | `--primary-foreground` |
| `--accent-hover` / `-tint` / `-surface` / `-border` / `-live` | `--primary` + opacity modifiers |
| `--danger` | `--destructive` |
| `--success` | kept as one canonical extra `@theme` token (shadcn has none) |

The full shadcn set (incl the neutral `--accent`/`--accent-foreground`, `--popover`, `--card-foreground`, `--input`, `--ring`) is defined so the ui kit resolves correctly.

## Still to land

- Rewrite `examples/blog/public/input.css` (@theme) + `app/layout.ts` (:root/dark/light value blocks).
- Rename all custom utilities across ~30 blog files.
- Update `examples/blog/CONVENTIONS.md`, `docs/app/docs/styling/page.ts`, `agent-docs/styling.md`.
- Boot + visually verify light AND dark, run the blog e2e.
