### PR TITLE
Rebuild the client router + light-DOM slots on structural boundaries (Next.js-parity)

### DIFF
--- a/packages/core/src/router-client.js
+++ b/packages/core/src/router-client.js
@@ -737,6 +737,53 @@ function warnOnce(key, message) {
 }
 
 /**
+ * Dev-only diagnostic: the client router degraded a soft navigation to a full
+ * page load. Records WHY (the `cause`) so the "why did my SPA nav do a full
+ * reload?" question is answerable from the console instead of guessed at. Silent
+ * in production and deduped per cause so a repeated trigger does not spam.
+ *
+ * @param {string} cause a short stable slug for the degradation reason
+ * @param {string} href the destination the router fell back to loading
+ */
+/**
+ * True when a nav must degrade to a full page load because the document is
+ * still parsing. A forward, main-document nav fired at `readyState: 'loading'`
+ * races the DOM: the leaving page's closing layout markers may not be attached
+ * yet, so a soft swap would snapshot an incomplete tree and corrupt the DOM
+ * (#1008 / #936). Scoped to frameless forward navs (popstate is browser-driven,
+ * a frame nav carries its own boundary element).
+ *
+ * @param {boolean} isPopState
+ * @param {string | null | undefined} frameId
+ * @returns {boolean}
+ */
+function shouldFullLoadDuringParse(isPopState, frameId) {
+  return (
+    !isPopState &&
+    !frameId &&
+    typeof document !== 'undefined' &&
+    document.readyState === 'loading'
+  );
+}
+
+/**
+ * Dev-only diagnostic: the client router degraded a soft navigation to a full
+ * page load. Records WHY (the `cause`) so the "why did my SPA nav do a full
+ * reload?" question is answerable from the console instead of guessed at. Silent
+ * in production and deduped per cause so a repeated trigger does not spam.
+ *
+ * @param {string} cause a short stable slug for the degradation reason
+ * @param {string} href the destination the router fell back to loading
+ */
+function devWarnFallback(cause, href) {
+  if (typeof process !== 'undefined' && process.env && process.env.NODE_ENV === 'production') return;
+  warnOnce(
+    `fallback:${cause}`,
+    `[webjs] client router fell back to a full page load (${cause}) navigating to ${href}. This is correct (no DOM corruption), just not a soft nav.`
+  );
+}
+
+/**
  * Dev-only, fire-once hint: the router forces an INSTANT scroll-to-top on a
  * forward navigation (matching a native page load), so an app-level
  * `scroll-behavior: smooth` on <html> does not affect route transitions (it
@@ -996,6 +1043,22 @@ function cacheKey(url) {
  * @param {string | null} frameId  Active <webjs-frame> id, or null.
  */
 async function performNavigation(href, isPopState, frameId) {
+  // #1008 / #936: a forward, main-document nav fired while the document is
+  // still parsing (`readyState === 'loading'`) races the DOM. The leaving
+  // page's closing layout markers at the bottom of the body may not exist yet,
+  // so `snapshotCurrent` plus region discovery would capture an incomplete tree
+  // and drive a corrupt or over-wide swap (the suspected root cause of the
+  // dropped-marker reports). The PREFETCH path already skips this window (see
+  // the `buildHaveHeader` call site); the click / `navigate()` path did not.
+  // Degrade to a correct full-page load, which is what an MPA would do anyway.
+  // Scoped to frameless forward navs: popstate is browser-driven, and a frame
+  // nav carries its own boundary element.
+  if (shouldFullLoadDuringParse(isPopState, frameId) && typeof location !== 'undefined') {
+    devWarnFallback('readyState-loading', href);
+    location.href = href;
+    return;
+  }
+
   // Cancel any in-flight fetch: Turbo Drive's navigator.stop().
   if (activeAbortController) activeAbortController.abort();
   activeAbortController = new AbortController();
@@ -3850,6 +3913,11 @@ export function _currentPageUrl() { return currentPageUrl; }
 export function _setCurrentPageUrl(u) { currentPageUrl = u; }
 /** Test-only: clear the fire-once warning guards so a case can be re-exercised. */
 export function _resetWarnOnce() { warnedKeys.clear(); smoothScrollChecked = false; }
+
+/** Test-only: the readyState-loading full-load degradation predicate (#1008). */
+export function _shouldFullLoadDuringParse(isPopState, frameId) {
+  return shouldFullLoadDuringParse(isPopState, frameId);
+}
 
 /**
  * Predicate used by the onClick handler to decide whether a same-origin

--- a/packages/core/src/router-client.js
+++ b/packages/core/src/router-client.js
@@ -2843,9 +2843,38 @@ function applySwap(doc, frameId, revalidating, href, incomingBuild, incomingSrc)
     return;
   }
 
-  // 2. Auto-derived layout-marker swap. Recover an orphaned open marker on
+  // 2. Structural region swap (#1013, Pillar 1 + 2). When BOTH the live DOM and
+  // the response carry <wj-region> boundary ELEMENTS, use the element-based
+  // two-tier swap. A real element delimits its own subtree, so an over-wide or
+  // corrupt swap is structurally impossible (no LIFO comment pairing, no
+  // orphaned close); the plan is: wholesale replace on a route-key change (Next
+  // remount), bounded morph on a searchParams-only nav (hydrated component state
+  // preserved). A response with no shared region degrades to the full-body swap
+  // below (the ladder). Dormant until the server emits regions, so the comment
+  // path below still runs for a marker-only response during the migration.
+  const liveRegions = collectRegions(document.body);
+  const incomingRegions = collectRegions(doc.body);
+  if (liveRegions.size && incomingRegions.size) {
+    const plan = planRegionSwap(liveRegions, incomingRegions);
+    if (plan) {
+      // ADD-ONLY head merge: outer layouts stay mounted, so their head-bound
+      // runtime state (Tailwind injection, etc.) must not be invalidated.
+      addNewHeadElements(doc.head);
+      runWithTransition(() => {
+        applyRegionContent(plan);
+        blurOutgoingFocus();
+      }, () => upgradeCustomElements(plan.live));
+      forwardSuspenseResolvers(doc.body);
+      return;
+    }
+    // Regions present but no shared region: fall through to the full-body swap
+    // (a genuine root-layout change). The root `/` region normally exists on
+    // both sides, so this is reached only for a divergent or malformed shell.
+  }
+
+  // 3. Auto-derived layout-marker swap. Recover an orphaned open marker on
   // either side (#994): a dropped close comment must not force the destructive
-  // path-3 fallback that wipes the outer layout (navbar).
+  // full-body fallback that wipes the outer layout (navbar).
   const here = collectChildrenSlots(document.body, { recoverOrphans: true });
   const there = collectChildrenSlots(doc.body, { recoverOrphans: true });
   const sharedPath = longestSharedPath(here, there);
@@ -2874,7 +2903,7 @@ function applySwap(doc, frameId, revalidating, href, incomingBuild, incomingSrc)
     return;
   }
 
-  // 3. Full body swap fallback: no shared layout marker (a genuine root-layout
+  // 4. Full body swap fallback: no shared layout marker (a genuine root-layout
   // change, or a same-layout nav whose markers could not be paired). Full head
   // merge, so a real root-layout change removes stale head elements. `mergeHead`
   // now PRESERVES stylesheets and `<style>` unconditionally (#936): even if the

--- a/packages/core/src/router-client.js
+++ b/packages/core/src/router-client.js
@@ -1060,6 +1060,46 @@ export function planRegionSwap(here, there) {
   };
 }
 
+/**
+ * Apply a region swap plan to the DOM (#1013, Pillar 2). Mutates ONLY the
+ * children of the plan's live `<wj-region>`; the region element itself and
+ * everything above it (outer layouts, root chrome) is never touched, which is
+ * how the "preserve outer-layout DOM identity" invariant holds structurally.
+ *
+ *  - `replace` (route-key changed, or a structural divergence below the deepest
+ *    shared region): wholesale `replaceChildren` with the imported incoming
+ *    nodes. This is Next's remount and Turbo's replace: no reconciler runs, so
+ *    no stale hydrated state survives a real route change. `data-webjs-permanent`
+ *    nodes are regrafted by identity first so they persist across the remount.
+ *  - `morph` (searchParams-only / refresh, same route-key, page region is the
+ *    leaf on both sides): the bounded same-route morph via `reconcileChildren`,
+ *    which reuses keyed + positional nodes, treats a hydrated component as an
+ *    opaque island (its render-owned subtree is never descended into, so its
+ *    state and instance survive while its attributes are synced), and regrafts
+ *    permanents. This is the only path that preserves component state, matching
+ *    React reconciliation for a client component at the same position.
+ *
+ * Script reactivation + custom-element upgrade run for the replace path (fresh
+ * nodes); the morph path's `reconcileChildren` handles its own upgrades. The
+ * caller wraps this in `runWithTransition` and does the head merge / focus blur.
+ *
+ * @param {{mode:'replace'|'morph', live:Element, incoming:Element}} plan
+ */
+function applyRegionContent(plan) {
+  const { mode, live, incoming } = plan;
+  if (mode === 'morph') {
+    reconcileChildren(live, incoming);
+    return;
+  }
+  // Wholesale replace (remount). Import incoming children, regraft live
+  // permanents into them by identity, then swap in one shot.
+  const imported = [...incoming.childNodes].map((n) => document.importNode(n, true));
+  regraftPermanentInSlice([...live.childNodes], imported);
+  live.replaceChildren(...imported);
+  reactivateScripts(live);
+  upgradeCustomElements(live);
+}
+
 /* ====================================================================
  * Snapshot cache (Turbo SnapshotCache pattern)
  * ==================================================================== */
@@ -3954,6 +3994,7 @@ export {
   collectChildrenSlots as _collectChildrenSlots,
   collectRegions as _collectRegions,
   planRegionSwap as _planRegionSwap,
+  applyRegionContent as _applyRegionContent,
   longestSharedPath as _longestSharedPath,
   parseHTML as _parseHTML,
   resetParseProbe as _resetParseProbe,

--- a/packages/core/src/router-client.js
+++ b/packages/core/src/router-client.js
@@ -1000,6 +1000,66 @@ export function collectRegions(root) {
   return regions;
 }
 
+/** Deepest (longest-segment) region in a map, or null. */
+function deepestSegment(regions) {
+  let best = null;
+  for (const s of regions.keys()) if (best === null || s.length > best.length) best = s;
+  return best;
+}
+
+/**
+ * Plan the two-tier region swap from the live + incoming region maps (#1013,
+ * Pillar 2). Region segments are nested path prefixes, so the shared segments
+ * form a chain from `/` down to the deepest shared region D.
+ *
+ * Rules (exact Next.js remount-vs-preserve parity):
+ *  - REPLACE at the SHALLOWEST shared region whose route-key changed. A param
+ *    change at a segment remounts that segment AND its whole subtree, so the
+ *    boundary is the shallowest changed region, not the deepest (`/blog/a` ->
+ *    `/blog/b` replaces the page region; `/a/settings` -> `/b/settings`
+ *    replaces the dynamic `[org]` layout region and everything under it).
+ *  - No route-key changed but the subtree below D diverges (D is a LAYOUT, not
+ *    the leaf, on either side, for example `/about` -> `/contact` under a shared
+ *    static root layout): REPLACE D's children wholesale.
+ *  - No route-key changed and D is the leaf (page) region on BOTH sides: MORPH
+ *    D. This is the searchParams-only / refresh / revalidate nav that must
+ *    preserve hydrated component state while updating searchParam-driven DOM.
+ *  - No shared region at all: null (caller degrades down the ladder to a full
+ *    load). In practice the root `/` region exists on both sides, so this is
+ *    reached only for a malformed / truncated response.
+ *
+ * The returned `live` / `incoming` are the `<wj-region>` ELEMENTS; the swap
+ * operates on their children (`replaceChildren` for `replace`, a bounded morph
+ * for `morph`), never on the region element itself.
+ *
+ * @param {Map<string,{el:Element,routeKey:string}>} here  live regions
+ * @param {Map<string,{el:Element,routeKey:string}>} there incoming regions
+ * @returns {{mode:'replace'|'morph', segment:string, live:Element, incoming:Element}|null}
+ */
+export function planRegionSwap(here, there) {
+  // Shared segments, shallowest first (a nested path prefix is shorter).
+  const shared = [...here.keys()].filter((s) => there.has(s)).sort((a, b) => a.length - b.length);
+  if (shared.length === 0) return null;
+  // Shallowest shared region whose route-key changed is the remount boundary.
+  for (const seg of shared) {
+    if (here.get(seg).routeKey !== there.get(seg).routeKey) {
+      return { mode: 'replace', segment: seg, live: here.get(seg).el, incoming: there.get(seg).el };
+    }
+  }
+  // No route-key changed. D = deepest shared region.
+  const D = shared[shared.length - 1];
+  const leafOnBoth = deepestSegment(here) === D && deepestSegment(there) === D;
+  // Leaf on both -> searchParams-only nav -> morph (state preserved). Otherwise
+  // the subtree below D diverges (a page change under a shared static layout)
+  // -> replace D's children wholesale.
+  return {
+    mode: leafOnBoth ? 'morph' : 'replace',
+    segment: D,
+    live: here.get(D).el,
+    incoming: there.get(D).el,
+  };
+}
+
 /* ====================================================================
  * Snapshot cache (Turbo SnapshotCache pattern)
  * ==================================================================== */
@@ -3893,6 +3953,7 @@ export {
   clearFormBusy as _clearFormBusy,
   collectChildrenSlots as _collectChildrenSlots,
   collectRegions as _collectRegions,
+  planRegionSwap as _planRegionSwap,
   longestSharedPath as _longestSharedPath,
   parseHTML as _parseHTML,
   resetParseProbe as _resetParseProbe,

--- a/packages/core/src/router-client.js
+++ b/packages/core/src/router-client.js
@@ -962,6 +962,44 @@ export function longestSharedPath(here, there) {
   return best;
 }
 
+/**
+ * Collect `<wj-region segment route-key>` boundary elements into a Map keyed
+ * by segment path. Regions are the structural replacement for the wj:children
+ * comment markers (#1013): SSR emits one around each layout's `${children}`
+ * and one around the page, for example
+ * `<wj-region segment="/blog/[slug]" route-key="/blog/a">`.
+ *
+ * Because the boundary is a real element, the HTML parser itself delimits the
+ * subtree: there is no LIFO pairing, no orphaned close, no over-wide range. A
+ * missing region is simply absent from the Map (the swap degrades to a wider
+ * shared region or a full load per the ladder), never a corrupt swap. The
+ * element's own children ARE the swap target, so the swap becomes
+ * `region.el.replaceChildren(...)` on a route-key change or a bounded morph of
+ * those children when the route-key is unchanged (searchParams-only nav).
+ *
+ * `segment` is the layout scope (route groups kept, so distinct `(group)`
+ * layouts at the same URL prefix stay distinct); `route-key` is the concrete
+ * resolved path the two-tier swap compares (see server `regionRouteKey`). A
+ * segment appears once per document (a self-including layout is pathological);
+ * first wins, matching `collectChildrenSlots`. The returned Map's KEYS are
+ * segment paths, so `longestSharedPath` picks the deepest shared region
+ * unchanged.
+ *
+ * @param {ParentNode} root
+ * @returns {Map<string, { el: Element, routeKey: string }>}
+ */
+export function collectRegions(root) {
+  /** @type {Map<string, { el: Element, routeKey: string }>} */
+  const regions = new Map();
+  if (!root || !root.querySelectorAll) return regions;
+  for (const el of root.querySelectorAll('wj-region[segment]')) {
+    const segment = el.getAttribute('segment');
+    if (!segment || regions.has(segment)) continue;
+    regions.set(segment, { el, routeKey: el.getAttribute('route-key') || segment });
+  }
+  return regions;
+}
+
 /* ====================================================================
  * Snapshot cache (Turbo SnapshotCache pattern)
  * ==================================================================== */
@@ -3854,6 +3892,7 @@ export {
   markFormBusy as _markFormBusy,
   clearFormBusy as _clearFormBusy,
   collectChildrenSlots as _collectChildrenSlots,
+  collectRegions as _collectRegions,
   longestSharedPath as _longestSharedPath,
   parseHTML as _parseHTML,
   resetParseProbe as _resetParseProbe,

--- a/packages/core/test/routing/browser/readystate-fullload-guard.test.js
+++ b/packages/core/test/routing/browser/readystate-fullload-guard.test.js
@@ -1,0 +1,84 @@
+/**
+ * Regression for #1008 (folded into #1013): a forward, main-document client-router
+ * nav fired while the document is still parsing (`readyState === 'loading'`) must
+ * degrade to a full page load, NOT attempt a soft swap. During parse the leaving
+ * page's closing layout markers may not be attached yet, so snapshotting the tree
+ * and running a scoped swap would corrupt the DOM. The prefetch path already skips
+ * this window (#936); the click / `navigate()` path did not.
+ *
+ * Testing the actual `location.href = href` full load in a browser would navigate
+ * the runner away, so this asserts the degradation PREDICATE directly, under a
+ * `document.readyState` override. Counterfactual: revert the guard in
+ * `performNavigation` (or make the predicate always return false) and the first
+ * assertion goes red.
+ */
+import { _shouldFullLoadDuringParse } from '../../../src/router-client.js';
+import { assert } from '../../../../../test/browser-assert.js';
+
+/**
+ * Run `fn` with `document.readyState` forced to `value`, restoring the native
+ * getter afterwards no matter what.
+ */
+function withReadyState(value, fn) {
+  const proto = Object.getPrototypeOf(document);
+  const original = Object.getOwnPropertyDescriptor(document, 'readyState');
+  Object.defineProperty(document, 'readyState', { get: () => value, configurable: true });
+  try {
+    fn();
+  } finally {
+    if (original) Object.defineProperty(document, 'readyState', original);
+    else delete document.readyState;
+    // Sanity: the native value is back.
+    void proto;
+  }
+}
+
+suite('client router: readyState-loading full-load degradation (#1008)', () => {
+  test('a forward frameless nav during parse degrades to a full load', () => {
+    withReadyState('loading', () => {
+      assert.equal(
+        _shouldFullLoadDuringParse(/* isPopState */ false, /* frameId */ null),
+        true,
+        'forward frameless nav at readyState=loading must full-load'
+      );
+    });
+  });
+
+  test('a nav after the document is complete stays a soft nav', () => {
+    withReadyState('complete', () => {
+      assert.equal(
+        _shouldFullLoadDuringParse(false, null),
+        false,
+        'complete document keeps the soft-nav path'
+      );
+    });
+  });
+
+  test('popstate is never hijacked (browser-driven), even during parse', () => {
+    withReadyState('loading', () => {
+      assert.equal(
+        _shouldFullLoadDuringParse(/* isPopState */ true, null),
+        false,
+        'popstate during parse is left to the browser'
+      );
+    });
+  });
+
+  test('a frame nav during parse is scoped out (carries its own boundary)', () => {
+    withReadyState('loading', () => {
+      assert.equal(
+        _shouldFullLoadDuringParse(false, /* frameId */ 'sidebar'),
+        false,
+        'frame nav during parse is not a full-document full-load'
+      );
+    });
+  });
+
+  test('interactive readyState still counts as parsing (markers may be incomplete)', () => {
+    // 'interactive' means the DOM is parsed but sub-resources still load; the
+    // guard only fires on 'loading', so interactive stays a soft nav.
+    withReadyState('interactive', () => {
+      assert.equal(_shouldFullLoadDuringParse(false, null), false);
+    });
+  });
+});

--- a/packages/core/test/routing/region-apply.test.js
+++ b/packages/core/test/routing/region-apply.test.js
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for applyRegionContent (Pillar 2 DOM mutation, #1013).
+ *
+ * Given a swap plan it mutates ONLY the live <wj-region>'s children:
+ *   - 'replace' does a wholesale replaceChildren (Next remount): new nodes,
+ *     old identity gone, except data-webjs-permanent nodes regrafted by identity.
+ *   - 'morph' reuses keyed/positional live nodes (state preserved), the
+ *     bounded same-route swap for a searchParams-only nav.
+ * The region element itself and everything above it is never touched.
+ */
+import { test, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseHTML } from 'linkedom';
+
+let _applyRegionContent;
+
+before(async () => {
+  const { window } = parseHTML('<!doctype html><html><head></head><body></body></html>');
+  globalThis.document = window.document;
+  globalThis.window = window;
+  globalThis.HTMLElement = window.HTMLElement;
+  globalThis.Element = window.Element;
+  globalThis.Node = window.Node;
+  globalThis.Comment = window.Comment;
+  globalThis.Text = window.Text;
+  globalThis.MutationObserver = window.MutationObserver;
+  globalThis.customElements = window.customElements;
+  globalThis.CustomEvent = window.CustomEvent;
+  globalThis.DOMParser = window.DOMParser;
+  globalThis.CSS = globalThis.CSS || { escape: (s) => String(s).replace(/[^a-zA-Z0-9_-]/g, (m) => `\\${m}`) };
+  if (typeof globalThis.sessionStorage === 'undefined') {
+    const store = new Map();
+    globalThis.sessionStorage = /** @type any */ ({
+      getItem: (k) => (store.has(k) ? store.get(k) : null),
+      setItem: (k, v) => { store.set(k, String(v)); },
+      removeItem: (k) => { store.delete(k); }, clear: () => store.clear(),
+    });
+  }
+  ({ _applyRegionContent } = await import('../../src/router-client.js'));
+});
+
+/** Make a detached <wj-region> element with the given inner HTML. */
+function region(inner) {
+  const { document: doc } = parseHTML(`<!doctype html><html><body><wj-region segment="/x">${inner}</wj-region></body></html>`);
+  // Adopt into the global document so importNode / replaceChildren operate there.
+  const el = doc.body.firstChild;
+  return document.importNode(el, true);
+}
+
+test('replace swaps children wholesale (remount, no old identity kept)', () => {
+  const live = region('<article id="a">old</article>');
+  const oldNode = live.firstChild;
+  const incoming = region('<article id="b">new</article>');
+  _applyRegionContent({ mode: 'replace', live, incoming });
+  assert.equal(live.children.length, 1);
+  assert.equal(live.firstElementChild.id, 'b');
+  assert.equal(live.textContent.trim(), 'new');
+  assert.notEqual(live.firstChild, oldNode); // remounted, not reused
+});
+
+test('replace regrafts a data-webjs-permanent node by identity', () => {
+  const live = region('<div data-webjs-permanent id="player">LIVE-PLAYER</div><p>old</p>');
+  const permanent = live.querySelector('#player');
+  const incoming = region('<div data-webjs-permanent id="player">INCOMING-PLAYER</div><p>new</p>');
+  _applyRegionContent({ mode: 'replace', live, incoming });
+  // The live permanent node object survives (identity), not the incoming copy.
+  assert.equal(live.querySelector('#player'), permanent);
+  assert.equal(live.querySelector('#player').textContent, 'LIVE-PLAYER');
+  assert.equal(live.querySelector('p').textContent, 'new'); // non-permanent updated
+});
+
+test('morph reuses a keyed live node (state-preservation path)', () => {
+  const live = region('<li data-key="1">a</li><li data-key="2">b</li>');
+  const keptNode = live.querySelector('[data-key="1"]');
+  const incoming = region('<li data-key="1">a-updated</li><li data-key="2">b</li>');
+  _applyRegionContent({ mode: 'morph', live, incoming });
+  // Same node object reused for key "1" (identity kept), text updated.
+  assert.equal(live.querySelector('[data-key="1"]'), keptNode);
+  assert.equal(live.querySelector('[data-key="1"]').textContent, 'a-updated');
+});
+
+test('mutates only the region children, never the region element itself', () => {
+  const live = region('<span>x</span>');
+  const el = live;
+  _applyRegionContent({ mode: 'replace', live, incoming: region('<span>y</span>') });
+  assert.equal(live, el); // same region element object
+  assert.equal(live.getAttribute('segment'), '/x'); // untouched
+});

--- a/packages/core/test/routing/region-discovery.test.js
+++ b/packages/core/test/routing/region-discovery.test.js
@@ -1,0 +1,105 @@
+/**
+ * Unit tests for structural region discovery (Pillar 1, #1013).
+ *
+ * `collectRegions` replaces the wj:children comment-marker walk
+ * (`collectChildrenSlots`): it finds `<wj-region segment route-key>` boundary
+ * ELEMENTS. Because a real element delimits the subtree, there is no LIFO
+ * pairing and no orphaned-close class of bug: a missing region is just absent
+ * from the Map. The returned map's keys are segment paths, so the existing
+ * `longestSharedPath` picks the deepest shared region unchanged.
+ *
+ * The router-client auto-enables on import, so DOM globals are set up first.
+ */
+import { test, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseHTML } from 'linkedom';
+
+let _collectRegions, _longestSharedPath;
+
+before(async () => {
+  const { window } = parseHTML('<!doctype html><html><head></head><body></body></html>');
+  globalThis.document = window.document;
+  globalThis.window = window;
+  globalThis.HTMLElement = window.HTMLElement;
+  globalThis.Element = window.Element;
+  globalThis.Node = window.Node;
+  globalThis.Comment = window.Comment;
+  globalThis.Text = window.Text;
+  globalThis.MutationObserver = window.MutationObserver;
+  globalThis.customElements = window.customElements;
+  globalThis.CustomEvent = window.CustomEvent;
+  globalThis.DOMParser = window.DOMParser;
+  globalThis.CSS = globalThis.CSS || {
+    escape(s) { return String(s).replace(/[^a-zA-Z0-9_-]/g, (m) => `\\${m}`); },
+  };
+  if (typeof globalThis.sessionStorage === 'undefined') {
+    const store = new Map();
+    globalThis.sessionStorage = /** @type any */ ({
+      getItem: (k) => (store.has(k) ? store.get(k) : null),
+      setItem: (k, v) => { store.set(k, String(v)); },
+      removeItem: (k) => { store.delete(k); },
+      clear: () => { store.clear(); },
+    });
+  }
+  ({ _collectRegions, _longestSharedPath } = await import('../../src/router-client.js'));
+});
+
+/** Parse an HTML body string into a detached container with querySelectorAll. */
+function body(html) {
+  const { document: doc } = parseHTML(`<!doctype html><html><body>${html}</body></html>`);
+  return doc.body;
+}
+
+test('collects nested regions keyed by segment, carrying route-key', () => {
+  const root = body(`
+    <wj-region segment="/" route-key="/">
+      <header>chrome</header>
+      <wj-region segment="/blog" route-key="/blog">
+        <wj-region segment="/blog/[slug]" route-key="/blog/a">
+          <article>post a</article>
+        </wj-region>
+      </wj-region>
+    </wj-region>
+  `);
+  const regions = _collectRegions(root);
+  assert.deepEqual([...regions.keys()], ['/', '/blog', '/blog/[slug]']);
+  assert.equal(regions.get('/').routeKey, '/');
+  assert.equal(regions.get('/blog/[slug]').routeKey, '/blog/a');
+  assert.equal(regions.get('/blog/[slug]').el.tagName.toLowerCase(), 'wj-region');
+});
+
+test('route-key falls back to segment when the attribute is absent', () => {
+  const regions = _collectRegions(body('<wj-region segment="/docs"><p>x</p></wj-region>'));
+  assert.equal(regions.get('/docs').routeKey, '/docs');
+});
+
+test('a wj-region without a segment attribute is ignored', () => {
+  const regions = _collectRegions(body('<wj-region><p>x</p></wj-region><wj-region segment="/ok"></wj-region>'));
+  assert.deepEqual([...regions.keys()], ['/ok']);
+});
+
+test('first wins on a duplicate segment (pathological self-include)', () => {
+  const regions = _collectRegions(body(
+    '<wj-region segment="/a" route-key="/a/1"><wj-region segment="/a" route-key="/a/2"></wj-region></wj-region>',
+  ));
+  assert.equal(regions.size, 1);
+  assert.equal(regions.get('/a').routeKey, '/a/1');
+});
+
+test('longestSharedPath picks the deepest region present on both sides', () => {
+  const here = _collectRegions(body(
+    '<wj-region segment="/"><wj-region segment="/blog"><wj-region segment="/blog/[slug]" route-key="/blog/a"></wj-region></wj-region></wj-region>',
+  ));
+  const there = _collectRegions(body(
+    '<wj-region segment="/"><wj-region segment="/blog"><wj-region segment="/blog/[slug]" route-key="/blog/b"></wj-region></wj-region></wj-region>',
+  ));
+  assert.equal(_longestSharedPath(here, there), '/blog/[slug]');
+  // route-key differs at that region (a vs b) -> the swap tier will REPLACE
+  // (page remount), which the swap logic reads from the two maps' route-keys.
+  assert.notEqual(here.get('/blog/[slug]').routeKey, there.get('/blog/[slug]').routeKey);
+});
+
+test('empty / detached roots yield an empty map, never throw', () => {
+  assert.equal(_collectRegions(body('<main>no regions</main>')).size, 0);
+  assert.equal(_collectRegions(null).size, 0);
+});

--- a/packages/core/test/routing/region-swap-plan.test.js
+++ b/packages/core/test/routing/region-swap-plan.test.js
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for the two-tier region swap PLAN (Pillar 2, #1013).
+ *
+ * planRegionSwap(here, there) reads the live + incoming region maps and returns
+ * the swap verdict that gives exact Next.js remount-vs-preserve parity:
+ *   - a dynamic-param change remounts (replace) at the SHALLOWEST changed region
+ *   - a page change under a shared static layout replaces the deepest shared one
+ *   - a searchParams-only nav morphs the page region (state preserved)
+ * This is the pure decision core; the DOM mutation is a separate step.
+ */
+import { test, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseHTML } from 'linkedom';
+
+let _collectRegions, _planRegionSwap;
+
+before(async () => {
+  const { window } = parseHTML('<!doctype html><html><head></head><body></body></html>');
+  globalThis.document = window.document;
+  globalThis.window = window;
+  globalThis.HTMLElement = window.HTMLElement;
+  globalThis.Element = window.Element;
+  globalThis.Node = window.Node;
+  globalThis.Comment = window.Comment;
+  globalThis.Text = window.Text;
+  globalThis.MutationObserver = window.MutationObserver;
+  globalThis.customElements = window.customElements;
+  globalThis.CustomEvent = window.CustomEvent;
+  globalThis.DOMParser = window.DOMParser;
+  globalThis.CSS = globalThis.CSS || { escape: (s) => String(s).replace(/[^a-zA-Z0-9_-]/g, (m) => `\\${m}`) };
+  if (typeof globalThis.sessionStorage === 'undefined') {
+    const store = new Map();
+    globalThis.sessionStorage = /** @type any */ ({
+      getItem: (k) => (store.has(k) ? store.get(k) : null),
+      setItem: (k, v) => { store.set(k, String(v)); },
+      removeItem: (k) => { store.delete(k); }, clear: () => store.clear(),
+    });
+  }
+  ({ _collectRegions, _planRegionSwap } = await import('../../src/router-client.js'));
+});
+
+/** Build a region map from [segment, routeKey] pairs (nested prefix chain). */
+function regions(pairs) {
+  const inner = pairs.map(([seg, key]) => `<wj-region segment="${seg}" route-key="${key}">`).join('')
+    + pairs.map(() => '</wj-region>').join('');
+  const { document: doc } = parseHTML(`<!doctype html><html><body>${inner}</body></html>`);
+  return _collectRegions(doc.body);
+}
+
+test('searchParams-only nav morphs the page region (state preserved)', () => {
+  // /blog/a?x=1 -> /blog/a?x=2 : every route-key identical, page region is leaf.
+  const here = regions([['/', '/'], ['/blog', '/blog'], ['/blog/[slug]', '/blog/a']]);
+  const there = regions([['/', '/'], ['/blog', '/blog'], ['/blog/[slug]', '/blog/a']]);
+  const plan = _planRegionSwap(here, there);
+  assert.equal(plan.mode, 'morph');
+  assert.equal(plan.segment, '/blog/[slug]');
+});
+
+test('dynamic page-param change remounts the page region only', () => {
+  // /blog/a -> /blog/b : shallowest changed region is the page; layouts preserved.
+  const here = regions([['/', '/'], ['/blog', '/blog'], ['/blog/[slug]', '/blog/a']]);
+  const there = regions([['/', '/'], ['/blog', '/blog'], ['/blog/[slug]', '/blog/b']]);
+  const plan = _planRegionSwap(here, there);
+  assert.equal(plan.mode, 'replace');
+  assert.equal(plan.segment, '/blog/[slug]');
+});
+
+test('dynamic LAYOUT-param change remounts at the shallow layout, not the page', () => {
+  // /a/settings -> /b/settings : the [org] layout param changed, so the boundary
+  // is the shallow [org] region (its whole subtree, incl. the page, remounts).
+  const here = regions([['/', '/'], ['/[org]', '/a'], ['/[org]/settings', '/a/settings']]);
+  const there = regions([['/', '/'], ['/[org]', '/b'], ['/[org]/settings', '/b/settings']]);
+  const plan = _planRegionSwap(here, there);
+  assert.equal(plan.mode, 'replace');
+  assert.equal(plan.segment, '/[org]'); // shallowest changed, NOT the deeper page
+});
+
+test('page change under a shared static layout replaces the shared layout region', () => {
+  // /about -> /contact : root layout shared+unchanged, page segments differ
+  // (not shared), so replace the deepest shared region (root) wholesale.
+  const here = regions([['/', '/'], ['/about', '/about']]);
+  const there = regions([['/', '/'], ['/contact', '/contact']]);
+  const plan = _planRegionSwap(here, there);
+  assert.equal(plan.mode, 'replace');
+  assert.equal(plan.segment, '/');
+});
+
+test('the root layout region is never the remount boundary on a deeper change', () => {
+  // A deep change must not sweep the root layout: root stays preserved.
+  const here = regions([['/', '/'], ['/dash', '/dash'], ['/dash/[tab]', '/dash/a']]);
+  const there = regions([['/', '/'], ['/dash', '/dash'], ['/dash/[tab]', '/dash/b']]);
+  const plan = _planRegionSwap(here, there);
+  assert.notEqual(plan.segment, '/');
+  assert.equal(plan.segment, '/dash/[tab]');
+});
+
+test('no shared region yields null (caller degrades to a full load)', () => {
+  const here = regions([['/x', '/x']]);
+  const there = regions([['/y', '/y']]);
+  assert.equal(_planRegionSwap(here, there), null);
+});

--- a/packages/core/test/routing/router-client.test.js
+++ b/packages/core/test/routing/router-client.test.js
@@ -3555,6 +3555,89 @@ test('applySwap: a degenerate trailing-count mismatch sweeps to parent end, neve
   }
 });
 
+test('applySwap: region REPLACE remounts the page region and preserves outer chrome (#1013)', () => {
+  // A dynamic page-param change (/blog/a -> /blog/b): the page region route-key
+  // changed, so the swap wholesale-replaces the page region's children (Next
+  // remount) while the root region and the header chrome ABOVE it stay put.
+  const savedBody = globalThis.document.body.innerHTML;
+  const savedHead = globalThis.document.head.innerHTML;
+  const savedLocation = globalThis.location;
+  try {
+    globalThis.document.head.innerHTML = '';
+    globalThis.location = /** @type any */ ({ get href() { return 'http://x/blog/a'; }, set href(_v) {} });
+
+    globalThis.document.body.innerHTML =
+      '<header id="chrome">chrome</header>' +
+      '<wj-region segment="/" route-key="/">' +
+      '  <wj-region segment="/blog/[slug]" route-key="/blog/a"><article id="old">a</article></wj-region>' +
+      '</wj-region>';
+    const liveChrome = globalThis.document.getElementById('chrome');
+
+    const incoming = new globalThis.DOMParser().parseFromString(
+      '<!doctype html><html><head></head><body>' +
+      '<header id="chrome">chrome</header>' +
+      '<wj-region segment="/" route-key="/">' +
+      '  <wj-region segment="/blog/[slug]" route-key="/blog/b"><article id="new">b</article></wj-region>' +
+      '</wj-region>' +
+      '</body></html>', 'text/html');
+
+    _applySwap(incoming, null, false, 'http://x/blog/b');
+
+    assert.equal(globalThis.document.getElementById('chrome'), liveChrome, 'outer chrome identity preserved');
+    assert.ok(globalThis.document.getElementById('new'), 'page region children replaced with incoming');
+    assert.ok(!globalThis.document.getElementById('old'), 'old page children remounted away');
+    assert.equal(globalThis.document.querySelectorAll('wj-region[segment="/"]').length, 1, 'root region not duplicated');
+  } finally {
+    globalThis.location = savedLocation;
+    globalThis.document.head.innerHTML = savedHead;
+    globalThis.document.body.innerHTML = savedBody;
+  }
+});
+
+test('applySwap: region MORPH preserves node identity on a searchParams-only nav (#1013)', () => {
+  // /blog/a?x=1 -> /blog/a?x=2: no route-key changes, the page region is the
+  // leaf on both sides, so the swap MORPHS its children. A keyed node keeps its
+  // identity (the state-preservation guarantee) while its text updates.
+  const savedBody = globalThis.document.body.innerHTML;
+  const savedHead = globalThis.document.head.innerHTML;
+  const savedLocation = globalThis.location;
+  try {
+    globalThis.document.head.innerHTML = '';
+    globalThis.location = /** @type any */ ({ get href() { return 'http://x/blog/a?x=1'; }, set href(_v) {} });
+
+    globalThis.document.body.innerHTML =
+      '<header id="chrome">chrome</header>' +
+      '<wj-region segment="/" route-key="/">' +
+      '  <wj-region segment="/blog/[slug]" route-key="/blog/a"><li data-key="1" id="k1">a</li></wj-region>' +
+      '</wj-region>';
+    const keptNode = globalThis.document.getElementById('k1');
+
+    // The server re-emits the SAME keyed node with the same stable attributes
+    // (data-key + id); only the searchParam-driven text differs. The morph must
+    // reuse the live node by its data-key match, so its identity survives.
+    const incoming = new globalThis.DOMParser().parseFromString(
+      '<!doctype html><html><head></head><body>' +
+      '<header id="chrome">chrome</header>' +
+      '<wj-region segment="/" route-key="/">' +
+      '  <wj-region segment="/blog/[slug]" route-key="/blog/a"><li data-key="1" id="k1">a-updated</li></wj-region>' +
+      '</wj-region>' +
+      '</body></html>', 'text/html');
+
+    _applySwap(incoming, null, false, 'http://x/blog/a?x=2');
+
+    const got = globalThis.document.getElementById('k1');
+    // Compare identity via `===` (not assert.equal on the nodes): a failing
+    // assert.equal would util.inspect the linkedom node, which spins on its
+    // circular parent refs.
+    assert.ok(got === keptNode, 'keyed node identity preserved across the morph');
+    assert.equal(got.textContent, 'a-updated', 'morphed content updated');
+  } finally {
+    globalThis.location = savedLocation;
+    globalThis.document.head.innerHTML = savedHead;
+    globalThis.document.body.innerHTML = savedBody;
+  }
+});
+
 test('a prefetch that reveals a NEW build id evicts stale pre-deploy caches (#899)', async () => {
   const origFetch = globalThis.fetch;
   const savedHead = globalThis.document.head.innerHTML;

--- a/packages/server/src/ssr.js
+++ b/packages/server/src/ssr.js
@@ -669,6 +669,86 @@ function layoutSegmentPath(layoutFile) {
 }
 
 /**
+ * Like layoutSegmentPath but for the PAGE file. Strips the `page.ext`
+ * filename, yielding the page's own segment path (the full route pattern,
+ * dynamic tokens included):
+ *
+ *   app/page.ts                    -> '/'
+ *   app/blog/[slug]/page.ts        -> '/blog/[slug]'
+ *   app/files/[...rest]/page.ts    -> '/files/[...rest]'
+ *
+ * This is the segment for the PAGE-level region (Pillar 1 / #1013): the page
+ * needs its own region keyed by the full resolved path so a dynamic-param
+ * change remounts the page (Next parity) while a shared parent LAYOUT (a
+ * shorter segment path whose route-key does not change) is preserved.
+ *
+ * @param {string} pageFile  Absolute path to the page source file.
+ * @returns {string}
+ */
+function pageSegmentPath(pageFile) {
+  const p = pageFile
+    .replace(/^.*\/app\//, '')
+    .replace(/\/?page\.[jt]sx?$/, '');
+  return p === '' ? '/' : '/' + p;
+}
+
+/**
+ * Derive a region's ROUTE-KEY from its segment path pattern and the render's
+ * resolved params. The route-key is the CONCRETE resolved URL path for the
+ * region: dynamic `[param]` / catch-all `[...param]` / optional-catch-all
+ * `[[...param]]` tokens are substituted with their param values, and `(group)`
+ * segments are dropped (they scope layouts but never appear in the URL).
+ * searchParams are excluded by construction (params carries route params only).
+ *
+ * The client router compares a region's OLD vs NEW route-key to pick the swap
+ * tier: route-key CHANGED -> wholesale replace (Next page-remount parity),
+ * route-key SAME -> bounded same-route morph (hydrated component state kept, the
+ * searchParams-only-nav case). A static segment (`/`, `/docs`) has a constant
+ * route-key, so that layout's region never remounts and its chrome always
+ * survives.
+ *
+ *   regionRouteKey('/', {})                          -> '/'
+ *   regionRouteKey('/docs', {})                      -> '/docs'
+ *   regionRouteKey('/blog/[slug]', {slug:'a'})       -> '/blog/a'
+ *   regionRouteKey('/(marketing)/about', {})         -> '/about'
+ *   regionRouteKey('/files/[...rest]', {rest:'a/b'}) -> '/files/a/b'
+ *   regionRouteKey('/shop/[[...slug]]', {})          -> '/shop'
+ *
+ * @param {string} segmentPath  Region segment pattern, e.g. '/blog/[slug]'.
+ * @param {Record<string,string>} params  Resolved route params (values are
+ *   strings; a catch-all value is already slash-joined, e.g. 'a/b/c').
+ * @returns {string}
+ */
+function regionRouteKey(segmentPath, params) {
+  const p = params || {};
+  const out = [];
+  for (const seg of segmentPath.split('/')) {
+    if (!seg) continue;
+    // Route group `(marketing)`: scopes layouts, absent from the URL.
+    if (seg.startsWith('(') && seg.endsWith(')')) continue;
+    // Optional catch-all `[[...name]]` / catch-all `[...name]`: the value is
+    // the already-slash-joined tail (may be '' for an empty optional one).
+    if (seg.startsWith('[[...') && seg.endsWith(']]')) {
+      const v = p[seg.slice(5, -2)];
+      if (v) out.push(v);
+      continue;
+    }
+    if (seg.startsWith('[...') && seg.endsWith(']')) {
+      const v = p[seg.slice(4, -1)];
+      if (v) out.push(v);
+      continue;
+    }
+    // Dynamic `[name]`.
+    if (seg.startsWith('[') && seg.endsWith(']')) {
+      out.push(p[seg.slice(1, -1)] ?? '');
+      continue;
+    }
+    out.push(seg);
+  }
+  return '/' + out.join('/');
+}
+
+/**
  * Wrap a TemplateResult-or-renderable child in the partial-nav children
  * marker pair. Returns a synthetic TemplateResult: server `renderToString`
  * walks `.strings` and `.values` exactly the same way as for the `html` tag.
@@ -694,6 +774,8 @@ function wrapWithChildrenMarker(tree, segmentPath) {
 // Re-export for unit testing.
 export {
   layoutSegmentPath as _layoutSegmentPath,
+  pageSegmentPath as _pageSegmentPath,
+  regionRouteKey as _regionRouteKey,
   wrapWithChildrenMarker as _wrapWithChildrenMarker,
 };
 

--- a/packages/server/test/ssr/region-route-key.test.js
+++ b/packages/server/test/ssr/region-route-key.test.js
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for the region route-key derivation (Pillar 1, #1013).
+ *
+ * The client router's structural rebuild replaces comment layout markers with
+ * `<wj-region segment="..." route-key="...">` elements and picks its swap tier
+ * by comparing a region's OLD vs NEW route-key: changed -> wholesale replace
+ * (Next page-remount parity), same -> bounded same-route morph (state kept, the
+ * searchParams-only-nav case). These are the pure server-side building blocks
+ * that emit `segment` (the pattern) and `route-key` (the resolved path).
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { _pageSegmentPath, _regionRouteKey } from '../../src/ssr.js';
+
+test('pageSegmentPath derives the page own segment (full route pattern)', () => {
+  assert.equal(_pageSegmentPath('/x/app/page.ts'), '/');
+  assert.equal(_pageSegmentPath('/x/app/blog/[slug]/page.tsx'), '/blog/[slug]');
+  assert.equal(_pageSegmentPath('/x/app/files/[...rest]/page.js'), '/files/[...rest]');
+  assert.equal(_pageSegmentPath('/x/app/(marketing)/about/page.ts'), '/(marketing)/about');
+});
+
+test('regionRouteKey: static segments have a constant key', () => {
+  assert.equal(_regionRouteKey('/', {}), '/');
+  assert.equal(_regionRouteKey('/docs', {}), '/docs');
+  assert.equal(_regionRouteKey('/docs/components', {}), '/docs/components');
+});
+
+test('regionRouteKey: dynamic [param] is substituted', () => {
+  assert.equal(_regionRouteKey('/blog/[slug]', { slug: 'a' }), '/blog/a');
+  assert.equal(_regionRouteKey('/blog/[slug]', { slug: 'b' }), '/blog/b');
+  assert.equal(_regionRouteKey('/[org]/[repo]', { org: 'webjsdev', repo: 'webjs' }), '/webjsdev/webjs');
+});
+
+test('regionRouteKey: route groups are dropped (not in the URL)', () => {
+  assert.equal(_regionRouteKey('/(marketing)/about', {}), '/about');
+  assert.equal(_regionRouteKey('/(marketing)', {}), '/');
+  assert.equal(_regionRouteKey('/(shop)/[id]', { id: '7' }), '/7');
+});
+
+test('regionRouteKey: catch-all value is already slash-joined', () => {
+  assert.equal(_regionRouteKey('/files/[...rest]', { rest: 'a/b/c' }), '/files/a/b/c');
+  assert.equal(_regionRouteKey('/files/[...rest]', { rest: 'a' }), '/files/a');
+});
+
+test('regionRouteKey: optional catch-all collapses when empty', () => {
+  assert.equal(_regionRouteKey('/shop/[[...slug]]', {}), '/shop');
+  assert.equal(_regionRouteKey('/shop/[[...slug]]', { slug: '' }), '/shop');
+  assert.equal(_regionRouteKey('/shop/[[...slug]]', { slug: 'x/y' }), '/shop/x/y');
+});
+
+test('regionRouteKey: Next remount-vs-preserve semantics by construction', () => {
+  // /blog/a -> /blog/b : the page region key changes (remount), the '/' layout
+  // region key is constant (preserved). This is the whole two-tier decision.
+  const pageA = _regionRouteKey('/blog/[slug]', { slug: 'a' });
+  const pageB = _regionRouteKey('/blog/[slug]', { slug: 'b' });
+  assert.notEqual(pageA, pageB); // page remounts on a param change
+  assert.equal(_regionRouteKey('/', { slug: 'a' }), _regionRouteKey('/', { slug: 'b' })); // layout preserved
+
+  // /blog/a -> /blog/a?x=1 : params are identical (searchParams excluded by
+  // construction), so every region key is unchanged -> morph, state preserved.
+  assert.equal(pageA, _regionRouteKey('/blog/[slug]', { slug: 'a' }));
+});


### PR DESCRIPTION
Rebuilds the client router and light-DOM slots on structural boundaries, per the plan in #1013. One PR, commit per logical unit, phased.

This replaces the closed conservative-retrofit attempts (#1006 / PR #1012, #1003, #1011): rather than harden the three-actor projection and comment-marker machinery, it deletes it. `<wj-region>` elements replace comment markers (the parser delimits the subtree, so mispairing is impossible), a two-tier route-segment-keyed swap gives Next.js remount and searchParams-state parity, and light-DOM slots become children-as-values (one renderer owns all nodes, the projection observer ceases to exist).

## Phases (all land in this PR)

- [x] **Phase 0.** Quick win: full-load a forward soft nav fired at `readyState: 'loading'` (the #1008 root cause; the prefetch path already guarded it, the click path did not). Dev-only fallback-cause logging.
- [ ] **Phase 1.** Regions plus two-tier swap. `<wj-region segment route-key>` + `X-Webjs-Region` header in `ssr.js`; region discovery, degradation ladder, wholesale replace, bounded same-route morph in `router-client.js`; delete the marker/orphan/reconciler/carve-out towers and the full-body path.
- [ ] **Phase 2.** Children-as-values slots. `this.slots` / `setSlotContent()` + derived shims; capture-once in `component.js`; slot resolution into the render-time state machine in both `render-server.js` twins; delete the projection runtime (~600 lines of `slot.js`). Closes #1006 by construction.
- [ ] **Phase 3.** Elision narrow signals (drop `SLOT_RE`); docs sync (webjs-doc-sync); scaffold sync (webjs-scaffold-sync).

## Verification (tracked, run per phase)

- Golden-oracle CI property (post-nav live DOM equals cold-load DOM of the final URL), fault-injection degradation tests, 3-engine browser suite (WebKit mandatory), Bun parity for `ssr.js`, and the dogfood apps (website, docs, examples/blog, ui-website).
- The #906/#908/#912/#914/#994/#1003/#1006/#1007/#1011 regressions re-expressed with counterfactuals.

Closes #1013
Supersedes #1003, #1006, #1011.
