### PR TITLE
feat: split /articles (evergreen explainers) from /blog (design notes)

### DIFF
--- a/articles/html-web-components.md
+++ b/articles/html-web-components.md
@@ -35,3 +35,21 @@ I did not want this to be a discipline you have to remember, so WebJs is built a
 The payoff is resilience for free. You are not picking between a rich interactive component and one that survives JavaScript failing. The HTML-web-components shape gives you both, because the baseline is real HTML and the component only ever adds to it.
 
 If you have been writing custom elements as empty tags that build everything on the client, the shift is mostly in your head. Render the content, then reach for a component to enhance it, instead of reaching for a component to produce it. Once it clicks, the empty-tag version starts to look like a liability.
+
+## FAQ
+
+### What is the difference between HTML web components and regular web components?
+
+Regular custom elements are often written as empty tags that render all their content from JavaScript once loaded. An HTML web component instead wraps real, server-rendered markup and enhances it, so the content exists before the script runs. The term describes a usage pattern (augmentation over replacement), not a different browser API. WebJs makes this pattern the default by server-rendering components in light DOM.
+
+### Why are HTML web components better for progressive enhancement?
+
+Because the meaningful content is real HTML that exists before the component's JavaScript runs. If the script is slow or fails, the text still reads, links still navigate, and forms still submit. The custom element is the enhancement layer rather than the source of the content, so nothing essential depends on JavaScript executing successfully.
+
+### Do HTML web components use shadow DOM?
+
+Usually not. The pattern is about enhancing real page markup, which fits light DOM, where the component's content is ordinary HTML that global CSS styles and crawlers read. WebJs defaults to light DOM for this reason and keeps shadow DOM as an opt-in for components that genuinely need style isolation.
+
+### Can I use HTML web components with server-side rendering?
+
+Yes, and server-side rendering is what makes them work. The markup the element wraps has to be in the first HTML response, which means the server renders it. WebJs server-renders components by default, so the content is present before any JavaScript loads and the element enhances it once its module runs.

--- a/articles/no-build-javascript-framework.md
+++ b/articles/no-build-javascript-framework.md
@@ -44,3 +44,21 @@ WebJs runs a full-stack app this way, on Node 24+ or Bun: file-based routing, se
 No-build is not free, and I would rather say so than pretend. You give up build-time optimizations like tree-shaking dead code out of a dependency and aggressive minification. For a large app pulling in heavy third-party libraries, a bundler can still ship fewer bytes. My answer is to lean on the platform (HTTP/2, module preload, caching) and to keep the framework itself small, rather than to bundle. For most apps that is the better trade. For a few it is not, and that is a real decision to make with your eyes open, not a slogan to repeat.
 
 If your instinct is that a build step is just how frontend works, that instinct is a couple of years out of date. The platform caught up. A no-build framework is what you get when you take that seriously and stop paying for a step you no longer need.
+
+## FAQ
+
+### What is a no-build JavaScript framework?
+
+It is a framework that serves your source directly to the browser with no bundler or compile step. Native ES modules load the code by its import statements, an import map resolves bare package names, and TypeScript types are stripped at load rather than compiled ahead of time. WebJs is a full-stack example: the `.ts` file you write is the file that runs, with no generated build output.
+
+### Do no-build frameworks have worse performance?
+
+Not necessarily. The reason bundlers existed was to cut network requests, and HTTP/2 multiplexing plus module-preload hints cover most of that gap by loading the module graph in parallel over one connection. You do give up build-time tree-shaking and minification, so a very large app with heavy dependencies can still ship fewer bytes bundled. For most apps the no-build path is competitive and much simpler.
+
+### How does a no-build framework run TypeScript?
+
+By stripping the types instead of compiling. TypeScript's type annotations are erasable, so removing them leaves valid JavaScript. Node 24 has a built-in stripper that does this in place and preserves line numbers, so stack traces stay accurate with no sourcemap. There is no `tsc` step and no compiled output to keep in sync with your source.
+
+### Is Lit a no-build framework?
+
+Lit can be used without a build step (it works from a CDN with import maps), but it is a component library, not a full-stack framework, so you assemble the server, routing, and data layer yourself. WebJs is a full-stack no-build framework: routing, server actions, SSR, and auth are built in, all served without a bundler.

--- a/articles/run-typescript-without-a-build-step.md
+++ b/articles/run-typescript-without-a-build-step.md
@@ -38,3 +38,21 @@ For most modern TypeScript this costs you nothing, because the erasable subset i
 WebJs is built entirely on type stripping, with no build step anywhere. The `.ts` files you write are the files that run on the server and the files the browser fetches, with the types stripped at load by Node's built-in stripper or Bun's. There is no `tsc` in the serving path, no `dist/` folder, and no sourcemap layer, so an error in the browser console points at `app/posts/[id]/page.ts` at the real line. The framework enforces the erasable constraint with a check, so a non-erasable construct is caught before it ships rather than blowing up at strip time. Why I chose stripping over running esbuild, and what that cost, is in [strip the types, not esbuild](/blog/strip-types-not-esbuild).
 
 If your project still runs `tsc` in a watch loop only to execute your code, you can almost certainly delete that step today. Keep `tsc --noEmit` for checking, and let the runtime strip and run. That was the change that made my own dev loop feel immediate again.
+
+## FAQ
+
+### Can you run TypeScript without compiling it?
+
+Yes. Modern runtimes strip the type annotations at load and run the resulting JavaScript, with no compile step. Node 24 does this natively (`node app.ts`), Bun has always done it, and a server can strip a `.ts` file before sending it to the browser. Stripping is much faster than compiling because it deletes types rather than checking and resolving them. WebJs runs a full-stack app this way.
+
+### Is type stripping the same as compiling TypeScript?
+
+No. Compiling (`tsc`) checks all your types, resolves the type graph, and emits JavaScript plus declaration files and sourcemaps. Stripping only removes the type annotations, leaving valid JavaScript, and does no type checking. Stripping is far faster and is enough to run the code. You still run `tsc --noEmit` separately in your editor and CI to check types.
+
+### What are the limitations of running TypeScript without a build step?
+
+Your TypeScript has to be erasable, meaning removing the types must leave valid JavaScript. That rules out features that emit runtime code: `enum`, value `namespace`, constructor parameter properties, and legacy decorators with metadata. The `erasableSyntaxOnly` compiler flag flags these so you catch them in the editor. Type checking also does not happen at runtime, so you run it separately in CI.
+
+### Does WebJs need a build step to run TypeScript?
+
+No. WebJs strips TypeScript types at load using Node's built-in stripper or Bun, so the `.ts` files you write run directly on the server and ship to the browser with no bundler, no `tsc` in the serving path, and no `dist/` folder. Stack traces point at your real source lines because stripping preserves positions with no sourcemap.

