### PR TITLE
fix: copy the articles/ content tree into the deploy image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,11 @@ COPY blog ./blog
 # modules/compare/queries/*.server.ts). Same reason as blog: without the
 # tree in the image, /compare renders "No comparisons yet."
 COPY compare ./compare
+# website/app/articles/[slug]/page.ts and app/sitemap.ts read
+# ../../../../articles/<slug>.md at SSR time (via
+# modules/articles/queries/*.server.ts). Same reason as compare: without
+# the tree in the image, /articles renders "No articles yet."
+COPY articles ./articles
 
 # --- 3. Build-time work --------------------------------------------------
 # Core: build the dist/ bundles. The package.json `prepare` hook is a


### PR DESCRIPTION
Closes #998

The live `/articles` renders "No articles yet" because the deploy image (repo-root `Dockerfile`) copies `changelog`, `blog`, and `compare` but not the `articles/` tree that #996 added. The SSR query `listArticles()` reads `../../../../articles/*.md` at request time, finds nothing in the image, and returns `[]`.

One-line fix: add `COPY articles ./articles` next to `COPY compare ./compare`. After redeploy, `/articles` lists the six articles.

No test/app changes (build-config only); the app itself was already verified in #996.