### PR TITLE
fix: reactive-props-no-class-field false positive on object-literal keys in a method

### DIFF
--- a/packages/server/src/check.js
+++ b/packages/server/src/check.js
@@ -235,74 +235,70 @@ function isArrayTypeText(type) {
 function findFieldInitializers(classBody, props) {
   /** @type {string[]} */
   const out = [];
-  // Walk the body, tracking brace depth. At depth 0, look for
-  // class-field-shaped lines.
+  const n = classBody.length;
+  // Match class-field declarations. Two shapes:
+  // 1. With initializer: `count = 0`, `count: number = 0`, `public count = 0`
+  // 2. Type-only (no initializer): `count!: number`, `count?: number`, `count: number`
+  // Both compile to Object.defineProperty after super() under modern class-field
+  // semantics, clobbering the reactive accessor.
+  // The initializer regex: optional modifier, identifier, optional type, then `=`.
+  const initRe = /^\s*(?:(public|private|protected|readonly)\s+)?([A-Za-z_$][\w$]*)\s*(?::\s*[^=;]+)?\s*=\s*[^=>]/;
+  // The type-only regex: optional modifier, identifier, then `!:` or `?:` or `:` with a type.
+  const typeOnlyRe = /^\s*(?:(public|private|protected|readonly)\s+)?([A-Za-z_$][\w$]*)\s*[!?]?\s*:\s*\S/;
+  const examineLine = (lineStart) => {
+    let j = lineStart;
+    while (j < n && classBody[j] !== '\n') j++;
+    const line = classBody.slice(lineStart, j);
+    const initM = initRe.exec(line);
+    const typeM = typeOnlyRe.exec(line);
+    // Prefer the initializer match; if neither, skip.
+    const name = initM ? initM[2] : (typeM ? typeM[2] : null);
+    // `declare`, `static`, and `this.` patterns shouldn't reach here
+    // (declare/static start with their keyword, this.x has the dot in
+    // the regex group), but guard against matching keywords as names:
+    if (name && name !== 'declare' && name !== 'static' && props.has(name)) out.push(name);
+  };
+  // Walk the body char by char, tracking brace depth. A class field lives at
+  // the class-body top level (depth 0). We examine a line ONCE, at its first
+  // non-whitespace char, only while depth is 0, and WITHOUT skipping the braces
+  // on that line: an opening brace on the line (`method() {`, `field = {`) must
+  // still be counted so the lines inside its block are seen at depth > 0. The
+  // earlier version jumped `i` past the whole examined line, which dropped that
+  // line's braces and let object-literal keys inside a method body (`{ game:
+  // ..., scoreboard: ... }`) be misread as depth-0 class fields (#934).
   let depth = 0;
   let i = 0;
   let lineStart = 0;
+  let examined = false;
   let str = '';
-  while (i < classBody.length) {
+  while (i < n) {
     const c = classBody[i];
     if (str) {
       if (c === '\\') { i += 2; continue; }
       if (c === str) str = '';
-      else if (str === '`' && c === '$' && classBody[i + 1] === '{') {
-        depth++;
-        i += 2;
-        continue;
-      }
       i++;
       continue;
     }
-    if (c === '\n') {
-      lineStart = i + 1;
-      i++;
-      continue;
-    }
+    if (c === '\n') { lineStart = i + 1; examined = false; i++; continue; }
     if (c === '/' && classBody[i + 1] === '/') {
-      while (i < classBody.length && classBody[i] !== '\n') i++;
+      while (i < n && classBody[i] !== '\n') i++;
       continue;
     }
     if (c === '/' && classBody[i + 1] === '*') {
       i += 2;
-      while (i < classBody.length && !(classBody[i] === '*' && classBody[i + 1] === '/')) i++;
+      while (i < n && !(classBody[i] === '*' && classBody[i + 1] === '/')) i++;
       i += 2;
       continue;
     }
     if (c === "'" || c === '"' || c === '`') { str = c; i++; continue; }
+    // First non-whitespace char of a class-body top-level line: examine it for
+    // a field declaration BEFORE consuming any brace it opens.
+    if (depth === 0 && !examined && !/\s/.test(c)) {
+      examined = true;
+      examineLine(lineStart);
+    }
     if (c === '{') { depth++; i++; continue; }
     if (c === '}') { depth--; i++; continue; }
-    // At class-body top level, examine candidate lines starting at lineStart.
-    if (depth === 0 && i === lineStart || (depth === 0 && /\s/.test(c) && i === lineStart)) {
-      // Take the rest of the line up to a newline.
-      let j = lineStart;
-      while (j < classBody.length && classBody[j] !== '\n') j++;
-      const line = classBody.slice(lineStart, j);
-      // Match class-field declarations. Two shapes:
-      // 1. With initializer: `count = 0`, `count: number = 0`, `public count = 0`
-      // 2. Type-only (no initializer): `count!: number`, `count?: number`, `count: number`
-      // Both compile to Object.defineProperty after super() under modern class-field
-      // semantics, clobbering the reactive accessor.
-      // The initializer regex: optional modifier, identifier, optional type, then `=`.
-      const initRe = /^\s*(?:(public|private|protected|readonly)\s+)?([A-Za-z_$][\w$]*)\s*(?::\s*[^=;]+)?\s*=\s*[^=>]/;
-      // The type-only regex: optional modifier, identifier, then `!:` or `?:` or `:` with a type.
-      const typeOnlyRe = /^\s*(?:(public|private|protected|readonly)\s+)?([A-Za-z_$][\w$]*)\s*[!?]?\s*:\s*\S/;
-      const initM = initRe.exec(line);
-      const typeM = typeOnlyRe.exec(line);
-      // Prefer the initializer match; if neither, skip.
-      const name = initM ? initM[2] : (typeM ? typeM[2] : null);
-      if (name) {
-        // `declare`, `static`, and `this.` patterns shouldn't reach here
-        // (declare/static start with their keyword, this.x has the dot in
-        // the regex group), but guard against matching keywords as names:
-        if (name !== 'declare' && name !== 'static' && props.has(name)) {
-          out.push(name);
-        }
-      }
-      // Advance past this line so we don't re-match.
-      i = j;
-      continue;
-    }
     i++;
   }
   return out;

--- a/packages/server/test/check/check.test.js
+++ b/packages/server/test/check/check.test.js
@@ -574,6 +574,48 @@ Methods.register('methods-prop');
   }
 });
 