--- a/articles/server-side-rendering-web-components.md
+++ b/articles/server-side-rendering-web-components.md
@@ -38,3 +38,21 @@ Because the content is in the first response, a WebJs page reads with JavaScript
 The old browser-global problem still bites during a server render, and this is the one thing people trip on. Code that touches `window` or `localStorage` at render time has no browser to touch. WebJs runs only the constructor, attribute wiring, and `render()` on the server, and it flags browser-global access that would crash there, so you get a clear message instead of a mystery 500. If you want the render-time data story (fetching in the component and still landing it in the first paint), that is [async rendering in web components](/blog/async-render-in-web-components).
 
 The short version is that the reason SSR for web components felt impossible was a genuine platform gap, and the platform closed it. What is left is a framework choosing to render on the server by default, which is the choice I made.
+
+## FAQ
+
+### Can web components be server rendered?
+
+Yes. The obstacle used to be that shadow DOM could only be attached with JavaScript, so a custom element could not be expressed as server HTML. Declarative Shadow DOM removed that limit by letting a shadow root be written directly in markup, so browsers attach it during parsing with no script. A framework like WebJs walks the component tree on the server, runs each render, and emits the HTML.
+
+### Do I need shadow DOM to server-render a web component?
+
+No. Shadow DOM is one option, and it ships as Declarative Shadow DOM when you use it. WebJs renders components in light DOM by default, where the output is ordinary page HTML with no shadow root at all, which sidesteps the whole shadow-serialization question and lets global CSS cascade in. Shadow DOM stays a per-component opt-in for the cases that want isolation.
+
+### What is Declarative Shadow DOM?
+
+Declarative Shadow DOM is a way to write a shadow root as HTML, using a `<template shadowrootmode="open">` element, instead of attaching it imperatively with JavaScript. The browser reads it during HTML parsing and attaches the shadow tree before any script runs. It is what makes server-side rendering of shadow-DOM web components possible, and it is supported in every current browser (Chrome and Safari for years, Firefox since version 123).
+
+### Does server-side rendering web components help SEO?
+
+Yes. When the content is in the first HTML response, a crawler reads it immediately with no JavaScript to execute. WebJs server-renders components whether they use light DOM or shadow DOM, so the content is in that first response either way: light-DOM output is plain HTML, and shadow-DOM output is server-rendered too, shipped as Declarative Shadow DOM in the same response. The post body, headings, and navigation are in the initial HTML, which is what search engines index.

--- a/articles/web-components-framework.md
+++ b/articles/web-components-framework.md
@@ -42,3 +42,21 @@ Here is the distinction that trips people up, and it is why "just use Lit" is no
 WebJs uses a Lit-compatible component API on purpose, so the authoring experience feels familiar, and then wraps it in the pieces you would otherwise stitch together by hand. If you already reach for custom elements and keep wishing the full-stack story around them were as solid as the component model itself, that gap is the reason WebJs exists.
 
 None of it couples you to a particular database or CSS approach. The scaffold ships Drizzle, SQLite, and Tailwind as defaults because they pair well, but each is swappable. The constant is the foundation: native web components, server-rendered, with the framework filling in everything the platform leaves out.
+
+## FAQ
+
+### What is the difference between a web components framework and React?
+
+React uses its own component model, a virtual DOM and a proprietary runtime that only exists inside React. A web components framework builds on native custom elements, which the browser understands directly. React components run only inside React; web components run anywhere the DOM runs. WebJs is a full-stack web components framework, so it gives you the app-level pieces (SSR, routing, data) on top of the standard component model.
+
+### Is Lit a web components framework?
+
+Lit is a component library, not a full framework. It is an excellent way to author individual custom elements, but you still assemble server rendering, routing, and a data layer yourself. WebJs uses a Lit-compatible component API and adds those full-stack pieces around it, so you keep the authoring feel and get the whole app.
+
+### Do web components work with server-side rendering?
+
+Yes, and it is a core job of a good web components framework. WebJs renders components to HTML on the server, using Declarative Shadow DOM for components that opt into shadow DOM, so the first paint is real content and the element hydrates in place. Raw hand-written custom elements usually render only on the client, which is the gap the framework closes.
+
+### Do I need a build step for a web components framework?
+
+Not with WebJs. It serves native ES modules directly and strips TypeScript types at load, so there is no bundler and no compiled output to keep in sync with your source. Some other web-components setups still use a bundler, but a build step is not inherent to the approach.

--- a/articles/web-components-framework.md
+++ b/articles/web-components-framework.md
@@ -23,7 +23,7 @@ There is also less to learn. A React component lives inside React's virtual DOM 
 
 Native custom elements give you the component and nothing above it. That gap is real, and closing it is the entire job of a web components framework.
 
-**Server-side rendering.** Hand-written custom elements usually render on the client, which hurts first paint and indexing. WebJs renders components to HTML on the server, using Declarative Shadow DOM for the ones that opt into shadow DOM, so the first response carries real content and the element hydrates in place. One code path produces the server HTML and the client render, so the two do not drift. I went deeper on this in [server-side rendering for web components](/blog/server-side-rendering-web-components).
+**Server-side rendering.** Hand-written custom elements usually render on the client, which hurts first paint and indexing. WebJs renders components to HTML on the server, using Declarative Shadow DOM for the ones that opt into shadow DOM, so the first response carries real content and the element hydrates in place. One code path produces the server HTML and the client render, so the two do not drift. I went deeper on this in [server-side rendering for web components](/articles/server-side-rendering-web-components).
 
 **Progressive enhancement.** A WebJs page works with JavaScript turned off. Content reads, links navigate, forms submit through server actions. Interactivity is added per behaviour, so you never ship a first paint that depends on hydration to show anything.
 

