### PR TITLE
chore: release cli 0.10.41, server 0.8.52, mcp 0.1.8, intellisense 0.5.4, core 0.7.38

### DIFF
--- a/changelog/cli/0.10.41.md
+++ b/changelog/cli/0.10.41.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.41
+date: 2026-07-14T04:52:12.624Z
+commit_count: 1
+---
+## Features
+
+- **re-skin the scaffold, single-source the agent skill, add gallery:clear** ([#971](https://github.com/webjsdev/webjs/pull/971)) [`11f5f609`](https://github.com/webjsdev/webjs/commit/11f5f609)
+  * feat: remove scaffold design-distinctness enforcement (#969)
+  
+  The scaffold shipped six overlapping surfaces to force a generated app to
+  look distinct from the scaffold (a blocking no-scaffold-placeholder check, a

--- a/changelog/core/0.7.38.md
+++ b/changelog/core/0.7.38.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/core"
+version: 0.7.38
+date: 2026-07-14T04:52:12.503Z
+commit_count: 1
+---
+## Features
+
+- **re-skin the scaffold, single-source the agent skill, add gallery:clear** ([#971](https://github.com/webjsdev/webjs/pull/971)) [`11f5f609`](https://github.com/webjsdev/webjs/commit/11f5f609)
+  * feat: remove scaffold design-distinctness enforcement (#969)
+  
+  The scaffold shipped six overlapping surfaces to force a generated app to
+  look distinct from the scaffold (a blocking no-scaffold-placeholder check, a

--- a/changelog/intellisense/0.5.4.md
+++ b/changelog/intellisense/0.5.4.md
@@ -1,0 +1,17 @@
+---
+package: "@webjsdev/intellisense"
+version: 0.5.4
+date: 2026-07-14T04:52:12.718Z
+commit_count: 2
+---
+## Features
+
+- **enforce WebJs brand casing with one simple prose rule + one-time fix** ([#855](https://github.com/webjsdev/webjs/pull/855)) [`f41d105b`](https://github.com/webjsdev/webjs/commit/f41d105b)
+  * feat: enforce WebJs brand casing with one simple prose rule
+  
+  * docs: capitalize WebJs brand across markdown docs
+- **re-skin the scaffold, single-source the agent skill, add gallery:clear** ([#971](https://github.com/webjsdev/webjs/pull/971)) [`11f5f609`](https://github.com/webjsdev/webjs/commit/11f5f609)
+  * feat: remove scaffold design-distinctness enforcement (#969)
+  
+  The scaffold shipped six overlapping surfaces to force a generated app to
+  look distinct from the scaffold (a blocking no-scaffold-placeholder check, a

--- a/changelog/mcp/0.1.8.md
+++ b/changelog/mcp/0.1.8.md
@@ -1,0 +1,17 @@
+---
+package: "@webjsdev/mcp"
+version: 0.1.8
+date: 2026-07-14T04:52:12.775Z
+commit_count: 2
+---
+## Features
+
+- **enforce WebJs brand casing with one simple prose rule + one-time fix** ([#855](https://github.com/webjsdev/webjs/pull/855)) [`f41d105b`](https://github.com/webjsdev/webjs/commit/f41d105b)
+  * feat: enforce WebJs brand casing with one simple prose rule
+  
+  * docs: capitalize WebJs brand across markdown docs
+- **re-skin the scaffold, single-source the agent skill, add gallery:clear** ([#971](https://github.com/webjsdev/webjs/pull/971)) [`11f5f609`](https://github.com/webjsdev/webjs/commit/11f5f609)
+  * feat: remove scaffold design-distinctness enforcement (#969)
+  
+  The scaffold shipped six overlapping surfaces to force a generated app to
+  look distinct from the scaffold (a blocking no-scaffold-placeholder check, a

--- a/changelog/server/0.8.52.md
+++ b/changelog/server/0.8.52.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/server"
+version: 0.8.52
+date: 2026-07-14T04:52:12.561Z
+commit_count: 1
+---
+## Features
+
+- **re-skin the scaffold, single-source the agent skill, add gallery:clear** ([#971](https://github.com/webjsdev/webjs/pull/971)) [`11f5f609`](https://github.com/webjsdev/webjs/commit/11f5f609)
+  * feat: remove scaffold design-distinctness enforcement (#969)
+  
+  The scaffold shipped six overlapping surfaces to force a generated app to
+  look distinct from the scaffold (a blocking no-scaffold-placeholder check, a

--- a/package-lock.json
+++ b/package-lock.json
@@ -6975,7 +6975,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.40",
+      "version": "0.10.41",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -6991,7 +6991,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.37",
+      "version": "0.7.38",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.25.0"
@@ -6999,7 +6999,7 @@
     },
     "packages/editors/intellisense": {
       "name": "@webjsdev/intellisense",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "MIT",
       "peerDependencies": {
         "typescript": ">=5.0.0"
@@ -7025,7 +7025,7 @@
     },
     "packages/mcp": {
       "name": "@webjsdev/mcp",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/server": "^0.8.0"
@@ -7039,7 +7039,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.51",
+      "version": "0.8.52",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.40",
+  "version": "0.10.41",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.37",
+  "version": "0.7.38",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/editors/intellisense/package.json
+++ b/packages/editors/intellisense/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/intellisense",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "type": "commonjs",
   "description": "Standalone TypeScript language-service plugin for webjs (no Lit dependency). Adds in-template intelligence inside html`` templates: go-to-definition on tags / attributes / CSS classes, binding-aware completions, value/binding diagnostics, and hover, all driven by its own template parser and gated on import-graph reachability.",
   "main": "src/index.js",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/mcp",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "type": "module",
   "description": "The webjs Model Context Protocol server: live app introspection (routes / actions / components / check) plus the framework knowledge layer (docs, recipes, source) for AI coding agents",
   "bin": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.51",
+  "version": "0.8.52",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Release bump clearing the debt after #971 (the scaffold rework) and #855 (brand casing):

- **cli** 0.10.40 → 0.10.41 (#971: new gallery scaffold, gallery:clear, single-source skill)
- **server** 0.8.51 → 0.8.52 (#971: removed the no-scaffold-placeholder check rule)
- **mcp** 0.1.7 → 0.1.8 (#971: knowledge layer repointed to the skill; #855: brand casing)
- **intellisense** 0.5.3 → 0.5.4 (#855: brand casing)
- **core** 0.7.37 → 0.7.38 (#971: metadata.d.ts type tweak)

Changelog files auto-generated by the pre-commit hook. Merging to main triggers release.yml, which publishes to npm + GitHub Packages, cuts the GitHub Release, and lockstep-bumps the create-webjs / webjsdev wrappers. `ui` needs no release (no unreleased changes).