### PR TITLE
fix: make light-DOM slot projection idempotent over projected HTML

### DIFF
--- a/packages/core/src/component.js
+++ b/packages/core/src/component.js
@@ -837,8 +837,15 @@ class WebComponentBase extends Base {
       //    the freshly-cloned slot. DOM identity preserved through the
       //    hydration round-trip.
       //
-      // c. First mount, no SSR. Move authored children into the
-      //    assignment table before _performRender wipes the host.
+      // c. First mount, no SSR: move authored children into the
+      //    assignment table before _performRender wipes the host. This
+      //    branch ALSO catches a client-router re-entry where the
+      //    boot-time webjs-hydrate marker is gone (a forward soft nav on a
+      //    marker-stripping parse, or a back/forward snapshot restore of
+      //    the already-hydrated DOM). captureAuthoredChildren is idempotent
+      //    over that already-projected HTML: it adopts the existing slot
+      //    assignments instead of hoovering its own render output into a
+      //    fresh slot (#1006).
       if (hasSlotState(this)) {
         // (a) Reconnection. State already populated; nothing to do here.
       } else if (this.__isHydrating()) {

--- a/packages/core/src/slot.js
+++ b/packages/core/src/slot.js
@@ -337,15 +337,73 @@ export function hasSlotState(host) {
 // ---------------------------------------------------------------------------
 
 /**
+ * True when `slot` belongs directly to `host`, i.e. no OTHER custom element
+ * sits between them. A slot nested inside a child custom element belongs to
+ * THAT component (its own slot state owns it), so the host must not adopt or
+ * capture it. Mirrors the router's own `isOwnLightSlot` (#906).
+ *
+ * @param {Element} slot
+ * @param {Element} host
+ * @returns {boolean}
+ */
+function isOwnLightSlot(slot, host) {
+  for (let p = slot.parentElement; p && p !== host; p = p.parentElement) {
+    if (p.tagName.includes('-')) return false;
+  }
+  return true;
+}
+
+/**
+ * True when `host` already carries its own projected render tree, i.e. its
+ * subtree contains a `slot[data-webjs-light][data-projection]` that belongs
+ * to THIS host (not a nested child component's slot). This is the durable
+ * structural signal that the host's children are its own rendered output with
+ * the authored content already sitting inside its slots, NOT freshly-authored
+ * light children waiting to be captured.
+ *
+ * Unlike the boot-time `webjs-hydrate` first-child marker (which hydration
+ * deletes, so it cannot answer this question after the first render), the
+ * `data-projection` attribute survives serialization into a client-router
+ * snapshot and a soft-nav fragment, so it is reliable on every re-entry into
+ * `connectedCallback` (a forward nav, a back/forward snapshot restore). See
+ * #1006.
+ *
+ * @param {Element} host
+ * @returns {boolean}
+ */
+function isAlreadyProjected(host) {
+  const slots = host.querySelectorAll(
+    `slot[${LIGHT_SLOT_ATTR}][${PROJECTION_ATTR}]`
+  );
+  for (const slot of slots) {
+    if (isOwnLightSlot(slot, host)) return true;
+  }
+  return false;
+}
+
+/**
  * Move every authored child of `host` into the slot state, partitioning
  * by each child's `slot=""` attribute. After this runs, `host` has no
  * children; the framework re-inserts them at projection time inside the
- * correct <slot> elements. Idempotent.
+ * correct <slot> elements.
+ *
+ * Idempotent over already-projected HTML. When `host` already carries its
+ * own rendered subtree (the soft-nav and snapshot-restore paths, where the
+ * boot-time `webjs-hydrate` marker is absent so `connectedCallback` reaches
+ * here instead of the hydration branch), hoovering every host child would
+ * capture the render output itself and re-project it into a fresh <slot>,
+ * nesting the whole tree one level inside itself (#1006). Detect that case
+ * via the durable `data-projection` marker and adopt the existing slot
+ * assignments in place instead of moving DOM.
  *
  * @param {Element} host
  */
 export function captureAuthoredChildren(host) {
   const state = ensureSlotState(host);
+  if (isAlreadyProjected(host)) {
+    adoptSSRAssignments(host);
+    return;
+  }
   while (host.firstChild) {
     const node = host.firstChild;
     const name = slotNameOf(node);
@@ -359,6 +417,10 @@ export function captureAuthoredChildren(host) {
  * <slot data-webjs-light> elements. Walk the host's render tree and
  * record those existing assignments in the state without moving DOM.
  *
+ * Only the host's OWN slots are adopted; a `data-webjs-light` slot nested
+ * inside a child custom element belongs to that component's slot state, so
+ * reaching into it here would clobber render-owned nodes (#906).
+ *
  * @param {Element} host
  */
 export function adoptSSRAssignments(host) {
@@ -368,6 +430,7 @@ export function adoptSSRAssignments(host) {
     /** @type {HTMLSlotElement} */
     const s = /** @type {any} */ (slot);
     if (s.getAttribute(PROJECTION_ATTR) !== PROJECTION_ACTUAL) continue;
+    if (!isOwnLightSlot(s, host)) continue;
     const name = s.getAttribute('name') || null;
     if (!state.assignedByName.has(name)) {
       const children = Array.from(s.childNodes);

--- a/packages/core/test/routing/browser/slot-soft-nav-idempotent.test.js
+++ b/packages/core/test/routing/browser/slot-soft-nav-idempotent.test.js
@@ -1,0 +1,98 @@
+/**
+ * Real-browser regression for #1006, the CLIENT-ROUTER paths: a slotted
+ * light-DOM component must not double its render output when the router
+ * re-inserts it on a soft nav or a back/forward snapshot restore.
+ *
+ * Two independent paths reach the buggy `captureAuthoredChildren` branch, and
+ * both are browser-independent (they do not need a comment-stripping parser):
+ *
+ *   Path 1 (forward soft nav): the incoming SSR host is parsed and grafted in.
+ *   Path 2 (snapshot restore): `snapshotCurrent` stores the LIVE, already-
+ *     hydrated `documentElement.outerHTML` (whose hosts no longer carry the
+ *     `webjs-hydrate` marker, since hydration removed it). On back/forward that
+ *     marker-less HTML is parsed and each host imported via
+ *     `document.importNode(node, true)` and inserted, firing `connectedCallback`.
+ *
+ * This test reproduces the snapshot round-trip exactly: render a live component,
+ * serialize it (what the snapshot stores), parse it back through the router's
+ * own `parseHTML`, `importNode` the host, and connect it. Without the fix the
+ * reconnected host shows the render output nested inside its own slot (two
+ * buttons); with the fix it projects the authored content exactly once.
+ *
+ * It runs on the lossless runner Chromium, so it CANNOT pass by accident on a
+ * comment-preserving parser: the marker is absent by DESIGN here (the live DOM
+ * never had it after hydration), not because a parser stripped it. Counterfactual:
+ * revert the `isAlreadyProjected` guard in `slot.js` and both assertions go red.
+ */
+import { html } from '../../../src/html.js';
+import { WebComponent } from '../../../src/component.js';
+import { _parseHTML } from '../../../src/router-client.js';
+
+import { assert } from '../../../../../test/browser-assert.js';
+
+function tick() {
+  return new Promise((r) => queueMicrotask(() => queueMicrotask(r)));
+}
+
+let counter = 0;
+
+suite('Client router: slotted component survives a snapshot restore without doubling (#1006)', () => {
+
+  test('a re-imported already-hydrated host projects its authored content exactly once', async () => {
+    const tag = `snap-copy-${counter++}`;
+    class SnapCopy extends WebComponent({ copied: Boolean }) {
+      constructor() { super(); this.copied = false; }
+      render() {
+        return html`<span class="group"
+          ><span data-copy-text><slot></slot></span
+          ><button @click=${() => { this.copied = true; }}>copy</button></span>`;
+      }
+    }
+    customElements.define(tag, SnapCopy);
+
+    // 1. A live, hydrated component: authored text projected into its slot.
+    const live = document.createElement(tag);
+    live.innerHTML = 'npm create webjs@latest my-app';
+    document.body.appendChild(live);
+    await live.updateComplete;
+    await tick();
+    assert.equal(live.querySelectorAll('button').length, 1, 'live: one button');
+    assert.equal(live.querySelector('slot').textContent, 'npm create webjs@latest my-app');
+
+    // 2. The snapshot stores the LIVE, already-hydrated outerHTML. It has NO
+    //    webjs-hydrate marker (hydration removed it), but it DOES carry the
+    //    durable data-projection="actual" slot.
+    const snapshotHTML = live.outerHTML;
+    assert.equal(snapshotHTML.includes('webjs-hydrate'), false,
+      'the live snapshot never carries the boot-time hydrate marker');
+    assert.equal(snapshotHTML.includes('data-projection="actual"'), true,
+      'the live snapshot carries the durable projection marker');
+
+    // 3. Back/forward restore: parse that HTML through the router parser and
+    //    import + connect the host, exactly as applySwap does.
+    const doc = _parseHTML(`<!doctype html><html><body>${snapshotHTML}</body></html>`);
+    const parsedHost = doc.body.querySelector(tag);
+    assert.ok(parsedHost, 'parsed the host back out of the snapshot');
+    const restored = document.importNode(parsedHost, true);
+    document.body.appendChild(restored); // fires connectedCallback
+    await tick();
+    await restored.updateComplete;
+    await tick();
+
+    // 4. THE ASSERTIONS THAT FAIL WITHOUT THE FIX: no nested render, one button.
+    assert.equal(restored.querySelectorAll('button').length, 1,
+      'restored host has exactly one button (render not duplicated inside its slot)');
+    assert.equal(restored.querySelector('slot [data-copy-text]'), null,
+      'no render output nested inside the restored slot');
+    assert.equal(restored.querySelector('slot').textContent, 'npm create webjs@latest my-app',
+      'authored content projected once into the restored slot');
+
+    // 5. The restored component is still interactive.
+    restored.querySelector('button').click();
+    await restored.updateComplete;
+    assert.equal(restored.copied, true, 'restored component still reacts to a click');
+
+    live.remove();
+    restored.remove();
+  });
+});

--- a/packages/core/test/slots/browser/slot-idempotent-projection.test.js
+++ b/packages/core/test/slots/browser/slot-idempotent-projection.test.js
@@ -1,0 +1,152 @@
+/**
+ * Real-browser regression for #1006: light-DOM slot projection must be
+ * idempotent over already-projected SSR HTML.
+ *
+ * The bug: on a client-router path that re-enters `connectedCallback` after the
+ * boot-time `webjs-hydrate` marker is already gone (a forward soft nav whose
+ * parse dropped the marker, or a back/forward snapshot restore of the live,
+ * already-hydrated DOM), `__isHydrating()` returns false, so control falls to
+ * `captureAuthoredChildren`. That function used to hoover EVERY host child into
+ * the assignment table. But on this path the host's children ARE its own
+ * rendered output (the render tree with the authored content already sitting
+ * inside a `<slot data-webjs-light data-projection="actual">`). Capturing that
+ * whole subtree and re-projecting it into a fresh slot nests the entire render
+ * one level inside itself: two copy buttons, the render output duplicated
+ * inside its own slot.
+ *
+ * The fix makes `captureAuthoredChildren` idempotent: it detects an
+ * already-projected host via the durable `data-projection` marker (which,
+ * unlike the transient `webjs-hydrate` comment, survives serialization into a
+ * snapshot / soft-nav fragment) and adopts the existing slot assignments in
+ * place instead of moving DOM.
+ *
+ * Counterfactual: revert the `isAlreadyProjected` guard in `slot.js` and both
+ * assertions below go red (two buttons, render output nested inside the slot).
+ */
+import { html } from '../../../src/html.js';
+import { WebComponent } from '../../../src/component.js';
+import {
+  installSlotPolyfills,
+  captureAuthoredChildren,
+  SLOT_STATE,
+} from '../../../src/slot.js';
+
+installSlotPolyfills();
+
+import { assert } from '../../../../../test/browser-assert.js';
+
+function tick() {
+  return new Promise((r) => queueMicrotask(() => queueMicrotask(r)));
+}
+
+let nextTag = 0;
+function tagName(base) { return `idem-${base}-${++nextTag}`; }
+
+suite('Light-DOM slot projection is idempotent over projected HTML (#1006)', () => {
+
+  test('captureAuthoredChildren adopts an already-projected host instead of hoovering', () => {
+    // A plain host (no custom-element upgrade needed) already carrying a
+    // component's rendered output: the copy-cmd shape, with the authored
+    // command text inside a data-projection="actual" slot.
+    const host = document.createElement('div');
+    host.innerHTML =
+      '<span class="group"><span data-copy-text>' +
+      '<slot data-webjs-light data-projection="actual">npm create webjs@latest my-app</slot>' +
+      '</span><button>copy</button></span>';
+    const renderRoot = host.firstElementChild; // the span.group render output
+
+    captureAuthoredChildren(host);
+
+    const state = /** @type {any} */ (host)[SLOT_STATE];
+    const def = state.assignedByName.get(null);
+    // Idempotent: it recorded ONLY the slot's authored content, not the whole
+    // render subtree. Without the fix, `def` is `[span.group]` (the render
+    // output) and the host is emptied.
+    assert.ok(def && def.length === 1, 'exactly one default-slot assignment recorded');
+    assert.equal(def[0].nodeType, 3, 'the recorded assignment is the authored text node');
+    assert.equal(def[0].textContent, 'npm create webjs@latest my-app');
+    // Adoption does not move DOM: the render output is untouched, still in place.
+    assert.equal(host.firstElementChild, renderRoot, 'render output left in place (no hoover)');
+    assert.equal(host.querySelectorAll('button').length, 1, 'still exactly one button');
+  });
+
+  test('a slotted component inserted already-projected does not nest its render inside its own slot', async () => {
+    const tag = tagName('card');
+    class Card extends WebComponent({ label: String }) {
+      render() {
+        return html`<span class="group"
+          ><span data-copy-text><slot></slot></span
+          ><button @click=${() => { this.label = 'x'; }}>copy</button></span>`;
+      }
+    }
+    Card.register(tag);
+
+    // Simulate the soft-nav / snapshot-restore insertion: the host arrives
+    // ALREADY projected (its own render output, authored text inside a
+    // data-projection="actual" slot) and WITHOUT the webjs-hydrate marker.
+    const host = document.createElement(tag);
+    host.innerHTML =
+      '<span class="group"><span data-copy-text>' +
+      '<slot data-webjs-light data-projection="actual">npm create webjs@latest my-app</slot>' +
+      '</span><button>copy</button></span>';
+    document.body.appendChild(host);
+    await tick();
+    await host.updateComplete;
+    await tick();
+
+    assert.equal(host.querySelectorAll('button').length, 1,
+      'exactly one button after projection (not two)');
+    assert.equal(host.querySelector('slot [data-copy-text]'), null,
+      'render output must NOT be nested inside the slot');
+    assert.equal(host.querySelector('slot').textContent, 'npm create webjs@latest my-app',
+      'the authored command text is the slot content');
+
+    host.remove();
+  });
+
+  test('a first mount with real authored children (no SSR) still captures normally', async () => {
+    // The non-projected path must be unchanged: raw authored children get
+    // hoovered and projected into the slot exactly once.
+    const tag = tagName('fresh');
+    class Fresh extends WebComponent {
+      render() { return html`<div class="wrap"><slot></slot></div>`; }
+    }
+    Fresh.register(tag);
+
+    const host = document.createElement(tag);
+    host.innerHTML = '<p>hi</p><b>!</b>';
+    document.body.appendChild(host);
+    await tick();
+
+    const slot = host.querySelector('slot[data-webjs-light]');
+    assert.ok(slot, 'slot exists');
+    assert.equal(slot.getAttribute('data-projection'), 'actual');
+    assert.equal(slot.children.length, 2, 'both authored children projected once');
+    assert.equal(host.querySelectorAll('slot').length, 1, 'exactly one slot, no nesting');
+
+    host.remove();
+  });
+
+  test('an already-projected host does not adopt a NESTED child component slot (#906)', () => {
+    // The idempotency guard must scope to the host's OWN slots. A
+    // data-projection slot that belongs to a nested child custom element is
+    // owned by THAT component; the outer host must not adopt its content.
+    const host = document.createElement('div');
+    host.innerHTML =
+      '<section>' +
+      '<slot data-webjs-light data-projection="actual">OUTER</slot>' +
+      '<nested-child><slot data-webjs-light data-projection="actual">INNER</slot></nested-child>' +
+      '</section>';
+
+    captureAuthoredChildren(host);
+
+    const state = /** @type {any} */ (host)[SLOT_STATE];
+    const def = state.assignedByName.get(null);
+    // Only the outer's own default slot content ("OUTER") is adopted; the
+    // nested child's slot ("INNER") is left to that component.
+    assert.ok(def && def.length === 1, 'one assignment for the outer default slot');
+    assert.equal(def[0].textContent, 'OUTER', 'adopted the OUTER slot content only');
+    assert.equal(host.querySelector('nested-child slot').textContent, 'INNER',
+      'nested child slot content untouched');
+  });
+});


### PR DESCRIPTION
## Problem

Light-DOM slot projection was not idempotent over already-projected SSR HTML. On a client-router path that re-enters `connectedCallback` after the boot-time `webjs-hydrate` marker is gone, `captureAuthoredChildren` hoovered the host's own render output into a fresh `<slot>`, nesting the whole render tree one level inside itself. Live symptom: every `<copy-cmd>` on webjs.dev showed two copy buttons after a soft nav.

Two independent, browser-independent paths reached the bug.

1. Forward soft nav where the parse dropped the `webjs-hydrate` comment (partly addressed by #1010, which fixed the comment-preserving parse).
2. Back/forward snapshot restore. `snapshotCurrent` stores the live, already-hydrated `outerHTML`, which never carries the `webjs-hydrate` marker (hydration removed it). This path is untouched by #1010 and reproduces on lossless engines too.

`__isHydrating()` was the wrong discriminator. It keys off a transient boot-time marker that hydration itself deletes, so it cannot answer the question "are these children authored, or my own render output?" on any re-entry after the first render.

## Fix

Trust the durable structural marker `data-projection="actual"` instead. Unlike the `webjs-hydrate` comment, the attribute survives serialization into a snapshot and a soft-nav fragment. `captureAuthoredChildren` now detects an already-projected host and delegates to `adoptSSRAssignments` (read the existing slot assignments without moving DOM) rather than hoovering. This makes the function's long-standing `Idempotent.` docstring claim true and fixes every slotted light-DOM component, not just `copy-cmd`.

The detection is scoped to the host's OWN slots (`isOwnLightSlot`), so a `data-webjs-light` slot nested inside a child custom element is never adopted or clobbered (#906). `adoptSSRAssignments` gained the same guard.

## Tests

- `packages/core/test/slots/browser/slot-idempotent-projection.test.js` covers unit-level idempotency (adopts instead of hoovering, first-mount-no-SSR path unchanged, nested-child #906 scoping).
- `packages/core/test/routing/browser/slot-soft-nav-idempotent.test.js` reproduces the snapshot round-trip (serialize live host, parse via the router's `parseHTML`, `importNode` then connect) and asserts exactly one button, no nested render, still interactive. It runs on the lossless runner Chromium so it cannot pass by accident.
- Counterfactual verified: reverting the `isAlreadyProjected` guard turns 4 assertions red.
- Full `packages/core/test/slots/browser/**` and `packages/core/test/routing/browser/**` suites report 152 passed, 0 failed (no #906 / #907 / #910 / #912 / #914 regression).

## Notes

- Client-side browser code only (`slot.js` projection, `component.js` `connectedCallback`). No server-runtime path is touched, so Bun parity is not applicable.
- No doc surface changes. The fix restores the already-documented contract (core AGENTS.md invariant 7, light and shadow slots behave identically). It adds no export, config key, or authoring surface.

Closes #1006