--- a/articles/web-components-vs-react.md
+++ b/articles/web-components-vs-react.md
@@ -36,3 +36,21 @@ The honest problem with "just use web components" is the reactivity and full-sta
 That gap is the reason I built WebJs. It stands on native web components, so you keep the portability and the platform-standard model, and it adds the pieces React users take for granted: reactive properties and signals for state, server-side rendering with hydration, file-based routing, typed server actions, and progressive enhancement by default. The component model is the browser's; the framework fills in everything above it. The authoring API is deliberately close to Lit, so web-component knowledge transfers directly, which I wrote about in [WebJs vs Lit](/blog/betting-on-lits-mental-model).
 
 So the real choice is not "web components or React" as raw technologies. It is whether you want your UI built on a portable browser standard with a framework filling the gaps, or on React's library runtime with its ecosystem. Both are defensible. WebJs is my bet that the standard is the better foundation once the gaps are actually filled.
+
+## FAQ
+
+### What is the difference between web components and React?
+
+Web components are native browser APIs (custom elements, shadow DOM, templates) for building reusable elements the browser understands directly. React is a JavaScript library with its own virtual DOM and component model that exists only inside React. Web components run anywhere the DOM runs; React components run only in React. They sit at different layers, which is why they are more complementary than competing.
+
+### Can web components replace React?
+
+For the component layer, often yes, but not on their own. Raw web components give you the element without React's automatic state-to-UI reactivity, server rendering, or routing, which is why teams reach for React plus a framework instead. A web components framework like WebJs closes that gap by adding reactivity, SSR, and routing on top of the native element, which is what makes replacing React practical rather than just possible.
+
+### Are web components faster than React?
+
+It depends more on the framework around them than on the primitive. Native custom elements avoid React's virtual-DOM diffing overhead and ship no library runtime by default, which can mean less JavaScript. But raw web components without a reactivity layer are not automatically faster in practice. The bigger performance lever is server rendering and shipping less JavaScript, which WebJs does by default.
+
+### Should I use web components or React?
+
+Use React when its ecosystem, hiring pool, and library selection are the priority, or when your team is already fluent in it. Use web components, through a framework like WebJs, when you want a portable, platform-standard component model, less JavaScript, progressive enhancement, and no build step. Both are defensible; the choice is about which foundation fits your constraints.

