### PR TITLE
chore: release core 0.7.36, server 0.8.50, cli 0.10.39

### DIFF
--- a/changelog/cli/0.10.39.md
+++ b/changelog/cli/0.10.39.md
@@ -1,0 +1,26 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.39
+date: 2026-07-13T10:08:26.682Z
+commit_count: 3
+---
+## Features
+
+- **reduce first-feature scaffold friction (json column, db generate TTY, placeholder teardown)** ([#932](https://github.com/webjsdev/webjs/pull/932)) [`dd96d7fd`](https://github.com/webjsdev/webjs/commit/dd96d7fd)
+  * feat: add a json<T>() column helper to the scaffold db seam
+  
+  Persisting a structured value (a board, a tag list, a settings blob) is
+  one of the first things a real app needs, but the generated
+
+## Fixes
+
+- **scaffold ships a static Tailwind stylesheet, not the browser runtime** ([#950](https://github.com/webjsdev/webjs/pull/950)) [`6336d35d`](https://github.com/webjsdev/webjs/commit/6336d35d)
+  * fix: scaffold ships a static Tailwind stylesheet, not the browser runtime
+  
+  A webjs create app rendered UNSTYLED with JavaScript disabled: the layout
+  delivered Tailwind through the browser JIT runtime (tailwind-browser.js +
+- **dogfood CLI DX papercuts (vendor pin, worktree resolve, prose hook) + engine recipe** ([#959](https://github.com/webjsdev/webjs/pull/959)) [`1990dd60`](https://github.com/webjsdev/webjs/commit/1990dd60)
+  * fix: prose hook allows a CLI subcommand before a closing quote
+  
+  The block-prose-punctuation brand-casing rule treated a subcommand
+  followed by a closing quote as lowercase brand prose, because its CLI

--- a/changelog/core/0.7.36.md
+++ b/changelog/core/0.7.36.md
@@ -1,0 +1,26 @@
+---
+package: "@webjsdev/core"
+version: 0.7.36
+date: 2026-07-13T10:08:26.579Z
+commit_count: 3
+---
+## Features
+
+- **reduce first-feature scaffold friction (json column, db generate TTY, placeholder teardown)** ([#932](https://github.com/webjsdev/webjs/pull/932)) [`dd96d7fd`](https://github.com/webjsdev/webjs/commit/dd96d7fd)
+  * feat: add a json<T>() column helper to the scaffold db seam
+  
+  Persisting a structured value (a board, a tag list, a settings blob) is
+  one of the first things a real app needs, but the generated
+
+## Fixes
+
+- **parse client-router partial-nav fragments in body context (#936)** ([#941](https://github.com/webjsdev/webjs/pull/941)) [`7d3a5141`](https://github.com/webjsdev/webjs/commit/7d3a5141)
+  * fix: parse client-router partial-nav fragments in body context (#936)
+  
+  A same-layout client nav receives an INNER fragment that begins with the
+  <!--wj:children:/--> layout marker and carries no doctype or html. parseHTML
+- **client router never strips stylesheets on a soft nav (#936)** ([#945](https://github.com/webjsdev/webjs/pull/945)) [`ffc63bc0`](https://github.com/webjsdev/webjs/commit/ffc63bc0)
+  * fix: client router full-loads instead of a destructive body swap (#936)
+  
+  On real Android Chrome a soft nav stripped the head CSS and the outer layout
+  (navbar), cascading to a broken fixed-header offset on Back. Root cause: the

--- a/changelog/server/0.8.50.md
+++ b/changelog/server/0.8.50.md
@@ -1,0 +1,21 @@
+---
+package: "@webjsdev/server"
+version: 0.8.50
+date: 2026-07-13T10:08:26.631Z
+commit_count: 2
+---
+## Features
+
+- **reduce first-feature scaffold friction (json column, db generate TTY, placeholder teardown)** ([#932](https://github.com/webjsdev/webjs/pull/932)) [`dd96d7fd`](https://github.com/webjsdev/webjs/commit/dd96d7fd)
+  * feat: add a json<T>() column helper to the scaffold db seam
+  
+  Persisting a structured value (a board, a tag list, a settings blob) is
+  one of the first things a real app needs, but the generated
+
+## Fixes
+
+- **dogfood CLI DX papercuts (vendor pin, worktree resolve, prose hook) + engine recipe** ([#959](https://github.com/webjsdev/webjs/pull/959)) [`1990dd60`](https://github.com/webjsdev/webjs/commit/1990dd60)
+  * fix: prose hook allows a CLI subcommand before a closing quote
+  
+  The block-prose-punctuation brand-casing rule treated a subcommand
+  followed by a closing quote as lowercase brand prose, because its CLI

--- a/package-lock.json
+++ b/package-lock.json
@@ -6975,7 +6975,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.38",
+      "version": "0.10.39",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -6991,7 +6991,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.35",
+      "version": "0.7.36",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.25.0"
@@ -7039,7 +7039,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.48",
+      "version": "0.8.50",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.38",
+  "version": "0.10.39",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.35",
+  "version": "0.7.36",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.49",
+  "version": "0.8.50",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Patch bumps for the three packages that accrued unreleased shippable work.

## Bumps

| Package | From | To | Carries |
|---|---|---|---|
| `@webjsdev/core` | 0.7.35 | 0.7.36 | #936 client-router soft-nav fixes (#941, #945) + #932 db json() seam |
| `@webjsdev/server` | 0.8.49 | 0.8.50 | #959 vendor-pin diagnostic + #932 db seam |
| `@webjsdev/cli` | 0.10.38 | 0.10.39 | #959 vendor-pin + worktree resolve check, #950 static-Tailwind scaffold fix, #932 friction reductions |

## Excluded (no shippable-surface change since last release)

- `@webjsdev/mcp`, `@webjsdev/intellisense`: only #855 comment/JSDoc brand-casing touched their `src`, no behaviour or served-output change.
- `@webjsdev/ui`: only the nested `packages/ui/packages/website` sub-app + tests changed, not the published surface (the known ui-changelog over-attribution trap).

## Mechanics

- Version lines bumped in the three `package.json` files only; `package-lock.json` regenerated (`npm install --package-lock-only`, 3 lines, also corrected a stale server lock entry).
- Dependents all pin `^0.x.0`, so patch bumps satisfy every range with no widening.
- Changelogs auto-generated by the pre-commit `backfill-changelog.js` from the conventional PR titles.
- Merging adds `changelog/**.md` to `main`, which triggers `release.yml` to `npm publish` and cut the GitHub Releases (idempotent).