+test('reactive-props-no-class-field: does not trip on object-literal keys inside a method (#934)', async () => {
+  // A multi-line object literal built inside a method body whose keys match a
+  // factory prop name (`game:` / `scoreboard:`) is NOT a class-field
+  // declaration. The brace-depth walker must count the method's and the
+  // literal's opening braces so those keys are seen at depth > 0, never depth 0.
+  const appDir = await makeTempApp();
+  try {
+    await mkdir(join(appDir, 'components'), { recursive: true });
+    await writeFile(
+      join(appDir, 'components', 'board.ts'),
+      `import { WebComponent, prop, html } from '@webjsdev/core';
+class Board extends WebComponent({
+  game: prop(Object),
+  scoreboard: prop(Object),
+}) {
+  constructor() {
+    super();
+    this.game = null;
+    this.scoreboard = null;
+  }
+
+  makeMove(op) {
+    const next = {
+      game: { ...this.game, board: op },
+      scoreboard: { ...this.scoreboard, x: 1 },
+    };
+    return next;
+  }
+
+  render() { return html\`<div>\${this.game}</div>\`; }
+}
+Board.register('x-board');
+`,
+    );
+    const violations = await checkConventions(appDir);
+    const v = violations.find((v) => v.rule === 'reactive-props-no-class-field');
+    assert.equal(v, undefined, 'object-literal keys inside a method are not class fields');
+  } finally {
+    await rm(appDir, { recursive: true, force: true });
+  }
+});
+
 test('reactive-props-no-class-field: flags a type-only declaration (`count!: number`)', async () => {
   const appDir = await makeTempApp();
   try {


### PR DESCRIPTION
Closes #934

`webjs check`'s `reactive-props-no-class-field` rule fired a false positive on a
correctly-declared factory prop when a method body later built a multi-line
object literal whose keys matched a prop name (`{ game: ..., scoreboard: ... }`).
The prop was never a class field, yet `check` reported it and failed. Found by
dogfooding a tic-tac-toe app.

## Root cause

`findFieldInitializers()` walks the class body tracking brace depth and only
treats a line as a candidate class field at `depth === 0`. When it examined a
top-level line it did `i = j; continue`, jumping past the whole line, which
DROPPED any brace on that line. So `makeMove(op) {` and `const next = {` never
incremented depth, and the object-literal keys inside the method were then read
at `depth === 0` and matched by the type-only regex.

(The issue speculated the trigger was template-literal `${...}` depth accounting.
That is not the live path: the redactor already blanks template bodies AND the
braces inside `${...}` holes to spaces before this walker runs, so no `${`
reaches it. The real bug is the brace-dropping line-skip above.)

## Fix

Rewrote the walker to examine a top-level line ONCE, at its first
non-whitespace char, WITHOUT skipping the line's braces. The character walk
continues normally so an opening brace on the examined line is still counted,
and every line inside its block is correctly seen at depth > 0. Genuine
class-field declarations (`count = 0`, `count: number = 0`, `count!: number`,
`count?: number`) at the class-body top level still match and still fail.

## Test plan

- Added a unit test with the exact #934 reproduction; it passes (no violation).
- Counterfactual: reverting only the source flips the new test red (verified),
  so it genuinely guards the fix.
- All existing `reactive-props-no-class-field` true-positive and negative cases
  still pass (65/65 in `packages/server/test/check/check.test.js`).

## Doc / surface checklist

- Tests: unit updated + counterfactual. Browser / e2e / Bun: N/A because this is
  a Node-only static analyser in `webjs check`, not on the serialize / listener /
  SSR / browser-wire path.
- Docs (markdown, docs site, README, AGENTS.md): N/A because the rule's
  documented behaviour is unchanged; this only removes a false positive.
- Scaffold / MCP / editor plugins / marketing: N/A (no generated code, no
  projected surface, no runtime behaviour change).
- Dogfood four-app boot: N/A because `check` is a static validator and does not
  affect served output, SSR, the importmap, or core/server runtime.