--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -25,12 +25,16 @@ website/
                        Dockerfile's `COPY changelog ./changelog` line
                        is what ships it on Railway.
     blog/              /blog hub + /blog/[slug]. Reads ../../../blog/*.md.
-                       Home of the keyword-targeted SEO posts. Emits
-                       per-post JSON-LD (BlogPosting + BreadcrumbList).
+                       WebJs design notes (dated). Emits per-post JSON-LD
+                       (BlogPosting + BreadcrumbList). No FAQ.
+    articles/          /articles hub + /articles/[slug]. Reads
+                       ../../../articles/*.md. Evergreen keyword explainers
+                       (tags, no dates). Emits TechArticle + BreadcrumbList
+                       + FAQPage.
     compare/           /compare hub + /compare/[slug]. Reads
                        ../../../compare/*.md. Emits per-page JSON-LD
                        (TechArticle + BreadcrumbList + FAQPage).
-    sitemap.ts         /sitemap.xml (enumerates compare + blog)
+    sitemap.ts         /sitemap.xml (enumerates articles + compare + blog)
     robots.ts          /robots.txt (allow-all, points at the sitemap)
     llms.txt/route.ts  /llms.txt (llmstxt.org overview for AI agents)
   components/
@@ -58,38 +62,42 @@ key into the local `ICON` map (for example `ICON.bolt`). Add a new entry
 in the correct order and the grid reflows automatically. If no existing
 icon fits, add one to the `ICON` map first.
 
-## SEO surfaces (blog, comparisons, structured data)
+## SEO surfaces (articles, blog, comparisons, structured data)
 
 The site targets real search keywords ("web components framework", "no
-build javascript framework", and so on) and "WebJs vs X" queries. There
-is deliberately NO separate `/guides` section: keyword-targeted explainer
-articles are just blog posts. A page ranks the same under `/blog` as
-under any other path, so a second near-identical section only adds upkeep
-and risks the two competing for the same term. The moving parts:
+build javascript framework", and so on) and "WebJs vs X" queries. Content
+is split by editorial intent, which is what decides where a piece goes:
 
-- **SEO explainer posts and comparisons.** An evergreen, keyword-targeted
-  explainer is a normal `blog/<slug>.md` post. Only write one for a term
-  with real search demand where WebJs is a legitimate answer (validate
-  the query first; a coined phrase nobody searches does not belong here).
-  A "WebJs vs <framework>" head-to-head is a `compare/<slug>.md` under
-  `/compare`. Do NOT let a blog post and a compare page chase the same
-  exact keyword (cannibalization).
-- **FAQ convention.** End a blog or comparison body with a `## FAQ`
-  section, each question a `### <question>` heading followed by its
-  answer paragraph. `lib/faq.ts` (`parseFaq`) turns that into a
-  `FAQPage` JSON-LD block. The FAQ is BOTH rendered (normal markdown)
-  and emitted as schema, so the two never drift (Google discounts FAQ
-  schema that is not visible on the page).
+- **`/articles`** is evergreen, keyword-targeted explainers on the web
+  platform ("what a web components framework is", "run TypeScript with no
+  build step"). Timeless reference, presented WITHOUT dates. An article is
+  an `articles/<slug>.md` file. Only write one for a term with real search
+  demand where WebJs is a legitimate answer (validate the query first; a
+  coined phrase nobody searches does not belong here). Articles carry a
+  `## FAQ` (SEO landing pages, like `/compare`).
+- **`/blog`** is dated WebJs design notes ("the decisions, the trade-offs,
+  the things that did not work"). A `blog/<slug>.md` post, FAQ-free, in
+  the author's first-person voice. A general web-platform explainer does
+  NOT belong here (that is why the split exists); it goes in `/articles`.
+- **`/compare`** is "WebJs vs <framework>" head-to-heads (`compare/<slug>.md`).
+- Do NOT let two pages chase the same exact keyword (cannibalization);
+  an article owns the general term, a blog post owns the WebJs-specific angle.
+- **FAQ convention.** End an article or comparison body with a `## FAQ`
+  section, each question a `### <question>` heading followed by its answer
+  paragraph. `lib/faq.ts` (`parseFaq`) turns that into a `FAQPage` JSON-LD
+  block. The FAQ is BOTH rendered (normal markdown) and emitted as schema,
+  so the two never drift (Google discounts FAQ schema that is not visible
+  on the page). Blog posts do NOT use FAQ.
 - **JSON-LD** is set via `metadata.jsonLd` (the framework emits a
-  `<script type="application/ld+json">`): `BlogPosting` + `BreadcrumbList`
-  (+ `FAQPage`) on blog posts, `TechArticle` + `BreadcrumbList` (+
-  `FAQPage`) on comparisons, and `WebSite` + `Organization` +
-  `SoftwareApplication` on the home page (jsonLd-only `export const
-  metadata`, so it does not split the layout-sourced title). Keep the
+  `<script type="application/ld+json">`): `TechArticle` + `BreadcrumbList`
+  + `FAQPage` on articles and comparisons, `BlogPosting` + `BreadcrumbList`
+  on blog posts, and `WebSite` + `Organization` + `SoftwareApplication` on
+  the home page (jsonLd-only `export const metadata`, so it does not split
+  the layout-sourced title). Article schemas carry an `image`. Keep the
   schema honest: it must match the visible page content.
 - **`/robots.txt`, `/sitemap.xml`, `/llms.txt`** are generated from the
-  live content queries, so a new comparison or post needs no edit to
-  those files.
+  live content queries, so a new article, comparison, or post needs no
+  edit to those files.
 
 ## Announcement banner
 

--- a/website/app/articles/[slug]/page.ts
+++ b/website/app/articles/[slug]/page.ts
@@ -83,7 +83,6 @@ export default async function ArticlePage({ params }: { params: { slug: string }
       </nav>
 
       <header class="mb-[64px]">
-        <p class="font-mono text-[12px] uppercase tracking-[0.14em] text-accent font-semibold mb-[20px]">Article</p>
         <h1 class="font-serif text-[clamp(36px,6vw,56px)] leading-[1.05] tracking-tight text-fg m-0 mb-[24px]">${a.title}</h1>
         <p class="text-fg-muted text-[19px] leading-[1.55] m-0 font-serif italic">${a.tagline}</p>
       </header>

--- a/website/app/articles/[slug]/page.ts
+++ b/website/app/articles/[slug]/page.ts
@@ -1,0 +1,99 @@
+import { html, unsafeHTML, notFound } from '@webjsdev/core';
+import { getArticle } from '#modules/articles/queries/get-article.server.ts';
+import { renderPostBody } from '#modules/blog/utils/render-post.ts';
+import { parseFaq, faqJsonLd } from '#lib/faq.ts';
+
+/**
+ * /articles/[slug]
+ *
+ * Thin route adapter over `modules/articles/`. The markdown body is
+ * rendered with the blog's `renderPostBody` (same typography), and the
+ * `## FAQ` at the end of the body is BOTH rendered (as normal `##`/`###`
+ * markdown) and parsed into a `FAQPage` JSON-LD block, so the structured
+ * data always matches what a visitor sees.
+ *
+ * `generateMetadata` gives each article its own title / description / og:*
+ * tags, a canonical URL at `/articles/<slug>`, and JSON-LD (`TechArticle`
+ * + `BreadcrumbList` + optional `FAQPage`), which is what makes these
+ * pages eligible for rich results and AI-answer-engine extraction.
+ *
+ * Deliberately mirrors `app/compare/[slug]/page.ts`. Articles are the
+ * evergreen SEO explainers; `/blog` is dated WebJs design notes.
+ */
+
+const SITE_URL = 'https://webjs.dev';
+
+export async function generateMetadata({ params }: { params: { slug: string } }) {
+  const a = await getArticle(params.slug);
+  if (!a) return { title: 'Article not found · WebJs' };
+
+  const canonical = `${SITE_URL}/articles/${a.slug}`;
+  const faq = faqJsonLd(parseFaq(a.body));
+
+  const jsonLd: Record<string, unknown>[] = [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'TechArticle',
+      headline: a.title,
+      description: a.description,
+      author: { '@type': 'Person', name: a.author },
+      publisher: { '@type': 'Organization', name: 'WebJs', url: SITE_URL },
+      datePublished: a.date || undefined,
+      mainEntityOfPage: canonical,
+      url: canonical,
+      image: `${SITE_URL}/public/og.png`,
+      keywords: a.keyword,
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Articles', item: `${SITE_URL}/articles` },
+        { '@type': 'ListItem', position: 2, name: a.title, item: canonical },
+      ],
+    },
+  ];
+  if (faq) jsonLd.push(faq);
+
+  return {
+    title: `${a.title} · WebJs`,
+    description: a.description,
+    openGraph: {
+      title: a.title,
+      description: a.description,
+      type: 'article',
+      url: canonical,
+      publishedTime: a.date,
+      authors: [a.author],
+      tags: a.tags,
+    },
+    twitter: { card: 'summary_large_image' },
+    jsonLd,
+  };
+}
+
+export default async function ArticlePage({ params }: { params: { slug: string } }) {
+  const a = await getArticle(params.slug);
+  if (!a) notFound();
+
+  return html`
+    <main id="main" tabindex="-1" class="max-w-[840px] mx-auto px-[24px] py-[64px] focus:outline-none">
+      <nav class="mb-[48px]">
+        <a href="/articles" class="font-mono text-[12px] text-fg-subtle no-underline hover:text-fg tracking-wide">← All articles</a>
+      </nav>
+
+      <header class="mb-[64px]">
+        <p class="font-mono text-[12px] uppercase tracking-[0.14em] text-accent font-semibold mb-[20px]">Article</p>
+        <h1 class="font-serif text-[clamp(36px,6vw,56px)] leading-[1.05] tracking-tight text-fg m-0 mb-[24px]">${a.title}</h1>
+        <p class="text-fg-muted text-[19px] leading-[1.55] m-0 font-serif italic">${a.tagline}</p>
+      </header>
+
+      <article class="mt-[16px]">${unsafeHTML(renderPostBody(a.body))}</article>
+
+      <footer class="mt-[104px] pt-[36px] border-t border-border flex flex-wrap gap-x-[24px] gap-y-[12px]">
+        <a href="/articles" class="font-mono text-[12px] text-fg-subtle no-underline hover:text-fg tracking-wide">← All articles</a>
+        <a href="/compare" class="font-mono text-[12px] text-fg-subtle no-underline hover:text-fg tracking-wide">Compare WebJs →</a>
+      </footer>
+    </main>
+  `;
+}

