### PR TITLE
chore: release core 0.7.40, server 0.8.54

### DIFF
--- a/changelog/core/0.7.40.md
+++ b/changelog/core/0.7.40.md
@@ -1,0 +1,20 @@
+---
+package: "@webjsdev/core"
+version: 0.7.40
+date: 2026-07-20T05:47:07.419Z
+commit_count: 2
+---
+## Features
+
+- **rebuild the client-router swap on route-keyed comment boundaries** ([#1016](https://github.com/webjsdev/webjs/pull/1016)) [`01b21276`](https://github.com/webjsdev/webjs/commit/01b21276)
+  * fix: full-load a soft nav fired while the document is still parsing
+  
+  Phase 0 of the router/slot structural rebuild (#1013): the quick win.
+
+## Fixes
+
+- **preserve comment markers when parsing a client-router navigation** ([#1010](https://github.com/webjsdev/webjs/pull/1010)) [`6cb3e8dc`](https://github.com/webjsdev/webjs/commit/6cb3e8dc)
+  * fix: preserve comment markers when parsing a client-router navigation
+  
+  Document.parseHTMLUnsafe strips every HTML comment in Chromium 150, and
+  parseHTML routed every doctype'd response through it. The whole partial-swap

--- a/changelog/server/0.8.54.md
+++ b/changelog/server/0.8.54.md
@@ -1,0 +1,12 @@
+---
+package: "@webjsdev/server"
+version: 0.8.54
+date: 2026-07-20T05:47:07.475Z
+commit_count: 1
+---
+## Features
+
+- **rebuild the client-router swap on route-keyed comment boundaries** ([#1016](https://github.com/webjsdev/webjs/pull/1016)) [`01b21276`](https://github.com/webjsdev/webjs/commit/01b21276)
+  * fix: full-load a soft nav fired while the document is still parsing
+  
+  Phase 0 of the router/slot structural rebuild (#1013): the quick win.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6991,7 +6991,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.39",
+      "version": "0.7.40",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.25.0"
@@ -7040,7 +7040,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.53",
+      "version": "0.8.54",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.39",
+  "version": "0.7.40",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.53",
+  "version": "0.8.54",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Release cut for the client-router keyed-comment-boundary work that landed since the last release (core 0.7.39 / cli 0.10.44, #1005).

## Packages

| Package | From | To | Bump |
|---|---|---|---|
| `@webjsdev/core` | 0.7.39 | 0.7.40 | feat (#1016) + fix (#1010) |
| `@webjsdev/server` | 0.8.53 | 0.8.54 | feat (#1016) |

## Included since last release

- **#1016** feat: rebuild the client-router swap on route-keyed comment boundaries
- **#1010** fix: preserve comment markers when parsing a client-router navigation

Changelogs auto-generated by the pre-commit backfill (`changelog/core/0.7.40.md`, `changelog/server/0.8.54.md`). cli/create-webjs/webjsdev lockstep versions left to the release workflow. No cli source changed since the last release, so cli is not bumped here.