### PR TITLE
chore: release core 0.7.37, server 0.8.51, cli 0.10.40

### DIFF
--- a/changelog/cli/0.10.40.md
+++ b/changelog/cli/0.10.40.md
@@ -1,0 +1,22 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.40
+date: 2026-07-13T19:37:53.049Z
+commit_count: 3
+---
+## Features
+
+- **replace static refresh with static interactive force-ship override** ([#965](https://github.com/webjsdev/webjs/pull/965)) [`ef23671d`](https://github.com/webjsdev/webjs/commit/ef23671d)
+  * feat: replace static refresh with static interactive force-ship override
+  
+  The `static refresh = true` elision flag was a pre-seeding vestige. Its
+  only mechanism was forcing a bare async component's module to ship, and
+- **path-aware import-only elision for route modules** ([#964](https://github.com/webjsdev/webjs/pull/964)) [`38ef79ae`](https://github.com/webjsdev/webjs/commit/38ef79ae)
+  * feat: path-aware import-only elision for route modules
+  
+  A client-effecting non-component module (the module-scope-signal idiom
+  of invariant 5) reachable ONLY through shipping components no longer
+- **regenerate stale dev build outputs on request so local CSS never goes stale** ([#970](https://github.com/webjsdev/webjs/pull/970)) [`d6cddfb9`](https://github.com/webjsdev/webjs/commit/d6cddfb9)
+  * feat: regenerate stale dev build outputs on request (webjs.dev.regenerate)
+  
+  * feat: scaffold uses dev.regenerate for Tailwind instead of a --watch task

--- a/changelog/core/0.7.37.md
+++ b/changelog/core/0.7.37.md
@@ -1,0 +1,17 @@
+---
+package: "@webjsdev/core"
+version: 0.7.37
+date: 2026-07-13T19:37:52.923Z
+commit_count: 2
+---
+## Features
+
+- **replace static refresh with static interactive force-ship override** ([#965](https://github.com/webjsdev/webjs/pull/965)) [`ef23671d`](https://github.com/webjsdev/webjs/commit/ef23671d)
+  * feat: replace static refresh with static interactive force-ship override
+  
+  The `static refresh = true` elision flag was a pre-seeding vestige. Its
+  only mechanism was forcing a bare async component's module to ship, and
+- **regenerate stale dev build outputs on request so local CSS never goes stale** ([#970](https://github.com/webjsdev/webjs/pull/970)) [`d6cddfb9`](https://github.com/webjsdev/webjs/commit/d6cddfb9)
+  * feat: regenerate stale dev build outputs on request (webjs.dev.regenerate)
+  
+  * feat: scaffold uses dev.regenerate for Tailwind instead of a --watch task

--- a/changelog/server/0.8.51.md
+++ b/changelog/server/0.8.51.md
@@ -1,0 +1,22 @@
+---
+package: "@webjsdev/server"
+version: 0.8.51
+date: 2026-07-13T19:37:52.982Z
+commit_count: 3
+---
+## Features
+
+- **replace static refresh with static interactive force-ship override** ([#965](https://github.com/webjsdev/webjs/pull/965)) [`ef23671d`](https://github.com/webjsdev/webjs/commit/ef23671d)
+  * feat: replace static refresh with static interactive force-ship override
+  
+  The `static refresh = true` elision flag was a pre-seeding vestige. Its
+  only mechanism was forcing a bare async component's module to ship, and
+- **path-aware import-only elision for route modules** ([#964](https://github.com/webjsdev/webjs/pull/964)) [`38ef79ae`](https://github.com/webjsdev/webjs/commit/38ef79ae)
+  * feat: path-aware import-only elision for route modules
+  
+  A client-effecting non-component module (the module-scope-signal idiom
+  of invariant 5) reachable ONLY through shipping components no longer
+- **regenerate stale dev build outputs on request so local CSS never goes stale** ([#970](https://github.com/webjsdev/webjs/pull/970)) [`d6cddfb9`](https://github.com/webjsdev/webjs/commit/d6cddfb9)
+  * feat: regenerate stale dev build outputs on request (webjs.dev.regenerate)
+  
+  * feat: scaffold uses dev.regenerate for Tailwind instead of a --watch task

--- a/package-lock.json
+++ b/package-lock.json
@@ -6975,7 +6975,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.39",
+      "version": "0.10.40",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -6991,7 +6991,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.36",
+      "version": "0.7.37",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.25.0"
@@ -7039,7 +7039,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.50",
+      "version": "0.8.51",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.39",
+  "version": "0.10.40",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.36",
+  "version": "0.7.37",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.50",
+  "version": "0.8.51",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Release bump for the three published packages carrying unreleased `feat:` work.

## Versions

- `@webjsdev/core` 0.7.36 → **0.7.37** (patch): #965, #970
- `@webjsdev/server` 0.8.50 → **0.8.51** (patch): #964, #965, #970
- `@webjsdev/cli` 0.10.39 → **0.10.40** (patch): #964, #970

All bumps are patch-level; every in-repo dependent pins a caret (`^0.7.0` / `^0.8.0` / `^0.10.0`) that the new versions still satisfy, so no dependent range edits. Lockfile regenerated (only the three version lines changed).

## Changelogs

Auto-generated by the pre-commit hook from the conventional-prefixed squash subjects (`changelog/{core,server,cli}/*.md`). Attribution verified against actual package touches (#964 hit server + cli but not core, so it is absent from the core changelog).

## What ships

- **#970** the headline: on-request dev CSS regeneration (`webjs.dev.regenerate`) replacing the fragile `tailwindcss --watch`.
- **#965** static-interactive force-ship elision override.
- **#964** path-aware import-only elision for route modules.

Merging this (adding `changelog/**.md` to `main`) triggers `release.yml` to `npm publish` and cut the GitHub Releases. No editor-plugin republish is owed (no `@webjsdev/intellisense/src` change since the last release).
