### PR TITLE
chore: release ui 0.3.9, mcp 0.1.10, cli 0.10.43

### DIFF
--- a/changelog/cli/0.10.43.md
+++ b/changelog/cli/0.10.43.md
@@ -1,0 +1,12 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.43
+date: 2026-07-14T12:12:00.172Z
+commit_count: 1
+---
+## Features
+
+- **local-first ui registry, on-demand example delivery, MCP ui tool** ([#984](https://github.com/webjsdev/webjs/pull/984)) [`5e9be0b1`](https://github.com/webjsdev/webjs/commit/5e9be0b1)
+  * chore: begin ui local-first registry work (#983)
+  
+  * feat: resolve the ui registry local-first, deliver examples on demand

--- a/changelog/mcp/0.1.10.md
+++ b/changelog/mcp/0.1.10.md
@@ -1,0 +1,12 @@
+---
+package: "@webjsdev/mcp"
+version: 0.1.10
+date: 2026-07-14T12:12:00.323Z
+commit_count: 1
+---
+## Features
+
+- **local-first ui registry, on-demand example delivery, MCP ui tool** ([#984](https://github.com/webjsdev/webjs/pull/984)) [`5e9be0b1`](https://github.com/webjsdev/webjs/commit/5e9be0b1)
+  * chore: begin ui local-first registry work (#983)
+  
+  * feat: resolve the ui registry local-first, deliver examples on demand

--- a/changelog/ui/0.3.9.md
+++ b/changelog/ui/0.3.9.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/ui"
+version: 0.3.9
+date: 2026-07-14T12:12:00.294Z
+commit_count: 1
+---
+## Features
+
+- **local-first registry resolution + on-demand example delivery** ([#984](https://github.com/webjsdev/webjs/pull/984)) [`5e9be0b1`](https://github.com/webjsdev/webjs/commit/5e9be0b1)
+  * `init` / `add` / `list` / `view` resolve components from the packaged registry with no network round-trip; a custom `--registry` (or `REGISTRY_URL`) still fetches, and `diff` keeps comparing against the live upstream.
+  * `add` copies a Tier-1 helper as a lean file (the class helpers plus a pointer) and strips the worked `@example`; the full structural example is served on demand by `webjsui view` and the new read-only MCP `ui` tool (one shared `@webjsdev/ui/registry/extract` projector).
+  * `diff` now compares each local file against what `add` would write (import-rewrite plus example-strip), so a pristine install diffs clean.
+  * `init` exits non-zero when the theme tokens cannot be written (previously a silent, unstyled install), and `add` self-heals missing tokens.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6975,7 +6975,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.42",
+      "version": "0.10.43",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -7025,11 +7025,11 @@
     },
     "packages/mcp": {
       "name": "@webjsdev/mcp",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/server": "^0.8.0",
-        "@webjsdev/ui": "^0.3.8"
+        "@webjsdev/ui": "^0.3.9"
       },
       "bin": {
         "webjs-mcp": "bin/webjs-mcp.js"
@@ -7076,7 +7076,7 @@
     },
     "packages/ui": {
       "name": "@webjsdev/ui",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.42",
+  "version": "0.10.43",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/mcp",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "type": "module",
   "description": "The webjs Model Context Protocol server: live app introspection (routes / actions / components / check) plus the framework knowledge layer (docs, recipes, source) for AI coding agents",
   "bin": {
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "@webjsdev/server": "^0.8.0",
-    "@webjsdev/ui": "^0.3.8"
+    "@webjsdev/ui": "^0.3.9"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/ui",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "type": "module",
   "description": "An AI-first component library - class-helper functions for visuals, custom elements only where state matters. Source-copied into your repo, you own it. Works with any Tailwind v4 project.",
   "bin": {


### PR DESCRIPTION
Releases the #984 work across the three packages it touched.

| Package | Bump | What ships |
|---|---|---|
| `@webjsdev/ui` | 0.3.8 -> 0.3.9 | Local-first registry resolution; the `registry/extract` export; `add` strips the worked example and leaves a pointer (served by `webjsui view` + the MCP `ui` tool); `init` hard-fails on unwritten theme tokens; `add` self-heals them. |
| `@webjsdev/mcp` | 0.1.9 -> 0.1.10 | New read-only `ui` tool (kit inventory + per-component helpers / paste-ready example / a11y header), sharing one drift-guarded projector with `webjsui view`. Adds `@webjsdev/ui` as a dependency, ranged at `^0.3.9` (the version that first ships `./registry/extract`). |
| `@webjsdev/cli` | 0.10.42 -> 0.10.43 | `webjs create` copies lean Tier-1 ui components (example stripped, pointer left), matching `webjs ui add`. |

Merging this adds the `changelog/**.md` files to `main`, which triggers `release.yml` to `npm publish` and cut the GitHub Releases (idempotent).

- The ui changelog was hand-trimmed to the published surface (#984 only); the auto-generated draft over-attributed commits from the non-published nested website sub-app.
- No dependent range edits: cli's dependents pin `^0.10.0` (a patch bump satisfies); the lockstep wrappers are left to the release workflow.