### PR TITLE
fix: correct core .d.ts type surface (phantom base + register param)

### DIFF
--- a/packages/core/src/component.d.ts
+++ b/packages/core/src/component.d.ts
@@ -179,6 +179,21 @@ export interface WebComponentConstructor extends WebComponentStatics {
   };
 }
 
+/**
+ * A constructor for a registered component: the static surface plus a plain
+ * `new ()`, WITHOUT the factory call signature that `WebComponentConstructor`
+ * carries. That call signature is what the `WebComponent` const needs (it is
+ * both a class and a factory), but it means no ordinary component class is
+ * assignable to `WebComponentConstructor` (a plain class is not callable as a
+ * factory). So the standalone `register(tag, cls)` / `lookup` / `tagOf` surface
+ * types against THIS instead, and a user's `class X extends WebComponent({…})`
+ * satisfies it (#1033).
+ */
+export interface WebComponentInstanceConstructor extends WebComponentStatics {
+  new (): WebComponentBase;
+  prototype: WebComponentBase;
+}
+
 export declare const WebComponent: WebComponentConstructor;
 
 export declare function prop<C extends PropertyConstructor<any>>(

--- a/packages/core/src/component.d.ts
+++ b/packages/core/src/component.d.ts
@@ -72,25 +72,15 @@ export interface ReactiveController {
  * See the Editor Setup doc for tooling that gives attribute/tag
  * intelligence inside `html\`…\`` templates.
  */
-abstract class WebComponentBase extends HTMLElement {
-  static shadow: boolean;
-  static hydrate: 'visible' | undefined;
-  /** @internal Populated by the `WebComponent({ … })` factory, not by hand. */
-  static properties: Record<string, PropertyDeclaration>;
-  static styles: CSSResult | CSSResult[] | null;
-  static lazy?: boolean;
-  /**
-   * Force this component to ship (hydrate) even when the elision analyser would
-   * drop it as display-only. The escape hatch for interactivity the analyser
-   * cannot see statically: a dynamically-computed tag string, or a `:defined`
-   * rule in an external stylesheet outside the module graph. Leave unset for
-   * the automatic verdict.
-   */
-  static interactive?: boolean;
-  /** Register this class as a custom element under `tag`. Tag must contain a hyphen. */
-  static register(tag: string): void;
-  static readonly observedAttributes: string[];
-
+// An INTERFACE, not an `abstract class`, on purpose. A class is a value as well
+// as a type, and a non-exported class referenced from exported positions
+// (`new (): WebComponentBase`, `export type WebComponent = WebComponentBase`)
+// still leaks into the module's VALUE namespace, so `import { WebComponentBase }
+// from '@webjsdev/core'` type-checks and then crashes at load because the runtime
+// never exports it (#1032). An interface has no value meaning, so it describes the
+// instance shape without becoming a phantom export. The static surface lives on
+// `WebComponentStatics` / `WebComponentConstructor` below.
+interface WebComponentBase extends HTMLElement {
   /**
    * Schedule a re-render. Optionally record a property change so lifecycle
    * hooks can branch on what changed via `changedProperties`.
@@ -167,6 +157,14 @@ interface WebComponentStatics {
   properties: Record<string, PropertyDeclaration>;
   styles: CSSResult | CSSResult[] | null;
   lazy?: boolean;
+  /**
+   * Force this component to ship (hydrate) even when the elision analyser would
+   * drop it as display-only. The escape hatch for interactivity the analyser
+   * cannot see statically: a dynamically-computed tag string, or a `:defined`
+   * rule in an external stylesheet outside the module graph. Leave unset for
+   * the automatic verdict.
+   */
+  interactive?: boolean;
   register(tag: string): void;
   readonly observedAttributes: string[];
 }

--- a/packages/core/src/registry.d.ts
+++ b/packages/core/src/registry.d.ts
@@ -1,4 +1,4 @@
-import type { WebComponentConstructor, WebComponentInstanceConstructor } from './component.d.ts';
+import type { WebComponentConstructor, WebComponentInstanceConstructor } from './component.js';
 
 // Re-exported for `@webjsdev/core/registry` consumers; it is the type of the
 // `WebComponent` const itself (class + factory dual).

--- a/packages/core/src/registry.d.ts
+++ b/packages/core/src/registry.d.ts
@@ -1,11 +1,17 @@
-import type { WebComponent } from './component.js';
+import type { WebComponentConstructor, WebComponentInstanceConstructor } from './component.d.ts';
 
-export type WebComponentConstructor = typeof WebComponent;
+// Re-exported for `@webjsdev/core/registry` consumers; it is the type of the
+// `WebComponent` const itself (class + factory dual).
+export type { WebComponentConstructor };
 
-export function register(tag: string, cls: WebComponentConstructor): void;
+// `register` / `lookup` / `tagOf` deal in ordinary component classes, which are
+// NOT assignable to the class+factory `WebComponentConstructor` (a plain class is
+// not callable as a factory). They type against the instance-constructor shape so
+// a user's `class X extends WebComponent({…})` is accepted (#1033).
+export function register(tag: string, cls: WebComponentInstanceConstructor): void;
 export function primeModuleUrl(tag: string, moduleUrl: string): void;
-export function lookup(tag: string): WebComponentConstructor | undefined;
+export function lookup(tag: string): WebComponentInstanceConstructor | undefined;
 export function lookupModuleUrl(tag: string): string | undefined;
 export function isLazy(tag: string): boolean;
-export function tagOf(cls: WebComponentConstructor): string | undefined;
+export function tagOf(cls: WebComponentInstanceConstructor): string | undefined;
 export function allTags(): string[];

--- a/test/types/complex-export-signatures.test-d.ts
+++ b/test/types/complex-export-signatures.test-d.ts
@@ -18,6 +18,7 @@
  */
 import {
   WebComponent,
+  register,
   Task,
   createContext,
   ContextProvider,
@@ -27,10 +28,21 @@ import {
 } from '@webjsdev/core';
 import { ref, createRef } from '@webjsdev/core/directives';
 
-// NOTE: the standalone `register(tag, cls)` / `lookup` signatures are pinned by
-// #1033 (its param type rejects a user component class today); their positive
-// cases land with that fix. The static `Class.register('tag')` idiom is covered
-// by `component-types.test-d.ts`.
+/* ---- register(tag, cls): accepts a user component class (#1033) ---- */
+// The second param is a component constructor, NOT the class+factory dual
+// `WebComponentConstructor` (which no ordinary class satisfies, since a plain
+// class is not callable as a factory). A class produced by the factory is fine.
+class RegWidget extends WebComponent({ count: Number }) {
+  render() { return html``; }
+}
+register('reg-widget', RegWidget);
+// A subclass of a factory-produced class is a component constructor too.
+class RegWidget2 extends RegWidget {}
+register('reg-widget-2', RegWidget2);
+// @ts-expect-error a plain object is not a component constructor
+register('reg-widget', {});
+// @ts-expect-error the tag must be a string
+register(123, RegWidget);
 
 type Assert<T extends true> = T;
 type Equal<X, Y> =

--- a/test/types/dts-no-phantom-exports.test.mjs
+++ b/test/types/dts-no-phantom-exports.test.mjs
@@ -75,8 +75,9 @@ const PACKAGES = [
 // silence a fresh finding without first filing the issue and confirming the
 // phantom is real.
 const KNOWN_PHANTOMS = new Map(Object.entries({
-  '@webjsdev/core#WebComponentBase':
-    'internal base class exported as a value by the overlay but absent at runtime; fix tracked in #1032',
+  // (empty) Each entry is a genuine phantom deferred to a tracked issue; it is
+  // deleted the moment that issue lands so the guard proves the fix. #1032
+  // (WebComponentBase) is fixed, so its entry is gone.
 }));
 
 // Dual-surface entries (#1035). The Node phantom check above maps `.` to the


### PR DESCRIPTION
Two dogfood type-surface bugs in `@webjsdev/core`'s hand-written `.d.ts` overlays. Both are type-only (no runtime change) and buildless.

Closes #1032
Closes #1033

## #1032: WebComponentBase phantom value export

`WebComponentBase` is an internal base class the runtime never exports, but the overlay declared it as an `abstract class`. A class carries a value meaning, and a non-exported class referenced from exported positions (`new (): WebComponentBase`, `export type WebComponent = WebComponentBase`) still leaks into the module's VALUE namespace, so `import { WebComponentBase } from '@webjsdev/core'` type-checked and then crashed at load. Fix: make it an `interface` (a type with no value meaning). The static surface already lives on `WebComponentStatics`, which gains the `interactive` flag the class carried.

## #1033: register(tag, cls) rejected a user component class

`register`'s second param was typed `WebComponentConstructor`, which includes the factory call signature (`WebComponent` is a class+factory dual). No ordinary component class is callable as a factory, so `register('t', MyClass)` errored. Fix: a new `WebComponentInstanceConstructor` type (statics plus `new ()`, no factory call signature) for `register` / `lookup` / `tagOf`. A `class X extends WebComponent({ ... })` satisfies it, while `register('t', {})` and `register(123, C)` still error.

## Tests

- `test/types/dts-no-phantom-exports.test.mjs`: `WebComponentBase` removed from `KNOWN_PHANTOMS`; the guard now proves #1032 with no exception.
- `test/types/complex-export-signatures.test-d.ts`: positive `register(tag, UserClass)` case added, plus the two negative cases.
- `dts-export-coverage` and all component/lifecycle type fixtures stay green.

## Docs

N/A: `WebComponentBase` was never a documented public export, and `register(tag, C)` is already documented as accepting a component class (this only makes it type-check).
