### PR TITLE
chore: release core 0.7.39, cli 0.10.44

### DIFF
--- a/changelog/cli/0.10.44.md
+++ b/changelog/cli/0.10.44.md
@@ -1,0 +1,12 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.44
+date: 2026-07-15T19:05:19.987Z
+commit_count: 1
+---
+## Features
+
+- **add webjs-frame gallery demo and rework the server-actions demo** ([#989](https://github.com/webjsdev/webjs/pull/989)) [`69b3e3f9`](https://github.com/webjsdev/webjs/commit/69b3e3f9)
+  * feat: add webjs-frame partial-swap gallery demo
+  
+  * fix: prune modules/frames in gallery:clear reset

--- a/changelog/core/0.7.39.md
+++ b/changelog/core/0.7.39.md
@@ -1,0 +1,10 @@
+---
+package: "@webjsdev/core"
+version: 0.7.39
+date: 2026-07-15T19:05:19.871Z
+commit_count: 1
+---
+## Fixes
+
+- **recover a dropped wj:children close marker on soft nav** ([#994](https://github.com/webjsdev/webjs/pull/994)) [`779dbb1d`](https://github.com/webjsdev/webjs/commit/779dbb1d)
+  Recover an orphaned wj:children open marker whose close comment was dropped by the browser parser (a cross-engine parse race seen on Android Chrome and desktop Chromium), so a soft nav takes the correct scoped swap and the outer-layout navbar keeps its DOM identity instead of being wiped by the destructive full-body fallback. Bound the recovered range against the well-formed side's trailing-sibling count so a footer in the marker's own parent is preserved, and keep buildHaveHeader strict so an orphaned page fetches the full page where the bounding aligns.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6975,7 +6975,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.43",
+      "version": "0.10.44",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -6991,7 +6991,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.38",
+      "version": "0.7.39",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.25.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.43",
+  "version": "0.10.44",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.38",
+  "version": "0.7.39",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",


### PR DESCRIPTION
Release the two published packages with unreleased qualifying commits since their last release.

## Bumps

- **@webjsdev/core** 0.7.38 -> 0.7.39 (patch): `fix` #994, recover a dropped wj:children close marker on soft nav so the outer-layout navbar survives a client-router swap when a browser drops the close comment (a cross-engine parse race, Android Chrome + desktop Chromium).
- **@webjsdev/cli** 0.10.43 -> 0.10.44 (patch): `feat` #989, add the webjs-frame gallery demo and rework the server-actions demo in the scaffold.

server 0.8.53, ui 0.3.9, mcp 0.1.10, intellisense 0.5.4 have zero qualifying commits since their last release, so they are not bumped.

## Mechanics

- Both are patch bumps within their existing minor line, so every in-repo dependent's caret range (`^0.7.x` for core, `^0.10.x` for cli) still resolves; no dependent range edits needed.
- `package-lock.json` regenerated (`npm install --package-lock-only`); the only diff is the two version refs.
- Changelogs auto-generated by the pre-commit hook from the conventional commit subjects (`changelog/core/0.7.39.md`, `changelog/cli/0.10.44.md`); the core entry's redundant issue-closing lines were trimmed.
- The create-webjs / webjsdev wrappers are intentionally not bumped here; the release workflow owns them (lockstep with cli).

Merging adds the `changelog/**.md` files to `main`, which triggers `release.yml` to `npm publish` core + cli and cut their GitHub Releases (idempotent).