### PR TITLE
chore: release core 0.7.41, server 0.8.55

### DIFF
--- a/changelog/core/0.7.41.md
+++ b/changelog/core/0.7.41.md
@@ -1,0 +1,17 @@
+---
+package: "@webjsdev/core"
+version: 0.7.41
+date: 2026-07-21T11:37:11.859Z
+commit_count: 2
+---
+## Breaking
+
+- **The WebJs-specific light-DOM slot API is removed in favour of the native DOM slot API** ([#1022](https://github.com/webjsdev/webjs/pull/1022)). `setSlotContent()`, `hasSlot()`, and the `this.slots` record no longer exist. Light DOM and shadow DOM now share one native surface: read slotted content with `assignedNodes()` / `assignedElements()` / `assignedSlot` / `slotchange`, and write it with `appendChild` / `insertBefore` / `removeChild` / `el.slot =` / `innerHTML`. Conditioning a `render()` on the slot record is gone. Use CSS `:has()` / `slot:empty` or a `slotchange` listener instead.
+
+## Features
+
+- **Full light-DOM slot parity with shadow DOM (native API, one writer)** ([#1022](https://github.com/webjsdev/webjs/pull/1022)) [`842f9f84`](https://github.com/webjsdev/webjs/commit/842f9f84). Light-DOM `<slot>` now behaves identically to shadow DOM: post-mount native writes are live, the full read surface matches, and flipping `static shadow` changes nothing else. Built on a single-writer record model that ends the pre-#1016 three-observer bug lineage.
+
+## Fixes
+
+- **Project forwarded-slot content and named-slot slices on the client** ([#1026](https://github.com/webjsdev/webjs/pull/1026)) [`4367b318`](https://github.com/webjsdev/webjs/commit/4367b318). A template that forwards its slot into a nested component (`html\`<inner><slot></slot></inner>\``) now projects on client mount, not only during SSR (#1023), and a layout's `${children}` partitioned across multiple named slots now re-projects every named slice across a soft-nav swap, not just the default slice (#1024).

--- a/changelog/server/0.8.55.md
+++ b/changelog/server/0.8.55.md
@@ -1,0 +1,9 @@
+---
+package: "@webjsdev/server"
+version: 0.8.55
+date: 2026-07-21T11:37:11.908Z
+commit_count: 1
+---
+## Features
+
+- **Elision tokens track the native light-DOM slot surface** ([#1022](https://github.com/webjsdev/webjs/pull/1022)) [`842f9f84`](https://github.com/webjsdev/webjs/commit/842f9f84). Component elision drops the removed `setSlotContent` / `hasSlot` client-method signals and narrows the dynamic-slot detector to the native read surface (`slotchange`, `assignedNodes` / `assignedElements` / `assignedSlot`), so a display-only slotted wrapper stays elidable while a component that genuinely reads its slots still ships.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.40",
+  "version": "0.7.41",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.54",
+  "version": "0.8.55",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Release cut for the light-DOM slot parity work merged since the last release (#1017).

## Packages bumped

| Package | From | To | Why |
|---|---|---|---|
| `@webjsdev/core` | 0.7.40 | 0.7.41 | #1022 full light-DOM slot parity (native API, one writer) + #1026 forwarded/named-slot client projection fix |
| `@webjsdev/server` | 0.8.54 | 0.8.55 | #1022 elision-token update for the native slot surface (`component-elision.js`) |

## Not bumped

- **cli / mcp / intellisense** have no source changes since #1017.
- **ui** shows a diff only in its nested `packages/ui/packages/website` sub-app (not the published `@webjsdev/ui` surface), so it is deliberately left un-bumped.

Patch bumps for both, matching every core/server release in this repo's history (pre-1.0, breaking changes ride patch per the no-backward-compat posture). Core 0.7.41 keeps server's `^0.7.1` caret satisfied and server 0.8.55 keeps cli/mcp's `^0.8.0` caret satisfied, so no dependency-pin cascade.

Changelogs auto-generated by the pre-commit hook, then hand-edited: a **Breaking** section added to core's for the removed `setSlotContent`/`hasSlot`/`this.slots` API with the native-migration guidance, and the noisy squash sub-bullets trimmed.

On merge, `release.yml` publishes both to npm and creates the GitHub Releases.