--- a/website/app/articles/page.ts
+++ b/website/app/articles/page.ts
@@ -1,0 +1,52 @@
+import { html } from '@webjsdev/core';
+import { listArticles } from '#modules/articles/queries/list-articles.server.ts';
+
+/**
+ * /articles
+ *
+ * The articles hub: evergreen, keyword-targeted explainers on the web
+ * platform ideas WebJs is built on (what a web components framework is,
+ * building with no build step, server-rendering custom elements, and so
+ * on). Distinct from `/blog`, which is dated WebJs design notes; these
+ * are timeless reference, so the cards surface tags and NO dates.
+ *
+ * Thin route adapter over `modules/articles/queries/list-articles.server.ts`.
+ * Each card links to `/articles/<slug>`, the long-form explainer where the
+ * SEO value sits. Reached from the footer (Resources), not the header nav.
+ */
+
+export const metadata = {
+  title: 'Articles: web components, no-build, and the web platform · WebJs',
+  description: 'Plain-English explainers on the ideas behind WebJs: what a web components framework is, building a full-stack app with no build step, server-rendering web components, and running TypeScript without a build.',
+};
+
+export default async function Articles() {
+  const articles = await listArticles();
+  return html`
+    <main id="main" tabindex="-1" class="max-w-[840px] mx-auto px-6 py-12 focus:outline-none">
+      <header class="mb-10">
+        <p class="font-mono text-[11px] uppercase tracking-[0.15em] text-accent font-semibold mb-2">Articles</p>
+        <h1 class="font-serif text-[clamp(28px,4vw,40px)] leading-[1.05] tracking-tight text-fg mb-3">Articles</h1>
+        <p class="text-fg-muted text-[15px] leading-relaxed max-w-[640px]">
+          Evergreen explainers on how the web platform works and the ideas WebJs is built on: web components, building with no build step, server-side rendering, and running TypeScript straight from the runtime. Reference reading, not release notes.
+        </p>
+      </header>
+
+      ${articles.length === 0
+        ? html`<p class="text-fg-subtle italic">No articles yet.</p>`
+        : articles.map((a) => html`
+            <article class="border border-border rounded-xl bg-bg-elev p-5 sm:p-6 mb-5 shadow-sm transition-colors hover:border-border-strong">
+              <a href=${'/articles/' + a.slug} class="block no-underline text-fg">
+                ${a.tags.length > 0
+                  ? html`<header class="flex flex-wrap items-baseline gap-x-2 gap-y-1 mb-3">
+                      ${a.tags.map((t) => html`<span class="bg-fg-subtle/10 text-fg-subtle font-mono text-[10.5px] uppercase tracking-[0.1em] px-2 py-0.5 rounded">${t}</span>`)}
+                    </header>`
+                  : ''}
+                <h2 class="font-serif text-[clamp(20px,3vw,26px)] leading-[1.15] tracking-tight text-fg m-0 mb-2">${a.title}</h2>
+                <p class="text-fg-muted text-[14.5px] leading-relaxed m-0">${a.description || a.tagline}</p>
+              </a>
+            </article>
+          `)}
+    </main>
+  `;
+}

--- a/website/app/articles/page.ts
+++ b/website/app/articles/page.ts
@@ -26,7 +26,7 @@ export default async function Articles() {
     <main id="main" tabindex="-1" class="max-w-[840px] mx-auto px-6 py-12 focus:outline-none">
       <header class="mb-10">
         <p class="font-mono text-[11px] uppercase tracking-[0.15em] text-accent font-semibold mb-2">Articles</p>
-        <h1 class="font-serif text-[clamp(28px,4vw,40px)] leading-[1.05] tracking-tight text-fg mb-3">Articles</h1>
+        <h1 class="font-serif text-[clamp(28px,4vw,40px)] leading-[1.05] tracking-tight text-fg mb-3">Explainers for the web platform</h1>
         <p class="text-fg-muted text-[15px] leading-relaxed max-w-[640px]">
           Evergreen explainers on how the web platform works and the ideas WebJs is built on: web components, building with no build step, server-side rendering, and running TypeScript straight from the runtime. Reference reading, not release notes.
         </p>

--- a/website/app/blog/[slug]/page.ts
+++ b/website/app/blog/[slug]/page.ts
@@ -1,7 +1,6 @@
 import { html, unsafeHTML, notFound } from '@webjsdev/core';
 import { getPost } from '#modules/blog/queries/get-post.server.ts';
 import { renderPostBody } from '#modules/blog/utils/render-post.ts';
-import { parseFaq, faqJsonLd } from '#lib/faq.ts';
 
 /**
  * /blog/[slug]
@@ -12,8 +11,9 @@ import { parseFaq, faqJsonLd } from '#lib/faq.ts';
  * `generateMetadata` derives <head> from the post's frontmatter so
  * each post gets its own title / description / og:* tags for SEO,
  * a canonical URL per post at `/blog/<slug>`, and JSON-LD
- * (`BlogPosting` + `BreadcrumbList`, plus `FAQPage` when the post body
- * carries a `## FAQ` section) for rich results.
+ * (`BlogPosting` + `BreadcrumbList`) for rich results. Blog posts are
+ * WebJs design notes and carry no `## FAQ` section; the evergreen SEO
+ * explainers under `/articles` are where FAQ + FAQPage live.
  */
 
 const SITE_URL = 'https://webjs.dev';
@@ -23,7 +23,6 @@ export async function generateMetadata({ params }: { params: { slug: string } })
   if (!post) return { title: 'Post not found · WebJs' };
 
   const canonical = `${SITE_URL}/blog/${post.slug}`;
-  const faq = faqJsonLd(parseFaq(post.body));
   const jsonLd: Record<string, unknown>[] = [
     {
       '@context': 'https://schema.org',
@@ -47,7 +46,6 @@ export async function generateMetadata({ params }: { params: { slug: string } })
       ],
     },
   ];
