### PR TITLE
feat: local-first ui registry, on-demand example delivery, MCP ui tool

### DIFF
--- a/.agents/skills/webjs/SKILL.md
+++ b/.agents/skills/webjs/SKILL.md
@@ -44,6 +44,7 @@ Classify the task first, then load the smallest useful reference set. Each refer
 | Tailwind, light-DOM tag-prefix rule, tokens, fixed headers, no-reflow layout | `references/styling.md`                        |
 | Client router, prefetch, frames, view transitions, Suspense streaming        | `references/client-router-and-streaming.md`   |
 | Optimistic UI for a user-facing mutation                                     | `references/optimistic-ui.md`                 |
+| The `@webjsdev/ui` component kit (a `components.json` is present): class helpers, tokens, `add` / `view`, the MCP `ui` tool | `references/ui-kit.md`                         |
 | TypeScript at runtime, erasable syntax, full-stack types                     | `references/typescript.md`                     |
 | Unit, browser, e2e tests, the `handle()` harness, Bun parity                 | `references/testing.md`                        |
 | Auth, caching, env vars, rate limit, file storage, the `webjs` config block  | `references/built-ins.md`                      |

--- a/.agents/skills/webjs/references/ui-kit.md
+++ b/.agents/skills/webjs/references/ui-kit.md
@@ -1,0 +1,68 @@
+# The `@webjsdev/ui` component kit
+
+Load this when the app has a `components.json` (it uses `@webjsdev/ui`, the
+shadcn-style kit for WebJs). The source is copied into your repo (`components/ui/`),
+so you own and edit it. Two tiers:
+
+- **Tier 1, class helpers (23 components).** Pure functions returning Tailwind
+  class strings (`buttonClass({ variant })`, `cardClass()`), composed with
+  whatever native element you write. Reach for these instead of expanding
+  Tailwind by hand: the call site is a fraction of the tokens and the class list
+  cannot drift.
+- **Tier 2, stateful custom elements (9 components).** `<ui-dialog>`, `<ui-tabs>`,
+  `<ui-dropdown-menu>`, and friends own their ARIA (focus trap, roving tabindex,
+  `aria-controls` / `inert`, live regions). Write the tag and the accessible
+  behaviour comes with it. Do NOT hand-roll these; the wiring is easy to get
+  subtly wrong.
+
+## The workflow: query for the structure, do not guess it
+
+`add` copies a Tier-1 component's class helpers plus a lean header (what each
+helper is, the accessibility obligations) and a one-line pointer. It does NOT
+copy the worked structural example, because that example is guidance you consume
+once while composing, not code that should sit in your repo. Get the full
+paste-ready structure on demand:
+
+- **MCP `ui` tool** (preferred when available): call `ui` with no args for the
+  kit inventory (each component's tier, helper signatures, npm deps); pass
+  `{ name: "accordion" }` for one component's helper signatures, the paste-ready
+  structural example, the accessibility header, and deps.
+- **CLI**: `webjs ui list` (inventory), `webjs ui view <name>` (the projected
+  view plus the full source). Same data as the MCP tool (one shared projector).
+
+So the loop is: `add` the component, then query `ui <name>` (MCP) or
+`webjs ui view <name>` for the accessible structure, paste it, and fill it in.
+
+## Setup and resolution
+
+- `webjs ui init` writes `components.json`, `lib/utils.ts`, and the CSS design
+  tokens the helpers render against (`--background`, `--foreground`,
+  `--destructive`, ...). It HARD-FAILS if the tokens cannot be written, so a
+  clean exit means the kit is styled. `add` self-heals the tokens if they go
+  missing.
+- Resolution is LOCAL-FIRST: `init` / `add` / `list` / `view` read the registry
+  that ships inside the installed `@webjsdev/ui`, with no network. This pins you
+  to the installed version; run `webjs ui diff` to see where your local copies
+  drift from the upstream (that command alone compares against the live registry).
+
+## Inventory (run `webjs ui list` or the MCP `ui` tool for the authoritative, current set)
+
+**Tier 1 (class helpers):** accordion, alert, aspect-ratio, avatar, badge,
+breadcrumb, button, card, checkbox, collapsible, input, kbd, label,
+native-select, pagination, popover, progress, radio-group, separator, skeleton,
+switch, table, textarea.
+
+**Tier 2 (custom elements, own their ARIA):** alert-dialog, dialog,
+dropdown-menu, hover-card, sonner, tabs, tooltip, plus toggle and toggle-group
+(these two register an element AND export a `*Class` helper).
+
+## Idioms
+
+- A helper is a function, so compose it: `class=${buttonClass({ variant: 'outline' })}`.
+  The unquoted `${...}` is a normal `html` attribute hole.
+- Tier-1 helpers assume the design tokens exist; if a component paints unstyled,
+  the tokens are missing (re-run `webjs ui init` or let `add` self-heal them).
+- Custom elements are display-only-safe at SSR and hydrate in the browser, the
+  standard WebJs component model (`references/components.md`).
+
+Full per-package reference lives in the installed `@webjsdev/ui/AGENTS.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,7 @@ Self-check: `page.ts` / `layout.ts` should NOT appear in the network tab or the 
 
 ## Framework source: where to find it
 
-Plain JS with JSDoc lives in `node_modules/@webjsdev/` (`core/`, `server/`, `cli/`, `mcp/`, `intellisense/`, `ui/`); what you read is what runs. Starting points: SSR `@webjsdev/server/src/ssr.js`, client hydration `@webjsdev/core/src/render-client.js`, client router `@webjsdev/core/src/router-client.js`, convention rules `@webjsdev/server/src/check.js`. For UI debugging use the Playwright MCP server; for live introspection the scaffold wires the read-only `@webjsdev/mcp` server (`npx @webjsdev/mcp`, also reachable as `webjs mcp`): `list_routes`, `list_actions`, `list_components`, `check`, plus a knowledge layer (docs / recipes / framework source).
+Plain JS with JSDoc lives in `node_modules/@webjsdev/` (`core/`, `server/`, `cli/`, `mcp/`, `intellisense/`, `ui/`); what you read is what runs. Starting points: SSR `@webjsdev/server/src/ssr.js`, client hydration `@webjsdev/core/src/render-client.js`, client router `@webjsdev/core/src/router-client.js`, convention rules `@webjsdev/server/src/check.js`. For UI debugging use the Playwright MCP server; for live introspection the scaffold wires the read-only `@webjsdev/mcp` server (`npx @webjsdev/mcp`, also reachable as `webjs mcp`): `list_routes`, `list_actions`, `list_components`, `check`, `ui` (the `@webjsdev/ui` kit inventory + a component's helpers / paste-ready example / a11y header), plus a knowledge layer (docs / recipes / framework source).
 
 ---
 
@@ -463,7 +463,7 @@ webjs start  [--port N]            # prod server; source IS the runtime, plain H
 webjs test   [--server] [--browser] [--watch]
 webjs check  [--rules] [--json]    # correctness validator (report-only, no autofix); --json for an agent loop
 webjs routes [--json] [--table] [--no-headers]   # print the route table (path / owner file / methods, #975). Default tree; --json is byte-identical to the MCP list_routes tool; --no-headers drops the --table header for piping
-webjs mcp                          # read-only MCP: routes, actions (RPC hashes), components, check
+webjs mcp                          # read-only MCP: routes, actions (RPC hashes), components, check, ui kit
 webjs doctor [--json] [--strict]   # project-health checklist (incl. a framework-resolve check that warns when @webjsdev/core can't be resolved from the app dir, the fresh-worktree-without-node_modules trap #954; a page/layout elision advisory); non-zero exit on a hard fail. --json emits `{ results, summary }` (results is the DoctorResult[], each carrying a stable code); --strict also fails the exit on warnings (#975)
 webjs types                        # generate .webjs/routes.d.ts (typed Route union + per-route params, #258)
 webjs version                      # print the installed @webjsdev/cli version (also: webjs --version / -v, #975)

--- a/docs/app/docs/ai-first/page.ts
+++ b/docs/app/docs/ai-first/page.ts
@@ -49,6 +49,7 @@ export default function AIFirst() {
       <li><code>list_actions</code>: server actions with their <code>/__webjs/action/&lt;hash&gt;/&lt;fn&gt;</code> RPC endpoints (the real hashes).</li>
       <li><code>list_components</code>: the registered custom-element tags.</li>
       <li><code>check</code>: the structured <code>webjs check</code> violations.</li>
+      <li><code>ui</code>: the <code>@webjsdev/ui</code> kit inventory, or one component's helper signatures, paste-ready example, and a11y header.</li>
     </ul>
     <p>Use these to learn the real route, action, and component surface before editing, instead of grepping or assuming.</p>
     <p><strong>Knowledge and authoring layer:</strong> an <code>init</code> tool (a read-first pointer with the mental model and invariants, the primer for a fresh setup), a <code>docs</code> tool (retrieve a topic or search the <code>.agents/skills/webjs/</code> reference corpus), and a <code>source</code> tool that reads the framework's OWN no-build source from <code>node_modules/@webjsdev/*/src</code> (what actually runs). On top of the tools, the server exposes MCP <code>resources</code> (the docs corpus plus this app's <code>AGENTS.md</code>) and recipe <code>prompts</code> (guided page, route, action, and component workflows), so the no-build framework source and the docs/recipes are surfaced directly to the agent.</p>

--- a/docs/app/docs/ui/page.ts
+++ b/docs/app/docs/ui/page.ts
@@ -41,14 +41,20 @@ npx webjsui add button card dialog</pre>
     <table>
       <thead><tr><th>Command</th><th>What it does</th></tr></thead>
       <tbody>
-        <tr><td><code>init</code></td><td>Writes <code>components.json</code>, copies <code>lib/utils.ts</code>, appends theme CSS</td></tr>
-        <tr><td><code>add &lt;names...&gt;</code></td><td>Copy components into your project, install needed deps</td></tr>
+        <tr><td><code>init</code></td><td>Writes <code>components.json</code>, copies <code>lib/utils.ts</code>, installs the theme tokens (exits non-zero if they cannot be written)</td></tr>
+        <tr><td><code>add &lt;names...&gt;</code></td><td>Copy components in, install needed deps, self-heal the theme tokens (Tier-1 files keep the helpers plus a pointer, not the worked example)</td></tr>
         <tr><td><code>list</code></td><td>List all components in the registry</td></tr>
-        <tr><td><code>view &lt;name&gt;</code></td><td>Print a component's source</td></tr>
-        <tr><td><code>diff [name]</code></td><td>Show differences between local and registry</td></tr>
+        <tr><td><code>view &lt;name&gt;</code></td><td>Print a component's projected view (helpers plus the paste-ready example) and full source</td></tr>
+        <tr><td><code>diff [name]</code></td><td>Show differences between your local copy and the live registry</td></tr>
         <tr><td><code>info</code></td><td>Project diagnostics</td></tr>
       </tbody>
     </table>
+    <p>
+      Resolution is local-first: <code>init</code> / <code>add</code> / <code>list</code> / <code>view</code>
+      read the registry that ships inside the installed <code>@webjsdev/ui</code> package, so they need no
+      network. A Tier-1 component's worked structural example is served on demand by
+      <code>webjsui view &lt;name&gt;</code> (and the read-only MCP <code>ui</code> tool), not copied into your file.
+    </p>
 
     <h2>Usage</h2>
     <p>Every component is a standards-compliant custom element. Tag convention: single <code>ui-</code> prefix, sub-components hyphenated.</p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -7028,7 +7028,8 @@
       "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
-        "@webjsdev/server": "^0.8.0"
+        "@webjsdev/server": "^0.8.0",
+        "@webjsdev/ui": "^0.3.8"
       },
       "bin": {
         "webjs-mcp": "bin/webjs-mcp.js"

--- a/packages/cli/lib/create.js
+++ b/packages/cli/lib/create.js
@@ -18,6 +18,7 @@ import { existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { spawnSync } from 'node:child_process';
 import { bunifyProse, bunifyDockerfile, bunifyCompose, bunifyCi } from './runtime-rewrite.js';
+import { leanComponentSource } from './lean-copy.js';
 
 /**
  * Detect which package manager invoked us. Reads `npm_config_user_agent`,
@@ -115,42 +116,21 @@ const UI_REGISTRY_ROOT = resolveUiRegistryRoot();
  * @param {string} name  component name without `.ts` (e.g. 'button')
  * @returns {Promise<string>} source with import rewritten
  */
-/**
- * Lazily load the @webjsdev/ui lean-copy primitives (the example-strip + the
- * Tier detection), so a scaffolded Tier-1 component matches what `webjs ui add`
- * writes (helpers + a pointer, no worked example, #983). Falls back to a no-op
- * (keep the example) if the subpath cannot be resolved, so the strip is never a
- * reason `webjs create` fails.
- */
-let _leanCopy = null;
-async function loadLeanCopy() {
-  if (_leanCopy) return _leanCopy;
-  try {
-    const m = await import('@webjsdev/ui/registry/extract');
-    _leanCopy = { stripExample: m.stripExample, isCustomElementSource: m.isCustomElementSource };
-  } catch {
-    _leanCopy = { stripExample: (s) => s, isCustomElementSource: () => true };
-  }
-  return _leanCopy;
-}
-
 async function readUiComponent(name) {
   const src = join(UI_REGISTRY_ROOT, 'components', `${name}.ts`);
   const raw = await readFile(src, 'utf8');
   // The registry component imports cn() via a relative `../lib/utils.ts`; rewrite
   // it to the scaffolded app's aliased path (cn lives at lib/utils/cn.ts).
-  let out = raw
+  const rewritten = raw
     .replaceAll("'../lib/utils.ts'", "'#lib/utils/cn.ts'")
     .replaceAll('"../lib/utils.ts"', '"#lib/utils/cn.ts"')
     // onBeforeCache lives in its own client-only module so cn() stays pure (#819).
     .replaceAll("'../lib/dom.ts'", "'#lib/utils/dom.ts'")
     .replaceAll('"../lib/dom.ts"', '"#lib/utils/dom.ts"');
-  // Strip the worked @example from a Tier-1 helper, same as `webjs ui add`, so
-  // the scaffolded component is lean and the example is served on demand by
-  // `webjs ui view` / the MCP `ui` tool. Tier-2 elements are left whole.
-  const { stripExample, isCustomElementSource } = await loadLeanCopy();
-  if (!isCustomElementSource(out)) out = stripExample(out, name);
-  return out;
+  // Strip the worked @example from a Tier-1 helper (same as `webjs ui add`), so
+  // the scaffolded component is lean and the example is served on demand. The
+  // shared helper is used by the saas-template copier too, so they cannot drift.
+  return leanComponentSource(rewritten, name);
 }
 
 /**

--- a/packages/cli/lib/create.js
+++ b/packages/cli/lib/create.js
@@ -115,17 +115,42 @@ const UI_REGISTRY_ROOT = resolveUiRegistryRoot();
  * @param {string} name  component name without `.ts` (e.g. 'button')
  * @returns {Promise<string>} source with import rewritten
  */
+/**
+ * Lazily load the @webjsdev/ui lean-copy primitives (the example-strip + the
+ * Tier detection), so a scaffolded Tier-1 component matches what `webjs ui add`
+ * writes (helpers + a pointer, no worked example, #983). Falls back to a no-op
+ * (keep the example) if the subpath cannot be resolved, so the strip is never a
+ * reason `webjs create` fails.
+ */
+let _leanCopy = null;
+async function loadLeanCopy() {
+  if (_leanCopy) return _leanCopy;
+  try {
+    const m = await import('@webjsdev/ui/registry/extract');
+    _leanCopy = { stripExample: m.stripExample, isCustomElementSource: m.isCustomElementSource };
+  } catch {
+    _leanCopy = { stripExample: (s) => s, isCustomElementSource: () => true };
+  }
+  return _leanCopy;
+}
+
 async function readUiComponent(name) {
   const src = join(UI_REGISTRY_ROOT, 'components', `${name}.ts`);
   const raw = await readFile(src, 'utf8');
   // The registry component imports cn() via a relative `../lib/utils.ts`; rewrite
   // it to the scaffolded app's aliased path (cn lives at lib/utils/cn.ts).
-  return raw
+  let out = raw
     .replaceAll("'../lib/utils.ts'", "'#lib/utils/cn.ts'")
     .replaceAll('"../lib/utils.ts"', '"#lib/utils/cn.ts"')
     // onBeforeCache lives in its own client-only module so cn() stays pure (#819).
     .replaceAll("'../lib/dom.ts'", "'#lib/utils/dom.ts'")
     .replaceAll('"../lib/dom.ts"', '"#lib/utils/dom.ts"');
+  // Strip the worked @example from a Tier-1 helper, same as `webjs ui add`, so
+  // the scaffolded component is lean and the example is served on demand by
+  // `webjs ui view` / the MCP `ui` tool. Tier-2 elements are left whole.
+  const { stripExample, isCustomElementSource } = await loadLeanCopy();
+  if (!isCustomElementSource(out)) out = stripExample(out, name);
+  return out;
 }
 
 /**

--- a/packages/cli/lib/lean-copy.js
+++ b/packages/cli/lib/lean-copy.js
@@ -1,0 +1,43 @@
+/**
+ * The scaffold's lean-copy of a ui component (#983).
+ *
+ * `webjs create` copies a few `@webjsdev/ui` registry components into a
+ * generated app. To match what `webjs ui add` writes, a Tier-1 helper's worked
+ * `@example` is stripped (the example is served on demand by `webjs ui view` /
+ * the MCP `ui` tool), while a Tier-2 element file is kept whole. Both scaffold
+ * copiers (`create.js` and `saas-template.js`) go through THIS one helper so
+ * they cannot drift.
+ *
+ * The strip primitives live in `@webjsdev/ui/registry/extract`; if that subpath
+ * cannot be resolved, this degrades to a no-op (keep the example) so the strip
+ * is never a reason `webjs create` fails.
+ *
+ * @module lean-copy
+ */
+
+let _mod = null;
+
+async function loadPrimitives() {
+  if (_mod) return _mod;
+  try {
+    const m = await import('@webjsdev/ui/registry/extract');
+    _mod = { stripExample: m.stripExample, isCustomElementSource: m.isCustomElementSource };
+  } catch {
+    _mod = { stripExample: (s) => s, isCustomElementSource: () => true };
+  }
+  return _mod;
+}
+
+/**
+ * Return the component source as `webjs ui add` would write it: a Tier-1 helper
+ * has its worked `@example` stripped and a pointer left; a Tier-2 element is
+ * returned unchanged.
+ *
+ * @param {string} source  the component source (imports already rewritten)
+ * @param {string} name    the component name (for the pointer)
+ * @returns {Promise<string>}
+ */
+export async function leanComponentSource(source, name) {
+  const { stripExample, isCustomElementSource } = await loadPrimitives();
+  return isCustomElementSource(source) ? source : stripExample(source, name);
+}

--- a/packages/cli/lib/saas-template.js
+++ b/packages/cli/lib/saas-template.js
@@ -5,6 +5,7 @@
 
 import { mkdir, writeFile, readFile } from 'node:fs/promises';
 import { bunifyProse } from './runtime-rewrite.js';
+import { leanComponentSource } from './lean-copy.js';
 import { existsSync } from 'node:fs';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -25,7 +26,7 @@ async function readUiComponent(name) {
   const raw = await readFile(src, 'utf8');
   // The registry component imports cn() via a relative `../lib/utils.ts`; rewrite
   // it to the scaffolded app's aliased path (cn lives at lib/utils/cn.ts).
-  return raw
+  const rewritten = raw
     .replaceAll("'../lib/utils.ts'", "'#lib/utils/cn.ts'")
     .replaceAll('"../lib/utils.ts"', '"#lib/utils/cn.ts"')
     // onBeforeCache lives in its own client-only module so cn() stays pure (#819).
@@ -33,6 +34,9 @@ async function readUiComponent(name) {
     // (which resolves to a nonexistent components/lib/dom.ts) and fails typecheck.
     .replaceAll("'../lib/dom.ts'", "'#lib/utils/dom.ts'")
     .replaceAll('"../lib/dom.ts"', '"#lib/utils/dom.ts"');
+  // Strip a Tier-1 helper's worked @example (same as create.js + `webjs ui add`)
+  // so switch / checkbox are lean, not just the full-stack base set (#983).
+  return leanComponentSource(rewritten, name);
 }
 
 /** Copy named registry components into `<appDir>/components/ui/`. */

--- a/packages/mcp/AGENTS.md
+++ b/packages/mcp/AGENTS.md
@@ -44,8 +44,15 @@ src/
                          are extracted LEXICALLY (extractExportNames /
                          extractRouteMethods / extractActionConfig) so no app
                          module is loaded.
-                         `deps` / `docsDeps` / `sourceDeps` are injectable for
-                         in-process tests.
+                         The `ui` tool (#983) is KIT-scoped, not appDir-scoped:
+                         it projects the shared `@webjsdev/ui/registry/extract`
+                         leaf (the kit inventory, or one component's helper
+                         signatures + paste-ready @example + a11y header + deps),
+                         the SAME leaf `webjsui view` renders. A drift test in
+                         mcp.test.mjs asserts the tool output equals that leaf's
+                         output.
+                         `deps` / `docsDeps` / `sourceDeps` / `uiDeps` are
+                         injectable for in-process tests.
   mcp-docs.js            KNOWLEDGE layer (#376): resolveDocsLocation (bundled
                          resources/ first, repo-root skill fallback in
                          dev), the init primer (sources the AGENTS.md

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -35,6 +35,10 @@ subcommand) delegates to this same server, so both routes run identical code.
   and `prompts` (the recipes as guided workflows).
 - **`source` tool**: reads the framework's own no-build source from
   `node_modules/@webjsdev/*/src` (read-only, traversal-guarded).
+- **`ui` tool**: the `@webjsdev/ui` kit inventory (no args) or one component's
+  helper signatures, paste-ready structural example, a11y header, and deps (pass
+  `name`). Kit-scoped (not `appDir`-scoped); shares one projector with
+  `webjsui view`.
 
 The docs corpus is bundled into the package at `prepack`, so `npx @webjsdev/mcp`
 is self-contained; in the monorepo it falls back to the live repo-root docs.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -25,7 +25,8 @@
     "resources"
   ],
   "dependencies": {
-    "@webjsdev/server": "^0.8.0"
+    "@webjsdev/server": "^0.8.0",
+    "@webjsdev/ui": "^0.3.8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mcp/src/mcp.js
+++ b/packages/mcp/src/mcp.js
@@ -81,6 +81,18 @@ const DOCS_SCHEMA = {
   required: [],
 };
 
+/** `ui` lists the @webjsdev/ui kit, or details one component by `name`. */
+const UI_SCHEMA = {
+  type: 'object',
+  properties: {
+    name: {
+      type: 'string',
+      description: 'A component name (e.g. button, accordion, dialog). Omit for the full kit inventory.',
+    },
+  },
+  required: [],
+};
+
 /** `source` reads the framework source: a `path` to read, a `query` to grep, or a `package` to list. */
 const SOURCE_SCHEMA = {
   type: 'object',
@@ -126,6 +138,12 @@ const TOOL_DEFS = [
     description:
       'Read the FRAMEWORK authored source (webjs is buildless: node_modules/@webjsdev/*/src is the JSDoc source, run directly server-side; only the core browser bundle is built into dist/, which this skips). Pass `path` to read a file (e.g. server/src/ssr.js), `query` to grep the @webjsdev/* src trees, or no args to list the packages + entry points. Use when the docs do not answer something. Read-only.',
     inputSchema: SOURCE_SCHEMA,
+  },
+  {
+    name: 'ui',
+    description:
+      'The @webjsdev/ui component kit (shadcn-style, copied into your repo). No args returns the inventory (each component: tier, helper signatures, npm deps); pass `name` for one component: helper signatures, the paste-ready structural example, the a11y/description header, and deps. Use before hand-writing UI so you reach for a helper (e.g. buttonClass()) and the accessible structure instead of expanding Tailwind blind. Reads the kit, not your app. Read-only.',
+    inputSchema: UI_SCHEMA,
   },
   {
     name: 'list_routes',
@@ -359,6 +377,26 @@ export function makeToolRunners(deps) {
 }
 
 /**
+ * Run the `ui` tool: the @webjsdev/ui kit inventory (no args) or one component's
+ * projection (helper signatures + paste-ready example + a11y/description header
+ * + deps). Projects the SHARED `@webjsdev/ui/registry/extract` leaf, the same
+ * one `webjsui view` renders, so the CLI and MCP cannot drift (#983, the #979
+ * shared-projector pattern). `uiDeps` is injected so tests need no real package.
+ *
+ * @param {{ uiInventory: Function, uiComponent: Function }} uiDeps
+ * @param {{ name?: string }} args
+ */
+export function runUiTool(uiDeps, args) {
+  const name = typeof args.name === 'string' && args.name ? args.name : null;
+  if (!name) return { inventory: uiDeps.uiInventory() };
+  const component = uiDeps.uiComponent(name);
+  if (!component) {
+    throw new Error(`Unknown component "${String(name)}". Call ui with no args for the inventory.`);
+  }
+  return component;
+}
+
+/**
  * A JSON-RPC 2.0 result frame.
  * @param {string|number|null} id
  * @param {any} result
@@ -454,6 +492,15 @@ export async function runMcpServer(opts) {
     };
   }
 
+  // The `ui` tool (#983): the @webjsdev/ui kit inventory / per-component
+  // projection, read from the shared `@webjsdev/ui/registry/extract` leaf.
+  // Injectable for tests; otherwise resolved from the installed package.
+  let uiDeps = opts.uiDeps;
+  if (!uiDeps) {
+    const ui = await import('@webjsdev/ui/registry/extract');
+    uiDeps = { uiInventory: ui.uiInventory, uiComponent: ui.uiComponent };
+  }
+
   /** Write one JSON-RPC frame as a single line to stdout. */
   const send = (frame) => {
     stdout.write(JSON.stringify(frame) + '\n');
@@ -526,7 +573,9 @@ export async function runMcpServer(opts) {
       const args = params.arguments || {};
       // The knowledge tools route to the docs / source layer; they return text.
       const isKnowledgeTool = name === 'init' || name === 'docs' || name === 'source';
-      if (!isKnowledgeTool && !runners[name]) {
+      // `ui` is kit-scoped (not app-scoped), so it is dispatched separately.
+      const isUiTool = name === 'ui';
+      if (!isKnowledgeTool && !isUiTool && !runners[name]) {
         return rpcError(id, -32602, `Unknown tool: ${String(name)}`);
       }
       const appDir = typeof args.appDir === 'string' && args.appDir ? args.appDir : cwd;
@@ -537,7 +586,9 @@ export async function runMcpServer(opts) {
             : name === 'docs'
               ? await searchDocs(docsDeps, args)
               : await runSourceTool(sourceDeps, args)
-          : await runners[name](appDir);
+          : isUiTool
+            ? runUiTool(uiDeps, args)
+            : await runners[name](appDir);
         // Knowledge tools return a markdown string; introspection tools return
         // a JSON-serialisable object.
         const text = typeof result === 'string' ? result : JSON.stringify(result, null, 2);

--- a/packages/mcp/src/mcp.js
+++ b/packages/mcp/src/mcp.js
@@ -386,6 +386,30 @@ export function makeToolRunners(deps) {
  * @param {{ uiInventory: Function, uiComponent: Function }} uiDeps
  * @param {{ name?: string }} args
  */
+/**
+ * Resolve the `ui` tool's deps from the shared `@webjsdev/ui/registry/extract`
+ * leaf, GUARDED (#983): if `@webjsdev/ui` is absent or too old to carry the
+ * `./registry/extract` subpath (a cross-package version skew), only the `ui`
+ * tool degrades (its deps throw a clear "unavailable" error, surfaced as an
+ * isError tool result) while the rest of the server keeps working. An unguarded
+ * top-level import would instead reject during bootstrap and sink the whole
+ * server. `importer` is injected so the failure path is unit-testable.
+ *
+ * @param {() => Promise<{ uiInventory: Function, uiComponent: Function }>} importer
+ * @returns {Promise<{ uiInventory: Function, uiComponent: Function }>}
+ */
+export async function loadUiDeps(importer) {
+  try {
+    const ui = await importer();
+    return { uiInventory: ui.uiInventory, uiComponent: ui.uiComponent };
+  } catch {
+    const unavailable = () => {
+      throw new Error('@webjsdev/ui is not available (install/upgrade @webjsdev/ui to use the ui tool)');
+    };
+    return { uiInventory: unavailable, uiComponent: unavailable };
+  }
+}
+
 export function runUiTool(uiDeps, args) {
   const name = typeof args.name === 'string' && args.name ? args.name : null;
   if (!name) return { inventory: uiDeps.uiInventory() };
@@ -494,23 +518,10 @@ export async function runMcpServer(opts) {
 
   // The `ui` tool (#983): the @webjsdev/ui kit inventory / per-component
   // projection, read from the shared `@webjsdev/ui/registry/extract` leaf.
-  // Injectable for tests; otherwise resolved from the installed package. The
-  // import is GUARDED: if @webjsdev/ui is absent or too old to carry the
-  // `./registry/extract` subpath (a cross-package version skew), only the `ui`
-  // tool degrades (it reports the kit is unavailable), the rest of the server
-  // keeps working. An unguarded import here would sink the whole server.
+  // Injectable for tests; otherwise resolved (guarded) from the installed
+  // package. See {@link loadUiDeps} for why the import is guarded.
   let uiDeps = opts.uiDeps;
-  if (!uiDeps) {
-    try {
-      const ui = await import('@webjsdev/ui/registry/extract');
-      uiDeps = { uiInventory: ui.uiInventory, uiComponent: ui.uiComponent };
-    } catch {
-      const unavailable = () => {
-        throw new Error('@webjsdev/ui is not available (install/upgrade @webjsdev/ui to use the ui tool)');
-      };
-      uiDeps = { uiInventory: unavailable, uiComponent: unavailable };
-    }
-  }
+  if (!uiDeps) uiDeps = await loadUiDeps(() => import('@webjsdev/ui/registry/extract'));
 
   /** Write one JSON-RPC frame as a single line to stdout. */
   const send = (frame) => {

--- a/packages/mcp/src/mcp.js
+++ b/packages/mcp/src/mcp.js
@@ -494,11 +494,22 @@ export async function runMcpServer(opts) {
 
   // The `ui` tool (#983): the @webjsdev/ui kit inventory / per-component
   // projection, read from the shared `@webjsdev/ui/registry/extract` leaf.
-  // Injectable for tests; otherwise resolved from the installed package.
+  // Injectable for tests; otherwise resolved from the installed package. The
+  // import is GUARDED: if @webjsdev/ui is absent or too old to carry the
+  // `./registry/extract` subpath (a cross-package version skew), only the `ui`
+  // tool degrades (it reports the kit is unavailable), the rest of the server
+  // keeps working. An unguarded import here would sink the whole server.
   let uiDeps = opts.uiDeps;
   if (!uiDeps) {
-    const ui = await import('@webjsdev/ui/registry/extract');
-    uiDeps = { uiInventory: ui.uiInventory, uiComponent: ui.uiComponent };
+    try {
+      const ui = await import('@webjsdev/ui/registry/extract');
+      uiDeps = { uiInventory: ui.uiInventory, uiComponent: ui.uiComponent };
+    } catch {
+      const unavailable = () => {
+        throw new Error('@webjsdev/ui is not available (install/upgrade @webjsdev/ui to use the ui tool)');
+      };
+      uiDeps = { uiInventory: unavailable, uiComponent: unavailable };
+    }
   }
 
   /** Write one JSON-RPC frame as a single line to stdout. */

--- a/packages/mcp/test/mcp.test.mjs
+++ b/packages/mcp/test/mcp.test.mjs
@@ -375,6 +375,34 @@ test('mcp: tools/call ui returns the kit inventory and matches the shared extrac
   assert.ok(err.result.isError, 'an unknown component is a tool error, not a crash');
 });
 
+test('mcp: an unavailable @webjsdev/ui degrades only the ui tool, the server stays up', async () => {
+  // Simulate the version-skew case (the ./registry/extract subpath missing) by
+  // injecting uiDeps whose functions throw. The ui tool must report an error,
+  // but the rest of the server (here list_routes) must still answer.
+  const dir = tmpDir();
+  write(dir, 'app/page.ts', 'export default function P() {}\n');
+  const throwing = () => { throw new Error('@webjsdev/ui is not available'); };
+  const stdin = new PassThrough();
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  let outBuf = '';
+  stdout.on('data', (c) => { outBuf += c.toString(); });
+  const done = runMcpServer({
+    stdin, stdout, stderr, cwd: dir, version: '9.9.9',
+    uiDeps: { uiInventory: throwing, uiComponent: throwing },
+  });
+  stdin.write(JSON.stringify({ jsonrpc: '2.0', id: 70, method: 'tools/call', params: { name: 'ui', arguments: {} } }) + '\n');
+  stdin.write(JSON.stringify({ jsonrpc: '2.0', id: 71, method: 'tools/call', params: { name: 'list_routes', arguments: {} } }) + '\n');
+  stdin.end();
+  await done;
+  const frames = outBuf.split('\n').filter((l) => l.trim()).map((l) => JSON.parse(l));
+  const uiFrame = frames.find((f) => f.id === 70);
+  assert.ok(uiFrame.result.isError, 'the ui tool reports an error when the kit is unavailable');
+  const routesFrame = frames.find((f) => f.id === 71);
+  assert.ok(!routesFrame.result.isError, 'list_routes still works');
+  assert.ok(Array.isArray(JSON.parse(routesFrame.result.content[0].text).pages), 'list_routes returns the route projection');
+});
+
 /* ---------------- knowledge layer (#376): init / docs / resources / prompts ---------------- */
 
 test('mcp: tools/call init returns the read-first primer (NOT-React mental model + invariants)', async () => {

--- a/packages/mcp/test/mcp.test.mjs
+++ b/packages/mcp/test/mcp.test.mjs
@@ -112,7 +112,7 @@ test('mcp: tools/list returns the introspection + knowledge tools with inputSche
   ]);
   const tools = frames[0].result.tools;
   const names = tools.map((t) => t.name).sort();
-  assert.deepEqual(names, ['check', 'docs', 'init', 'list_actions', 'list_components', 'list_routes', 'source']);
+  assert.deepEqual(names, ['check', 'docs', 'init', 'list_actions', 'list_components', 'list_routes', 'source', 'ui']);
   for (const t of tools) {
     assert.equal(typeof t.description, 'string');
     assert.equal(t.inputSchema.type, 'object');
@@ -123,6 +123,7 @@ test('mcp: tools/list returns the introspection + knowledge tools with inputSche
   assert.deepEqual(byName.init.inputSchema.properties, {}, 'init takes no args');
   assert.ok(byName.docs.inputSchema.properties.topic && byName.docs.inputSchema.properties.query, 'docs takes topic/query');
   assert.ok(byName.source.inputSchema.properties.path && byName.source.inputSchema.properties.query, 'source takes path/query/package');
+  assert.ok(byName.ui.inputSchema.properties.name, 'ui takes an optional component name');
 });
 
 test('mcp: tools/call check returns a content array parsing to { violations, summary }', async () => {
@@ -345,6 +346,33 @@ test('mcp: tools/call source reads/greps/lists the framework source (driven agai
     { jsonrpc: '2.0', id: 44, method: 'tools/call', params: { name: 'source', arguments: { path: 'core/dist/webjs-core-browser.js' } } },
   ]));
   assert.match(frames[0].result.content[0].text, /Refusing to read outside/, 'dist (built bundle) not exposed, only src');
+});
+
+/* ---------------- the ui tool (#983): kit inventory + drift-guard ---------------- */
+
+test('mcp: tools/call ui returns the kit inventory and matches the shared extractor (drift-guard)', async () => {
+  // The ui tool projects @webjsdev/ui/registry/extract, the SAME leaf webjsui
+  // view renders. Assert the tool output IS that projection, so the CLI and MCP
+  // cannot drift (the #979 shared-projector pattern applied to the kit).
+  const { uiInventory, uiComponent } = await import('@webjsdev/ui/registry/extract');
+  const dir = tmpDir();
+  const { frames } = await driveMcp(dir, [
+    { jsonrpc: '2.0', id: 60, method: 'tools/call', params: { name: 'ui', arguments: {} } },
+    { jsonrpc: '2.0', id: 61, method: 'tools/call', params: { name: 'ui', arguments: { name: 'accordion' } } },
+    { jsonrpc: '2.0', id: 62, method: 'tools/call', params: { name: 'ui', arguments: { name: 'not-a-component' } } },
+  ]);
+
+  const inv = JSON.parse(frames.find((f) => f.id === 60).result.content[0].text);
+  assert.deepEqual(inv.inventory, uiInventory(), 'inventory matches the shared extractor');
+  assert.ok(inv.inventory.some((c) => c.name === 'button' && c.tier === 1));
+  assert.ok(inv.inventory.some((c) => c.name === 'dialog' && c.tier === 2));
+
+  const acc = JSON.parse(frames.find((f) => f.id === 61).result.content[0].text);
+  assert.deepEqual(acc, uiComponent('accordion'), 'per-component payload matches the shared extractor');
+  assert.ok(acc.helpers.length >= 4, 'accordion helper signatures are projected');
+
+  const err = frames.find((f) => f.id === 62);
+  assert.ok(err.result.isError, 'an unknown component is a tool error, not a crash');
 });
 
 /* ---------------- knowledge layer (#376): init / docs / resources / prompts ---------------- */

--- a/packages/mcp/test/mcp.test.mjs
+++ b/packages/mcp/test/mcp.test.mjs
@@ -24,7 +24,7 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO = resolve(__dirname, '..', '..', '..');
-const { runMcpServer, extractExportNames, extractRouteMethods, extractActionConfig } = await import(
+const { runMcpServer, extractExportNames, extractRouteMethods, extractActionConfig, loadUiDeps } = await import(
   resolve(REPO, 'packages', 'mcp', 'src', 'mcp.js')
 );
 
@@ -375,10 +375,24 @@ test('mcp: tools/call ui returns the kit inventory and matches the shared extrac
   assert.ok(err.result.isError, 'an unknown component is a tool error, not a crash');
 });
 
-test('mcp: an unavailable @webjsdev/ui degrades only the ui tool, the server stays up', async () => {
-  // Simulate the version-skew case (the ./registry/extract subpath missing) by
-  // injecting uiDeps whose functions throw. The ui tool must report an error,
-  // but the rest of the server (here list_routes) must still answer.
+test('loadUiDeps: a failing import (version skew / missing subpath) degrades to throwing stubs, does not reject', async () => {
+  // This drives the REAL guard: the importer rejects (as it would when the
+  // ./registry/extract subpath is missing), and loadUiDeps must resolve to a
+  // stub whose functions throw a clear error, NOT reject (which would sink the
+  // whole server at bootstrap).
+  const deps = await loadUiDeps(async () => { throw new Error('Cannot find package @webjsdev/ui'); });
+  assert.equal(typeof deps.uiInventory, 'function');
+  assert.throws(() => deps.uiInventory(), /@webjsdev\/ui is not available/);
+  assert.throws(() => deps.uiComponent('button'), /@webjsdev\/ui is not available/);
+  // The happy path passes the module's exports through unchanged.
+  const ok = await loadUiDeps(async () => ({ uiInventory: () => 'INV', uiComponent: () => 'C' }));
+  assert.equal(ok.uiInventory(), 'INV');
+});
+
+test('mcp: throwing ui deps degrade only the ui tool, the server stays up', async () => {
+  // With the ui deps unavailable (stubs that throw, as loadUiDeps returns on a
+  // skew), the ui tool must report an error while the rest of the server (here
+  // list_routes) still answers. Complements the loadUiDeps guard test above.
   const dir = tmpDir();
   write(dir, 'app/page.ts', 'export default function P() {}\n');
   const throwing = () => { throw new Error('@webjsdev/ui is not available'); };

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -97,6 +97,7 @@ packages/ui/
       local.js                    LOCAL-FIRST composer: read the packaged registry from disk (no network)
       fetcher.js                  network GET + cache; local-vs-network dispatch (getRegistryItem/Index)
       example.js                  extract / strip the module-JSDoc @example block
+      extract.js                  shared kit projector (view + MCP `ui` tool): inventory + per-component helpers/example/deps
       resolver.js                 walk registryDependencies transitively
     utils/
       get-config.js               read components.json

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -173,7 +173,7 @@ full per-directory breakdown.
 | 1a | `aspect-ratio` | `aspectRatioClass`, use Tailwind `aspect-[16/9]` directly |
 | 1a | `kbd` | `kbdClass`, `kbdGroupClass` |
 | 1a | `table` | `tableContainerClass`, `tableClass`, `tableHeaderClass`, `tableBodyClass`, `tableFooterClass`, `tableRowClass`, `tableHeadClass`, `tableCellClass`, `tableCaptionClass` |
-| 1a | `toggle` | `toggleClass({ variant, size })`, pair with native `<button>` |
+| 1a/2 | `toggle` | Hybrid: exports `toggleClass({ variant, size })` (pair with a native `<button>`) AND registers `<ui-toggle>`. Because it registers an element, the kit tooling (`webjs ui view` / the MCP `ui` tool / the `add` strip) treats it as Tier-2 and keeps its file whole. |
 | 1a | `breadcrumb` | `breadcrumbListClass`, `breadcrumbItemClass`, `breadcrumbLinkClass`, `breadcrumbPageClass`, `breadcrumbSeparatorClass`, `breadcrumbEllipsisClass` |
 | 1a | `pagination` | `paginationClass`, `paginationContentClass`, `paginationLinkClass({ isActive, size })`, `paginationPreviousClass`, `paginationNextClass`, `paginationEllipsisClass` |
 | 1b | `popover` | `popoverContentClass`, `popoverHeaderClass`, `popoverTitleClass`, `popoverDescriptionClass`. Compose with `<button popovertarget="id">` + `<div popover id="id">`; positioning via CSS anchor positioning or the exported `positionFloating` helper. |

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -255,10 +255,14 @@ when the caller passes an explicit custom `--registry <url>`.
 - **On-demand example delivery**: a Tier-1 helper file's accessible structure
   lives in its module-JSDoc `@example` block. That worked example is build-time
   guidance, so `add` STRIPS it from the copied file and leaves a one-line pointer
-  (`example.js`); the full snippet is served on demand by `webjsui view` and the
-  MCP `ui` tool. Tier-2 custom-element files are left whole (the element IS the
-  component). A version-skew note: local-first pins `add`/`view` to the INSTALLED
-  ui version, and `diff` is how a user detects upstream drift.
+  (`example.js` `pointerLine`, the explicit `npx @webjsdev/ui view <name>` form
+  so it resolves whether or not the bin is a direct dep); the full snippet is
+  served on demand by `webjsui view` and the MCP `ui` tool. Tier-2
+  custom-element files are left whole (the element IS the component). A
+  version-skew note: local-first pins `add`/`view` to the INSTALLED ui version,
+  and `diff` is how a user detects upstream drift. The scaffold copiers
+  (`create.js`, `saas-template.js`) go through the same lean-copy
+  (`packages/cli/lib/lean-copy.js`), so a scaffolded component matches `add`.
 
 ## Webjs‑CLI subcommand
 

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -94,11 +94,14 @@ packages/ui/
       build.js                    build, compile a custom registry (for registry authors)
     registry/
       schema.js                   zod schemas (wire-compatible with shadcn's)
-      fetcher.js                  HTTP GET + cache for registry items
+      local.js                    LOCAL-FIRST composer: read the packaged registry from disk (no network)
+      fetcher.js                  network GET + cache; local-vs-network dispatch (getRegistryItem/Index)
+      example.js                  extract / strip the module-JSDoc @example block
       resolver.js                 walk registryDependencies transitively
     utils/
       get-config.js               read components.json
       detect-project.js           webjs / next / vite / astro / plain detection
+      theme.js                    ensureTheme(): install the design tokens (init hard-fails, add self-heals)
       logger.js                   kleur-based logger
   test/
     schema.test.js                schema validation
@@ -224,13 +227,38 @@ Browser tests for the Tier-2 guarantees live in
 
 | Command | What it does |
 |---|---|
-| `webjsui init` | Initialize a project, writes `components.json`, copies `lib/utils.ts`, appends theme CSS |
-| `webjsui add <names...>` | Resolve transitive deps, copy component sources, install npm deps |
+| `webjsui init` | Initialize a project, writes `components.json`, copies `lib/utils.ts`, installs the theme tokens. HARD-FAILS (non-zero exit) when the tokens cannot be written (an unstyled install with a clean exit code was the old trap). |
+| `webjsui add <names...>` | Resolve transitive deps, copy component sources, install npm deps. Self-heals missing theme tokens. For a Tier-1 helper it strips the worked `@example` and leaves a pointer (see Registry resolution). |
 | `webjsui list [filter]` | List components in the registry |
-| `webjsui view <name>` | Print a component's source to stdout |
-| `webjsui diff [name]` | Show diffs between local and registry |
+| `webjsui view <name>` | Print a component's source to stdout (the human / offline path to the full example) |
+| `webjsui diff [name]` | Show diffs between local and registry (against the LIVE upstream) |
 | `webjsui info` | Print project type + config + registry URL |
 | `webjsui build [file]` | Compile a custom registry (for registry authors) |
+
+### Registry resolution: LOCAL-FIRST (#983)
+
+The registry sources ship inside this npm package (`package.json` `files`
+includes `packages/registry`), so `init` / `add` / `list` / `view` resolve
+components from disk with NO network round-trip. This makes an agent's install
+deterministic and offline-safe. The network path (`fetcher.js`) is used ONLY
+when the caller passes an explicit custom `--registry <url>`.
+
+- `getRegistryItem(name, url)` / `getRegistryIndex(url)` in `fetcher.js` are the
+  dispatch: local unless `url` is a custom (non-default) registry. `local.js` is
+  the on-disk composer (the plain-JS twin of the ui-website's
+  `_lib/registry.server.ts`).
+- **`webjsui diff` is the deliberate carve-out**: it compares local files
+  against the LIVE upstream, so it stays on the network path (local-first would
+  compare the package against itself). It also compares each local file against
+  what `add` WOULD write (import-rewrite + example-strip via
+  `transformForProject`, shared with `add`), so a pristine install diffs clean.
+- **On-demand example delivery**: a Tier-1 helper file's accessible structure
+  lives in its module-JSDoc `@example` block. That worked example is build-time
+  guidance, so `add` STRIPS it from the copied file and leaves a one-line pointer
+  (`example.js`); the full snippet is served on demand by `webjsui view` and the
+  MCP `ui` tool. Tier-2 custom-element files are left whole (the element IS the
+  component). A version-skew note: local-first pins `add`/`view` to the INSTALLED
+  ui version, and `diff` is how a user detects upstream drift.
 
 ## Webjs‑CLI subcommand
 

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -94,17 +94,26 @@ and picks sensible defaults.
 
 Copies the component's `.ts` source into `components/ui/<name>.ts` (or your
 configured alias). Resolves transitive deps via `registryDependencies` and
-auto-installs npm deps like `@floating-ui/dom` for popover-style components.
+auto-installs npm deps like `@floating-ui/dom` for popover-style components. For
+a Tier-1 class-helper component it copies the helpers plus a lean header and a
+one-line pointer, and leaves the worked structural example OUT of the file (get
+it on demand with `webjsui view <name>`). It also self-heals the theme tokens if
+they are missing.
+
+Resolution is LOCAL-FIRST: `init` / `add` / `list` / `view` read the registry
+that ships inside the installed `@webjsdev/ui` package, so they work with no
+network. Point at a custom registry with `--registry <url>`; `webjsui diff`
+always compares against the live upstream.
 
 ## Commands
 
 | Command | Effect |
 |---|---|
-| `webjsui init` | Initialize a project (writes `components.json`, theme CSS, `lib/utils.ts`) |
-| `webjsui add <names...>` | Add components to your project |
+| `webjsui init` | Initialize a project (writes `components.json`, `lib/utils.ts`, the theme tokens). Exits non-zero if the tokens cannot be written. |
+| `webjsui add <names...>` | Add components (copies helpers + a pointer for Tier-1, self-heals theme tokens) |
 | `webjsui list` | List all available components |
-| `webjsui view <name>` | Print a component's source to stdout |
-| `webjsui diff [name]` | Show diff between your local copy and the registry |
+| `webjsui view <name>` | Print a component's projected view (helpers + paste-ready example) and full source |
+| `webjsui diff [name]` | Show diff between your local copy and the live registry |
 | `webjsui info` | Print project diagnostics |
 | `webjsui build` | (For registry authors) Compile a custom registry |
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,6 +10,7 @@
   "exports": {
     ".": "./src/index.js",
     "./registry/schema": "./src/registry/schema.js",
+    "./registry/extract": "./src/registry/extract.js",
     "./utils": "./src/utils/index.js"
   },
   "files": [

--- a/packages/ui/packages/registry/components/accordion.ts
+++ b/packages/ui/packages/registry/components/accordion.ts
@@ -15,21 +15,6 @@
  *   <AccordionTrigger>                    → <summary class=${accordionTriggerClass()}>
  *   <AccordionContent>                    → <div class=${accordionContentClass()}>
  *
- * Usage (single-open, exclusive):
- *   <div class=${accordionClass()}>
- *     <details name="faq" class=${accordionItemClass()}>
- *       <summary class=${accordionTriggerClass()}>
- *         <span>Is it accessible?</span>
- *         <svg class="size-4 transition-transform group-open:rotate-180">…</svg>
- *       </summary>
- *       <div class=${accordionContentClass()}>Yes, native disclosure widget.</div>
- *     </details>
- *     <details name="faq" class=${accordionItemClass()} open>
- *       <summary class=${accordionTriggerClass()}>Is it styled?</summary>
- *       <div class=${accordionContentClass()}>Yes, shadcn design tokens.</div>
- *     </details>
- *   </div>
- *
  * Initial state: add `open` on the <details> that should render expanded
  * on first paint. Programmatic toggling: `el.open = true | false`.
  *
@@ -38,6 +23,26 @@
  * <ui-accordion> custom element set.
  *
  * Design tokens used: --border, --ring, --foreground.
+ *
+ * @example
+ * ```html
+ * <div class=${accordionClass()}>
+ *   <details name="faq" class=${accordionItemClass()} open>
+ *     <summary class=${accordionTriggerClass()}>
+ *       <span>Is it accessible?</span>
+ *       <svg class="size-4 shrink-0 transition-transform group-open:rotate-180" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="m6 9 6 6 6-6" /></svg>
+ *     </summary>
+ *     <div class=${accordionContentClass()}>Yes, it uses a native disclosure widget.</div>
+ *   </details>
+ *   <details name="faq" class=${accordionItemClass()}>
+ *     <summary class=${accordionTriggerClass()}>
+ *       <span>Is it styled?</span>
+ *       <svg class="size-4 shrink-0 transition-transform group-open:rotate-180" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="m6 9 6 6 6-6" /></svg>
+ *     </summary>
+ *     <div class=${accordionContentClass()}>Yes, with the shadcn design tokens.</div>
+ *   </details>
+ * </div>
+ * ```
  */
 
 /** Root wrapper. Holds the column-of-items rhythm; no display: rules. */

--- a/packages/ui/packages/registry/components/alert-dialog.ts
+++ b/packages/ui/packages/registry/components/alert-dialog.ts
@@ -25,23 +25,6 @@
  *   AlertDialogAction        → <ui-alert-dialog-action variant size>
  *   AlertDialogCancel        → <ui-alert-dialog-cancel variant size>
  *
- * Usage:
- *   <ui-alert-dialog>
- *     <ui-alert-dialog-trigger>
- *       <button class=${buttonClass({ variant: 'destructive' })}>Delete</button>
- *     </ui-alert-dialog-trigger>
- *     <ui-alert-dialog-content>
- *       <div class=${alertDialogHeaderClass()}>
- *         <h2 data-slot="alert-dialog-title" class=${alertDialogTitleClass()}>Delete account?</h2>
- *         <p data-slot="alert-dialog-description" class=${alertDialogDescriptionClass()}>This cannot be undone.</p>
- *       </div>
- *       <div class=${alertDialogFooterClass()}>
- *         <ui-alert-dialog-cancel>Cancel</ui-alert-dialog-cancel>
- *         <ui-alert-dialog-action variant="destructive">Delete</ui-alert-dialog-action>
- *       </div>
- *     </ui-alert-dialog-content>
- *   </ui-alert-dialog>
- *
  * Attributes on <ui-alert-dialog>:
  *   `open`:  boolean (reflected). Presence shows the dialog.
  *
@@ -62,6 +45,25 @@
  * Tab cycles trapped within the dialog (native focus trap).
  *
  * Design tokens used: --background, --border, --muted-foreground.
+ *
+ * @example
+ * ```html
+ * <ui-alert-dialog>
+ *   <ui-alert-dialog-trigger>
+ *     <button class=${buttonClass({ variant: 'destructive' })}>Delete</button>
+ *   </ui-alert-dialog-trigger>
+ *   <ui-alert-dialog-content>
+ *     <div class=${alertDialogHeaderClass()}>
+ *       <h2 data-slot="alert-dialog-title" class=${alertDialogTitleClass()}>Delete account?</h2>
+ *       <p data-slot="alert-dialog-description" class=${alertDialogDescriptionClass()}>This cannot be undone.</p>
+ *     </div>
+ *     <div class=${alertDialogFooterClass()}>
+ *       <ui-alert-dialog-cancel>Cancel</ui-alert-dialog-cancel>
+ *       <ui-alert-dialog-action variant="destructive">Delete</ui-alert-dialog-action>
+ *     </div>
+ *   </ui-alert-dialog-content>
+ * </ui-alert-dialog>
+ * ```
  */
 import { WebComponent, html, prop } from '@webjsdev/core';
 import { ref, createRef } from '@webjsdev/core/directives';

--- a/packages/ui/packages/registry/components/alert.ts
+++ b/packages/ui/packages/registry/components/alert.ts
@@ -7,30 +7,32 @@
  *   AlertTitle                              → alertTitleClass()
  *   AlertDescription                        → alertDescriptionClass()
  *
- * Usage:
- *   <div role="alert" class=${alertClass()}>
- *     <svg>…</svg>
- *     <div data-slot="alert-title" class=${alertTitleClass()}>Heads up</div>
- *     <div data-slot="alert-description" class=${alertDescriptionClass()}>
- *       Something happened. Probably fine.
- *     </div>
- *   </div>
- *
- *   <!-- Destructive variant: accent stripe + colored title/description. -->
- *   <div role="alert" class=${alertClass({ variant: 'destructive' })}>
- *     <svg>…</svg>
- *     <div data-slot="alert-title" class=${alertTitleClass()}>Failed</div>
- *     <div data-slot="alert-description" class=${alertDescriptionClass()}>
- *       Couldn't save your changes.
- *     </div>
- *   </div>
- *
  * A11y (required for accessible output): put role="alert" on the container
  * for an urgent, interrupting message, or role="status" for a polite,
  * non-urgent update. The class helper sets no role, so without one the
  * banner is silent to assistive tech.
  *
  * Design tokens used: --card, --card-foreground, --destructive, --muted-foreground.
+ *
+ * @example
+ * ```html
+ * <div role="alert" class=${alertClass()}>
+ *   <svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="10" /><path d="M12 16v-4M12 8h.01" /></svg>
+ *   <div data-slot="alert-title" class=${alertTitleClass()}>Heads up</div>
+ *   <div data-slot="alert-description" class=${alertDescriptionClass()}>
+ *     Something happened. Probably fine.
+ *   </div>
+ * </div>
+ *
+ * <!-- Destructive variant: accent stripe plus colored title and description. -->
+ * <div role="alert" class=${alertClass({ variant: 'destructive' })}>
+ *   <svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z" /><path d="M12 9v4M12 17h.01" /></svg>
+ *   <div data-slot="alert-title" class=${alertTitleClass()}>Failed</div>
+ *   <div data-slot="alert-description" class=${alertDescriptionClass()}>
+ *     Couldn't save your changes.
+ *   </div>
+ * </div>
+ * ```
  */
 import { cn } from '../lib/utils.ts';
 

--- a/packages/ui/packages/registry/components/aspect-ratio.ts
+++ b/packages/ui/packages/registry/components/aspect-ratio.ts
@@ -6,17 +6,19 @@
  * shadcn parity:
  *   AspectRatio (Radix primitive)  → aspectRatioClass() + inline `aspect-ratio` style
  *
- * Usage:
- *   <div style="aspect-ratio: 16/9;" class="${aspectRatioClass()}">
- *     <img src="…" class="h-full w-full object-cover rounded-md">
- *   </div>
- *
- *   <!-- Or with Tailwind's arbitrary aspect-ratio (no helper needed): -->
- *   <div class="aspect-[16/9]">
- *     <img …>
- *   </div>
- *
  * Design tokens used: none (layout only).
+ *
+ * @example
+ * ```html
+ * <div style="aspect-ratio: 16/9;" class="${aspectRatioClass()}">
+ *   <img src="/hero.jpg" alt="Team offsite" class="h-full w-full object-cover rounded-md">
+ * </div>
+ *
+ * <!-- Or with Tailwind's arbitrary aspect-ratio (no helper needed): -->
+ * <div class="aspect-[16/9]">
+ *   <img src="/hero.jpg" alt="Team offsite" class="h-full w-full object-cover rounded-md">
+ * </div>
+ * ```
  */
 
 export const aspectRatioClass = (): string => 'relative w-full';

--- a/packages/ui/packages/registry/components/avatar.ts
+++ b/packages/ui/packages/registry/components/avatar.ts
@@ -11,24 +11,32 @@
  *   AvatarGroup                       → avatarGroupClass()
  *   AvatarGroupCount                  → avatarGroupCountClass()
  *
- * Usage:
- *   <span class=${avatarClass()} data-size="default" data-slot="avatar">
- *     <img class=${avatarImageClass()} src="…" alt="…">
- *     <span class=${avatarFallbackClass()}>VK</span>
- *   </span>
- *
- *   <div class=${avatarGroupClass()}>
- *     <span class=${avatarClass()} data-size="default" data-slot="avatar">…</span>
- *     <span class=${avatarClass()} data-size="default" data-slot="avatar">…</span>
- *     <div class=${avatarGroupCountClass()}>+3</div>
- *   </div>
- *
  * A11y (required for accessible output): the <img> MUST have an alt that
  * names the person (alt="Vivek Khandelwal"), or alt="" when a visible text
  * fallback already names them. Always provide the fallback <span> so the
  * avatar is still named if the image fails to load.
  *
  * Design tokens used: --muted, --muted-foreground, --primary, --background.
+ *
+ * @example
+ * ```html
+ * <span class=${avatarClass()} data-size="default" data-slot="avatar">
+ *   <img class=${avatarImageClass()} src="/avatars/vivek.jpg" alt="Vivek Khandelwal">
+ *   <span class=${avatarFallbackClass()}>VK</span>
+ * </span>
+ *
+ * <div class=${avatarGroupClass()}>
+ *   <span class=${avatarClass()} data-size="default" data-slot="avatar">
+ *     <img class=${avatarImageClass()} src="/avatars/vivek.jpg" alt="Vivek Khandelwal">
+ *     <span class=${avatarFallbackClass()}>VK</span>
+ *   </span>
+ *   <span class=${avatarClass()} data-size="default" data-slot="avatar">
+ *     <img class=${avatarImageClass()} src="/avatars/amir.jpg" alt="Amir Rao">
+ *     <span class=${avatarFallbackClass()}>AR</span>
+ *   </span>
+ *   <div class=${avatarGroupCountClass()}>+3</div>
+ * </div>
+ * ```
  */
 import { cn } from '../lib/utils.ts';
 

--- a/packages/ui/packages/registry/components/badge.ts
+++ b/packages/ui/packages/registry/components/badge.ts
@@ -6,11 +6,6 @@
  *   Badge (variant: default | secondary | destructive | outline | ghost | link)
  *                                  → badgeClass({ variant })
  *
- * Usage:
- *   <span class=${badgeClass()}>New</span>
- *   <span class=${badgeClass({ variant: 'destructive' })}>Error</span>
- *   <a    class=${badgeClass({ variant: 'link' })} href="/profile">@vivek</a>
- *
  * The `[a&]:hover:...` hover styles only apply when the element is an `<a>`,
  * so a static `<span>` doesn't pick up an unwanted hover.
  *
@@ -20,6 +15,13 @@
  *
  * Design tokens used: --primary, --secondary, --destructive, --foreground,
  * --accent, --border, --ring.
+ *
+ * @example
+ * ```html
+ * <span class=${badgeClass()}>New</span>
+ * <span class=${badgeClass({ variant: 'destructive' })}>Error</span>
+ * <a class=${badgeClass({ variant: 'link' })} href="/profile">@vivek</a>
+ * ```
  */
 import { cn } from '../lib/utils.ts';
 

--- a/packages/ui/packages/registry/components/breadcrumb.ts
+++ b/packages/ui/packages/registry/components/breadcrumb.ts
@@ -11,27 +11,29 @@
  *   BreadcrumbSeparator  → breadcrumbSeparatorClass() (aria-hidden + role="presentation")
  *   BreadcrumbEllipsis   → breadcrumbEllipsisClass()
  *
- * Usage:
- *   <nav aria-label="breadcrumb" data-slot="breadcrumb">
- *     <ol class=${breadcrumbListClass()}>
- *       <li class=${breadcrumbItemClass()}>
- *         <a class=${breadcrumbLinkClass()} href="/">Home</a>
- *       </li>
- *       <li class=${breadcrumbSeparatorClass()} role="presentation" aria-hidden="true">
- *         <svg>›</svg>
- *       </li>
- *       <li class=${breadcrumbItemClass()}>
- *         <span class=${breadcrumbPageClass()} aria-current="page">Posts</span>
- *       </li>
- *     </ol>
- *   </nav>
- *
  * A11y (required for accessible output): wrap the list in <nav
  * aria-label="breadcrumb">, set aria-current="page" on the current-page
  * element, and mark each separator role="presentation" aria-hidden="true".
  * The class helpers emit none of these.
  *
  * Design tokens used: --muted-foreground, --foreground.
+ *
+ * @example
+ * ```html
+ * <nav aria-label="breadcrumb" data-slot="breadcrumb">
+ *   <ol class=${breadcrumbListClass()}>
+ *     <li class=${breadcrumbItemClass()}>
+ *       <a class=${breadcrumbLinkClass()} href="/">Home</a>
+ *     </li>
+ *     <li class=${breadcrumbSeparatorClass()} role="presentation" aria-hidden="true">
+ *       <svg class="size-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="m9 18 6-6-6-6" /></svg>
+ *     </li>
+ *     <li class=${breadcrumbItemClass()}>
+ *       <span class=${breadcrumbPageClass()} aria-current="page">Posts</span>
+ *     </li>
+ *   </ol>
+ * </nav>
+ * ```
  */
 
 export const breadcrumbListClass = (): string =>

--- a/packages/ui/packages/registry/components/button.ts
+++ b/packages/ui/packages/registry/components/button.ts
@@ -8,12 +8,6 @@
  *         (size:    default | xs | sm | lg | icon | icon-xs | icon-sm | icon-lg)
  *                                            → buttonClass({ variant, size })
  *
- * Usage:
- *   <button class=${buttonClass()} type="submit">Save</button>
- *   <button class=${buttonClass({ variant: 'outline', size: 'sm' })}>Cancel</button>
- *   <button class=${buttonClass({ size: 'icon' })} aria-label="Settings">⚙</button>
- *   <a       class=${buttonClass({ variant: 'link' })} href="/about">About</a>
- *
  * shadcn React's `asChild` (Slot) prop has no equivalent here: just call
  * `buttonClass(...)` and spread the classes onto whatever element you want.
  *
@@ -26,6 +20,14 @@
  * Design tokens used: --primary, --primary-foreground, --destructive,
  * --secondary, --secondary-foreground, --accent, --accent-foreground,
  * --background, --input, --ring.
+ *
+ * @example
+ * ```html
+ * <button class=${buttonClass()} type="submit">Save</button>
+ * <button class=${buttonClass({ variant: 'outline', size: 'sm' })}>Cancel</button>
+ * <button class=${buttonClass({ size: 'icon' })} aria-label="Settings">⚙</button>
+ * <a class=${buttonClass({ variant: 'link' })} href="/about">About</a>
+ * ```
  */
 import { cn } from '../lib/utils.ts';
 

--- a/packages/ui/packages/registry/components/card.ts
+++ b/packages/ui/packages/registry/components/card.ts
@@ -11,22 +11,26 @@
  *   CardContent                → cardContentClass()
  *   CardFooter                 → cardFooterClass()
  *
- * Usage:
- *   <div class=${cardClass()}>
- *     <div class=${cardHeaderClass()}>
- *       <div class=${cardTitleClass()}>Notifications</div>
- *       <div class=${cardDescriptionClass()}>You have 3 unread messages.</div>
- *       <div class=${cardActionClass()}>
- *         <button class=${buttonClass({ variant: 'ghost', size: 'sm' })}>Mark all read</button>
- *       </div>
- *     </div>
- *     <div class=${cardContentClass()}>…</div>
- *     <div class=${cardFooterClass()}>
- *       <button class=${buttonClass()}>Save</button>
+ * Design tokens used: --card, --card-foreground, --muted-foreground, --border.
+ *
+ * @example
+ * ```html
+ * <div class=${cardClass()}>
+ *   <div class=${cardHeaderClass()}>
+ *     <div class=${cardTitleClass()}>Notifications</div>
+ *     <div class=${cardDescriptionClass()}>You have 3 unread messages.</div>
+ *     <div class=${cardActionClass()}>
+ *       <button class=${buttonClass({ variant: 'ghost', size: 'sm' })}>Mark all read</button>
  *     </div>
  *   </div>
- *
- * Design tokens used: --card, --card-foreground, --muted-foreground, --border.
+ *   <div class=${cardContentClass()}>
+ *     <p class="text-sm">Your weekly digest is ready to review.</p>
+ *   </div>
+ *   <div class=${cardFooterClass()}>
+ *     <button class=${buttonClass()}>Save</button>
+ *   </div>
+ * </div>
+ * ```
  */
 
 export type CardSize = 'default' | 'sm';

--- a/packages/ui/packages/registry/components/checkbox.ts
+++ b/packages/ui/packages/registry/components/checkbox.ts
@@ -9,12 +9,14 @@
  *                                 when checked, inset shadow, focus ring;
  *                                 bypasses Radix)
  *
- * Usage:
- *   <input type="checkbox" name="terms" id="terms" class=${checkboxClass()}>
- *   <label class=${labelClass()} for="terms">I accept the terms</label>
- *
  * Design tokens used: --input, --primary, --primary-foreground, --background,
  * --ring, --destructive.
+ *
+ * @example
+ * ```html
+ * <input type="checkbox" name="terms" id="terms" class=${checkboxClass()}>
+ * <label class=${labelClass()} for="terms">I accept the terms</label>
+ * ```
  */
 import { cn } from '../lib/utils.ts';
 

--- a/packages/ui/packages/registry/components/collapsible.ts
+++ b/packages/ui/packages/registry/components/collapsible.ts
@@ -10,24 +10,26 @@
  *   CollapsibleTrigger  → <summary class=${collapsibleTriggerClass()}>
  *   CollapsibleContent  → <div class=${collapsibleContentClass()}>
  *
- * Usage:
- *   <details class=${collapsibleClass()}>
- *     <summary class=${collapsibleTriggerClass()}>
- *       Show details
- *       <svg class="size-4 transition-transform group-open:rotate-180">…</svg>
- *     </summary>
- *     <div class=${collapsibleContentClass()}>
- *       Hidden until <summary> is clicked, Enter / Space pressed, or the
- *       <details> element's `open` property is set via JS.
- *     </div>
- *   </details>
- *
  * Initial state: add `open` on <details> to render expanded on first
  * paint. Programmatic toggling: `el.open = true | false`. Migrated from
  * the prior <ui-collapsible> custom element; the trigger class hides
  * the native disclosure marker so callers can render their own chevron.
  *
  * Design tokens used: --border, --ring, --foreground.
+ *
+ * @example
+ * ```html
+ * <details class=${collapsibleClass()}>
+ *   <summary class=${collapsibleTriggerClass()}>
+ *     Show details
+ *     <svg class="size-4 transition-transform group-open:rotate-180" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="m6 9 6 6 6-6" /></svg>
+ *   </summary>
+ *   <div class=${collapsibleContentClass()}>
+ *     Hidden until <summary> is clicked, Enter / Space pressed, or the
+ *     <details> element's `open` property is set via JS.
+ *   </div>
+ * </details>
+ * ```
  */
 
 /**

--- a/packages/ui/packages/registry/components/dialog.ts
+++ b/packages/ui/packages/registry/components/dialog.ts
@@ -22,30 +22,6 @@
  *   DialogDescription  → <p class=${dialogDescriptionClass()}>
  *   DialogFooter       → <div class=${dialogFooterClass()}>
  *
- * Usage:
- *   <ui-dialog>
- *     <ui-dialog-trigger>
- *       <button class=${buttonClass({ variant: 'outline' })}>Edit profile</button>
- *     </ui-dialog-trigger>
- *     <ui-dialog-content>
- *       <div class=${dialogHeaderClass()}>
- *         <h2 data-slot="dialog-title" class=${dialogTitleClass()}>Edit profile</h2>
- *         <p data-slot="dialog-description" class=${dialogDescriptionClass()}>Make changes and click save.</p>
- *       </div>
- *       <div class="grid gap-3">
- *         <label class=${labelClass()} for="dlg-name">Name</label>
- *         <input class=${inputClass()} id="dlg-name" placeholder="Your name">
- *       </div>
- *       <div class=${dialogFooterClass()}>
- *         <ui-dialog-close><button class=${buttonClass({ variant: 'outline' })}>Cancel</button></ui-dialog-close>
- *         <button class=${buttonClass()}>Save</button>
- *       </div>
- *     </ui-dialog-content>
- *   </ui-dialog>
- *
- *   <!-- Suppress the auto-injected top-right X close: -->
- *   <ui-dialog-content show-close-button="false">…</ui-dialog-content>
- *
  * Attributes on <ui-dialog>:
  *   `open`:  boolean (reflected). Presence shows the dialog.
  *
@@ -62,6 +38,36 @@
  * within the dialog (native focus trap).
  *
  * Design tokens used: --background, --border, --muted-foreground.
+ *
+ * @example
+ * ```html
+ * <ui-dialog>
+ *   <ui-dialog-trigger>
+ *     <button class=${buttonClass({ variant: 'outline' })}>Edit profile</button>
+ *   </ui-dialog-trigger>
+ *   <ui-dialog-content>
+ *     <div class=${dialogHeaderClass()}>
+ *       <h2 data-slot="dialog-title" class=${dialogTitleClass()}>Edit profile</h2>
+ *       <p data-slot="dialog-description" class=${dialogDescriptionClass()}>Make changes and click save.</p>
+ *     </div>
+ *     <div class="grid gap-3">
+ *       <label class=${labelClass()} for="dlg-name">Name</label>
+ *       <input class=${inputClass()} id="dlg-name" placeholder="Your name">
+ *     </div>
+ *     <div class=${dialogFooterClass()}>
+ *       <ui-dialog-close><button class=${buttonClass({ variant: 'outline' })}>Cancel</button></ui-dialog-close>
+ *       <button class=${buttonClass()}>Save</button>
+ *     </div>
+ *   </ui-dialog-content>
+ * </ui-dialog>
+ *
+ * <!-- Suppress the auto-injected top-right X close button. -->
+ * <ui-dialog-content show-close-button="false">
+ *   <div class=${dialogHeaderClass()}>
+ *     <h2 data-slot="dialog-title" class=${dialogTitleClass()}>Quiet dialog</h2>
+ *   </div>
+ * </ui-dialog-content>
+ * ```
  */
 import { WebComponent, html, unsafeHTML, prop } from '@webjsdev/core';
 import { ref, createRef } from '@webjsdev/core/directives';

--- a/packages/ui/packages/registry/components/dropdown-menu.ts
+++ b/packages/ui/packages/registry/components/dropdown-menu.ts
@@ -20,26 +20,6 @@
  *   DropdownMenuSubTrigger    → <ui-dropdown-menu-sub-trigger inset>
  *   DropdownMenuSubContent    → <ui-dropdown-menu-sub-content>
  *
- * Usage:
- *   <ui-dropdown-menu>
- *     <ui-dropdown-menu-trigger>
- *       <button class=${buttonClass({ variant: 'outline' })}>Options</button>
- *     </ui-dropdown-menu-trigger>
- *     <ui-dropdown-menu-content align="end">
- *       <ui-dropdown-menu-label>My Account</ui-dropdown-menu-label>
- *       <ui-dropdown-menu-separator></ui-dropdown-menu-separator>
- *       <ui-dropdown-menu-item>Profile</ui-dropdown-menu-item>
- *       <ui-dropdown-menu-sub>
- *         <ui-dropdown-menu-sub-trigger>Invite users</ui-dropdown-menu-sub-trigger>
- *         <ui-dropdown-menu-sub-content>
- *           <ui-dropdown-menu-item>Email</ui-dropdown-menu-item>
- *         </ui-dropdown-menu-sub-content>
- *       </ui-dropdown-menu-sub>
- *       <ui-dropdown-menu-separator></ui-dropdown-menu-separator>
- *       <ui-dropdown-menu-item variant="destructive">Sign out</ui-dropdown-menu-item>
- *     </ui-dropdown-menu-content>
- *   </ui-dropdown-menu>
- *
  * Attributes on <ui-dropdown-menu>:
  *   `open`:  boolean (reflected). Open state.
  *
@@ -76,6 +56,28 @@
  *
  * Design tokens used: --popover, --popover-foreground, --accent,
  * --accent-foreground, --destructive, --muted-foreground, --border.
+ *
+ * @example
+ * ```html
+ * <ui-dropdown-menu>
+ *   <ui-dropdown-menu-trigger>
+ *     <button class=${buttonClass({ variant: 'outline' })}>Options</button>
+ *   </ui-dropdown-menu-trigger>
+ *   <ui-dropdown-menu-content align="end">
+ *     <ui-dropdown-menu-label>My Account</ui-dropdown-menu-label>
+ *     <ui-dropdown-menu-separator></ui-dropdown-menu-separator>
+ *     <ui-dropdown-menu-item>Profile</ui-dropdown-menu-item>
+ *     <ui-dropdown-menu-sub>
+ *       <ui-dropdown-menu-sub-trigger>Invite users</ui-dropdown-menu-sub-trigger>
+ *       <ui-dropdown-menu-sub-content>
+ *         <ui-dropdown-menu-item>Email</ui-dropdown-menu-item>
+ *       </ui-dropdown-menu-sub-content>
+ *     </ui-dropdown-menu-sub>
+ *     <ui-dropdown-menu-separator></ui-dropdown-menu-separator>
+ *     <ui-dropdown-menu-item variant="destructive">Sign out</ui-dropdown-menu-item>
+ *   </ui-dropdown-menu-content>
+ * </ui-dropdown-menu>
+ * ```
  */
 import { WebComponent, html, unsafeHTML, signal, prop } from '@webjsdev/core';
 import { ensureId } from '../lib/utils.ts';

--- a/packages/ui/packages/registry/components/hover-card.ts
+++ b/packages/ui/packages/registry/components/hover-card.ts
@@ -9,16 +9,6 @@
  *   HoverCardTrigger   → <ui-hover-card-trigger>
  *   HoverCardContent   → <ui-hover-card-content side align side-offset align-offset>
  *
- * Usage:
- *   <ui-hover-card open-delay="700" close-delay="300">
- *     <ui-hover-card-trigger>
- *       <a href="/user/vivek">@vivek</a>
- *     </ui-hover-card-trigger>
- *     <ui-hover-card-content>
- *       <div class="flex gap-3">…</div>
- *     </ui-hover-card-content>
- *   </ui-hover-card>
- *
  * Attributes on <ui-hover-card>:
  *   `open`:        boolean (reflected). Open state.
  *   `open-delay`:  ms, default 700. Hover delay before opening.
@@ -37,6 +27,24 @@
  * Programmatic API on <ui-hover-card>: `.show()` · `.hide()`.
  *
  * Design tokens used: --popover, --popover-foreground, --border.
+ *
+ * @example
+ * ```html
+ * <ui-hover-card open-delay="700" close-delay="300">
+ *   <ui-hover-card-trigger>
+ *     <a href="/user/vivek">@vivek</a>
+ *   </ui-hover-card-trigger>
+ *   <ui-hover-card-content>
+ *     <div class="flex gap-3">
+ *       <img class="size-10 rounded-full" src="/avatars/vivek.jpg" alt="Vivek Khandelwal">
+ *       <div>
+ *         <div class="text-sm font-semibold">Vivek Khandelwal</div>
+ *         <p class="text-sm text-muted-foreground">Builds the platform, not against it.</p>
+ *       </div>
+ *     </div>
+ *   </ui-hover-card-content>
+ * </ui-hover-card>
+ * ```
  */
 import { WebComponent, html, prop } from '@webjsdev/core';
 import { ensureId } from '../lib/utils.ts';

--- a/packages/ui/packages/registry/components/input.ts
+++ b/packages/ui/packages/registry/components/input.ts
@@ -8,16 +8,18 @@
  * shadcn parity:
  *   Input  → inputClass()
  *
- * Usage:
- *   <input class=${inputClass()} type="email" name="email" id="email" required
- *          aria-describedby="email-hint">
- *
  * Pair with `<label class=${labelClass()} for="...">` and a hint paragraph
  * (`<p class=${hintClass()} id="...-hint">`). Wrap all three in
  * `<div class=${fieldClass()}>` for the canonical field rhythm.
  *
  * Design tokens used: --input, --background, --primary, --primary-foreground,
  * --muted-foreground, --foreground, --ring, --destructive.
+ *
+ * @example
+ * ```html
+ * <input class=${inputClass()} type="email" name="email" id="email" required
+ *        aria-describedby="email-hint">
+ * ```
  */
 import { cn } from '../lib/utils.ts';
 

--- a/packages/ui/packages/registry/components/kbd.ts
+++ b/packages/ui/packages/registry/components/kbd.ts
@@ -6,17 +6,19 @@
  *   Kbd       → kbdClass()
  *   KbdGroup  → kbdGroupClass()
  *
- * Usage:
- *   <kbd class=${kbdClass()}>⌘</kbd>
- *   <kbd class=${kbdClass()}>K</kbd>
- *
- *   <div class=${kbdGroupClass()}>
- *     <kbd class=${kbdClass()}>⌘</kbd>
- *     <kbd class=${kbdClass()}>Shift</kbd>
- *     <kbd class=${kbdClass()}>P</kbd>
- *   </div>
- *
  * Design tokens used: --muted, --muted-foreground, --background.
+ *
+ * @example
+ * ```html
+ * <kbd class=${kbdClass()}>⌘</kbd>
+ * <kbd class=${kbdClass()}>K</kbd>
+ *
+ * <div class=${kbdGroupClass()}>
+ *   <kbd class=${kbdClass()}>⌘</kbd>
+ *   <kbd class=${kbdClass()}>Shift</kbd>
+ *   <kbd class=${kbdClass()}>P</kbd>
+ * </div>
+ * ```
  */
 
 export const kbdClass = (): string =>

--- a/packages/ui/packages/registry/components/label.ts
+++ b/packages/ui/packages/registry/components/label.ts
@@ -6,15 +6,17 @@
  * shadcn parity:
  *   Label  → labelClass()
  *
- * Usage:
- *   <label class=${labelClass()} for="email">Email</label>
- *   <input class=${inputClass()} id="email" name="email" type="email">
- *
  * Disabled-state inheritance: when the label is inside a container with
  * `data-disabled="true"` (the "field" pattern), or next to a peer-disabled
  * control, it dims automatically.
  *
  * Design tokens used: none (typography only).
+ *
+ * @example
+ * ```html
+ * <label class=${labelClass()} for="email">Email</label>
+ * <input class=${inputClass()} id="email" name="email" type="email">
+ * ```
  */
 
 /** Compose Tailwind classes for a native `<label>`. */

--- a/packages/ui/packages/registry/components/native-select.ts
+++ b/packages/ui/packages/registry/components/native-select.ts
@@ -13,16 +13,6 @@
  *                              stylesheet sets Canvas / CanvasText on
  *                              every <option> automatically)
  *
- * Usage:
- *   <div class=${nativeSelectWrapperClass()}>
- *     <select class=${nativeSelectClass()} name="plan">
- *       <option>Basic</option>
- *       <option>Pro</option>
- *     </select>
- *     <!-- chevron icon, decorative -->
- *     <svg class="${nativeSelectIconClass()}" aria-hidden="true">…</svg>
- *   </div>
- *
  * Importing this module installs a stylesheet that forces Canvas /
  * CanvasText on every <option> inside the wrapper so the dropdown reads
  * in both light and dark themes regardless of OS preference; advanced
@@ -30,6 +20,18 @@
  *
  * Design tokens used: --input, --background, --primary, --primary-foreground,
  * --muted-foreground, --ring, --destructive.
+ *
+ * @example
+ * ```html
+ * <div class=${nativeSelectWrapperClass()}>
+ *   <select class=${nativeSelectClass()} name="plan">
+ *     <option>Basic</option>
+ *     <option>Pro</option>
+ *   </select>
+ *   <!-- chevron icon, decorative -->
+ *   <svg class="${nativeSelectIconClass()}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="m6 9 6 6 6-6" /></svg>
+ * </div>
+ * ```
  */
 import { cn } from '../lib/utils.ts';
 

--- a/packages/ui/packages/registry/components/pagination.ts
+++ b/packages/ui/packages/registry/components/pagination.ts
@@ -12,23 +12,27 @@
  *   PaginationNext       → paginationNextClass()
  *   PaginationEllipsis   → paginationEllipsisClass()
  *
- * Usage:
- *   <nav role="navigation" aria-label="pagination" class=${paginationClass()}>
- *     <ul class=${paginationContentClass()}>
- *       <li><a class=${paginationPreviousClass()} href="?page=1">‹ Previous</a></li>
- *       <li><a class=${paginationLinkClass({ isActive: false })} href="?page=2">2</a></li>
- *       <li><a class=${paginationLinkClass({ isActive: true })} aria-current="page">3</a></li>
- *       <li class=${paginationEllipsisClass()} aria-hidden="true">…</li>
- *       <li><a class=${paginationNextClass()} href="?page=4">Next ›</a></li>
- *     </ul>
- *   </nav>
- *
  * A11y (required for accessible output): wrap the list in <nav
  * aria-label="pagination">, set aria-current="page" on the active page
  * link, give an icon-only Previous / Next control an aria-label, and mark
  * the ellipsis aria-hidden="true". The class helpers emit none of these.
  *
  * Design tokens used: inherited from buttonClass.
+ *
+ * @example
+ * ```html
+ * <nav role="navigation" aria-label="pagination" class=${paginationClass()}>
+ *   <ul class=${paginationContentClass()}>
+ *     <li><a class=${paginationPreviousClass()} href="?page=1">‹ Previous</a></li>
+ *     <li><a class=${paginationLinkClass({ isActive: false })} href="?page=2">2</a></li>
+ *     <li><a class=${paginationLinkClass({ isActive: true })} aria-current="page">3</a></li>
+ *     <li class=${paginationEllipsisClass()} aria-hidden="true">
+ *       <svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="1" /><circle cx="19" cy="12" r="1" /><circle cx="5" cy="12" r="1" /></svg>
+ *     </li>
+ *     <li><a class=${paginationNextClass()} href="?page=4">Next ›</a></li>
+ *   </ul>
+ * </nav>
+ * ```
  */
 import { cn } from '../lib/utils.ts';
 import { buttonClass, type ButtonSize } from './button.ts';

--- a/packages/ui/packages/registry/components/popover.ts
+++ b/packages/ui/packages/registry/components/popover.ts
@@ -18,28 +18,36 @@
  *   PopoverTitle          → popoverTitleClass()
  *   PopoverDescription    → popoverDescriptionClass()
  *
- * Usage (single invoker, implicit anchor, zero inline style):
- *   <button popovertarget="filter" class=${buttonClass({ variant: 'outline' })}>Filter</button>
- *   <div id="filter" popover
- *        class=${popoverContentClass({ side: 'bottom', align: 'start', sideOffset: 4 })}>
- *     <div class=${popoverHeaderClass()}>
- *       <h3 class=${popoverTitleClass()}>Filter posts</h3>
- *       <p class=${popoverDescriptionClass()}>By tag and status.</p>
- *     </div>
- *   </div>
- *
- *   <!-- Explicit anchor (multiple invokers / anchoring to a different element): -->
- *   <span style="anchor-name: --picker">@vivek</span>
- *   <button popovertarget="profile">Show</button>
- *   <div id="profile" popover style="position-anchor: --picker"
- *        class=${popoverContentClass({ side: 'bottom' })}>…</div>
- *
  * The `positionFloating` helper is also exported (used by the Tier-2
  * tooltip / hover-card / dropdown-menu components for imperative
  * positioning where CSS Anchor Positioning isn't enough). Migrated from
  * the prior <ui-popover> custom element set.
  *
  * Design tokens used: --popover, --popover-foreground, --border.
+ *
+ * @example
+ * ```html
+ * <!-- Single invoker, implicit anchor, zero inline style. -->
+ * <button popovertarget="filter" class=${buttonClass({ variant: 'outline' })}>Filter</button>
+ * <div id="filter" popover
+ *      class=${popoverContentClass({ side: 'bottom', align: 'start', sideOffset: 4 })}>
+ *   <div class=${popoverHeaderClass()}>
+ *     <h3 class=${popoverTitleClass()}>Filter posts</h3>
+ *     <p class=${popoverDescriptionClass()}>By tag and status.</p>
+ *   </div>
+ * </div>
+ *
+ * <!-- Explicit anchor, for multiple invokers or anchoring to a different element. -->
+ * <span style="anchor-name: --picker">@vivek</span>
+ * <button popovertarget="profile">Show</button>
+ * <div id="profile" popover style="position-anchor: --picker"
+ *      class=${popoverContentClass({ side: 'bottom' })}>
+ *   <div class=${popoverHeaderClass()}>
+ *     <h3 class=${popoverTitleClass()}>Vivek Khandelwal</h3>
+ *     <p class=${popoverDescriptionClass()}>@vivek</p>
+ *   </div>
+ * </div>
+ * ```
  */
 
 // --------------------------------------------------------------------------

--- a/packages/ui/packages/registry/components/progress.ts
+++ b/packages/ui/packages/registry/components/progress.ts
@@ -10,18 +10,20 @@
  *                                 `::-webkit-progress-value`, and
  *                                 `::-moz-progress-bar`)
  *
- * Usage:
- *   <progress value="42" max="100" class=${progressClass()}></progress>
- *
- *   <!-- Indeterminate (no `value` attribute): -->
- *   <progress class=${progressClass()}></progress>
- *
  * A11y (required for accessible output): give the <progress> an accessible
  * name with aria-label (or a <label for>), e.g. aria-label="Upload
  * progress". The native element supplies the role and value; only the name
  * is the author's responsibility.
  *
  * Design tokens used: --primary.
+ *
+ * @example
+ * ```html
+ * <progress value="42" max="100" class=${progressClass()}></progress>
+ *
+ * <!-- Indeterminate state, with no value attribute. -->
+ * <progress class=${progressClass()}></progress>
+ * ```
  */
 
 /**

--- a/packages/ui/packages/registry/components/radio-group.ts
+++ b/packages/ui/packages/registry/components/radio-group.ts
@@ -9,19 +9,21 @@
  *                          → radioGroupClass({ orientation }) on a <div role="radiogroup">
  *   RadioGroupItem         → radioClass() on a native <input type="radio">
  *
- * Usage:
- *   <div role="radiogroup" class=${radioGroupClass()}>
- *     <div class="flex items-center gap-2">
- *       <input type="radio" name="plan" value="basic" id="plan-basic" class=${radioClass()}>
- *       <label class=${labelClass()} for="plan-basic">Basic</label>
- *     </div>
- *     <div class="flex items-center gap-2">
- *       <input type="radio" name="plan" value="pro" id="plan-pro" class=${radioClass()}>
- *       <label class=${labelClass()} for="plan-pro">Pro</label>
- *     </div>
- *   </div>
- *
  * Design tokens used: --input, --primary, --ring, --destructive.
+ *
+ * @example
+ * ```html
+ * <div role="radiogroup" class=${radioGroupClass()}>
+ *   <div class="flex items-center gap-2">
+ *     <input type="radio" name="plan" value="basic" id="plan-basic" class=${radioClass()}>
+ *     <label class=${labelClass()} for="plan-basic">Basic</label>
+ *   </div>
+ *   <div class="flex items-center gap-2">
+ *     <input type="radio" name="plan" value="pro" id="plan-pro" class=${radioClass()}>
+ *     <label class=${labelClass()} for="plan-pro">Pro</label>
+ *   </div>
+ * </div>
+ * ```
  */
 import { cn } from '../lib/utils.ts';
 

--- a/packages/ui/packages/registry/components/separator.ts
+++ b/packages/ui/packages/registry/components/separator.ts
@@ -7,18 +7,20 @@
  *   Separator (orientation: horizontal | vertical, decorative: bool)
  *                          → separatorClass({ orientation }) + role + data-orientation
  *
- * Usage:
- *   <div role="none" class=${separatorClass()} data-orientation="horizontal"></div>
- *   <div role="separator" aria-orientation="vertical"
- *        class=${separatorClass({ orientation: 'vertical' })}
- *        data-orientation="vertical"></div>
- *
  * A11y (required for accessible output): a meaningful divider needs
  * role="separator" plus aria-orientation. A purely decorative one needs
  * role="none" (or aria-hidden="true") so assistive tech does not announce
  * an empty separator.
  *
  * Design tokens used: --border.
+ *
+ * @example
+ * ```html
+ * <div role="none" class=${separatorClass()} data-orientation="horizontal"></div>
+ * <div role="separator" aria-orientation="vertical"
+ *      class=${separatorClass({ orientation: 'vertical' })}
+ *      data-orientation="vertical"></div>
+ * ```
  */
 import { cn } from '../lib/utils.ts';
 

--- a/packages/ui/packages/registry/components/skeleton.ts
+++ b/packages/ui/packages/registry/components/skeleton.ts
@@ -6,16 +6,18 @@
  * shadcn parity:
  *   Skeleton  → skeletonClass()  (visual: animated rounded muted block)
  *
- * Usage:
- *   <div class=${cn(skeletonClass(), 'h-4 w-32')}></div>
- *   <div class=${cn(skeletonClass(), 'h-12 w-12 rounded-full')}></div>
- *
  * A11y (required for accessible output): a skeleton is a decorative
  * placeholder, so hide it from assistive tech with aria-hidden="true" (or
  * mark the loading region aria-busy="true"). Announce the real content
  * once it replaces the skeleton.
  *
  * Design tokens used: --accent.
+ *
+ * @example
+ * ```html
+ * <div class=${cn(skeletonClass(), 'h-4 w-32')}></div>
+ * <div class=${cn(skeletonClass(), 'h-12 w-12 rounded-full')}></div>
+ * ```
  */
 
 export const skeletonClass = (): string => 'animate-pulse rounded-md bg-accent';

--- a/packages/ui/packages/registry/components/sonner.ts
+++ b/packages/ui/packages/registry/components/sonner.ts
@@ -12,18 +12,6 @@
  *                   → toast()  (plus toast.success / .error / .info / .warning /
  *                     .loading / .promise / .dismiss)
  *
- * Usage:
- *   <!-- Mount once at the root of your app (typically in layout.ts): -->
- *   <ui-sonner position="bottom-right"></ui-sonner>
- *
- *   // Then from anywhere (server or client component):
- *   import { toast } from '@/components/ui/sonner.ts';
- *   toast('Saved!');
- *   toast.success('Account created');
- *   toast.error('Failed to save', { description: 'Try again' });
- *   toast.promise(savePost(), { loading: 'Saving…', success: 'Saved', error: 'Failed' });
- *   toast.dismiss(id);
- *
  * Attributes on <ui-sonner>:
  *   `position`: "top-left" | "top-center" | "top-right" |
  *               "bottom-left" | "bottom-center" | "bottom-right" (default).
@@ -42,6 +30,22 @@
  * uses); typically only needed when mounting multiple viewports.
  *
  * Design tokens used: --popover, --popover-foreground, --border, --radius.
+ *
+ * @example
+ * ```html
+ * <!-- Mount once at the root of your app, typically in layout.ts. -->
+ * <ui-sonner position="bottom-right"></ui-sonner>
+ *
+ * <!-- Then from anywhere, in a server or client component, call the API. -->
+ * <script type="module">
+ *   import { toast } from '@/components/ui/sonner.ts';
+ *   toast('Saved!');
+ *   toast.success('Account created');
+ *   toast.error('Failed to save', { description: 'Try again' });
+ *   toast.promise(savePost(), { loading: 'Saving', success: 'Saved', error: 'Failed' });
+ *   toast.dismiss(id);
+ * </script>
+ * ```
  */
 import { WebComponent, html, repeat, unsafeHTML, signal, prop } from '@webjsdev/core';
 import { onBeforeCache } from '../lib/dom.ts';

--- a/packages/ui/packages/registry/components/switch.ts
+++ b/packages/ui/packages/registry/components/switch.ts
@@ -8,19 +8,21 @@
  *   Switch (size: default | sm)  → switchInputClass() on a hidden <input> +
  *                                   switchTrackClass({ size }) on a sibling <span>
  *
- * Usage:
- *   <label class="inline-flex items-center gap-2">
- *     <input type="checkbox" role="switch" name="notify" class=${switchInputClass()}>
- *     <span class=${switchTrackClass()}></span>
- *     <span class=${labelClass()}>Notifications</span>
- *   </label>
- *
- *   <!-- Small size: -->
- *   <input type="checkbox" role="switch" name="x" class=${cn(switchInputClass(), 'peer/sm')}>
- *   <span class=${switchTrackClass({ size: 'sm' })}></span>
- *
  * Design tokens used: --primary, --input, --background, --foreground, --ring,
  * --primary-foreground.
+ *
+ * @example
+ * ```html
+ * <label class="inline-flex items-center gap-2">
+ *   <input type="checkbox" role="switch" name="notify" class=${switchInputClass()}>
+ *   <span class=${switchTrackClass()}></span>
+ *   <span class=${labelClass()}>Notifications</span>
+ * </label>
+ *
+ * <!-- Small size. -->
+ * <input type="checkbox" role="switch" name="x" class=${cn(switchInputClass(), 'peer/sm')}>
+ * <span class=${switchTrackClass({ size: 'sm' })}></span>
+ * ```
  */
 import { cn } from '../lib/utils.ts';
 

--- a/packages/ui/packages/registry/components/table.ts
+++ b/packages/ui/packages/registry/components/table.ts
@@ -13,31 +13,33 @@
  *   TableHead / TableCell / TableCaption
  *                                     → tableHeadClass() / tableCellClass() / tableCaptionClass()
  *
- * Usage:
- *   <div class=${tableContainerClass()}>
- *     <table class=${tableClass()}>
- *       <thead class=${tableHeaderClass()}>
- *         <tr class=${tableRowClass()}>
- *           <th scope="col" class=${tableHeadClass()}>Name</th>
- *           <th scope="col" class=${tableHeadClass()}>Status</th>
- *         </tr>
- *       </thead>
- *       <tbody class=${tableBodyClass()}>
- *         <tr class=${tableRowClass()}>
- *           <td class=${tableCellClass()}>Vivek</td>
- *           <td class=${tableCellClass()}>Active</td>
- *         </tr>
- *       </tbody>
- *       <caption class=${tableCaptionClass()}>Users</caption>
- *     </table>
- *   </div>
- *
  * A11y (required for accessible output): every header cell needs a scope
  * (scope="col" on a column header, scope="row" on a row header) so screen
  * readers map cells to their headers. Add a <caption> naming the table's
  * purpose (it can be visually hidden if a heading already names it).
  *
  * Design tokens used: --muted, --muted-foreground, --foreground.
+ *
+ * @example
+ * ```html
+ * <div class=${tableContainerClass()}>
+ *   <table class=${tableClass()}>
+ *     <thead class=${tableHeaderClass()}>
+ *       <tr class=${tableRowClass()}>
+ *         <th scope="col" class=${tableHeadClass()}>Name</th>
+ *         <th scope="col" class=${tableHeadClass()}>Status</th>
+ *       </tr>
+ *     </thead>
+ *     <tbody class=${tableBodyClass()}>
+ *       <tr class=${tableRowClass()}>
+ *         <td class=${tableCellClass()}>Vivek</td>
+ *         <td class=${tableCellClass()}>Active</td>
+ *       </tr>
+ *     </tbody>
+ *     <caption class=${tableCaptionClass()}>Users</caption>
+ *   </table>
+ * </div>
+ * ```
  */
 
 export const tableContainerClass = (): string => 'relative w-full overflow-x-auto';

--- a/packages/ui/packages/registry/components/tabs.ts
+++ b/packages/ui/packages/registry/components/tabs.ts
@@ -11,16 +11,6 @@
  *   TabsTrigger    → <ui-tabs-trigger value>
  *   TabsContent    → <ui-tabs-content value>
  *
- * Usage:
- *   <ui-tabs value="account">
- *     <ui-tabs-list>
- *       <ui-tabs-trigger value="account">Account</ui-tabs-trigger>
- *       <ui-tabs-trigger value="password">Password</ui-tabs-trigger>
- *     </ui-tabs-list>
- *     <ui-tabs-content value="account">…</ui-tabs-content>
- *     <ui-tabs-content value="password">…</ui-tabs-content>
- *   </ui-tabs>
- *
  * Attributes on <ui-tabs>:
  *   `value`:       string (reflected, controlled). Active tab value.
  *   `orientation`: "horizontal" (default) | "vertical".
@@ -42,6 +32,22 @@
  *
  * Design tokens used: --muted, --muted-foreground, --foreground, --background,
  * --input, --ring.
+ *
+ * @example
+ * ```html
+ * <ui-tabs value="account">
+ *   <ui-tabs-list>
+ *     <ui-tabs-trigger value="account">Account</ui-tabs-trigger>
+ *     <ui-tabs-trigger value="password">Password</ui-tabs-trigger>
+ *   </ui-tabs-list>
+ *   <ui-tabs-content value="account">
+ *     <p class="text-sm">Update your name and email here.</p>
+ *   </ui-tabs-content>
+ *   <ui-tabs-content value="password">
+ *     <p class="text-sm">Change your password here.</p>
+ *   </ui-tabs-content>
+ * </ui-tabs>
+ * ```
  */
 import { WebComponent, html, prop } from '@webjsdev/core';
 import { cn, ensureId } from '../lib/utils.ts';

--- a/packages/ui/packages/registry/components/textarea.ts
+++ b/packages/ui/packages/registry/components/textarea.ts
@@ -6,15 +6,17 @@
  * shadcn parity:
  *   Textarea  → textareaClass()
  *
- * Usage:
- *   <textarea class=${textareaClass()} name="message" rows="4" placeholder="Your message…">
- *   </textarea>
- *
  * Pair with `<label class=${labelClass()} for="...">` and wrap in
  * `<div class=${fieldClass()}>` for the canonical field rhythm.
  *
  * Design tokens used: --input, --background, --muted-foreground, --ring,
  * --destructive.
+ *
+ * @example
+ * ```html
+ * <textarea class=${textareaClass()} name="message" rows="4" placeholder="Your message">
+ * </textarea>
+ * ```
  */
 import { cn } from '../lib/utils.ts';
 

--- a/packages/ui/packages/registry/components/toggle-group.ts
+++ b/packages/ui/packages/registry/components/toggle-group.ts
@@ -12,19 +12,6 @@
  *                                 → <ui-toggle-group type variant size value>
  *   ToggleGroupItem               → <ui-toggle-group-item value>
  *
- * Usage:
- *   <ui-toggle-group type="single" value="bold">
- *     <ui-toggle-group-item value="bold" aria-label="Bold"><b>B</b></ui-toggle-group-item>
- *     <ui-toggle-group-item value="italic" aria-label="Italic"><i>I</i></ui-toggle-group-item>
- *     <ui-toggle-group-item value="underline" aria-label="Underline"><u>U</u></ui-toggle-group-item>
- *   </ui-toggle-group>
- *
- *   <!-- Multiple selection (comma-separated value): -->
- *   <ui-toggle-group type="multiple" value="bold,italic">
- *     <ui-toggle-group-item value="bold">B</ui-toggle-group-item>
- *     <ui-toggle-group-item value="italic">I</ui-toggle-group-item>
- *   </ui-toggle-group>
- *
  * Attributes on <ui-toggle-group>:
  *   `type`:        "single" (default) | "multiple".
  *   `value`:       string. Selected value(s). Single: a single value;
@@ -47,6 +34,21 @@
  *
  * Design tokens used: inherited from toggleClass (--muted, --accent, --ring,
  * --input, --destructive).
+ *
+ * @example
+ * ```html
+ * <ui-toggle-group type="single" value="bold">
+ *   <ui-toggle-group-item value="bold" aria-label="Bold"><b>B</b></ui-toggle-group-item>
+ *   <ui-toggle-group-item value="italic" aria-label="Italic"><i>I</i></ui-toggle-group-item>
+ *   <ui-toggle-group-item value="underline" aria-label="Underline"><u>U</u></ui-toggle-group-item>
+ * </ui-toggle-group>
+ *
+ * <!-- Multiple selection, with a comma-separated value. -->
+ * <ui-toggle-group type="multiple" value="bold,italic">
+ *   <ui-toggle-group-item value="bold">B</ui-toggle-group-item>
+ *   <ui-toggle-group-item value="italic">I</ui-toggle-group-item>
+ * </ui-toggle-group>
+ * ```
  */
 import { WebComponent, html, prop } from '@webjsdev/core';
 import { cn } from '../lib/utils.ts';

--- a/packages/ui/packages/registry/components/toggle.ts
+++ b/packages/ui/packages/registry/components/toggle.ts
@@ -10,20 +10,6 @@
  *                                 → toggleClass({ variant, size })  (class helper)
  *                                 → <ui-toggle pressed variant size>  (custom element)
  *
- * Usage (Tier-1 class helper, caller owns state):
- *   <button class=${toggleClass()} data-state="off" aria-pressed="false"
- *           onclick="this.dataset.state = this.dataset.state==='on'?'off':'on'">
- *     <svg>…</svg>
- *   </button>
- *
- * Usage (Tier-2 custom element, state managed):
- *   <ui-toggle aria-label="Toggle bold">
- *     <svg>…</svg>
- *   </ui-toggle>
- *
- *   <!-- Controlled / initial: -->
- *   <ui-toggle variant="outline" size="sm" pressed>B</ui-toggle>
- *
  * Attributes on <ui-toggle>:
  *   `pressed`:  boolean (reflected). Active state.
  *   `variant`:  "default" (default) | "outline".
@@ -37,6 +23,23 @@
  *
  * Design tokens used: --muted, --muted-foreground, --accent, --accent-foreground,
  * --input, --background, --ring, --destructive.
+ *
+ * @example
+ * ```html
+ * <!-- Tier-1 class helper, caller owns state. -->
+ * <button class=${toggleClass()} data-state="off" aria-pressed="false"
+ *         onclick="this.dataset.state = this.dataset.state==='on'?'off':'on'">
+ *   <svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M14 12a4 4 0 0 0 0-8H6v8" /><path d="M15 20a4 4 0 0 0 0-8H6v8Z" /></svg>
+ * </button>
+ *
+ * <!-- Tier-2 custom element, state managed. -->
+ * <ui-toggle aria-label="Toggle bold">
+ *   <svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M14 12a4 4 0 0 0 0-8H6v8" /><path d="M15 20a4 4 0 0 0 0-8H6v8Z" /></svg>
+ * </ui-toggle>
+ *
+ * <!-- Controlled or initial state. -->
+ * <ui-toggle variant="outline" size="sm" pressed>B</ui-toggle>
+ * ```
  */
 import { WebComponent, html, prop } from '@webjsdev/core';
 import { cn } from '../lib/utils.ts';

--- a/packages/ui/packages/registry/components/tooltip.ts
+++ b/packages/ui/packages/registry/components/tooltip.ts
@@ -11,14 +11,6 @@
  *   TooltipProvider       → not needed; delay state is per-tooltip (and globally
  *                           shared via `skip-delay-duration` cooldown).
  *
- * Usage:
- *   <ui-tooltip delay-duration="500" skip-delay-duration="300">
- *     <ui-tooltip-trigger>
- *       <button class=${buttonClass({ size: 'icon', variant: 'ghost' })} aria-label="Help">?</button>
- *     </ui-tooltip-trigger>
- *     <ui-tooltip-content side="top">Helpful tip</ui-tooltip-content>
- *   </ui-tooltip>
- *
  * Attributes on <ui-tooltip>:
  *   `open`:                boolean (reflected). Open state.
  *   `delay-duration`:      ms, default 700. Initial hover delay before opening.
@@ -39,6 +31,16 @@
  * Programmatic API on <ui-tooltip>: `.show()` · `.hide()`.
  *
  * Design tokens used: --foreground, --background.
+ *
+ * @example
+ * ```html
+ * <ui-tooltip delay-duration="500" skip-delay-duration="300">
+ *   <ui-tooltip-trigger>
+ *     <button class=${buttonClass({ size: 'icon', variant: 'ghost' })} aria-label="Help">?</button>
+ *   </ui-tooltip-trigger>
+ *   <ui-tooltip-content side="top">Helpful tip</ui-tooltip-content>
+ * </ui-tooltip>
+ * ```
  */
 import { WebComponent, html, prop } from '@webjsdev/core';
 import { ensureId } from '../lib/utils.ts';

--- a/packages/ui/src/commands/add.js
+++ b/packages/ui/src/commands/add.js
@@ -41,11 +41,15 @@ export const add = new Command()
     // Self-heal missing theme tokens (#983): the helpers render against CSS
     // design tokens; if the app never ran (or lost) the theme block, plant it
     // so a copied component is not unstyled. Idempotent when already present.
-    const theme = await ensureTheme(cwd, config.tailwind.baseColor, config.tailwind.css, opts.registry);
-    if (theme.status === 'written') {
-      logger.success(`Planted missing theme tokens into ${config.tailwind.css}`);
-    } else if (theme.status === 'failed') {
-      logger.warn(`Could not verify theme tokens in ${config.tailwind.css}: ${theme.error}`);
+    // Skip if the config predates / lacks the tailwind fields (never crash add).
+    const tw = config.tailwind || {};
+    if (tw.css && tw.baseColor) {
+      const theme = await ensureTheme(cwd, tw.baseColor, tw.css, opts.registry);
+      if (theme.status === 'written') {
+        logger.success(`Planted missing theme tokens into ${tw.css}`);
+      } else if (theme.status === 'failed') {
+        logger.warn(`Could not verify theme tokens in ${tw.css}: ${theme.error}`);
+      }
     }
 
     for (const item of tree) {

--- a/packages/ui/src/commands/add.js
+++ b/packages/ui/src/commands/add.js
@@ -7,6 +7,9 @@ import { getConfig } from '../utils/get-config.js';
 import { logger } from '../utils/logger.js';
 import { resolveTree, collectNpmDeps } from '../registry/resolver.js';
 import { DEFAULT_REGISTRY_URL } from '../registry/fetcher.js';
+import { isCustomElementSource } from '../registry/local.js';
+import { stripExample } from '../registry/example.js';
+import { ensureTheme } from '../utils/theme.js';
 
 export const add = new Command()
   .name('add')
@@ -34,6 +37,16 @@ export const add = new Command()
 
     const tree = await resolveTree(components, opts.registry);
     logger.info(`Installing ${logger.bold(components.join(', '))}…`);
+
+    // Self-heal missing theme tokens (#983): the helpers render against CSS
+    // design tokens; if the app never ran (or lost) the theme block, plant it
+    // so a copied component is not unstyled. Idempotent when already present.
+    const theme = await ensureTheme(cwd, config.tailwind.baseColor, config.tailwind.css, opts.registry);
+    if (theme.status === 'written') {
+      logger.success(`Planted missing theme tokens into ${config.tailwind.css}`);
+    } else if (theme.status === 'failed') {
+      logger.warn(`Could not verify theme tokens in ${config.tailwind.css}: ${theme.error}`);
+    }
 
     for (const item of tree) {
       for (const file of item.files || []) {
@@ -70,9 +83,36 @@ async function writeRegistryFile(cwd, config, item, file, opts) {
     }
   }
 
-  const content = rewriteUtilsImport(file.content || '', target, config);
+  const content = transformForProject(file.content || '', target, config, item);
   writeFileSync(target, content, 'utf8');
   logger.success(`Wrote ${relative(cwd, target)}`);
+}
+
+/**
+ * The single transform that turns a registry file's raw content into what
+ * lands in the user's project. `add` writes this; `diff` compares against it,
+ * so the two cannot disagree (#983). Two steps:
+ *
+ *  1. Retarget the registry-relative `../lib/utils.ts` / `../lib/dom.ts` imports
+ *     to the project's resolved helper paths (see {@link rewriteUtilsImport}).
+ *  2. For a Tier-1 helper component (a `registry:ui` file that is NOT a custom
+ *     element), strip the worked `@example` and leave a one-line pointer, so the
+ *     copied file keeps only the helpers + a lean header. Tier-2 custom-element
+ *     files are left whole (the element IS the component), and lib/theme files
+ *     have no example so the strip is a no-op.
+ *
+ * @param {string} content raw registry file content
+ * @param {string} target absolute path where the file will be written
+ * @param {{ resolvedPaths: { utils: string } }} config parsed components.json
+ * @param {{ name: string, type?: string }} [item] the registry item
+ * @returns {string}
+ */
+export function transformForProject(content, target, config, item) {
+  let out = rewriteUtilsImport(content, target, config);
+  if (item && item.type === 'registry:ui' && !isCustomElementSource(content)) {
+    out = stripExample(out, item.name);
+  }
+  return out;
 }
 
 /**

--- a/packages/ui/src/commands/diff.js
+++ b/packages/ui/src/commands/diff.js
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join, basename } from 'node:path';
 import { getConfig } from '../utils/get-config.js';
 import { fetchRegistryItem, fetchRegistryIndex, DEFAULT_REGISTRY_URL } from '../registry/fetcher.js';
+import { transformForProject } from './add.js';
 import { logger } from '../utils/logger.js';
 
 export const diff = new Command()
@@ -18,16 +19,32 @@ export const diff = new Command()
       process.exit(1);
     }
 
-    const items = name ? [await fetchRegistryItem(name, opts.registry)] : (await fetchRegistryIndex(opts.registry)).filter((i) => i.type === 'registry:ui');
+    // diff compares local files against the LIVE upstream, so it stays on the
+    // network path (NOT local-first): local-first would compare the package
+    // against itself. Resolve the names to compare, then fetch each item's full
+    // content (the index is metadata-only).
+    let names;
+    if (name) {
+      names = [name];
+    } else {
+      const index = await fetchRegistryIndex(opts.registry);
+      names = index.filter((i) => i.type === 'registry:ui').map((i) => i.name);
+    }
+
     const uiDir = config.resolvedPaths.ui;
     let changed = 0;
 
-    for (const item of items) {
+    for (const n of names) {
+      const item = await fetchRegistryItem(n, opts.registry);
       for (const file of item.files || []) {
         const target = join(uiDir, basename(file.path));
         if (!existsSync(target)) continue;
         const local = readFileSync(target, 'utf8');
-        if (local !== (file.content || '')) {
+        // Compare against what `add` WOULD write (import-rewrite + example
+        // strip), not the raw registry content: otherwise a pristine install
+        // reports every import-rewritten component as differing (#983).
+        const expected = transformForProject(file.content || '', target, config, item);
+        if (local !== expected) {
           logger.info(`${logger.bold(item.name)}: ${basename(file.path)} differs from registry`);
           changed++;
         }

--- a/packages/ui/src/commands/init.js
+++ b/packages/ui/src/commands/init.js
@@ -1,11 +1,12 @@
 import { Command } from 'commander';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import prompts from 'prompts';
 import { defaultsForProject } from '../utils/detect-project.js';
 import { writeConfig, CONFIG_FILE } from '../utils/get-config.js';
 import { logger } from '../utils/logger.js';
-import { fetchRegistryItem, DEFAULT_REGISTRY_URL } from '../registry/fetcher.js';
+import { getRegistryItem, DEFAULT_REGISTRY_URL } from '../registry/fetcher.js';
+import { ensureTheme } from '../utils/theme.js';
 
 const BASE_COLORS = ['neutral', 'stone', 'zinc', 'mauve', 'olive', 'mist', 'taupe'];
 
@@ -66,7 +67,18 @@ export const init = new Command()
 
     // Pull lib/utils + the chosen theme from the registry and write them in.
     await writeLibUtils(cwd, defaults.aliases.utils, opts.registry);
-    await writeTheme(cwd, answers.baseColor, answers.css, opts.registry);
+
+    // The theme tokens are what the class helpers render against. A silent
+    // failure here (the old behaviour) left an unstyled install with a clean
+    // exit code, the exact trap for an autonomous agent, so hard-fail (#983).
+    const theme = await ensureTheme(cwd, answers.baseColor, answers.css, opts.registry);
+    if (theme.status === 'failed') {
+      logger.error(`Could not write theme tokens into ${answers.css}: ${theme.error}`);
+      logger.info('The class helpers render against these tokens, so this must succeed.');
+      process.exit(1);
+    }
+    if (theme.status === 'written') logger.success(`Wrote theme into ${answers.css}`);
+    else logger.info(`Theme already present in ${answers.css}: skipping.`);
 
     logger.break();
     logger.success('Done.');
@@ -79,7 +91,7 @@ async function writeLibUtils(cwd, utilsAlias, registryUrl) {
   const utilsRel = utilsAlias.replace(/^@\//, '') + '.ts';
   const utilsTarget = join(cwd, utilsRel);
   try {
-    const item = await fetchRegistryItem('lib-utils', registryUrl);
+    const item = await getRegistryItem('lib-utils', registryUrl);
     if (item.files) {
       for (const f of item.files) {
         ensureDir(dirname(utilsTarget));
@@ -98,7 +110,7 @@ async function writeLibUtils(cwd, utilsAlias, registryUrl) {
   // sibling of the utils file (e.g. lib/utils/dom.ts next to cn.ts).
   const domTarget = join(dirname(utilsTarget), 'dom.ts');
   try {
-    const item = await fetchRegistryItem('lib-dom', registryUrl);
+    const item = await getRegistryItem('lib-dom', registryUrl);
     if (!item.files) return;
     for (const f of item.files) {
       ensureDir(dirname(domTarget));
@@ -112,26 +124,6 @@ async function writeLibUtils(cwd, utilsAlias, registryUrl) {
 
 function relative(cwd, p) {
   return p.startsWith(cwd) ? p.slice(cwd.length + 1) : p;
-}
-
-async function writeTheme(cwd, baseColor, cssPath, registryUrl) {
-  try {
-    const item = await fetchRegistryItem(`theme-${baseColor}`, registryUrl);
-    if (!item.files) return;
-    const target = join(cwd, cssPath);
-    ensureDir(dirname(target));
-    const existing = existsSync(target) ? readFileSync(target, 'utf8') : '';
-    const themeBlock = item.files[0]?.content || '';
-    // Idempotent: only append if our marker isn't already present.
-    if (existing.includes('/* @webjsdev/ui theme */')) {
-      logger.info(`Theme already present in ${cssPath}: skipping.`);
-      return;
-    }
-    writeFileSync(target, existing + (existing && !existing.endsWith('\n') ? '\n' : '') + themeBlock, 'utf8');
-    logger.success(`Wrote theme into ${cssPath}`);
-  } catch (e) {
-    logger.warn(`Could not fetch theme-${baseColor} (${e.message}). Skipping theme install.`);
-  }
 }
 
 function ensureDir(d) {

--- a/packages/ui/src/commands/list.js
+++ b/packages/ui/src/commands/list.js
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { fetchRegistryIndex, DEFAULT_REGISTRY_URL } from '../registry/fetcher.js';
+import { getRegistryIndex, DEFAULT_REGISTRY_URL } from '../registry/fetcher.js';
 import { logger } from '../utils/logger.js';
 
 export const list = new Command()
@@ -9,7 +9,7 @@ export const list = new Command()
   .argument('[filter]', 'filter by substring')
   .option('--registry <url>', 'registry base URL', DEFAULT_REGISTRY_URL)
   .action(async (filter, opts) => {
-    const items = await fetchRegistryIndex(opts.registry);
+    const items = await getRegistryIndex(opts.registry);
     const ui = items.filter((i) => i.type === 'registry:ui');
     const filtered = filter ? ui.filter((i) => i.name.includes(filter)) : ui;
     if (!filtered.length) {

--- a/packages/ui/src/commands/view.js
+++ b/packages/ui/src/commands/view.js
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { fetchRegistryItem, DEFAULT_REGISTRY_URL } from '../registry/fetcher.js';
+import { getRegistryItem, DEFAULT_REGISTRY_URL } from '../registry/fetcher.js';
 import { logger } from '../utils/logger.js';
 
 export const view = new Command()
@@ -8,7 +8,7 @@ export const view = new Command()
   .argument('<name>', 'component name')
   .option('--registry <url>', 'registry base URL', DEFAULT_REGISTRY_URL)
   .action(async (name, opts) => {
-    const item = await fetchRegistryItem(name, opts.registry);
+    const item = await getRegistryItem(name, opts.registry);
     logger.info(logger.dim(`# ${item.name}: ${item.type}`));
     if (item.description) logger.info(logger.dim(`# ${item.description}`));
     for (const f of item.files || []) {

--- a/packages/ui/src/commands/view.js
+++ b/packages/ui/src/commands/view.js
@@ -1,13 +1,28 @@
 import { Command } from 'commander';
-import { getRegistryItem, DEFAULT_REGISTRY_URL } from '../registry/fetcher.js';
+import { getRegistryItem, DEFAULT_REGISTRY_URL, isDefaultRegistry } from '../registry/fetcher.js';
+import { uiComponent, renderComponentText } from '../registry/extract.js';
 import { logger } from '../utils/logger.js';
 
 export const view = new Command()
   .name('view')
-  .description("Print a registry item's source to stdout")
+  .description("Print a registry item's source (and the paste-ready example) to stdout")
   .argument('<name>', 'component name')
   .option('--registry <url>', 'registry base URL', DEFAULT_REGISTRY_URL)
+  .option('--source', 'print only the raw source, not the projected view')
   .action(async (name, opts) => {
+    // For a local registry:ui component, lead with the projected view (helper
+    // signatures + the paste-ready @example + deps). This is the human /
+    // offline path to the example that `add` strips from the copied file, and
+    // it shares ONE projector with the MCP `ui` tool (`registry/extract.js`).
+    // The projection reads the LOCAL packaged registry, so it only applies to
+    // the default registry (a custom --registry gets the raw fetched source).
+    const projected = opts.source || !isDefaultRegistry(opts.registry) ? null : uiComponent(name);
+    if (projected) {
+      console.log(renderComponentText(projected));
+      console.log('');
+      logger.info(logger.dim('# --- full source ---'));
+    }
+
     const item = await getRegistryItem(name, opts.registry);
     logger.info(logger.dim(`# ${item.name}: ${item.type}`));
     if (item.description) logger.info(logger.dim(`# ${item.description}`));

--- a/packages/ui/src/registry/example.js
+++ b/packages/ui/src/registry/example.js
@@ -61,10 +61,12 @@ export function extractExample(src) {
   const lines = block.text.split('\n');
   const exIdx = lines.findIndex((l) => /^\s*\*\s*@example\b/.test(l));
   if (exIdx === -1) return '';
-  // Everything after the @example line, up to the closing */ line.
+  // Everything after the @example line, up to the closing */ OR the next JSDoc
+  // tag (so a trailing @see / @module after the example is not captured).
   const bodyLines = [];
   for (let i = exIdx + 1; i < lines.length; i++) {
     if (/^\s*\*\/\s*$/.test(lines[i])) break; // closing */
+    if (/^\s*\*\s*@\w+/.test(lines[i])) break; // next tag ends the example body
     // Strip the leading ` * ` JSDoc gutter, preserving inner indentation.
     bodyLines.push(lines[i].replace(/^\s*\*\s?/, ''));
   }
@@ -97,8 +99,16 @@ export function stripExample(src, name) {
   const exIdx = lines.findIndex((l) => /^\s*\*\s*@example\b/.test(l));
   if (exIdx === -1) return src;
   const head = lines.slice(0, exIdx);
+  // Preserve any JSDoc tags that follow the @example block (so a trailing
+  // @see / @module survives the strip). The example body ends at the next tag
+  // line or the closing */.
+  const tail = [];
+  for (let i = exIdx + 1; i < lines.length; i++) {
+    if (/^\s*\*\/\s*$/.test(lines[i])) break;
+    if (/^\s*\*\s*@\w+/.test(lines[i])) { tail.push(...lines.slice(i, lines.length - 1)); break; }
+  }
   // Drop trailing blank JSDoc gutter lines (` *`) so we don't double the gap.
   while (head.length && /^\s*\*\s*$/.test(head[head.length - 1])) head.pop();
-  const rebuilt = [...head, ' *', ` * ${pointerLine(name)}`, ' */'].join('\n');
+  const rebuilt = [...head, ' *', ` * ${pointerLine(name)}`, ...tail, ' */'].join('\n');
   return src.slice(0, block.start) + rebuilt + src.slice(block.end);
 }

--- a/packages/ui/src/registry/example.js
+++ b/packages/ui/src/registry/example.js
@@ -1,0 +1,104 @@
+/**
+ * The registry component `@example` block: extract it, strip it (#983).
+ *
+ * A Tier-1 component file is a handful of class-helper functions plus a module
+ * JSDoc whose `@example` block carries the ACCESSIBLE STRUCTURE an author
+ * composes (the `<details name>` exclusive-open wiring, the `group-open`
+ * chevron, the `aria-*` attributes). That worked example is BUILD-TIME
+ * guidance, consumed once while composing, so it should NOT persist in the
+ * copied project file as dead boilerplate. This module is the single source of
+ * truth for that block:
+ *
+ * - {@link extractExample} pulls the paste-ready snippet out (for `webjsui view`
+ *   and the MCP `ui` tool, which serve it on demand without copying it in).
+ * - {@link stripExample} removes it from the file `add` writes and leaves a
+ *   one-line pointer, so the copied file keeps only the helpers + a lean header.
+ *
+ * Both key on the SAME `@example` delimiter in the module JSDoc, so the snippet
+ * has exactly one home (the JSDoc) and cannot drift from a parallel field.
+ * Hand-rolled (no JSDoc/markdown parser dependency: `@webjsdev/ui` ships no
+ * third-party runtime deps).
+ *
+ * @module registry/example
+ */
+
+/**
+ * Locate the first block comment (`/** ... *\/`), i.e. the module JSDoc.
+ *
+ * @param {string} src
+ * @returns {{ start: number, end: number, text: string } | null}
+ */
+function firstBlockComment(src) {
+  const start = src.indexOf('/**');
+  if (start === -1) return null;
+  const end = src.indexOf('*/', start + 3);
+  if (end === -1) return null;
+  return { start, end: end + 2, text: src.slice(start, end + 2) };
+}
+
+/**
+ * True when the module JSDoc carries an `@example` block.
+ *
+ * @param {string} src
+ * @returns {boolean}
+ */
+export function hasExample(src) {
+  const block = firstBlockComment(src);
+  return !!block && /^\s*\*\s*@example\b/m.test(block.text);
+}
+
+/**
+ * Extract the paste-ready example snippet from the module JSDoc. Returns the
+ * fenced code (unwrapped) when the `@example` body is a ```` ```lang ```` block,
+ * else the de-indented text. Empty string when there is no `@example`.
+ *
+ * @param {string} src
+ * @returns {string}
+ */
+export function extractExample(src) {
+  const block = firstBlockComment(src);
+  if (!block) return '';
+  const lines = block.text.split('\n');
+  const exIdx = lines.findIndex((l) => /^\s*\*\s*@example\b/.test(l));
+  if (exIdx === -1) return '';
+  // Everything after the @example line, up to the closing */ line.
+  const bodyLines = [];
+  for (let i = exIdx + 1; i < lines.length; i++) {
+    if (/^\s*\*\/\s*$/.test(lines[i])) break; // closing */
+    // Strip the leading ` * ` JSDoc gutter, preserving inner indentation.
+    bodyLines.push(lines[i].replace(/^\s*\*\s?/, ''));
+  }
+  let body = bodyLines.join('\n').replace(/\s+$/, '');
+  // Unwrap a fenced code block if the example is wrapped in one.
+  const fence = body.match(/^\s*```[A-Za-z0-9]*\n([\s\S]*?)\n```\s*$/);
+  if (fence) body = fence[1];
+  return body.replace(/^\n+/, '').replace(/\s+$/, '');
+}
+
+/** The one-line pointer left in place of a stripped example. */
+export function pointerLine(name) {
+  return `Full usage example: npx webjsui view ${name}  (or the MCP tool: ui ${name})`;
+}
+
+/**
+ * Remove the `@example` block from the module JSDoc and leave a one-line
+ * pointer to `webjsui view` / the MCP `ui` tool. No-op when there is no
+ * `@example`. This runs at `add` write-time so the copied project file keeps
+ * only the helpers + a lean header, not the worked example.
+ *
+ * @param {string} src
+ * @param {string} name  the component name, for the pointer
+ * @returns {string}
+ */
+export function stripExample(src, name) {
+  const block = firstBlockComment(src);
+  if (!block) return src;
+  const lines = block.text.split('\n');
+  const exIdx = lines.findIndex((l) => /^\s*\*\s*@example\b/.test(l));
+  if (exIdx === -1) return src;
+  const head = lines.slice(0, exIdx);
+  // Drop trailing blank JSDoc gutter lines (` *`) so we don't double the gap.
+  while (head.length && /^\s*\*\s*$/.test(head[head.length - 1])) head.pop();
+  const rebuilt = [...head, ' *', ` * ${pointerLine(name)}`, ' */'].join('\n');
+  return src.slice(0, block.start) + rebuilt + src.slice(block.end);
+}

--- a/packages/ui/src/registry/example.js
+++ b/packages/ui/src/registry/example.js
@@ -77,9 +77,15 @@ export function extractExample(src) {
   return body.replace(/^\n+/, '').replace(/\s+$/, '');
 }
 
-/** The one-line pointer left in place of a stripped example. */
+/**
+ * The one-line pointer left in place of a stripped example. Uses the EXPLICIT
+ * `npx @webjsdev/ui view` form (not the bare `webjsui` bin name, which npx would
+ * resolve to an unrelated `webjsui` package when it is not a direct dep, e.g. in
+ * a scaffolded app where `@webjsdev/ui` is only transitive). Works in a webjs
+ * app and a standalone project alike.
+ */
 export function pointerLine(name) {
-  return `Full usage example: npx webjsui view ${name}  (or the MCP tool: ui ${name})`;
+  return `Full usage example: npx @webjsdev/ui view ${name}  (or the MCP tool: ui ${name})`;
 }
 
 /**

--- a/packages/ui/src/registry/example.js
+++ b/packages/ui/src/registry/example.js
@@ -81,7 +81,7 @@ export function extractExample(src) {
  * The one-line pointer left in place of a stripped example. Uses the EXPLICIT
  * `npx @webjsdev/ui view` form (not the bare `webjsui` bin name, which npx would
  * resolve to an unrelated `webjsui` package when it is not a direct dep, e.g. in
- * a scaffolded app where `@webjsdev/ui` is only transitive). Works in a webjs
+ * a scaffolded app where `@webjsdev/ui` is only transitive). Works in a WebJs
  * app and a standalone project alike.
  */
 export function pointerLine(name) {

--- a/packages/ui/src/registry/extract.js
+++ b/packages/ui/src/registry/extract.js
@@ -21,8 +21,10 @@
 import { loadRegistryItem, loadRegistryIndex, isCustomElementSource } from './local.js';
 import { extractExample, stripExample } from './example.js';
 
-// Re-export the lean-copy primitives so a copier (the CLI's `add`, the scaffold
-// generator) has one import surface for the shared example-strip behaviour.
+// Re-export the lean-copy primitives so the scaffold generator (via
+// `packages/cli/lib/lean-copy.js`) has one import surface for the shared
+// example-strip. (The CLI's own `add` imports them directly from local.js /
+// example.js.)
 export { isCustomElementSource, stripExample };
 
 /**

--- a/packages/ui/src/registry/extract.js
+++ b/packages/ui/src/registry/extract.js
@@ -19,7 +19,11 @@
  */
 
 import { loadRegistryItem, loadRegistryIndex, isCustomElementSource } from './local.js';
-import { extractExample } from './example.js';
+import { extractExample, stripExample } from './example.js';
+
+// Re-export the lean-copy primitives so a copier (the CLI's `add`, the scaffold
+// generator) has one import surface for the shared example-strip behaviour.
+export { isCustomElementSource, stripExample };
 
 /**
  * Extract the exported class-helper signatures from a Tier-1 source, e.g.

--- a/packages/ui/src/registry/extract.js
+++ b/packages/ui/src/registry/extract.js
@@ -1,0 +1,145 @@
+/**
+ * The shared ui-kit projector (#983).
+ *
+ * ONE leaf that turns the packaged registry into an agent-facing view of the
+ * kit, consumed by BOTH `webjsui view` (the CLI / offline path) and the MCP
+ * `ui` tool (the in-context agent path). Following the #979 shared-projector
+ * pattern (one module backs both the CLI and the MCP surface, guarded by a
+ * drift test), so the two cannot disagree. It lives in `@webjsdev/ui` (exported
+ * as `@webjsdev/ui/registry/extract`), NOT in `@webjsdev/mcp`, because the
+ * registry is THIS package's source of truth and mcp has no path to it.
+ *
+ * It reads the LOCAL packaged registry (via `local.js`): the kit inventory and
+ * per-component helper signatures + the paste-ready `@example` + the JSDoc
+ * header (description + a11y obligations) + npm deps. Pure over the on-disk
+ * registry; no network, no app scope (this is about the KIT, unlike the MCP
+ * `list_components` which is about the app).
+ *
+ * @module registry/extract
+ */
+
+import { loadRegistryItem, loadRegistryIndex, isCustomElementSource } from './local.js';
+import { extractExample } from './example.js';
+
+/**
+ * Extract the exported class-helper signatures from a Tier-1 source, e.g.
+ * `accordionTriggerClass(opts: { disabled?: boolean } = {})`. Best-effort
+ * lexical scan (no TS parser dependency); the parameter list is captured up to
+ * its closing paren, the return-type annotation dropped.
+ *
+ * @param {string} src
+ * @returns {string[]}
+ */
+export function extractHelperSignatures(src) {
+  /** @type {string[]} */
+  const out = [];
+  // Two authored forms, both class-helper functions:
+  //   export const NAME = (params): T => ...      (arrow; the `=>` gates out
+  //                                                 non-function consts)
+  //   export function NAME(params): T { ... }
+  // `export type` / `export interface` never match (no arrow, no `function`).
+  const re =
+    /export\s+(?:const\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?(\([^)]*\))\s*(?::[^=]+?)?=>|function\s+([A-Za-z_$][\w$]*)\s*(\([^)]*\)))/g;
+  let m;
+  while ((m = re.exec(src)) !== null) {
+    if (m[1]) out.push(`${m[1]}${m[2]}`);
+    else if (m[3]) out.push(`${m[3]}${m[4]}`);
+  }
+  return out;
+}
+
+/**
+ * The JSDoc header text (description + a11y obligations + token notes), with the
+ * `@example` block and the `@module`/`@param`-style tags dropped. This is the
+ * "lean header" the copied file keeps; serving it lets an agent read the
+ * obligations without the worked example.
+ *
+ * @param {string} src
+ * @returns {string}
+ */
+export function extractDocHeader(src) {
+  const start = src.indexOf('/**');
+  if (start === -1) return '';
+  const end = src.indexOf('*/', start + 3);
+  if (end === -1) return '';
+  const lines = src.slice(start + 3, end).split('\n');
+  /** @type {string[]} */
+  const out = [];
+  for (const raw of lines) {
+    const line = raw.replace(/^\s*\*\s?/, '');
+    if (/^\s*@\w+/.test(line)) break; // stop at the first tag (@example, @module, ...)
+    out.push(line);
+  }
+  return out.join('\n').trim();
+}
+
+/**
+ * Project one registry component into the agent-facing shape. Returns null when
+ * the name is not a `registry:ui` component.
+ *
+ * @param {string} name
+ * @returns {{
+ *   name: string, tier: 1|2, type: string,
+ *   description: string, helpers: string[], example: string,
+ *   dependencies: string[], registryDependencies: string[],
+ * } | null}
+ */
+export function uiComponent(name) {
+  const item = loadRegistryItem(name);
+  if (!item || item.type !== 'registry:ui') return null;
+  const src = (item.files || []).map((f) => f.content || '').join('\n');
+  const tier = isCustomElementSource(src) ? 2 : 1;
+  return {
+    name: item.name,
+    tier,
+    type: item.type,
+    description: extractDocHeader(src),
+    helpers: tier === 1 ? extractHelperSignatures(src) : [],
+    example: extractExample(src),
+    dependencies: item.dependencies || [],
+    registryDependencies: item.registryDependencies || [],
+  };
+}
+
+/**
+ * The kit inventory: one compact entry per `registry:ui` component (name, tier,
+ * helper signatures, npm deps). The no-args payload for the MCP `ui` tool and
+ * the `references/ui-kit.md` skill surface, so an agent reaches for a helper
+ * instead of expanding Tailwind by hand.
+ *
+ * @returns {Array<{ name: string, tier: 1|2, helpers: string[], dependencies: string[] }>}
+ */
+export function uiInventory() {
+  return loadRegistryIndex()
+    .filter((i) => i.type === 'registry:ui')
+    .map((i) => {
+      const c = uiComponent(i.name);
+      return {
+        name: i.name,
+        tier: c ? c.tier : 1,
+        helpers: c ? c.helpers : [],
+        dependencies: c ? c.dependencies : [],
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Render a component projection as human-readable text for `webjsui view`.
+ * Shares the SAME {@link uiComponent} data the MCP `ui` tool returns, so the
+ * two never drift.
+ *
+ * @param {ReturnType<typeof uiComponent>} c
+ * @returns {string}
+ */
+export function renderComponentText(c) {
+  if (!c) return '';
+  const lines = [];
+  lines.push(`# ${c.name}  (Tier ${c.tier})`);
+  if (c.description) lines.push('', c.description);
+  if (c.helpers.length) lines.push('', 'Helpers:', ...c.helpers.map((h) => `  ${h}`));
+  if (c.dependencies.length) lines.push('', `npm: ${c.dependencies.join(', ')}`);
+  if (c.registryDependencies.length) lines.push(`registry deps: ${c.registryDependencies.join(', ')}`);
+  if (c.example) lines.push('', 'Example:', '', c.example);
+  return lines.join('\n');
+}

--- a/packages/ui/src/registry/fetcher.js
+++ b/packages/ui/src/registry/fetcher.js
@@ -1,4 +1,5 @@
 import { registryItemSchema, registryIndexSchema } from './schema.js';
+import { loadRegistryItem, loadRegistryIndex } from './local.js';
 
 /**
  * Default registry URL. Override via REGISTRY_URL env var, or per-call.
@@ -6,6 +7,52 @@ import { registryItemSchema, registryIndexSchema } from './schema.js';
 export const DEFAULT_REGISTRY_URL = process.env.REGISTRY_URL || 'https://ui.webjs.dev/registry';
 
 const cache = new Map();
+
+/**
+ * True when `url` is the default hosted registry (or unset), meaning a caller
+ * did not point at a CUSTOM registry. Local-first resolution kicks in here;
+ * an explicit `--registry <url>` forces the network path.
+ *
+ * @param {string} [url]
+ */
+export function isDefaultRegistry(url) {
+  return !url || url === DEFAULT_REGISTRY_URL;
+}
+
+/**
+ * Resolve one registry item LOCAL-FIRST (#983): read the packaged registry
+ * sources unless the caller pointed at a custom `--registry` URL, in which case
+ * fetch over the network. This is the resolver `add` / `init` / `view` / `list`
+ * use, so a scaffolded app installs components with no network dependency.
+ *
+ * NOTE: `webjsui diff` deliberately does NOT use this (it compares local files
+ * against the LIVE upstream, so it calls {@link fetchRegistryItem} directly).
+ *
+ * @param {string} name
+ * @param {string} [registryUrl]
+ */
+export async function getRegistryItem(name, registryUrl) {
+  if (isDefaultRegistry(registryUrl)) {
+    const item = loadRegistryItem(name);
+    if (!item) {
+      throw new Error(
+        `Unknown registry item "${name}". Run \`webjsui list\` to see the available components.`,
+      );
+    }
+    return item;
+  }
+  return fetchRegistryItem(name, registryUrl);
+}
+
+/**
+ * Resolve the flat registry index LOCAL-FIRST (#983). See {@link getRegistryItem}.
+ *
+ * @param {string} [registryUrl]
+ */
+export async function getRegistryIndex(registryUrl) {
+  if (isDefaultRegistry(registryUrl)) return loadRegistryIndex();
+  return fetchRegistryIndex(registryUrl);
+}
 
 /**
  * Fetch a registry item by name.

--- a/packages/ui/src/registry/fetcher.js
+++ b/packages/ui/src/registry/fetcher.js
@@ -2,21 +2,32 @@ import { registryItemSchema, registryIndexSchema } from './schema.js';
 import { loadRegistryItem, loadRegistryIndex } from './local.js';
 
 /**
- * Default registry URL. Override via REGISTRY_URL env var, or per-call.
+ * The canonical hosted registry. Local-first resolution applies ONLY for this
+ * exact URL: it is the one registry whose sources ship inside the package.
  */
-export const DEFAULT_REGISTRY_URL = process.env.REGISTRY_URL || 'https://ui.webjs.dev/registry';
+export const HOSTED_REGISTRY_URL = 'https://ui.webjs.dev/registry';
+
+/**
+ * Default registry URL. A `REGISTRY_URL` env var points at a CUSTOM registry,
+ * which (like an explicit `--registry`) forces the NETWORK path, since its
+ * sources are not the packaged ones.
+ */
+export const DEFAULT_REGISTRY_URL = process.env.REGISTRY_URL || HOSTED_REGISTRY_URL;
 
 const cache = new Map();
 
 /**
- * True when `url` is the default hosted registry (or unset), meaning a caller
- * did not point at a CUSTOM registry. Local-first resolution kicks in here;
- * an explicit `--registry <url>` forces the network path.
+ * True when the effective registry is the hosted one whose sources ship in the
+ * package, i.e. local-first resolution applies. A custom registry (via
+ * `--registry <url>` OR a `REGISTRY_URL` env override) is NOT default and forces
+ * the network path, so a self-hosted registry is never silently shadowed by the
+ * packaged sources.
  *
  * @param {string} [url]
  */
 export function isDefaultRegistry(url) {
-  return !url || url === DEFAULT_REGISTRY_URL;
+  const effective = url || DEFAULT_REGISTRY_URL;
+  return effective === HOSTED_REGISTRY_URL;
 }
 
 /**

--- a/packages/ui/src/registry/local.js
+++ b/packages/ui/src/registry/local.js
@@ -167,11 +167,14 @@ export function loadRegistryIndex() {
 }
 
 /**
- * The list of Tier-1 helper component names (registry:ui items that are NOT
- * custom elements). Derived from the manifest + source, so it stays correct as
- * components migrate between tiers. See {@link isCustomElementSource}.
+ * The tier of a `registry:ui` component: `1` for a class-helper file, `2` for a
+ * file that defines/registers a custom element. Returns `null` for a name that
+ * is not a `registry:ui` item. Derived from the source (via
+ * {@link isCustomElementSource}), so it stays correct as components migrate
+ * between tiers.
  *
- * @returns {string[]}
+ * @param {string} name
+ * @returns {1 | 2 | null}
  */
 export function tierOfItem(name) {
   const item = loadRegistryItem(name);

--- a/packages/ui/src/registry/local.js
+++ b/packages/ui/src/registry/local.js
@@ -167,23 +167,6 @@ export function loadRegistryIndex() {
 }
 
 /**
- * The tier of a `registry:ui` component: `1` for a class-helper file, `2` for a
- * file that defines/registers a custom element. Returns `null` for a name that
- * is not a `registry:ui` item. Derived from the source (via
- * {@link isCustomElementSource}), so it stays correct as components migrate
- * between tiers.
- *
- * @param {string} name
- * @returns {1 | 2 | null}
- */
-export function tierOfItem(name) {
-  const item = loadRegistryItem(name);
-  if (!item || item.type !== 'registry:ui') return null;
-  const src = (item.files || []).map((f) => f.content || '').join('\n');
-  return isCustomElementSource(src) ? 2 : 1;
-}
-
-/**
  * Strip `/* *​/` block comments and `//` line comments so a token check keys on
  * CODE, not prose. Rough (does not honour a `//` inside a string), but a
  * component's JSDoc is the realistic false-positive source, and the leading

--- a/packages/ui/src/registry/local.js
+++ b/packages/ui/src/registry/local.js
@@ -1,0 +1,206 @@
+/**
+ * Local registry composer (#983).
+ *
+ * The registry SOURCES ship inside this npm package (`packages/ui/package.json`
+ * `files` includes `packages/registry`), so `webjsui add` / `list` / `view` and
+ * the MCP `ui` tool can resolve a component with NO network round-trip. This
+ * module reads those on-disk sources and composes the same shadcn-compatible
+ * item shape the hosted registry serves, so a local read and a network fetch
+ * are interchangeable for every consumer.
+ *
+ * It is the plain-JS twin of the ui-website composer
+ * (`packages/ui/packages/website/app/_lib/registry.server.ts`): both read
+ * `packages/registry/registry.json` + the `components/*.ts` sources and
+ * synthesize the 6 non-neutral base-colour themes from `themes/base-colors.js`.
+ * Keeping the CLI on this module (rather than always hitting the network) is
+ * what makes an autonomous agent's `add` deterministic and offline-safe.
+ *
+ * Resolution is relative to THIS module (`import.meta.url`), i.e. the installed
+ * `@webjsdev/ui` package, NOT `process.cwd()`: `webjsui` runs inside a user's
+ * project but the registry lives in the installed package.
+ *
+ * @module registry/local
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  BASE_COLORS,
+  BASE_TITLES,
+  BASE_DESCRIPTIONS,
+  BASE_OVERRIDES,
+  mergeThemeCss,
+} from '../../packages/registry/themes/base-colors.js';
+
+/** Absolute path to the packaged registry root (`packages/ui/packages/registry`). */
+export const REGISTRY_ROOT = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  'packages',
+  'registry',
+);
+const MANIFEST_PATH = join(REGISTRY_ROOT, 'registry.json');
+const NEUTRAL_CSS_PATH = join(REGISTRY_ROOT, 'themes', 'index.css');
+const SCHEMA = 'https://ui.webjs.dev/schema/registry-item.json';
+
+let manifestCache = null;
+let neutralCssCache = null;
+const itemCache = new Map();
+let indexCache = null;
+
+function readManifest() {
+  if (manifestCache) return manifestCache;
+  manifestCache = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'));
+  return manifestCache;
+}
+
+function readNeutralCss() {
+  if (neutralCssCache) return neutralCssCache;
+  neutralCssCache = readFileSync(NEUTRAL_CSS_PATH, 'utf8');
+  return neutralCssCache;
+}
+
+/**
+ * Return the item with each declared file's on-disk content inlined. A file
+ * whose source is missing degrades to empty content rather than throwing.
+ *
+ * @param {any} item
+ * @returns {any}
+ */
+function inlineFiles(item) {
+  return {
+    $schema: SCHEMA,
+    ...item,
+    files: (item.files || []).map((f) => {
+      const abs = resolve(REGISTRY_ROOT, f.path);
+      if (!existsSync(abs)) return { ...f, content: '' };
+      return { ...f, content: readFileSync(abs, 'utf8') };
+    }),
+  };
+}
+
+/**
+ * Synthesize a `theme-<color>` item by merging the colour's overrides into the
+ * canonical neutral CSS, matching the manifest's `theme-neutral` shape so
+ * `webjsui init --base-color <color>` handles all 7 colours via one path.
+ *
+ * @param {string} color
+ * @returns {any|null}
+ */
+function synthesizeColorTheme(color) {
+  if (!BASE_COLORS.includes(color)) return null;
+  const overrides = BASE_OVERRIDES[color];
+  const content = mergeThemeCss(readNeutralCss(), overrides);
+  return {
+    $schema: SCHEMA,
+    name: `theme-${color}`,
+    type: 'registry:theme',
+    title: BASE_TITLES[color],
+    description: BASE_DESCRIPTIONS[color],
+    files: [
+      {
+        path: 'themes/index.css',
+        type: 'registry:file',
+        target: 'app/globals.css',
+        content,
+      },
+    ],
+  };
+}
+
+/**
+ * Load one registry item by name with its file content inlined. Returns null
+ * when the name is neither a manifest item nor a synthesizable colour theme.
+ *
+ * @param {string} name
+ * @returns {any|null}
+ */
+export function loadRegistryItem(name) {
+  if (itemCache.has(name)) return itemCache.get(name);
+
+  const manifestItem = readManifest().items.find((it) => it.name === name);
+  if (manifestItem) {
+    const composed = inlineFiles(manifestItem);
+    itemCache.set(name, composed);
+    return composed;
+  }
+
+  if (name.startsWith('theme-')) {
+    const color = name.slice('theme-'.length);
+    const synth = synthesizeColorTheme(color);
+    if (synth) {
+      itemCache.set(name, synth);
+      return synth;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Load the flat registry index (metadata only, no inlined content), including
+ * the synthesized non-neutral colour themes.
+ *
+ * @returns {any[]}
+ */
+export function loadRegistryIndex() {
+  if (indexCache) return indexCache;
+  const fromManifest = readManifest().items.map((item) => ({
+    name: item.name,
+    type: item.type,
+    description: item.description,
+    dependencies: item.dependencies,
+    registryDependencies: item.registryDependencies,
+  }));
+  const manifestNames = new Set(fromManifest.map((it) => it.name));
+  const synthesized = BASE_COLORS.filter(
+    (color) => !manifestNames.has(`theme-${color}`),
+  ).map((color) => ({
+    name: `theme-${color}`,
+    type: 'registry:theme',
+    description: BASE_DESCRIPTIONS[color],
+  }));
+  indexCache = [...fromManifest, ...synthesized];
+  return indexCache;
+}
+
+/**
+ * The list of Tier-1 helper component names (registry:ui items that are NOT
+ * custom elements). Derived from the manifest + source, so it stays correct as
+ * components migrate between tiers. See {@link isCustomElementSource}.
+ *
+ * @returns {string[]}
+ */
+export function tierOfItem(name) {
+  const item = loadRegistryItem(name);
+  if (!item || item.type !== 'registry:ui') return null;
+  const src = (item.files || []).map((f) => f.content || '').join('\n');
+  return isCustomElementSource(src) ? 2 : 1;
+}
+
+/**
+ * True when a component source defines/registers a custom element (Tier-2). A
+ * Tier-1 helper file exports only class-string functions and matches none of
+ * these. Used to gate the example-strip (Tier-2 files are left whole) and to
+ * label the kit inventory.
+ *
+ * @param {string} src
+ * @returns {boolean}
+ */
+export function isCustomElementSource(src) {
+  return (
+    /\bextends\s+WebComponent\b/.test(src) ||
+    /\bcustomElements\.define\b/.test(src) ||
+    /\.register\(/.test(src)
+  );
+}
+
+/** Reset the in-memory caches. Test-only. */
+export function _resetCache() {
+  manifestCache = null;
+  neutralCssCache = null;
+  indexCache = null;
+  itemCache.clear();
+}

--- a/packages/ui/src/registry/local.js
+++ b/packages/ui/src/registry/local.js
@@ -181,19 +181,34 @@ export function tierOfItem(name) {
 }
 
 /**
+ * Strip `/* *​/` block comments and `//` line comments so a token check keys on
+ * CODE, not prose. Rough (does not honour a `//` inside a string), but a
+ * component's JSDoc is the realistic false-positive source, and the leading
+ * module JSDoc is exactly what this removes.
+ *
+ * @param {string} src
+ * @returns {string}
+ */
+function stripComments(src) {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
+
+/**
  * True when a component source defines/registers a custom element (Tier-2). A
  * Tier-1 helper file exports only class-string functions and matches none of
  * these. Used to gate the example-strip (Tier-2 files are left whole) and to
- * label the kit inventory.
+ * label the kit inventory. Comments are stripped first so a JSDoc that merely
+ * MENTIONS `.register(` or `WebComponent` does not misclassify a Tier-1 helper.
  *
  * @param {string} src
  * @returns {boolean}
  */
 export function isCustomElementSource(src) {
+  const code = stripComments(src);
   return (
-    /\bextends\s+WebComponent\b/.test(src) ||
-    /\bcustomElements\.define\b/.test(src) ||
-    /\.register\(/.test(src)
+    /\bextends\s+WebComponent\b/.test(code) ||
+    /\bcustomElements\.define\b/.test(code) ||
+    /\.register\(/.test(code)
   );
 }
 

--- a/packages/ui/src/registry/resolver.js
+++ b/packages/ui/src/registry/resolver.js
@@ -1,4 +1,4 @@
-import { fetchRegistryItem } from './fetcher.js';
+import { getRegistryItem } from './fetcher.js';
 
 /**
  * Walk `registryDependencies` transitively. Returns a flat array of items in
@@ -16,7 +16,7 @@ export async function resolveTree(names, baseUrl) {
   async function visit(name) {
     if (seen.has(name)) return;
     seen.set(name, true);
-    const item = await fetchRegistryItem(name, baseUrl);
+    const item = await getRegistryItem(name, baseUrl);
     for (const dep of item.registryDependencies || []) await visit(dep);
     ordered.push(item);
   }

--- a/packages/ui/src/utils/theme.js
+++ b/packages/ui/src/utils/theme.js
@@ -1,0 +1,65 @@
+/**
+ * Theme-token install, shared by `init` and `add` (#983).
+ *
+ * The class helpers render against CSS design tokens (`--background`,
+ * `--foreground`, `--destructive`, ...) that the app must define. `init` plants
+ * them; `add` self-heals if they are missing (an app that copied a component
+ * without the tokens paints unstyled). Both go through {@link ensureTheme} so
+ * the contract is one place: a token block is written exactly once, keyed by
+ * the {@link THEME_MARKER}, and a genuine failure to write is reported (never
+ * swallowed) so `init` can exit non-zero instead of leaving a clean exit code
+ * on an unstyled install.
+ *
+ * @module utils/theme
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { getRegistryItem } from '../registry/fetcher.js';
+
+/** Idempotency marker at the top of the theme block. */
+export const THEME_MARKER = '/* @webjsdev/ui theme */';
+
+function ensureDir(d) {
+  if (!existsSync(d)) mkdirSync(d, { recursive: true });
+}
+
+/**
+ * Ensure the theme tokens exist in the project's Tailwind CSS file. Idempotent:
+ * if the marker is already present it is a no-op. Returns a status so the caller
+ * decides how to react (`init` fails hard on `'failed'`; `add` warns).
+ *
+ * @param {string} cwd
+ * @param {string} baseColor  one of the base-colour names (`neutral`, ...)
+ * @param {string} cssPath    project-relative path to the Tailwind CSS file
+ * @param {string} [registryUrl]
+ * @returns {Promise<{ status: 'written'|'present'|'failed', cssPath: string, error?: string }>}
+ */
+export async function ensureTheme(cwd, baseColor, cssPath, registryUrl) {
+  const target = join(cwd, cssPath);
+  const existing = existsSync(target) ? readFileSync(target, 'utf8') : '';
+  if (existing.includes(THEME_MARKER)) {
+    return { status: 'present', cssPath };
+  }
+  let item;
+  try {
+    item = await getRegistryItem(`theme-${baseColor}`, registryUrl);
+  } catch (e) {
+    return { status: 'failed', cssPath, error: e && e.message ? e.message : String(e) };
+  }
+  const themeBlock = item && item.files && item.files[0] ? item.files[0].content || '' : '';
+  if (!themeBlock) {
+    return { status: 'failed', cssPath, error: `theme-${baseColor} has no content` };
+  }
+  try {
+    ensureDir(dirname(target));
+    writeFileSync(
+      target,
+      existing + (existing && !existing.endsWith('\n') ? '\n' : '') + themeBlock,
+      'utf8',
+    );
+  } catch (e) {
+    return { status: 'failed', cssPath, error: e && e.message ? e.message : String(e) };
+  }
+  return { status: 'written', cssPath };
+}

--- a/packages/ui/src/utils/theme.js
+++ b/packages/ui/src/utils/theme.js
@@ -36,6 +36,9 @@ function ensureDir(d) {
  * @returns {Promise<{ status: 'written'|'present'|'failed', cssPath: string, error?: string }>}
  */
 export async function ensureTheme(cwd, baseColor, cssPath, registryUrl) {
+  if (!cssPath || !baseColor) {
+    return { status: 'failed', cssPath: cssPath || '', error: 'missing tailwind.css / tailwind.baseColor in components.json' };
+  }
   const target = join(cwd, cssPath);
   const existing = existsSync(target) ? readFileSync(target, 'utf8') : '';
   if (existing.includes(THEME_MARKER)) {

--- a/packages/ui/test/add-command.test.js
+++ b/packages/ui/test/add-command.test.js
@@ -252,6 +252,16 @@ test('add: local-first (no --registry) installs a real component, strips its exa
   }
 });
 
+test('ensureTheme: returns a failure (does not throw) when css path / baseColor is missing', async () => {
+  // Defensive: a direct caller passing an incomplete config must get a
+  // structured failure, never a synchronous crash on join(cwd, undefined). #983.
+  const { ensureTheme } = await import('../src/utils/theme.js');
+  const r1 = await ensureTheme('/tmp/x', 'neutral', undefined);
+  assert.equal(r1.status, 'failed');
+  const r2 = await ensureTheme('/tmp/x', undefined, 'styles/globals.css');
+  assert.equal(r2.status, 'failed');
+});
+
 /* -------------------- rewriteUtilsImport (unit tests) -------------------- */
 
 test('rewriteUtilsImport: maps to lib/utils/cn alias for a Tier-1 file', () => {

--- a/packages/ui/test/add-command.test.js
+++ b/packages/ui/test/add-command.test.js
@@ -226,6 +226,32 @@ test('add: leaves a Tier-2 custom-element file whole (no example strip)', async 
   }
 });
 
+test('add: local-first (no --registry) installs a real component, strips its example, self-heals theme', async () => {
+  // No fetch stub and no --registry: resolves from the PACKAGED registry.
+  globalThis.fetch = async () => { throw new Error('should not fetch (local-first)'); };
+  const d = mkdtempSync(join(tmpdir(), 'webjsui-add-real-'));
+  writeFileSync(join(d, 'components.json'), JSON.stringify({
+    style: 'default',
+    tailwind: { css: 'styles/globals.css', baseColor: 'neutral', cssVariables: true },
+    aliases: { components: 'components', utils: 'lib/utils', ui: 'components/ui', lib: 'lib' },
+  }));
+  const origLog = console.log;
+  console.log = () => {};
+  try {
+    await add.parseAsync(['accordion', '--yes', '--no-deps', '--cwd', d], { from: 'user' });
+    const body = readFileSync(join(d, 'components', 'ui', 'accordion.ts'), 'utf8');
+    assert.doesNotMatch(body, /@example/, 'the real example is stripped from the copied file');
+    assert.match(body, /npx webjsui view accordion/, 'the pointer is left');
+    assert.match(body, /export const accordionClass/, 'the helper code is preserved');
+    // Self-heal planted the theme tokens.
+    assert.match(readFileSync(join(d, 'styles', 'globals.css'), 'utf8'), /@webjsdev\/ui theme/);
+  } finally {
+    console.log = origLog;
+    globalThis.fetch = origFetch;
+    rmSync(d, { recursive: true });
+  }
+});
+
 /* -------------------- rewriteUtilsImport (unit tests) -------------------- */
 
 test('rewriteUtilsImport: maps to lib/utils/cn alias for a Tier-1 file', () => {

--- a/packages/ui/test/add-command.test.js
+++ b/packages/ui/test/add-command.test.js
@@ -190,7 +190,7 @@ test('add: strips the worked @example from a Tier-1 helper and leaves a pointer'
     const body = readFileSync(join(d, 'components', 'ui', 'accordion.ts'), 'utf8');
     assert.doesNotMatch(body, /@example/, 'the worked example is stripped');
     assert.doesNotMatch(body, /<div class=/, 'the structural snippet does not persist');
-    assert.match(body, /npx webjsui view accordion/, 'a pointer to the full example is left');
+    assert.match(body, /npx @webjsdev\/ui view accordion/, 'a pointer to the full example is left');
     assert.match(body, /a11y: same name/, 'the lean header (a11y note) is kept');
     assert.match(body, /export const accordionClass/, 'the helper code is untouched');
   } finally {
@@ -241,7 +241,7 @@ test('add: local-first (no --registry) installs a real component, strips its exa
     await add.parseAsync(['accordion', '--yes', '--no-deps', '--cwd', d], { from: 'user' });
     const body = readFileSync(join(d, 'components', 'ui', 'accordion.ts'), 'utf8');
     assert.doesNotMatch(body, /@example/, 'the real example is stripped from the copied file');
-    assert.match(body, /npx webjsui view accordion/, 'the pointer is left');
+    assert.match(body, /npx @webjsdev\/ui view accordion/, 'the pointer is left');
     assert.match(body, /export const accordionClass/, 'the helper code is preserved');
     // Self-heal planted the theme tokens.
     assert.match(readFileSync(join(d, 'styles', 'globals.css'), 'utf8'), /@webjsdev\/ui theme/);

--- a/packages/ui/test/add-command.test.js
+++ b/packages/ui/test/add-command.test.js
@@ -167,6 +167,65 @@ test('add: --overwrite replaces existing files without prompt', async () => {
   }
 });
 
+/* -------------------- example strip / lean copied file (#983) -------------------- */
+
+test('add: strips the worked @example from a Tier-1 helper and leaves a pointer', async () => {
+  globalThis.fetch = async (url) => {
+    const name = String(url).split('/').pop().replace('.json', '');
+    if (name === 'accordion') {
+      return new Response(JSON.stringify({
+        name: 'accordion', type: 'registry:ui',
+        files: [{
+          path: 'components/accordion.ts', type: 'registry:ui',
+          content:
+            '/**\n * Accordion helpers.\n *\n * a11y: same name on each <details> for exclusive-open.\n *\n * @example\n * ```html\n * <div class=${accordionClass()}></div>\n * ```\n */\nexport const accordionClass = () => \'w-full\';\n',
+        }],
+      }), { status: 200 });
+    }
+    return new Response('not found', { status: 404 });
+  };
+  const d = tmp();
+  try {
+    await add.parseAsync(['accordion', '--yes', '--no-deps', '--cwd', d, '--registry', 'http://test/strip'], { from: 'user' });
+    const body = readFileSync(join(d, 'components', 'ui', 'accordion.ts'), 'utf8');
+    assert.doesNotMatch(body, /@example/, 'the worked example is stripped');
+    assert.doesNotMatch(body, /<div class=/, 'the structural snippet does not persist');
+    assert.match(body, /npx webjsui view accordion/, 'a pointer to the full example is left');
+    assert.match(body, /a11y: same name/, 'the lean header (a11y note) is kept');
+    assert.match(body, /export const accordionClass/, 'the helper code is untouched');
+  } finally {
+    globalThis.fetch = origFetch;
+    rmSync(d, { recursive: true });
+  }
+});
+
+test('add: leaves a Tier-2 custom-element file whole (no example strip)', async () => {
+  globalThis.fetch = async (url) => {
+    const name = String(url).split('/').pop().replace('.json', '');
+    if (name === 'my-dialog') {
+      return new Response(JSON.stringify({
+        name: 'my-dialog', type: 'registry:ui',
+        files: [{
+          path: 'components/my-dialog.ts', type: 'registry:ui',
+          content:
+            '/**\n * Dialog element.\n *\n * @example\n * ```html\n * <ui-dialog></ui-dialog>\n * ```\n */\nclass Dialog extends WebComponent({}) {}\nDialog.register(\'ui-dialog\');\n',
+        }],
+      }), { status: 200 });
+    }
+    return new Response('not found', { status: 404 });
+  };
+  const d = tmp();
+  try {
+    await add.parseAsync(['my-dialog', '--yes', '--no-deps', '--cwd', d, '--registry', 'http://test/keep'], { from: 'user' });
+    const body = readFileSync(join(d, 'components', 'ui', 'my-dialog.ts'), 'utf8');
+    assert.match(body, /@example/, 'a Tier-2 element keeps its example');
+    assert.match(body, /<ui-dialog>/);
+  } finally {
+    globalThis.fetch = origFetch;
+    rmSync(d, { recursive: true });
+  }
+});
+
 /* -------------------- rewriteUtilsImport (unit tests) -------------------- */
 
 test('rewriteUtilsImport: maps to lib/utils/cn alias for a Tier-1 file', () => {

--- a/packages/ui/test/branch-coverage.test.js
+++ b/packages/ui/test/branch-coverage.test.js
@@ -63,8 +63,19 @@ test('detectProject: webjs via app/layout.ts (no @webjsdev dep)', () => {
   } finally { rmSync(d, { recursive: true }); }
 });
 
-test('init: warns gracefully when lib-utils fetch fails', async () => {
-  globalThis.fetch = async (url) => new Response('not found', { status: 404 });
+test('init: warns gracefully when lib-utils fetch fails but the theme succeeds', async () => {
+  // lib-utils / lib-dom 404 (soft warn), but the theme resolves: the theme is
+  // the hard-fail gate (#983), so init must still complete and write config.
+  globalThis.fetch = async (url) => {
+    const name = String(url).split('/').pop().replace('.json', '');
+    if (name.startsWith('theme-')) {
+      return new Response(JSON.stringify({
+        name, type: 'registry:theme',
+        files: [{ path: 'themes/index.css', type: 'registry:file', target: 'app/globals.css', content: '/* @webjsdev/ui theme */\n:root{}' }],
+      }), { status: 200 });
+    }
+    return new Response('not found', { status: 404 });
+  };
   console.log = () => {};
   const out = [];
   console.warn = (...args) => out.push(args.join(' '));

--- a/packages/ui/test/diff-command.test.js
+++ b/packages/ui/test/diff-command.test.js
@@ -4,6 +4,7 @@ import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { diff } from '../src/commands/diff.js';
+import { add } from '../src/commands/add.js';
 
 const origFetch = globalThis.fetch;
 const origLog = console.log;
@@ -85,6 +86,44 @@ test('diff: diffs all components when no name given', async () => {
     );
     assert.match(output, /button/);
   } finally {
+    globalThis.fetch = origFetch;
+    rmSync(d, { recursive: true });
+  }
+});
+
+test('diff: a pristine `add` reports MATCH (import-rewrite + example-strip parity, #983)', async () => {
+  // A component that BOTH imports ../lib/utils.ts AND carries an @example, so
+  // the transform is non-trivial. `add` writes the transformed file; `diff`
+  // must compare against the SAME transform, not the raw registry content, or a
+  // pristine install falsely reports as differing (the pre-existing bug).
+  const content =
+    '/**\n * Button.\n *\n * @example\n * ```html\n * <button class=${buttonClass()}></button>\n * ```\n */\n' +
+    "import { cn } from '../lib/utils.ts';\nexport const buttonClass = () => cn('p-2');\n";
+  const item = { name: 'button', type: 'registry:ui', files: [{ path: 'components/button.ts', type: 'registry:ui', content }] };
+  globalThis.fetch = async (url) => {
+    const u = String(url);
+    if (u.endsWith('/index.json')) return new Response(JSON.stringify([{ name: 'button', type: 'registry:ui' }]), { status: 200 });
+    const name = u.split('/').pop().replace('.json', '');
+    if (name === 'button') return new Response(JSON.stringify(item), { status: 200 });
+    return new Response('not found', { status: 404 });
+  };
+  const d = setupProject();
+  const origWarn = console.warn;
+  console.warn = () => {};
+  try {
+    await add.parseAsync(['button', '--yes', '--no-deps', '--cwd', d, '--registry', 'http://test/parity'], { from: 'user' });
+    const output = await captureLog(() =>
+      diff.parseAsync(['button', '--cwd', d, '--registry', 'http://test/parity'], { from: 'user' }),
+    );
+    assert.match(output, /match the registry/, 'a pristine add must diff clean');
+    // Counterfactual: a genuine local edit is still flagged.
+    writeFileSync(join(d, 'components', 'ui', 'button.ts'), 'export const buttonClass = () => "EDITED";');
+    const output2 = await captureLog(() =>
+      diff.parseAsync(['button', '--cwd', d, '--registry', 'http://test/parity'], { from: 'user' }),
+    );
+    assert.match(output2, /differ/, 'a real local edit is flagged');
+  } finally {
+    console.warn = origWarn;
     globalThis.fetch = origFetch;
     rmSync(d, { recursive: true });
   }

--- a/packages/ui/test/example.test.js
+++ b/packages/ui/test/example.test.js
@@ -1,0 +1,62 @@
+/**
+ * The `@example` extractor / stripper (#983).
+ *
+ * The module JSDoc's `@example` block is the SINGLE source of the structural
+ * snippet: `extractExample` serves it (view / MCP), `stripExample` removes it
+ * from the copied file and leaves a pointer. Both key on the same delimiter.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { extractExample, stripExample, hasExample, pointerLine } from '../src/registry/example.js';
+
+const SRC = `/**
+ * Accordion: native <details>/<summary>.
+ *
+ * a11y: give each <details> the same name for exclusive-open.
+ *
+ * @example
+ * \`\`\`html
+ * <div class=\${accordionClass()}>
+ *   <details name="faq" class=\${accordionItemClass()}>
+ *     <summary class=\${accordionTriggerClass()}>Q</summary>
+ *     <div class=\${accordionContentClass()}>A</div>
+ *   </details>
+ * </div>
+ * \`\`\`
+ */
+
+export const accordionClass = () => 'w-full';
+`;
+
+test('hasExample: true when the JSDoc carries an @example', () => {
+  assert.equal(hasExample(SRC), true);
+  assert.equal(hasExample('/** just docs */\nexport const x = 1;'), false);
+});
+
+test('extractExample: unwraps the fenced snippet, preserves inner indentation', () => {
+  const ex = extractExample(SRC);
+  assert.match(ex, /^<div class=\$\{accordionClass\(\)\}>/);
+  assert.match(ex, /\n {2}<details name="faq"/); // nested indent kept
+  assert.doesNotMatch(ex, /```/); // fence removed
+  assert.doesNotMatch(ex, /@example/);
+});
+
+test('stripExample: removes the example, leaves a pointer, keeps the helpers', () => {
+  const out = stripExample(SRC, 'accordion');
+  assert.doesNotMatch(out, /@example/);
+  assert.doesNotMatch(out, /<details name="faq"/); // structure gone
+  assert.match(out, /a11y: give each/); // lean header (a11y note) kept
+  assert.ok(out.includes(pointerLine('accordion'))); // pointer present
+  assert.match(out, /export const accordionClass/); // helper code untouched
+  // The block still closes cleanly.
+  assert.match(out, /\*\//);
+});
+
+test('stripExample: no-op when there is no @example', () => {
+  const src = '/** just docs */\nexport const x = 1;';
+  assert.equal(stripExample(src, 'x'), src);
+});
+
+test('extractExample: empty string when there is no @example', () => {
+  assert.equal(extractExample('/** docs */\nexport const x = 1;'), '');
+});

--- a/packages/ui/test/example.test.js
+++ b/packages/ui/test/example.test.js
@@ -60,3 +60,19 @@ test('stripExample: no-op when there is no @example', () => {
 test('extractExample: empty string when there is no @example', () => {
   assert.equal(extractExample('/** docs */\nexport const x = 1;'), '');
 });
+
+test('example: robust to a tag AFTER @example (extract stops at it, strip preserves it)', () => {
+  const src = '/**\n * Doc.\n *\n * @example\n * ```html\n * <x-y></x-y>\n * ```\n * @see other\n */\nexport const y = () => "z";';
+  // extract stops at @see, so no trailing tag leaks into the snippet
+  const ex = extractExample(src);
+  assert.match(ex, /<x-y><\/x-y>/);
+  assert.doesNotMatch(ex, /@see/);
+  assert.doesNotMatch(ex, /```/);
+  // strip removes the example but preserves the trailing @see tag
+  const out = stripExample(src, 'y');
+  assert.doesNotMatch(out, /@example/);
+  assert.doesNotMatch(out, /<x-y>/);
+  assert.match(out, /@see other/, 'trailing tag survives the strip');
+  assert.ok(out.includes(pointerLine('y')));
+  assert.match(out, /export const y/);
+});

--- a/packages/ui/test/extract.test.js
+++ b/packages/ui/test/extract.test.js
@@ -1,0 +1,71 @@
+/**
+ * The shared ui-kit projector (#983): `registry/extract.js`.
+ *
+ * One leaf backs both `webjsui view` and the MCP `ui` tool. These assert the
+ * projection shape; the MCP drift-guard (packages/mcp/test/mcp.test.mjs) asserts
+ * the tool output equals this projector's output.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  uiComponent,
+  uiInventory,
+  extractHelperSignatures,
+  extractDocHeader,
+  renderComponentText,
+} from '../src/registry/extract.js';
+
+test('extractHelperSignatures: captures both export const arrow and export function forms', () => {
+  const src =
+    'export const cardClass = (opts: { size?: S } = {}): string => "x";\n' +
+    'export function buttonClass(opts: O = {}): string { return "y"; }\n' +
+    'export type CardSize = "sm";\n' +
+    'export interface O {}\n';
+  const sigs = extractHelperSignatures(src);
+  assert.deepEqual(sigs, ['cardClass(opts: { size?: S } = {})', 'buttonClass(opts: O = {})']);
+  assert.doesNotMatch(sigs.join(' '), /CardSize|interface/); // types/interfaces excluded
+});
+
+test('extractDocHeader: returns the lead prose, drops the @example and tags', () => {
+  const src = '/**\n * Button helper.\n *\n * a11y: label icon-only buttons.\n *\n * @example\n * ```html\n * <button></button>\n * ```\n */\nexport const buttonClass = () => "x";';
+  const header = extractDocHeader(src);
+  assert.match(header, /Button helper/);
+  assert.match(header, /a11y: label/);
+  assert.doesNotMatch(header, /@example/);
+  assert.doesNotMatch(header, /<button>/);
+});
+
+test('uiComponent: Tier-1 button projects helper signatures + deps', () => {
+  const c = uiComponent('button');
+  assert.equal(c.tier, 1);
+  assert.equal(c.type, 'registry:ui');
+  assert.ok(c.helpers.some((h) => h.startsWith('buttonClass(')));
+  assert.ok(c.dependencies.includes('@webjsdev/core'));
+});
+
+test('uiComponent: Tier-2 dialog is tier 2 with no helper signatures', () => {
+  const c = uiComponent('dialog');
+  assert.equal(c.tier, 2);
+  assert.deepEqual(c.helpers, []);
+});
+
+test('uiComponent: null for a non-ui / unknown name', () => {
+  assert.equal(uiComponent('lib-utils'), null);
+  assert.equal(uiComponent('does-not-exist'), null);
+});
+
+test('uiInventory: one entry per registry:ui component, tier-labelled, sorted', () => {
+  const inv = uiInventory();
+  assert.equal(inv.length, 32);
+  assert.ok(inv.every((c) => c.tier === 1 || c.tier === 2));
+  const names = inv.map((c) => c.name);
+  assert.deepEqual(names, [...names].sort(), 'inventory is sorted by name');
+});
+
+test('renderComponentText: includes tier, helpers, and deps for a Tier-1 component', () => {
+  const text = renderComponentText(uiComponent('card'));
+  assert.match(text, /# card  \(Tier 1\)/);
+  assert.match(text, /Helpers:/);
+  assert.match(text, /cardClass/);
+  assert.match(text, /npm: @webjsdev\/core/);
+});

--- a/packages/ui/test/init-command.test.js
+++ b/packages/ui/test/init-command.test.js
@@ -130,3 +130,58 @@ test('init: accepts --css override', async () => {
     rmSync(d, { recursive: true });
   }
 });
+
+// #983: init must exit non-zero when the theme tokens could not be written
+// (the old soft-fail left an unstyled install with a clean exit code). The
+// counterfactual is the local-first success case just above it.
+test('init: hard-fails (exit non-zero) when the theme cannot be written', async () => {
+  globalThis.fetch = async () => new Response('nope', { status: 404 });
+  const origExit = process.exit;
+  const origErr = console.error;
+  const origLog = console.log;
+  let code = null;
+  process.exit = (c) => { code = c; throw new Error('__exit__'); };
+  console.log = () => {};
+  console.error = () => {};
+  const d = tmp();
+  try {
+    // A registry URL not used elsewhere, so the fetcher's per-URL cache can't
+    // shadow this 404 with an earlier test's cached success.
+    await init
+      .parseAsync(['--yes', '--cwd', d, '--registry', 'http://hardfail/r'], { from: 'user' })
+      .catch((e) => { if (e.message !== '__exit__') throw e; });
+    assert.equal(code, 1, 'init exits non-zero on an unwritten theme');
+  } finally {
+    process.exit = origExit;
+    console.error = origErr;
+    console.log = origLog;
+    globalThis.fetch = origFetch;
+    rmSync(d, { recursive: true });
+  }
+});
+
+test('init: local-first (default registry) writes the theme and exits 0', async () => {
+  // No fetch stub: proves the theme resolves from the PACKAGED registry with no
+  // network. This is the counterfactual to the hard-fail test above.
+  globalThis.fetch = async () => { throw new Error('should not fetch'); };
+  const origExit = process.exit;
+  let exited = false;
+  process.exit = () => { exited = true; throw new Error('__exit__'); };
+  const origLog = console.log;
+  console.log = () => {};
+  const d = tmp();
+  try {
+    const { mkdirSync } = await import('node:fs');
+    mkdirSync(join(d, 'styles'), { recursive: true });
+    writeFileSync(join(d, 'styles', 'globals.css'), '/* existing */\n');
+    await init.parseAsync(['--yes', '--cwd', d], { from: 'user' });
+    assert.equal(exited, false, 'init did not exit non-zero');
+    const css = readFileSync(join(d, 'styles', 'globals.css'), 'utf8');
+    assert.match(css, /@webjsdev\/ui theme/);
+  } finally {
+    process.exit = origExit;
+    console.log = origLog;
+    globalThis.fetch = origFetch;
+    rmSync(d, { recursive: true });
+  }
+});

--- a/packages/ui/test/local-registry.test.js
+++ b/packages/ui/test/local-registry.test.js
@@ -7,11 +7,15 @@
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 import {
   getRegistryItem,
   getRegistryIndex,
   isDefaultRegistry,
   DEFAULT_REGISTRY_URL,
+  HOSTED_REGISTRY_URL,
 } from '../src/registry/fetcher.js';
 import { loadRegistryItem, loadRegistryIndex, isCustomElementSource, tierOfItem } from '../src/registry/local.js';
 
@@ -88,8 +92,25 @@ test('getRegistryItem: throws a helpful error for an unknown local item', async 
 
 test('isDefaultRegistry: only the hosted URL (or unset) is default', () => {
   assert.equal(isDefaultRegistry(undefined), true);
-  assert.equal(isDefaultRegistry(DEFAULT_REGISTRY_URL), true);
+  assert.equal(isDefaultRegistry(HOSTED_REGISTRY_URL), true);
+  assert.equal(isDefaultRegistry(DEFAULT_REGISTRY_URL), true); // no env override here
   assert.equal(isDefaultRegistry('http://custom/registry'), false);
+});
+
+test('REGISTRY_URL env override forces the network path (not silently local)', () => {
+  // Set in a child process so DEFAULT_REGISTRY_URL is computed with the env
+  // present. A custom REGISTRY_URL must NOT be treated as the (local-first)
+  // default, so a self-hosted registry is never shadowed by the packaged one.
+  const fetcherPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'src', 'registry', 'fetcher.js');
+  const script = `import { isDefaultRegistry, DEFAULT_REGISTRY_URL } from ${JSON.stringify(fetcherPath)};
+    process.stdout.write(JSON.stringify({ def: DEFAULT_REGISTRY_URL, isDefault: isDefaultRegistry(DEFAULT_REGISTRY_URL) }));`;
+  const out = execFileSync(process.execPath, ['--input-type=module', '-e', script], {
+    env: { ...process.env, REGISTRY_URL: 'https://my.registry/r' },
+    encoding: 'utf8',
+  });
+  const r = JSON.parse(out);
+  assert.equal(r.def, 'https://my.registry/r');
+  assert.equal(r.isDefault, false, 'a custom REGISTRY_URL is NOT local-first');
 });
 
 test('loadRegistryItem: returns null for an unknown name', () => {
@@ -106,6 +127,11 @@ test('loadRegistryIndex: metadata-only entries (no inlined content)', () => {
 test('isCustomElementSource: distinguishes Tier-2 elements from Tier-1 helpers', () => {
   assert.equal(isCustomElementSource('class X extends WebComponent({}) {}\nX.register("x-y");'), true);
   assert.equal(isCustomElementSource('export const buttonClass = () => "px-4";'), false);
+});
+
+test('isCustomElementSource: a JSDoc that MENTIONS register()/WebComponent does not misclassify a Tier-1 helper', () => {
+  const src = '/**\n * Migrated from the prior <ui-accordion> set: it used to call\n * `.register()` and `extends WebComponent`, but is now a pure helper.\n */\nexport const accordionClass = () => "w-full";';
+  assert.equal(isCustomElementSource(src), false);
 });
 
 test('tierOfItem: dialog is Tier-2, button is Tier-1', () => {

--- a/packages/ui/test/local-registry.test.js
+++ b/packages/ui/test/local-registry.test.js
@@ -17,7 +17,8 @@ import {
   DEFAULT_REGISTRY_URL,
   HOSTED_REGISTRY_URL,
 } from '../src/registry/fetcher.js';
-import { loadRegistryItem, loadRegistryIndex, isCustomElementSource, tierOfItem } from '../src/registry/local.js';
+import { loadRegistryItem, loadRegistryIndex, isCustomElementSource } from '../src/registry/local.js';
+import { uiComponent } from '../src/registry/extract.js';
 
 const origFetch = globalThis.fetch;
 
@@ -134,7 +135,7 @@ test('isCustomElementSource: a JSDoc that MENTIONS register()/WebComponent does 
   assert.equal(isCustomElementSource(src), false);
 });
 
-test('tierOfItem: dialog is Tier-2, button is Tier-1', () => {
-  assert.equal(tierOfItem('dialog'), 2);
-  assert.equal(tierOfItem('button'), 1);
+test('tier classification: dialog is Tier-2, button is Tier-1 (production path)', () => {
+  assert.equal(uiComponent('dialog').tier, 2);
+  assert.equal(uiComponent('button').tier, 1);
 });

--- a/packages/ui/test/local-registry.test.js
+++ b/packages/ui/test/local-registry.test.js
@@ -1,0 +1,114 @@
+/**
+ * Local-first registry resolution (#983).
+ *
+ * The registry sources ship in the package, so `add` / `list` / `view` resolve
+ * with NO network by default; an explicit `--registry <url>` still fetches. The
+ * `diff` carve-out (stays network-default) is covered in diff-command.test.js.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  getRegistryItem,
+  getRegistryIndex,
+  isDefaultRegistry,
+  DEFAULT_REGISTRY_URL,
+} from '../src/registry/fetcher.js';
+import { loadRegistryItem, loadRegistryIndex, isCustomElementSource, tierOfItem } from '../src/registry/local.js';
+
+const origFetch = globalThis.fetch;
+
+/** Install a fetch that FAILS loudly, so any accidental network use reds the test. */
+function noNetwork() {
+  globalThis.fetch = async (url) => {
+    throw new Error(`network was hit for ${url} but local-first should not fetch`);
+  };
+}
+
+test('getRegistryItem: resolves the packaged registry with NO network (default registry)', async () => {
+  noNetwork();
+  try {
+    const btn = await getRegistryItem('button');
+    assert.equal(btn.name, 'button');
+    assert.ok(btn.files?.[0]?.content, 'file content is inlined from disk');
+    assert.deepEqual(btn.registryDependencies, ['lib-utils']);
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});
+
+test('getRegistryItem: synthesizes a non-neutral colour theme offline', async () => {
+  noNetwork();
+  try {
+    const theme = await getRegistryItem('theme-stone');
+    assert.equal(theme.name, 'theme-stone');
+    assert.match(theme.files[0].content, /@webjsdev\/ui theme/);
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});
+
+test('getRegistryItem: an explicit custom --registry still fetches over the network', async () => {
+  let hit = null;
+  globalThis.fetch = async (url) => {
+    hit = String(url);
+    return new Response(JSON.stringify({
+      name: 'button', type: 'registry:ui',
+      files: [{ path: 'button.ts', type: 'registry:ui', content: '// remote' }],
+    }), { status: 200 });
+  };
+  try {
+    const btn = await getRegistryItem('button', 'http://custom/registry');
+    assert.equal(btn.files[0].content, '// remote');
+    assert.match(hit, /^http:\/\/custom\/registry\/button\.json$/);
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});
+
+test('getRegistryIndex: resolves offline and includes synthesized themes', async () => {
+  noNetwork();
+  try {
+    const index = await getRegistryIndex();
+    assert.ok(index.length >= 32);
+    assert.ok(index.some((i) => i.name === 'button'));
+    assert.ok(index.some((i) => i.name === 'theme-mauve'));
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});
+
+test('getRegistryItem: throws a helpful error for an unknown local item', async () => {
+  noNetwork();
+  try {
+    await assert.rejects(() => getRegistryItem('does-not-exist'), /Unknown registry item/);
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});
+
+test('isDefaultRegistry: only the hosted URL (or unset) is default', () => {
+  assert.equal(isDefaultRegistry(undefined), true);
+  assert.equal(isDefaultRegistry(DEFAULT_REGISTRY_URL), true);
+  assert.equal(isDefaultRegistry('http://custom/registry'), false);
+});
+
+test('loadRegistryItem: returns null for an unknown name', () => {
+  assert.equal(loadRegistryItem('nope-nope'), null);
+});
+
+test('loadRegistryIndex: metadata-only entries (no inlined content)', () => {
+  const index = loadRegistryIndex();
+  const btn = index.find((i) => i.name === 'button');
+  assert.ok(btn);
+  assert.equal(btn.files, undefined);
+});
+
+test('isCustomElementSource: distinguishes Tier-2 elements from Tier-1 helpers', () => {
+  assert.equal(isCustomElementSource('class X extends WebComponent({}) {}\nX.register("x-y");'), true);
+  assert.equal(isCustomElementSource('export const buttonClass = () => "px-4";'), false);
+});
+
+test('tierOfItem: dialog is Tier-2, button is Tier-1', () => {
+  assert.equal(tierOfItem('dialog'), 2);
+  assert.equal(tierOfItem('button'), 1);
+});

--- a/packages/ui/test/registry-contents.test.js
+++ b/packages/ui/test/registry-contents.test.js
@@ -91,6 +91,31 @@ test('every v1 component has a complete, extractable @example', { skip }, async 
   }
 });
 
+// #983: guard the assumptions the hand-rolled JSDoc micro-parser (example.js,
+// extract.js) relies on. These hold for every current component; this test
+// turns a future violation (which would silently MIS-strip / mis-extract) into
+// a clear CI failure at authoring time rather than a latent trap.
+test('every component @example is safe for the JSDoc micro-parser', { skip }, () => {
+  for (const name of V1_COMPONENTS) {
+    const src = readSource(name);
+    // The module JSDoc must be a single block: a `*/` inside the @example would
+    // make firstBlockComment() terminate the block early.
+    const start = src.indexOf('/**');
+    const firstEnd = src.indexOf('*/', start + 3);
+    const exAt = src.indexOf('@example', start);
+    assert.ok(exAt !== -1 && exAt < firstEnd, `${name}: @example must sit inside the first JSDoc block (no */ before it)`);
+    // No example line may begin (after the ` * ` gutter) with a JSDoc-tag-shaped
+    // token (`@word`): the extractor/stripper treat such a line as the next tag
+    // and would truncate the example. The ```html fence line is fine.
+    const block = src.slice(start, firstEnd);
+    const exampleLines = block.slice(block.indexOf('@example') + '@example'.length).split('\n').slice(1);
+    for (const line of exampleLines) {
+      const body = line.replace(/^\s*\*\s?/, '');
+      assert.ok(!/^@\w+/.test(body), `${name}: an @example line starts with a tag-shaped token ("${body.slice(0, 20)}"), which the parser would treat as the next JSDoc tag`);
+    }
+  }
+});
+
 test('every v1 component is declared in registry.json', { skip }, () => {
   const m = readManifest();
   const names = new Set(m.items.map((it) => it.name));

--- a/packages/ui/test/registry-contents.test.js
+++ b/packages/ui/test/registry-contents.test.js
@@ -72,6 +72,25 @@ test('every v1 component source file exists and is non-trivial', { skip }, () =>
   }
 });
 
+// #983: every component's module JSDoc must carry a complete, machine-
+// extractable @example (the structural snippet served by `webjsui view` / the
+// MCP `ui` tool, and stripped from the copied file). This test fires when one
+// is missing, empty, or still elided.
+test('every v1 component has a complete, extractable @example', { skip }, async () => {
+  const { extractExample, hasExample } = await import('../src/registry/example.js');
+  const ELLIPSIS = String.fromCharCode(0x2026);
+  for (const name of V1_COMPONENTS) {
+    const src = readSource(name);
+    assert.ok(hasExample(src), `${name}: module JSDoc has no @example block`);
+    const ex = extractExample(src);
+    assert.ok(ex && ex.length > 20, `${name}: @example extracts empty/too short`);
+    assert.ok(!ex.includes(ELLIPSIS) && !ex.includes('...'), `${name}: @example still has an elision`);
+    // The example should reference the component (a tag or a helper call), so
+    // it is a real usage snippet, not placeholder prose.
+    assert.ok(/[<$]/.test(ex), `${name}: @example has no markup / helper call`);
+  }
+});
+
 test('every v1 component is declared in registry.json', { skip }, () => {
   const m = readManifest();
   const names = new Set(m.items.map((it) => it.name));

--- a/test/scaffolds/scaffold-ui-integration.test.js
+++ b/test/scaffolds/scaffold-ui-integration.test.js
@@ -123,7 +123,7 @@ test('saas scaffold uses Tier-1 helpers on native elements', async () => {
     // not dead boilerplate (the example is served on demand by view / MCP).
     const scaffoldButton = await readFile(join(appDir, 'components', 'ui', 'button.ts'), 'utf8');
     assert.doesNotMatch(scaffoldButton, /@example/, 'scaffolded Tier-1 component has no worked example');
-    assert.match(scaffoldButton, /webjsui view button/, 'scaffolded Tier-1 component carries the pointer');
+    assert.match(scaffoldButton, /npx @webjsdev\/ui view button/, 'scaffolded Tier-1 component carries the pointer');
     assert.match(scaffoldButton, /export function buttonClass/, 'the helper code is preserved');
 
     // Saas extras: only Tier-2 (dialog) + form-control class helpers
@@ -137,6 +137,14 @@ test('saas scaffold uses Tier-1 helpers on native elements', async () => {
     // A Tier-2 element keeps its file whole (the element IS the component).
     const scaffoldDialog = await readFile(join(appDir, 'components', 'ui', 'dialog.ts'), 'utf8');
     assert.match(scaffoldDialog, /@example/, 'scaffolded Tier-2 element keeps its example');
+
+    // #983: the saas-only Tier-1 extras (switch, checkbox) go through the SAME
+    // lean-copy, not just the base set, so a fresh saas scaffold diffs clean.
+    for (const name of ['switch', 'checkbox']) {
+      const src = await readFile(join(appDir, 'components', 'ui', `${name}.ts`), 'utf8');
+      assert.doesNotMatch(src, /@example/, `scaffolded ${name} (Tier-1) has no worked example`);
+      assert.match(src, new RegExp(`npx @webjsdev\\/ui view ${name}`), `scaffolded ${name} carries the pointer`);
+    }
 
     // Login page: imports + uses Tier-1 helpers, no stale Tier-1 tags
     const login = await readFile(join(appDir, 'app', 'login', 'page.ts'), 'utf8');

--- a/test/scaffolds/scaffold-ui-integration.test.js
+++ b/test/scaffolds/scaffold-ui-integration.test.js
@@ -118,6 +118,14 @@ test('saas scaffold uses Tier-1 helpers on native elements', async () => {
       assert.ok(await exists(join(appDir, 'components', 'ui', `${name}.ts`)));
     }
 
+    // #983: a scaffolded Tier-1 component is LEAN, same as `webjs ui add`: the
+    // worked @example is stripped and a pointer is left, so the copied file is
+    // not dead boilerplate (the example is served on demand by view / MCP).
+    const scaffoldButton = await readFile(join(appDir, 'components', 'ui', 'button.ts'), 'utf8');
+    assert.doesNotMatch(scaffoldButton, /@example/, 'scaffolded Tier-1 component has no worked example');
+    assert.match(scaffoldButton, /webjsui view button/, 'scaffolded Tier-1 component carries the pointer');
+    assert.match(scaffoldButton, /export function buttonClass/, 'the helper code is preserved');
+
     // Saas extras: only Tier-2 (dialog) + form-control class helpers
     // (switch, checkbox). form + field are v2-deferred (see ui AGENTS.md).
     for (const name of ['dialog', 'switch', 'checkbox']) {
@@ -126,6 +134,9 @@ test('saas scaffold uses Tier-1 helpers on native elements', async () => {
         `saas should include components/ui/${name}.ts`,
       );
     }
+    // A Tier-2 element keeps its file whole (the element IS the component).
+    const scaffoldDialog = await readFile(join(appDir, 'components', 'ui', 'dialog.ts'), 'utf8');
+    assert.match(scaffoldDialog, /@example/, 'scaffolded Tier-2 element keeps its example');
 
     // Login page: imports + uses Tier-1 helpers, no stale Tier-1 tags
     const login = await readFile(join(appDir, 'app', 'login', 'page.ts'), 'utf8');


### PR DESCRIPTION
Closes #983

Reshapes `@webjsdev/ui` for AI-agent consumers, following research record #981. The thesis: for a Tier-1 component, `add` was delivering only the easy half (the class-helper strings) while the error-prone half (the accessible structure) lived as elided JSDoc prose. Fix delivery, not the helpers.

## What changed

**Local-first registry resolution.** The registry sources ship inside the npm package, so `init` / `add` / `list` / `view` now read them from disk with no network round-trip (deterministic and offline-safe for an agent). The network path is used only for an explicit custom `--registry <url>`. A new `local.js` composer is the plain-JS twin of the ui-website's `_lib/registry.server.ts`.

**On-demand example delivery.** Each component's accessible structure lives in its module-JSDoc `@example` block (now complete and machine-extractable across all 32 components). That worked example is build-time guidance, so `add` STRIPS it from a Tier-1 helper file and leaves a lean header plus a one-line pointer; the full snippet is served on demand by `webjsui view` and a new read-only MCP `ui` tool. Tier-2 custom-element files (and the toggle/toggle-group hybrids) are left whole.

**One shared transform, so `diff` stops lying.** `add` and `diff` now share `transformForProject` (import-rewrite plus example-strip), so a pristine install diffs clean. Before this, `diff` raw-compared against the un-rewritten registry content, so every import-rewritten component read as differing on a fresh install.

**Shared extractor leaf.** `webjsui view` and the MCP `ui` tool both project one `@webjsdev/ui/registry/extract` leaf (the #979 shared-projector pattern), guarded by a drift test, so the CLI and MCP cannot disagree. The leaf lives in `@webjsdev/ui` (the registry is its source of truth); `@webjsdev/mcp` gains it as a dependency and keeps a thin tool handler.

**`init` hard-fails, `add` self-heals.** `init` now exits non-zero when the theme tokens cannot be written (the old soft-fail left an unstyled install with a clean exit code). `add` self-heals missing tokens. Both go through one `ensureTheme` helper.

**Cross-agent skill.** A `references/ui-kit.md` in the single cross-agent skill (auto-copied into every scaffolded app), routed from SKILL.md when the app has a `components.json`, so a non-MCP agent (Cursor, Copilot, Gemini) knows the kit and the on-demand-example workflow exist.

## Commits

- Local-first resolution + example strip + diff parity + init hard-fail / self-heal.
- The MCP `ui` tool + the shared `registry/extract` leaf.
- The `@example` hygiene pass across all 32 components.
- The `references/ui-kit.md` skill surface.
- Docs sync.

## Test plan

- **Unit (ui, 179 pass):** local-first resolution (resolves offline, custom `--registry` still fetches), the `@example` extractor/stripper, `init` hard-fail with the local-first success counterfactual, `add` example-strip (Tier-1 stripped, Tier-2 kept whole), a real local-first `add` end-to-end, the extractor projection, and a registry-contents gate that fires if any component's `@example` is missing or elided.
- **Unit (mcp, 60 pass):** the `ui` tool shape, and the drift-guard asserting the tool output equals the shared extractor over the same component (mirrors the #979 `list_routes == projectRoutes` guard).
- **`diff` counterfactual:** a pristine `add` diffs clean; a real local edit is flagged.
- **Adjacent suites:** website composer (12), scaffold-integration (9), knowledge-coverage (8), route-skills (14), mcp-docs (11), docs recipes (2), all pass.

## Definition of done

- **Tests:** unit at every layer this touches; counterfactuals on the `init` hard-fail and the `diff` parity.
- **Browser / e2e:** N/A. No client-router / component / browser-facing behaviour changed (the component edits are JSDoc-only; the rest is CLI + MCP tooling).
- **Bun parity:** N/A. Nothing runtime-sensitive changed (no serializer / listener / SSR / streams / crypto / TS-stripper / auth); the new code is `node:fs` reads that behave identically on Bun.
- **Docs:** `packages/ui/AGENTS.md` (module map + registry-resolution section), `packages/mcp/AGENTS.md` (the `ui` tool), the docs-site `docs/app/docs/ui` page, `packages/ui/README.md`, the framework `AGENTS.md` MCP tool list, and the new `references/ui-kit.md` in the cross-agent skill.
- **Scaffold:** the skill is single-sourced at repo-root and auto-copied by `create.js`; the gitignored templates bundle regenerates via `sync-scaffold-skill.mjs` (verified). scaffold-integration passes.
- **Dogfood:** the `docs` app boots in prod mode and `/docs/ui` (the page I edited) renders 200. The other three apps are unaffected (no core/server/cli/importmap change); the ui-website consumes the untouched `registry.server.ts` composer (its test passes).
- **Version bumps:** `@webjsdev/ui` (new `registry/extract` export) and `@webjsdev/mcp` (new `@webjsdev/ui` dep, lockfile synced) carry release debt; the release PR is separate, to be opened after merge.
