### PR TITLE
docs: use # root-alias imports in blog post examples

### DIFF
--- a/blog/file-based-routing.md
+++ b/blog/file-based-routing.md
@@ -46,7 +46,7 @@ The metadata routes (`sitemap`, `robots`, `manifest`, `icon`, `apple-icon`, `ope
 
 ```ts
 import { html } from '@webjsdev/core';
-import { listPosts } from '../../modules/posts/queries/list-posts.server.ts';
+import { listPosts } from '#modules/posts/queries/list-posts.server.ts';
 
 export const metadata = { title: 'Posts · my-app' };
 
@@ -80,8 +80,8 @@ Both throw a sentinel that the framework catches and translates to a 404 / 302 r
 # What route.ts looks like
 
 ```ts
-import { listPosts } from '../../../modules/posts/queries/list-posts.server.ts';
-import { createPost } from '../../../modules/posts/actions/create-post.server.ts';
+import { listPosts } from '#modules/posts/queries/list-posts.server.ts';
+import { createPost } from '#modules/posts/actions/create-post.server.ts';
 
 export async function GET() {
   return Response.json(await listPosts());

--- a/blog/prisma-vs-drizzle-default-orm.md
+++ b/blog/prisma-vs-drizzle-default-orm.md
@@ -67,7 +67,7 @@ Then you query it from a server action or a query module, importing the same `db
 ```ts
 // modules/posts/queries/list-posts.server.ts
 'use server';
-import { db } from '../../../db/connection.server.ts';
+import { db } from '#db/connection.server.ts';
 
 export async function listPosts() {
   return db.query.posts.findMany({ orderBy: { createdAt: 'desc' } });

--- a/blog/server-side-caching-explained.md
+++ b/blog/server-side-caching-explained.md
@@ -40,7 +40,7 @@ The HTTP header caches a whole response. Often you want to cache one expensive t
 // modules/posts/queries/list-posts.server.ts
 'use server';
 import { cache } from '@webjsdev/server';
-import { db } from '../../../db/connection.server.ts';
+import { db } from '#db/connection.server.ts';
 
 export const listPosts = cache(
   async () => db.query.posts.findMany({ orderBy: { createdAt: 'desc' } }),

--- a/blog/streaming-server-actions-llm.md
+++ b/blog/streaming-server-actions-llm.md
@@ -23,7 +23,7 @@ Here is an action that calls an LLM SDK and yields tokens as they come off the m
 // modules/chat/actions/stream-answer.server.ts
 'use server';
 import { actionSignal } from '@webjsdev/server';
-import { openai } from '../../../lib/llm.server.ts';
+import { openai } from '#lib/llm.server.ts';
 
 export async function* streamAnswer(prompt: string) {
   const signal = actionSignal();


### PR DESCRIPTION
Closes #1029

Four published blog posts still taught the deep-relative import style (`../../../db/...`) in their example snippets, from before the app-internal import convention moved to Node's `#` package-imports alias. The docs site, README, AGENTS.md, and the example app's conventions were migrated earlier; the blog posts were the remaining stale surface.

## What changed
- `blog/server-side-caching-explained.md`: `../../../db/...` -> `#db/...`
- `blog/prisma-vs-drizzle-default-orm.md`: `../../../db/...` -> `#db/...`
- `blog/streaming-server-actions-llm.md`: `../../../lib/llm.server.ts` -> `#lib/...`
- `blog/file-based-routing.md`: three `../../`/`../../../modules/...` -> `#modules/...`

## Deliberately unchanged (verified)
- `blog/fix-relative-import-paths.md`: the `../../../db/...` on line 13 is the intentional BEFORE in that post's before/after; the whole post is about replacing it with `#`.
- `blog/full-stack-type-safety-no-build.md` and `blog/streaming-server-actions-llm.md`: single-`../` intra-module sibling imports (`../actions/...`), which stay relative per the convention.

## Surfaces
- Tests: N/A (blog posts are static markdown parsed by the website; no code path changes). The website's blog list/render query reads front matter only.
- Docs / scaffold / MCP / editors / dogfood apps: N/A because this is prose-example content in `blog/`, not a framework surface.