### PR TITLE
chore: release cli 0.10.42, mcp 0.1.9, server 0.8.53

### DIFF
--- a/changelog/cli/0.10.42.md
+++ b/changelog/cli/0.10.42.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.42
+date: 2026-07-14T08:34:53.915Z
+commit_count: 1
+---
+## Features
+
+- **add `webjs routes`, `doctor --json`/`--strict`, per-command help** ([#979](https://github.com/webjsdev/webjs/pull/979)) [`c97159d6`](https://github.com/webjsdev/webjs/commit/c97159d6)
+  * refactor: extract shared routes projector into @webjsdev/mcp
+  
+  Pull the list_routes projection into a leaf routes-report.js module,
+  mirroring check-report.js. The MCP list_routes tool now delegates to

--- a/changelog/mcp/0.1.9.md
+++ b/changelog/mcp/0.1.9.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/mcp"
+version: 0.1.9
+date: 2026-07-14T08:34:54.047Z
+commit_count: 1
+---
+## Features
+
+- **add `webjs routes`, `doctor --json`/`--strict`, per-command help** ([#979](https://github.com/webjsdev/webjs/pull/979)) [`c97159d6`](https://github.com/webjsdev/webjs/commit/c97159d6)
+  * refactor: extract shared routes projector into @webjsdev/mcp
+  
+  Pull the list_routes projection into a leaf routes-report.js module,
+  mirroring check-report.js. The MCP list_routes tool now delegates to

--- a/changelog/server/0.8.53.md
+++ b/changelog/server/0.8.53.md
@@ -1,0 +1,9 @@
+---
+package: "@webjsdev/server"
+version: 0.8.53
+date: 2026-07-14T08:34:53.849Z
+commit_count: 1
+---
+## Fixes
+
+- **reactive-props-no-class-field false positive on object-literal keys in a method** ([#980](https://github.com/webjsdev/webjs/pull/980)) [`f55eab75`](https://github.com/webjsdev/webjs/commit/f55eab75)

--- a/package-lock.json
+++ b/package-lock.json
@@ -6975,7 +6975,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.41",
+      "version": "0.10.42",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -7025,7 +7025,7 @@
     },
     "packages/mcp": {
       "name": "@webjsdev/mcp",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/server": "^0.8.0"
@@ -7039,7 +7039,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.52",
+      "version": "0.8.53",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.41",
+  "version": "0.10.42",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/mcp",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "type": "module",
   "description": "The webjs Model Context Protocol server: live app introspection (routes / actions / components / check) plus the framework knowledge layer (docs, recipes, source) for AI coding agents",
   "bin": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.52",
+  "version": "0.8.53",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
## Summary

Release the three packages that accumulated unreleased commits since the last release (#978):

| Package | Bump | Why |
|---|---|---|
| `@webjsdev/cli` | 0.10.41 → **0.10.42** | `feat`: `webjs routes`, `doctor --json`/`--strict`, per-command help/Options, `--help`/`-h`, `version`/`--version`/`-v` (#979) |
| `@webjsdev/mcp` | 0.1.8 → **0.1.9** | `feat`: new public `./routes-report` subpath export + the shared route projector (#979) |
| `@webjsdev/server` | 0.8.52 → **0.8.53** | `fix`: `reactive-props-no-class-field` false positive on object-literal keys in a method (#980) |

All three are **patch** bumps within their existing minor lines, so every in-repo dependent's `^0.10.0` / `^0.8.0` range still resolves; no dependent range edits needed. `core`, `ui`, and `intellisense` have no unreleased commits, so they are not bumped.

## Contents

- Version bump in the three `packages/*/package.json` files.
- `package-lock.json` re-synced (`npm install --package-lock-only`), so `npm ci` stays green.
- `changelog/{cli/0.10.42,mcp/0.1.9,server/0.8.53}.md`, generated by the pre-commit hook from the conventional-commit subjects.

Merging this PR adds the `changelog/**.md` files to `main`, which triggers `release.yml` to `npm publish` the three packages and cut their GitHub Releases (idempotent). The `create-webjs` / `webjsdev` wrapper versions are intentionally left alone; the release workflow bumps them in lockstep with `cli`.

## Test plan

- [x] Lockfile re-synced (only the three version lines changed).
- [x] Changelogs generated with accurate entries + PR/commit links.
- [x] Dependent caret ranges unaffected by the patch bumps.