-  if (faq) jsonLd.push(faq);
 
   return {
     title: `${post.title} · WebJs Blog`,

--- a/website/app/llms.txt/route.ts
+++ b/website/app/llms.txt/route.ts
@@ -1,4 +1,5 @@
 import { listComparisons } from '#modules/compare/queries/list-comparisons.server.ts';
+import { listArticles } from '#modules/articles/queries/list-articles.server.ts';
 import { listPosts } from '#modules/blog/queries/list-posts.server.ts';
 
 /**
@@ -22,7 +23,7 @@ const SITE_URL = (env.SITE_URL || 'https://webjs.dev').replace(/\/$/, '');
 const DOCS_URL = (env.DOCS_URL || 'https://docs.webjs.dev').replace(/\/$/, '');
 
 export async function GET(): Promise<Response> {
-  const [comparisons, posts] = await Promise.all([listComparisons(), listPosts()]);
+  const [comparisons, articles, posts] = await Promise.all([listComparisons(), listArticles(), listPosts()]);
 
   const lines: string[] = [
     '# WebJs',
@@ -34,6 +35,9 @@ export async function GET(): Promise<Response> {
     '## Docs',
     `- [Getting started](${DOCS_URL}/docs/getting-started): install, scaffold, and run your first app`,
     `- [Documentation](${DOCS_URL}/docs): the full reference`,
+    '',
+    '## Articles',
+    ...articles.map((a) => `- [${a.title}](${SITE_URL}/articles/${a.slug}): ${a.tagline}`),
     '',
     '## Comparisons',
     ...comparisons.map((c) => `- [WebJs vs ${c.competitor}](${SITE_URL}/compare/${c.slug}): ${c.tagline}`),

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -422,6 +422,7 @@ lib/session.server.ts</pre>
           <div class="flex flex-col gap-3">
             <h4 class="text-xs font-bold uppercase tracking-wider text-fg">Resources</h4>
             <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href="/blog">Blog</a>
+            <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href="/articles">Articles</a>
             <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href="/changelog">Changelog</a>
             <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href=${GH_URL + '/releases'} target="_blank" rel="noopener noreferrer">Releases${NEW_TAB}</a>
           </div>

--- a/website/app/sitemap.ts
+++ b/website/app/sitemap.ts
@@ -1,14 +1,15 @@
 import { sitemap } from '@webjsdev/server';
 import { listComparisons } from '#modules/compare/queries/list-comparisons.server.ts';
+import { listArticles } from '#modules/articles/queries/list-articles.server.ts';
 import { listPosts } from '#modules/blog/queries/list-posts.server.ts';
 
 /**
  * /sitemap.xml
  *
- * Serialized from the live content queries so newly added comparison and
- * blog markdown is discoverable without touching this file. The compare
- * pages and the SEO blog posts are the reason this exists: each
- * `/compare/<slug>` and `/blog/<slug>` is a canonical page we want
+ * Serialized from the live content queries so newly added comparison,
+ * article, and blog markdown is discoverable without touching this file.
+ * The compare pages, the evergreen `/articles` explainers, and the blog
+ * posts are the reason this exists: each is a canonical page we want
  * search engines to crawl and index.
  *
  * `SITE_URL` falls back to the production origin; override it per
@@ -17,9 +18,9 @@ import { listPosts } from '#modules/blog/queries/list-posts.server.ts';
 const SITE_URL = ((globalThis as any).process?.env?.SITE_URL || 'https://webjs.dev').replace(/\/$/, '');
 
 export default async function Sitemap() {
-  const [comparisons, posts] = await Promise.all([listComparisons(), listPosts()]);
+  const [comparisons, articles, posts] = await Promise.all([listComparisons(), listArticles(), listPosts()]);
 
-  const staticRoutes = ['/', '/blog', '/compare', '/why', '/changelog'].map((path) => ({
+  const staticRoutes = ['/', '/blog', '/articles', '/compare', '/why', '/changelog'].map((path) => ({
     url: `${SITE_URL}${path}`,
     changeFrequency: 'weekly' as const,
     priority: path === '/' ? 1.0 : 0.7,
@@ -32,6 +33,13 @@ export default async function Sitemap() {
     priority: 0.8,
   }));
 
+  const articleRoutes = articles.map((a) => ({
+    url: `${SITE_URL}/articles/${a.slug}`,
+    lastModified: a.date || undefined,
+    changeFrequency: 'monthly' as const,
+    priority: 0.8,
+  }));
+
   const blogRoutes = posts.map((p) => ({
     url: `${SITE_URL}/blog/${p.slug}`,
     lastModified: p.date || undefined,
@@ -39,5 +47,5 @@ export default async function Sitemap() {
     priority: 0.6,
   }));
 
-  return sitemap([...staticRoutes, ...compareRoutes, ...blogRoutes]);
+  return sitemap([...staticRoutes, ...compareRoutes, ...articleRoutes, ...blogRoutes]);
 }

--- a/website/modules/articles/queries/get-article.server.ts
+++ b/website/modules/articles/queries/get-article.server.ts
@@ -1,0 +1,48 @@
+'use server';
+
+import { readFile } from 'node:fs/promises';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseFrontmatter } from '#lib/frontmatter.ts';
+import type { ArticleWithBody } from '#modules/articles/types.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..', '..', '..');
+const ARTICLES_DIR = resolve(REPO_ROOT, 'articles');
+
+/**
+ * Read a single `articles/<slug>.md` and return its metadata + body.
+ * Returns `null` if the slug is invalid or the file does not exist; the
+ * route handler turns that into a 404 via `notFound()`.
+ *
+ * Slug validation is `[a-z0-9-]+`, which also blocks path traversal
+ * before touching the filesystem. Mirrors the compare module
+ * (get-comparison).
+ *
+ * A GET server action (#488): a public, cacheable per-slug read,
+ * identical for every visitor, so `public: true` is safe. The cache key
+ * includes the `slug` arg; the per-page `article:` tag (plus the shared
+ * `articles` tag) lets a future write path evict it.
+ */
+export const method = 'GET';
+export const cache = { maxAge: 300, public: true };
+export const tags = (slug: string) => ['articles', `article:${slug}`];
+export async function getArticle(slug: string): Promise<ArticleWithBody | null> {
+  if (!/^[a-z0-9-]+$/.test(slug)) return null;
+  let raw: string;
+  try { raw = await readFile(join(ARTICLES_DIR, slug + '.md'), 'utf8'); }
+  catch { return null; }
+  const { fm, body } = parseFrontmatter(raw);
+  if (!fm.title || !fm.tagline || !fm.keyword) return null;
+  return {
+    slug,
+    title: fm.title,
+    date: fm.date || '',
+    description: fm.description || '',
+    tagline: fm.tagline,
+    keyword: fm.keyword,
+    tags: (fm.tags || '').split(',').map((t) => t.trim()).filter(Boolean),
+    author: fm.author || 'Vivek',
+    body: body.trim(),
+  };
+}

--- a/website/modules/articles/queries/list-articles.server.ts
+++ b/website/modules/articles/queries/list-articles.server.ts
@@ -1,0 +1,53 @@
+'use server';
+
+import { readdir, readFile } from 'node:fs/promises';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseFrontmatter } from '#lib/frontmatter.ts';
+import type { Article } from '#modules/articles/types.ts';
+
+// website/modules/articles/queries/list-articles.server.ts is 4 levels deep
+// from the repo root (website/modules/articles/queries/...).
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..', '..', '..');
+const ARTICLES_DIR = resolve(REPO_ROOT, 'articles');
+
+/**
+ * Read every `articles/<slug>.md` at the repo root, parse frontmatter, and
+ * return the metadata (not the body) for the `/articles` index cards.
+ *
+ * Mirrors the compare module (list-comparisons). Each file requires
+ * `title`, `tagline`, and `keyword`; files missing those are dropped
+ * silently (lets a draft sit in the directory). Sorted newest first for a
+ * stable order, though the evergreen hub does not surface dates.
+ *
+ * Declared as a GET server action (#488): a public, cacheable read of
+ * repo content identical for every visitor, so `public: true` is safe.
+ * The `articles` tag lets a future write path evict it.
+ */
+export const method = 'GET';
+export const cache = { maxAge: 300, public: true };
+export const tags = () => ['articles'];
+export async function listArticles(): Promise<Article[]> {
+  let files: string[];
+  try { files = await readdir(ARTICLES_DIR); } catch { return []; }
+  const articles: Article[] = [];
+  for (const f of files) {
+    if (!f.endsWith('.md')) continue;
+    const raw = await readFile(join(ARTICLES_DIR, f), 'utf8');
+    const { fm } = parseFrontmatter(raw);
+    if (!fm.title || !fm.tagline || !fm.keyword) continue;
+    articles.push({
+      slug: f.replace(/\.md$/, ''),
+      title: fm.title,
+      date: fm.date || '',
+      description: fm.description || '',
+      tagline: fm.tagline,
+      keyword: fm.keyword,
+      tags: (fm.tags || '').split(',').map((t) => t.trim()).filter(Boolean),
+      author: fm.author || 'Vivek',
+    });
+  }
+  articles.sort((a, b) => Date.parse(b.date || '0') - Date.parse(a.date || '0'));
+  return articles;
+}

