### PR TITLE
feat: add webjs-frame gallery demo and rework the server-actions demo

### DIFF
--- a/packages/cli/lib/create.js
+++ b/packages/cli/lib/create.js
@@ -1351,6 +1351,7 @@ const FEATURES = [
   { href: '/features/caching', title: 'Caching', blurb: 'export const revalidate caches the page HTML per URL, with the safety rule for when a shared cache is allowed.' },
   { href: '/features/env', title: 'Env vars', blurb: 'The server-only vs WEBJS_PUBLIC_ boundary, read during SSR so secrets never reach the browser.' },
   { href: '/features/client-router', title: 'Client router', blurb: 'Automatic soft navigation: fragment-only fetches, hover prefetch, scroll restore, and graceful no-JS fallback.' },
+  { href: '/features/frames', title: 'Frames', blurb: 'A webjs-frame region that swaps a filtered sub-list in place from a link, shipping zero component JS, with a no-JS full-nav fallback.' },
   { href: '/features/service-worker', title: 'Service worker', blurb: 'The opt-in offline enhancement, registered from a browser-only lifecycle hook (never a page or layout).' },
   { href: '/features/websockets', title: 'WebSockets', blurb: 'A WS(ws, req) route endpoint plus the connectWS() client, echoing messages over a live socket.' },
   { href: '/features/broadcast', title: 'Broadcast', blurb: 'Fan a message out to every connected client on a WebSocket path, so all open tabs stay in sync.' },

--- a/packages/cli/templates/gallery/app/features/frames/page.ts
+++ b/packages/cli/templates/gallery/app/features/frames/page.ts
@@ -1,0 +1,71 @@
+// <webjs-frame> is a URL-addressable region that swaps ON ITS OWN, driven by a
+// link targeting its id, shipping zero component JS. It is WebJs's take on Turbo
+// Frames. Unlike the client router (which swaps the whole page's children when
+// you navigate to a DIFFERENT url), a frame refreshes just ONE sub-region in
+// place. The filter links below live INSIDE the frame, so a click walks
+// closest('webjs-frame'), refetches THIS same page with the new ?status, and the
+// server returns ONLY the <webjs-frame id="tasks"> subtree (open the network tab
+// to see it). The router swaps that subtree in; everything outside the frame,
+// the heading and the intro copy, never re-renders.
+//
+// Progressive enhancement: with JS off, each filter link is a normal full-page
+// navigation to ?status=..., which re-renders the whole page with the same
+// filtered list. The frame is an enhancement on top of a working page, never a
+// requirement. The frame element itself upgrades because the root layout ships a
+// component (the theme toggle), so @webjsdev/core and the router load app-wide.
+import { html } from '@webjsdev/core';
+import type { Metadata } from '@webjsdev/core';
+import { filterTasks, normalizeStatus, type Status } from '#modules/frames/utils/tasks.ts';
+
+export const metadata: Metadata = { title: 'Frames (webjs-frame partial swap) | features' };
+
+// One filter tab. The href targets THIS page with a new ?status. Because it sits
+// inside the frame, the router scopes the swap to the frame id automatically. A
+// link OUTSIDE the frame would drive it from anywhere via data-webjs-frame="tasks".
+function filterTab(current: Status, status: Status, label: string) {
+  const active = current === status;
+  const base = 'px-3 py-1.5 rounded-lg font-semibold text-sm no-underline transition-colors';
+  const cls = active
+    ? base + ' bg-primary text-primary-foreground'
+    : base + ' bg-card border border-border text-foreground font-medium hover:border-border-strong';
+  return html`<a href="/features/frames?status=${status}" class=${cls}>${label}</a>`;
+}
+
+export default function FramesExample({ searchParams }: { searchParams: Record<string, string | undefined> }) {
+  const status = normalizeStatus(searchParams?.status);
+  const tasks = filterTasks(status);
+  return html`
+    <h1 class="text-h2 font-bold mb-4">Frames</h1>
+    <p class="text-muted-foreground mb-4">
+      Filter the list. With JS on, only the framed region swaps (the response is
+      just the frame's subtree, not the whole page) and the heading above never
+      re-renders. With JS off, the same links do full-page navigations. It is one
+      region refreshing independently of a navigation, which a page cannot express.
+    </p>
+    <webjs-frame id="tasks" class="block p-4 rounded-2xl bg-card border border-border">
+      <div class="flex gap-2 mb-4">
+        ${filterTab(status, 'all', 'All')}
+        ${filterTab(status, 'active', 'Active')}
+        ${filterTab(status, 'done', 'Done')}
+      </div>
+      <ul class="grid gap-2 m-0 p-0 list-none">
+        ${tasks.map(
+          (t) => html`
+            <li class="flex items-center gap-2 text-foreground">
+              <span class=${t.done ? 'text-primary' : 'text-muted-foreground'}>${t.done ? '✓' : '○'}</span>
+              <span class=${t.done ? 'line-through text-muted-foreground' : ''}>${t.title}</span>
+            </li>
+          `,
+        )}
+      </ul>
+    </webjs-frame>
+    <p class="text-muted-foreground text-sm mt-6">
+      A frame can also self-load with <code class="font-mono">src</code>
+      (<code class="font-mono">loading="lazy"</code> defers the fetch to viewport
+      entry), or be driven from outside via
+      <code class="font-mono">data-webjs-frame="tasks"</code>.
+      <code class="font-mono">data-webjs-frame="_top"</code> breaks out to a
+      full-page navigation.
+    </p>
+  `;
+}

--- a/packages/cli/templates/gallery/app/features/server-actions/page.ts
+++ b/packages/cli/templates/gallery/app/features/server-actions/page.ts
@@ -8,6 +8,14 @@ export default function ServerActionsExample() {
   return html`
     <h1 class="text-h2 font-bold mb-4">Server actions</h1>
     <p class="text-muted-foreground mb-4">A 'use server' action is RPC-callable from the client; a plain .server.ts is a server-only utility you never import into a component.</p>
+    <p class="text-muted-foreground mb-4">
+      This action also declares <code class="font-mono">export const middleware</code>: a
+      chain that runs around it on every boundary. The auth middleware sets the
+      caller on the request context (read back with <code class="font-mono">actionContext()</code>)
+      or 401s before the action runs. The action threads
+      <code class="font-mono">actionSignal()</code>, the request AbortSignal, through
+      its work so a client disconnect or a superseded render stops it early.
+    </p>
     <server-greeter></server-greeter>
   `;
 }

--- a/packages/cli/templates/gallery/modules/frames/utils/tasks.ts
+++ b/packages/cli/templates/gallery/modules/frames/utils/tasks.ts
@@ -1,0 +1,27 @@
+// Pure data plus a filter for the frames demo. No server-only deps and no
+// 'use server', so it is a plain browser-safe .ts the page reads during SSR to
+// render the frame's current contents. The frame swap re-renders THIS list in
+// place from the ?status query, shipping no component JS.
+export type Status = 'all' | 'active' | 'done';
+export interface Task {
+  title: string;
+  done: boolean;
+}
+
+const TASKS: Task[] = [
+  { title: 'Draft the release notes', done: true },
+  { title: 'Review the frames demo', done: false },
+  { title: 'Ship the gallery update', done: false },
+  { title: 'Reply on the tracking issue', done: true },
+];
+
+// Coerce an untrusted ?status value to a known Status (defaults to 'all').
+export function normalizeStatus(raw: unknown): Status {
+  return raw === 'active' || raw === 'done' ? raw : 'all';
+}
+
+export function filterTasks(status: Status): Task[] {
+  if (status === 'active') return TASKS.filter((t) => !t.done);
+  if (status === 'done') return TASKS.filter((t) => t.done);
+  return TASKS;
+}

--- a/packages/cli/templates/gallery/modules/server-actions/actions/greet.server.ts
+++ b/packages/cli/templates/gallery/modules/server-actions/actions/greet.server.ts
@@ -1,20 +1,44 @@
 'use server';
 // A 'use server' action IS the API: a client import is rewritten to a typed RPC
 // stub POSTing to the server. It may use server-only utilities (they run here,
-// server-side), which is why the util above stays off the client.
+// server-side), which is why the shout() util stays off the client.
 import { shout } from '../utils/format.server.ts';
 import { actionContext, actionSignal } from '@webjsdev/server';
 import type { ActionResult } from '@webjsdev/server';
+import { requireAuth, type AuthUser } from '../middleware/require-auth.server.ts';
 
-export async function greet(input: { name: string }): Promise<ActionResult<{ message: string }>> {
-  // actionSignal() is the request's AbortSignal (fires on client disconnect or a
-  // superseded render); bail early on long work instead of finishing wasted work.
-  if (actionSignal().aborted) return { success: false, error: 'Request cancelled.', status: 499 };
-  // actionContext() is the per-action middleware context (e.g. actionContext().user
-  // set by an auth middleware via `export const middleware`). Empty here, no middleware.
-  const who = (actionContext().user as { name?: string } | undefined)?.name;
+// `export const middleware` is a reserved sibling config export the framework
+// reads statically (the same way a page declares `export const revalidate`). The
+// chain runs around greet() on every boundary: requireAuth either short-circuits
+// (the action never runs) or stashes the caller on the request context.
+export const middleware = [requireAuth];
 
-  const name = String(input?.name ?? who ?? '').trim();
+export async function greet(input: { name: string; signedOut?: boolean }): Promise<ActionResult<{ message: string }>> {
+  // Non-empty and typed: requireAuth guaranteed a user before greet() ran (a
+  // signed-out request short-circuited and never reached here), so no optional
+  // chaining, the middleware contract owns the type. NOTE actionContext() is only
+  // populated on a boundary that runs the chain; a direct server-to-server greet()
+  // call skips middleware and would read an empty context, so a server-internal
+  // caller should pass the caller in explicitly rather than rely on it.
+  const who = (actionContext().user as AuthUser).name;
+
+  const name = String(input?.name ?? '').trim();
   if (!name) return { success: false, error: 'Name required.', status: 400 };
-  return { success: true, data: { message: shout('hello ' + name) } };
+
+  // actionSignal() is the request's AbortSignal (fires on a client disconnect or a
+  // superseded render). Thread it into the awaited work and re-check AFTER, so a
+  // slow action stops wasted work. This is the real use: a guard BEFORE any await
+  // can never have fired yet, since nothing has been awaited.
+  const message = await compose(name, who, actionSignal());
+  if (actionSignal().aborted) return { success: false, error: 'Request cancelled.', status: 499 };
+
+  return { success: true, data: { message } };
+}
+
+// A private (non-exported) stand-in for a slow lookup or upstream fetch that
+// honours the signal (a real fetch would pass { signal }). Not exported, so the
+// file still has exactly one action (the one-action-per-configured-file rule).
+async function compose(name: string, who: string, signal: AbortSignal): Promise<string> {
+  if (signal.aborted) throw new Error('aborted');
+  return shout('hello ' + name) + ' (greeted by ' + who + ')';
 }

--- a/packages/cli/templates/gallery/modules/server-actions/actions/greet.server.ts
+++ b/packages/cli/templates/gallery/modules/server-actions/actions/greet.server.ts
@@ -14,31 +14,38 @@ import { requireAuth, type AuthUser } from '../middleware/require-auth.server.ts
 export const middleware = [requireAuth];
 
 export async function greet(input: { name: string; signedOut?: boolean }): Promise<ActionResult<{ message: string }>> {
-  // Non-empty and typed: requireAuth guaranteed a user before greet() ran (a
-  // signed-out request short-circuited and never reached here), so no optional
-  // chaining, the middleware contract owns the type. NOTE actionContext() is only
-  // populated on a boundary that runs the chain; a direct server-to-server greet()
-  // call skips middleware and would read an empty context, so a server-internal
-  // caller should pass the caller in explicitly rather than rely on it.
-  const who = (actionContext().user as AuthUser).name;
+  // actionContext() is populated ONLY on a boundary that runs the middleware
+  // chain (the RPC stub here, or a route() adapter). requireAuth runs there and
+  // guarantees a user, so `caller` is set on every real call. A DIRECT
+  // server-to-server greet() call skips middleware and leaves it undefined, so
+  // GUARD rather than assume the cast (from server code, pass the caller in
+  // explicitly instead of relying on the context).
+  const caller = actionContext().user as AuthUser | undefined;
+  if (!caller) return { success: false, error: 'Unauthorized.', status: 401 };
 
   const name = String(input?.name ?? '').trim();
   if (!name) return { success: false, error: 'Name required.', status: 400 };
 
   // actionSignal() is the request's AbortSignal (fires on a client disconnect or a
-  // superseded render). Thread it into the awaited work and re-check AFTER, so a
-  // slow action stops wasted work. This is the real use: a guard BEFORE any await
-  // can never have fired yet, since nothing has been awaited.
-  const message = await compose(name, who, actionSignal());
-  if (actionSignal().aborted) return { success: false, error: 'Request cancelled.', status: 499 };
-
-  return { success: true, data: { message } };
+  // superseded render). Thread it into the slow work so the work itself aborts
+  // (a real fetch(url, { signal: actionSignal() }) or a DB driver rejects on
+  // abort). lookupGreeting models that, and we map an abort to a cancelled
+  // envelope. A guard BEFORE any await can never fire, since nothing has been
+  // awaited yet, which is why the re-check lives after the await.
+  try {
+    const message = await lookupGreeting(name, caller.name, actionSignal());
+    return { success: true, data: { message } };
+  } catch (e) {
+    if (actionSignal().aborted) return { success: false, error: 'Request cancelled.', status: 499 };
+    throw e;
+  }
 }
 
-// A private (non-exported) stand-in for a slow lookup or upstream fetch that
-// honours the signal (a real fetch would pass { signal }). Not exported, so the
-// file still has exactly one action (the one-action-per-configured-file rule).
-async function compose(name: string, who: string, signal: AbortSignal): Promise<string> {
-  if (signal.aborted) throw new Error('aborted');
+// A private (non-exported) stand-in for a slow lookup or upstream fetch, so the
+// file still has exactly one action (the one-action-per-configured-file rule). A
+// real fetch / DB call rejects with an AbortError when the request aborts; greet()
+// catches that and returns the 499 envelope.
+async function lookupGreeting(name: string, who: string, signal: AbortSignal): Promise<string> {
+  if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
   return shout('hello ' + name) + ' (greeted by ' + who + ')';
 }

--- a/packages/cli/templates/gallery/modules/server-actions/actions/greet.test.ts
+++ b/packages/cli/templates/gallery/modules/server-actions/actions/greet.test.ts
@@ -7,7 +7,7 @@
 // URL against it, params included. See the testing docs.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { createRequestHandler, buildRouteTable, matchPage, matchApi, rawActionRequest } from '@webjsdev/server';
+import { createRequestHandler, buildRouteTable, matchPage, matchApi, rawActionRequest, invokeActionForTest } from '@webjsdev/server';
 
 const appDir = process.cwd();
 
@@ -34,4 +34,35 @@ test('rawActionRequest fires the greet action through the pipeline', async () =>
     [{ name: 'Ada' }],
   );
   assert.equal(res.status, 200);
+});
+
+test('the middleware sets the caller on the context and greet reads it via actionContext()', async () => {
+  const app = await createRequestHandler({ appDir, dev: true });
+  if (app.warmup) await app.warmup();
+  const r = await invokeActionForTest(
+    app,
+    'modules/server-actions/actions/greet.server.ts',
+    'greet',
+    [{ name: 'Bob' }],
+  );
+  assert.equal(r.success, true);
+  // The message carries BOTH the input (Bob) and the middleware-set caller (Ada).
+  assert.match(r.data.message, /BOB/);
+  assert.match(r.data.message, /Ada/);
+});
+
+test('the auth middleware short-circuits a signed-out request before greet runs', async () => {
+  const app = await createRequestHandler({ appDir, dev: true });
+  if (app.warmup) await app.warmup();
+  // A middleware short-circuit rides as a normal failure envelope (200 with the
+  // status inside), so read the result rather than expecting a thrown non-2xx.
+  const r = await invokeActionForTest(
+    app,
+    'modules/server-actions/actions/greet.server.ts',
+    'greet',
+    [{ name: 'Bob', signedOut: true }],
+    { throwOnError: false },
+  );
+  assert.equal(r.success, false);
+  assert.equal(r.status, 401);
 });

--- a/packages/cli/templates/gallery/modules/server-actions/actions/greet.test.ts
+++ b/packages/cli/templates/gallery/modules/server-actions/actions/greet.test.ts
@@ -39,16 +39,18 @@ test('rawActionRequest fires the greet action through the pipeline', async () =>
 test('the middleware sets the caller on the context and greet reads it via actionContext()', async () => {
   const app = await createRequestHandler({ appDir, dev: true });
   if (app.warmup) await app.warmup();
-  const r = await invokeActionForTest(
+  // invokeActionForTest returns the deserialized result as unknown; cast to the
+  // action's ActionResult shape to read it.
+  const r = (await invokeActionForTest(
     app,
     'modules/server-actions/actions/greet.server.ts',
     'greet',
     [{ name: 'Bob' }],
-  );
+  )) as { success: boolean; data?: { message: string }; error?: string; status?: number };
   assert.equal(r.success, true);
   // The message carries BOTH the input (Bob) and the middleware-set caller (Ada).
-  assert.match(r.data.message, /BOB/);
-  assert.match(r.data.message, /Ada/);
+  assert.match(r.data?.message ?? '', /BOB/);
+  assert.match(r.data?.message ?? '', /Ada/);
 });
 
 test('the auth middleware short-circuits a signed-out request before greet runs', async () => {
@@ -56,13 +58,13 @@ test('the auth middleware short-circuits a signed-out request before greet runs'
   if (app.warmup) await app.warmup();
   // A middleware short-circuit rides as a normal failure envelope (200 with the
   // status inside), so read the result rather than expecting a thrown non-2xx.
-  const r = await invokeActionForTest(
+  const r = (await invokeActionForTest(
     app,
     'modules/server-actions/actions/greet.server.ts',
     'greet',
     [{ name: 'Bob', signedOut: true }],
     { throwOnError: false },
-  );
+  )) as { success: boolean; data?: { message: string }; error?: string; status?: number };
   assert.equal(r.success, false);
   assert.equal(r.status, 401);
 });

--- a/packages/cli/templates/gallery/modules/server-actions/components/greeter.ts
+++ b/packages/cli/templates/gallery/modules/server-actions/components/greeter.ts
@@ -5,11 +5,16 @@ import { greet } from '../actions/greet.server.ts';
 
 export class Greeter extends WebComponent {
   private msg = signal('');
+  // Drives the requireAuth middleware on the action: when true the request is
+  // treated as signed-out, so the middleware 401s BEFORE greet() runs.
+  private signedOut = signal(false);
+
   async run(e: SubmitEvent) {
     e.preventDefault();
     const name = String(new FormData(e.target as HTMLFormElement).get('name') ?? '');
-    const r = await greet({ name });
-    // Narrow on r.success so TS knows `data` (success) vs `error` (failure).
+    const r = await greet({ name, signedOut: this.signedOut.get() });
+    // Narrow on r.success so TS knows `data` (success) vs `error` (failure). A
+    // middleware short-circuit arrives here as a normal failure envelope.
     this.msg.set(r.success ? (r.data?.message ?? '') : (r.error ?? 'error'));
   }
   render() {
@@ -22,6 +27,10 @@ export class Greeter extends WebComponent {
           <button type="submit"
             class="shrink-0 px-4 py-2 rounded-xl bg-primary text-primary-foreground font-semibold text-sm border-0 cursor-pointer transition-all hover:bg-primary/90 active:scale-[0.97]">Greet</button>
         </form>
+        <label class="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer select-none">
+          <input type="checkbox" @change=${(e: Event) => this.signedOut.set((e.target as HTMLInputElement).checked)} />
+          Simulate a signed-out visitor (the middleware 401s before the action runs)
+        </label>
         ${this.msg.get() ? html`<p class="m-0 font-semibold text-foreground">${this.msg.get()}</p>` : ''}
       </div>
     `;

--- a/packages/cli/templates/gallery/modules/server-actions/middleware/require-auth.server.ts
+++ b/packages/cli/templates/gallery/modules/server-actions/middleware/require-auth.server.ts
@@ -1,0 +1,42 @@
+// Per-action middleware. An action opts in with `export const middleware =
+// [requireAuth]` (a reserved sibling config export), and the framework runs this
+// around the action on EVERY boundary (the RPC stub and a route.ts adapter). The
+// signature is `async (ctx, next) => result`, where ctx = { request, args,
+// signal, context }. Whatever it writes onto ctx.context is exactly what the
+// action reads back via actionContext(). This is a server-only utility (a
+// .server.ts with NO 'use server'): the action imports it server-side; it never
+// ships to the browser.
+import type { ActionResult } from '@webjsdev/server';
+
+export interface AuthUser {
+  id: string;
+  name: string;
+}
+
+// The context object the framework passes each middleware. `context` is the
+// shared mutable bag actionContext() returns to the action; `args` is the
+// action's argument list; `signal` is the request AbortSignal.
+interface ActionMiddlewareCtx {
+  request: Request;
+  args: unknown[];
+  signal: AbortSignal;
+  context: Record<string, unknown>;
+}
+
+export async function requireAuth(ctx: ActionMiddlewareCtx, next: () => Promise<unknown>): Promise<unknown> {
+  // A REAL guard reads the signed session or JWT off ctx.request, because auth
+  // belongs to the request, not the payload. This gallery has no login backend on
+  // the action path, so to keep BOTH branches exercisable the demo treats the
+  // caller as signed in UNLESS the request asks to simulate a signed-out visitor
+  // (the checkbox in the component sends { signedOut: true } in the action input).
+  const [input] = ctx.args as [{ signedOut?: boolean } | undefined];
+  const user: AuthUser | null = input?.signedOut ? null : { id: 'u_1', name: 'Ada' };
+
+  // Short-circuit: return an ActionResult WITHOUT calling next(), so the action
+  // never runs. On the RPC boundary the short-circuit rides as the result with its
+  // status inside the envelope, and a denied call is served no-store (never cached).
+  if (!user) return { success: false, error: 'Sign in to continue.', status: 401 } satisfies ActionResult<never>;
+
+  ctx.context.user = user; // what actionContext().user reads inside the action
+  return next(); // run the next middleware, ending at the action
+}

--- a/packages/cli/templates/scripts/clear-gallery.mjs
+++ b/packages/cli/templates/scripts/clear-gallery.mjs
@@ -40,8 +40,8 @@ const galleryPaths = [
 // 2) The gallery's feature modules (by name, so saas auth modules survive).
 const galleryModules = [
   'async-render', 'broadcast', 'caching', 'client-router', 'components',
-  'directives', 'file-storage', 'optimistic-ui', 'rate-limit', 'route-handler',
-  'server-actions', 'sessions', 'todo', 'websockets',
+  'directives', 'file-storage', 'frames', 'optimistic-ui', 'rate-limit',
+  'route-handler', 'server-actions', 'sessions', 'todo', 'websockets',
 ].map((m) => `modules/${m}`);
 
 let removed = 0;


### PR DESCRIPTION
Closes #988

Two independent scaffold-gallery demos.

**1. New `<webjs-frame>` demo (`/features/frames`).** `<webjs-frame>` was the one core browser-shipped feature with no gallery coverage. The demo is a filtered task list inside a frame: the filter tabs live inside the frame and target the same page with a new `?status`, so with JS the router swaps only the frame subtree in place (the heading and intro never re-render), and with JS off the same links do full-page navigations. It ships zero component JS and is deliberately distinct from the client-router soft-nav demo (whole-page children swap vs one sub-region swap). The frame upgrades because the root layout ships a component (the theme toggle), so core loads app-wide.

**2. Rework the server-actions demo** so `actionContext()` and `actionSignal()` are shown doing real work instead of in their inert state. Adds a real `export const middleware` auth guard whose middleware sets `ctx.context.user`, read back via `actionContext().user` (guarded, so a bypassed-middleware direct call returns a clean 401 rather than a TypeError), and threads `actionSignal()` into an awaited call that models a real fetch's AbortError and maps a cancel to a single 499 envelope. A checkbox in the greeter exercises the 401 short-circuit.

## Verification (generated a full-stack app from these templates)
- `webjs check` clean; `webjs typecheck` clean.
- Boot harness: frames page renders all four tasks; `?status=active` hides done items; an `x-webjs-frame: tasks` request returns only the frame subtree (smaller, no page `<h1>`, correctly filtered); server-actions page renders the greeter + middleware prose; home lists the Frames card.
- Example test (`greet.test.ts`) passes the middleware-context read and the 401 short-circuit.
- Scaffold suites green: gallery-coverage + scaffold-gallery + template-validation (22/22). The `WebjsFrame` / `actionContext` / `actionSignal` coverage manifest entries stay valid (no new export introduced).
- Self-review ran three rounds; round 2 caught two teaching bugs in the greet demo (a throw-vs-499 cancellation contradiction, and a comment that sold a TypeError as a benign empty read), both fixed in daf28a7e; the last round was clean.

## Definition-of-done surfaces
- **Tests:** unit/example + scaffold suites updated and run (above). Browser/e2e for the client-side frame swap: N/A new test, it rides core's already-e2e-tested `<webjs-frame>` behavior; SSR + server-side subtree extraction + PE fallback verified via the boot harness.
- **Bun parity:** N/A, this changes scaffold TEMPLATE files only, no runtime-sensitive framework source.
- **Docs:** N/A, no new public API. The demonstrated features (`<webjs-frame>`, per-action `middleware`, `actionContext()`, `actionSignal()`) are already documented in the skill references; the getting-started page describes the gallery generically (no per-card list to sync).
- **Scaffold:** generators (`create.js` FEATURES), gallery demos, and `gallery:clear` (`clear-gallery.mjs` prunes `modules/frames`) all updated; generate + boot + check verified.