--- a/website/modules/articles/types.ts
+++ b/website/modules/articles/types.ts
@@ -1,0 +1,16 @@
+export type Article = {
+  slug: string;
+  title: string;
+  date: string;
+  description: string;
+  /** One-line hook shown under the H1 (the evergreen index cards omit it). */
+  tagline: string;
+  /** The exact keyword phrase this article targets, e.g. "web components framework". */
+  keyword: string;
+  tags: string[];
+  author: string;
+};
+
+export type ArticleWithBody = Article & {
+  body: string;
+};

--- a/website/test/ssr/seo-ssr.test.ts
+++ b/website/test/ssr/seo-ssr.test.ts
@@ -1,21 +1,24 @@
 /**
- * SSR / metadata tests for the SEO surfaces (#985).
+ * SSR / metadata tests for the SEO surfaces (#985, #995).
  *
  * Covers the machine-readable routes (/robots.txt, /llms.txt) and the
- * JSON-LD structured data emitted by the compare, blog, and home pages.
- * JSON-LD lives in a page's metadata object (emitted into <head> by the
- * framework), so it is asserted at the `generateMetadata` / `metadata`
+ * JSON-LD structured data emitted by the article, compare, blog, and home
+ * pages. JSON-LD lives in a page's metadata object (emitted into <head> by
+ * the framework), so it is asserted at the `generateMetadata` / `metadata`
  * level rather than by scraping HTML.
  *
- * The keyword-targeted SEO explainer articles live under /blog (there is
- * no separate /guides section); a blog post that carries a `## FAQ`
- * section gets a FAQPage block on top of the usual BlogPosting.
+ * The keyword-targeted SEO explainers are evergreen articles under
+ * `/articles` and carry a `## FAQ` (so each emits `FAQPage`). `/blog` is
+ * dated WebJs design notes and carries no FAQ.
  */
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { renderToString } from '@webjsdev/core/server';
 
 import Robots from '#app/robots.ts';
 import { GET as llmsGet } from '#app/llms.txt/route.ts';
+import ArticlesHub from '#app/articles/page.ts';
+import { generateMetadata as articleMeta } from '#app/articles/[slug]/page.ts';
 import { generateMetadata as compareMeta } from '#app/compare/[slug]/page.ts';
 import { generateMetadata as blogMeta } from '#app/blog/[slug]/page.ts';
 import * as HomeModule from '#app/page.ts';
@@ -29,15 +32,44 @@ test('/robots.txt allows all and points at the sitemap', () => {
   assert.match(txt, /Sitemap: https:\/\/[^\s]+\/sitemap\.xml/, 'references the absolute sitemap URL');
 });
 
-test('/llms.txt is a valid llmstxt.org document listing comparisons and posts', async () => {
+test('/llms.txt lists articles, comparisons, and posts', async () => {
   const res = await llmsGet();
   assert.equal(res.status, 200);
   assert.match(res.headers.get('content-type') || '', /text\/plain/);
   const body = await res.text();
   assert.match(body, /^# WebJs/m, 'starts with the H1 name');
   assert.match(body, /^> /m, 'has the blockquote summary');
+  assert.match(body, /^## Articles$/m, 'has an Articles section');
+  assert.match(body, /\/articles\/web-components-framework/, 'lists an article');
   assert.match(body, /\/compare\/webjs-vs-/, 'lists at least one comparison');
   assert.match(body, /\/blog\//, 'lists blog posts');
+});
+
+test('the articles hub SSRs evergreen cards (tags, no dates)', async () => {
+  const out = await renderToString(await ArticlesHub());
+  assert.ok(out.includes('<main id="main"'), 'wraps content in a main landmark');
+  assert.match(out, /href="\/articles\/web-components-framework"/, 'links an article');
+  assert.ok(out.includes('web components framework'), 'renders a keyword tag on the card');
+  // Evergreen: the hub must not surface an ISO date the way a dated blog card would.
+  assert.doesNotMatch(out, /\b20\d{2}-\d{2}-\d{2}\b/, 'no dates on the evergreen article cards');
+});
+
+test('an article emits TechArticle + BreadcrumbList + FAQPage JSON-LD with canonical, keyword, image', async () => {
+  const m = await articleMeta({ params: { slug: 'web-components-framework' } });
+  const t = types(m.jsonLd);
+  assert.ok(t.includes('TechArticle'), 'has TechArticle');
+  assert.ok(t.includes('BreadcrumbList'), 'has BreadcrumbList');
+  assert.ok(t.includes('FAQPage'), 'has FAQPage (the article body carries a ## FAQ section)');
+  const article = (m.jsonLd as any[]).find((o) => o['@type'] === 'TechArticle');
+  assert.equal(article.url, 'https://webjs.dev/articles/web-components-framework', 'canonical self URL');
+  assert.equal(article.keywords, 'web components framework', 'carries the target keyword');
+  assert.equal(article.image, 'https://webjs.dev/public/og.png', 'Article carries an image for rich results');
+});
+
+test('a missing article slug yields a safe not-found metadata, no JSON-LD', async () => {
+  const m = await articleMeta({ params: { slug: 'does-not-exist' } });
+  assert.match(m.title, /not found/i);
+  assert.equal((m as any).jsonLd, undefined, 'no structured data for a missing page');
 });
 
 test('a compare page emits TechArticle + BreadcrumbList + FAQPage JSON-LD with a canonical URL', async () => {
@@ -52,16 +84,15 @@ test('a compare page emits TechArticle + BreadcrumbList + FAQPage JSON-LD with a
 });
 
 test('a blog post emits BlogPosting + BreadcrumbList JSON-LD, and no FAQPage', async () => {
-  const m = await blogMeta({ params: { slug: 'web-components-framework' } });
+  const m = await blogMeta({ params: { slug: 'why-webjs' } });
   const t = types(m.jsonLd);
   assert.ok(t.includes('BlogPosting'), 'has BlogPosting');
   assert.ok(t.includes('BreadcrumbList'), 'has BreadcrumbList');
-  // Blog posts do not carry a ## FAQ section (that reads as SEO-marketing and
-  // is not the author's style), so no FAQPage is emitted. The FAQPage code
-  // path is still exercised by the /compare pages, which do carry FAQs.
+  // Blog posts are WebJs design notes and carry no ## FAQ section, so no
+  // FAQPage. The FAQPage code path is exercised by /articles and /compare.
   assert.ok(!t.includes('FAQPage'), 'blog posts carry no FAQ, so no FAQPage');
   const article = (m.jsonLd as any[]).find((o) => o['@type'] === 'BlogPosting');
-  assert.equal(article.url, 'https://webjs.dev/blog/web-components-framework', 'canonical self URL');
+  assert.equal(article.url, 'https://webjs.dev/blog/why-webjs', 'canonical self URL');
   assert.equal(article.image, 'https://webjs.dev/public/og.png', 'Article carries an image for rich results');
 });
 


### PR DESCRIPTION
Closes #995

`/blog`'s sub-header promises WebJs design notes ("the design decisions, the trade-offs, the things that did not work, and what the framework looks like in production"), but PR #986 had folded six general web-platform explainers into it, which broke that editorial promise. This moves those explainers into a dedicated evergreen `/articles` section and restores `/blog` to design-notes-only.

## Delivered

- **`/articles`** section (hub + `/articles/<slug>`), a new `modules/articles/` + repo-root `articles/*.md`. Evergreen presentation: cards show tags, NO dates. Each article emits `TechArticle` + `BreadcrumbList` + `FAQPage` (+ `image`), the same convention as `/compare`.
- **Six explainers moved** from `blog/` to `articles/`, with their `## FAQ` sections restored (recovered from history): no-build-javascript-framework, web-components-framework, server-side-rendering-web-components, web-components-vs-react, html-web-components, run-typescript-without-a-build-step.
- **`/blog` restored** to the 42 design-notes posts; the blog page drops its FAQ parsing (blog is FAQ-free, emits `BlogPosting` + `BreadcrumbList` only).
- **Wiring**: sitemap + llms.txt enumerate articles; footer gets an "Articles" link under Resources. No header-nav entry (deliberate).
- **Docs**: `website/AGENTS.md` documents the `/blog` vs `/articles` editorial split and the FAQ/JSON-LD conventions.
- **Tests**: `test/ssr/seo-ssr.test.ts` adds article coverage (hub is evergreen/no-dates, article emits TechArticle+FAQPage with canonical/keyword/image) and fixes the blog test slug (the old one is now an article).

## Verification

- `npm test` (website): 47 unit + browser tests pass. `webjs check`: clean.
- Booted via `createRequestHandler` in prod mode: `/articles` hub renders 6 evergreen cards (tags, no dates); each article emits TechArticle+BreadcrumbList+FAQPage with visible FAQ; `/blog` no longer lists the six and a moved `/blog/<slug>` 404s; blog posts emit BlogPosting+BreadcrumbList only; sitemap + llms.txt include the articles; footer has the Articles link and the header nav does not.

## Doc surfaces

- Website-only change (`website/` + repo-root `blog/`, `articles/`). Framework `packages/*` source, scaffold, MCP, editor plugins, and Bun-runtime-sensitive paths are all N/A (untouched). The other three dogfood apps are unaffected.
