### PR TITLE
feat: add streaming-action, view-transition, and webjs-suspense gallery demos

### DIFF
--- a/packages/cli/lib/create.js
+++ b/packages/cli/lib/create.js
@@ -1346,6 +1346,7 @@ const FEATURES = [
   { href: '/features/async-render', title: 'Async render', blurb: 'A component that awaits server data in async render(), so the resolved value is in the first paint.' },
   { href: '/features/streaming', title: 'Streaming actions', blurb: 'A use-server action that returns an async generator, streamed to the call site token by token with for await.' },
   { href: '/features/suspense', title: 'Suspense boundary', blurb: 'The <webjs-suspense> element: a first-paint fallback for a SLOW component, with the resolved content streamed in.' },
+  { href: '/features/view-transitions', title: 'View transitions', blurb: 'The opt-in view-transition meta cross-fades a soft navigation, with a data-webjs-permanent element persisted across the swap.' },
   { href: '/features/directives', title: 'Directives', blurb: 'The lit-html directive set: repeat for keyed lists, watch(signal) for a fine-grained node swap.' },
   { href: '/features/route-handler', title: 'Route handlers', blurb: 'A server-only route.ts HTTP endpoint returning JSON, the WebJs equivalent of a Next route handler.' },
   { href: '/features/forms', title: 'Forms', blurb: 'A no-JS progressive-enhancement form posting to the page action, with server-side validation errors.' },

--- a/packages/cli/lib/create.js
+++ b/packages/cli/lib/create.js
@@ -1344,6 +1344,7 @@ const FEATURES = [
   { href: '/features/server-actions', title: 'Server actions', blurb: 'A use-server RPC action next to a server-only .server.ts utility, and why the boundary matters.' },
   { href: '/features/optimistic-ui', title: 'Optimistic UI', blurb: 'The imperative optimistic(signal, value, action) flip: instant update, automatic rollback on failure.' },
   { href: '/features/async-render', title: 'Async render', blurb: 'A component that awaits server data in async render(), so the resolved value is in the first paint.' },
+  { href: '/features/streaming', title: 'Streaming actions', blurb: 'A use-server action that returns an async generator, streamed to the call site token by token with for await.' },
   { href: '/features/directives', title: 'Directives', blurb: 'The lit-html directive set: repeat for keyed lists, watch(signal) for a fine-grained node swap.' },
   { href: '/features/route-handler', title: 'Route handlers', blurb: 'A server-only route.ts HTTP endpoint returning JSON, the WebJs equivalent of a Next route handler.' },
   { href: '/features/forms', title: 'Forms', blurb: 'A no-JS progressive-enhancement form posting to the page action, with server-side validation errors.' },

--- a/packages/cli/lib/create.js
+++ b/packages/cli/lib/create.js
@@ -1345,6 +1345,7 @@ const FEATURES = [
   { href: '/features/optimistic-ui', title: 'Optimistic UI', blurb: 'The imperative optimistic(signal, value, action) flip: instant update, automatic rollback on failure.' },
   { href: '/features/async-render', title: 'Async render', blurb: 'A component that awaits server data in async render(), so the resolved value is in the first paint.' },
   { href: '/features/streaming', title: 'Streaming actions', blurb: 'A use-server action that returns an async generator, streamed to the call site token by token with for await.' },
+  { href: '/features/suspense', title: 'Suspense boundary', blurb: 'The <webjs-suspense> element: a first-paint fallback for a SLOW component, with the resolved content streamed in.' },
   { href: '/features/directives', title: 'Directives', blurb: 'The lit-html directive set: repeat for keyed lists, watch(signal) for a fine-grained node swap.' },
   { href: '/features/route-handler', title: 'Route handlers', blurb: 'A server-only route.ts HTTP endpoint returning JSON, the WebJs equivalent of a Next route handler.' },
   { href: '/features/forms', title: 'Forms', blurb: 'A no-JS progressive-enhancement form posting to the page action, with server-side validation errors.' },

--- a/packages/cli/templates/gallery/app/features/streaming/page.ts
+++ b/packages/cli/templates/gallery/app/features/streaming/page.ts
@@ -1,0 +1,31 @@
+// Streaming server-action results (#489). A `'use server'` action that returns
+// an async generator streams its chunks over the one RPC response; the call
+// site consumes them with `for await`, rendering each as it arrives. This is
+// the token-by-token shape (LLM output, a log tail, a DB cursor) over the
+// normal action call site, back-pressured and cancelled on client disconnect.
+// Contrast with a route.ts that hands back a raw HTTP ReadableStream: this rides
+// the typed action mechanism, no hand-written fetch.
+import { html } from '@webjsdev/core';
+import type { Metadata } from '@webjsdev/core';
+import '#modules/streaming/components/token-stream.ts';
+
+export const metadata: Metadata = { title: 'Streaming actions (for await) | features' };
+
+export default function StreamingExample() {
+  return html`
+    <h1 class="text-h2 font-bold mb-4">Streaming actions</h1>
+    <p class="text-muted-foreground mb-4">
+      A <code class="font-mono">'use server'</code> action that returns an
+      <code class="font-mono">async function*</code> streams each
+      <code class="font-mono">yield</code> over the single RPC response. The call
+      site consumes it with <code class="font-mono">for await (const chunk of await streamTokens())</code>,
+      so tokens render as they arrive instead of waiting for the whole result.
+    </p>
+    <p class="text-muted-foreground mb-6 text-sm">
+      Detection is on the return value (no config export), and a streamed result
+      is never cached, ETagged, or seeded. The source generator is cancelled if
+      the client navigates away mid-stream.
+    </p>
+    <token-stream></token-stream>
+  `;
+}

--- a/packages/cli/templates/gallery/app/features/suspense/page.ts
+++ b/packages/cli/templates/gallery/app/features/suspense/page.ts
@@ -1,0 +1,34 @@
+// Component-level <webjs-suspense> streaming (#471). Page-level Suspense (the
+// async-render demo) streams a region of the PAGE; <webjs-suspense> is the
+// element that wraps one or more COMPONENTS, flushes its .fallback on the first
+// byte, and streams the resolved content in. It is the only way to show a
+// first-paint fallback for a SLOW component, and the deliberate choice when
+// blocking the first byte on that component's data would hurt. Plain async
+// render() blocks SSR so its data is in the first paint with NO fallback (right
+// for fast data); reach for <webjs-suspense> when the data is genuinely slow.
+import { html } from '@webjsdev/core';
+import type { Metadata } from '@webjsdev/core';
+import '#modules/suspense/components/slow-fact.ts';
+
+export const metadata: Metadata = { title: 'Suspense boundary (<webjs-suspense>) | features' };
+
+export default function SuspenseExample() {
+  return html`
+    <h1 class="text-h2 font-bold mb-4">Suspense boundary</h1>
+    <p class="text-muted-foreground mb-4">
+      The slow component below is wrapped in
+      <code class="font-mono">&lt;webjs-suspense&gt;</code>. Its fallback shows on
+      the first byte and the resolved content streams in when the slow await
+      settles. Reload to see the fallback, then the fact stream in.
+    </p>
+    <p class="text-muted-foreground mb-6 text-sm">
+      <code class="font-mono">.fallback</code> is a property hole (unquoted, per
+      invariant 4). Contrast with the
+      <a href="/features/async-render" class="text-primary no-underline font-medium">async render</a>
+      demo, where SSR blocks so the data is in the first paint with no fallback.
+    </p>
+    <webjs-suspense .fallback=${html`<p class="rounded-2xl border border-dashed border-border p-5 text-muted-foreground">loading the fact…</p>`}>
+      <slow-fact></slow-fact>
+    </webjs-suspense>
+  `;
+}

--- a/packages/cli/templates/gallery/app/features/view-transitions/page.ts
+++ b/packages/cli/templates/gallery/app/features/view-transitions/page.ts
@@ -1,0 +1,41 @@
+// View Transitions: opt in with a <meta name="view-transition" content="same-origin">
+// (declared here via metadata.other, so it scopes to this page, not the whole
+// app). When present, the client router wraps its DOM swap in the native View
+// Transitions API, so a soft navigation cross-fades instead of snapping. Where
+// startViewTransition is unavailable the swap runs synchronously with no flash
+// and no throw, so it degrades cleanly. The <input> below is marked
+// data-webjs-permanent with an id, so the router carries the SAME live node
+// across the swap: type into it, navigate, and your text survives the transition.
+import { html } from '@webjsdev/core';
+import type { Metadata } from '@webjsdev/core';
+
+export const metadata: Metadata = {
+  title: 'View transitions (soft-nav cross-fade) | features',
+  other: { 'view-transition': 'same-origin' },
+};
+
+export default function ViewTransitionsExample() {
+  return html`
+    <h1 class="text-h2 font-bold mb-4">View transitions</h1>
+    <div class="rounded-2xl bg-primary/10 border border-primary/30 p-6 mb-6">
+      <p class="text-foreground m-0">Page one. Navigate to page two: with the
+        <code class="font-mono">&lt;meta name="view-transition"&gt;</code> opt-in,
+        the swap cross-fades.</p>
+    </div>
+    <label class="block mb-6">
+      <span class="text-muted-foreground text-sm">Type here, then navigate. This input is
+        <code class="font-mono">data-webjs-permanent</code>, so its value survives the swap:</span>
+      <input id="vt-note" data-webjs-permanent type="text" placeholder="type something…"
+        class="mt-2 block w-full max-w-sm rounded-xl border border-border bg-card px-4 py-2 text-foreground" />
+    </label>
+    <div class="flex gap-3 items-center">
+      <a href="/features/view-transitions/second" class="inline-flex items-center px-4 py-2 rounded-xl bg-primary text-primary-foreground font-semibold text-sm no-underline transition-all hover:bg-primary/90 active:scale-[0.97]">Go to page two</a>
+      <a href="/" class="text-muted-foreground no-underline font-medium text-sm hover:text-foreground transition-colors">Home</a>
+    </div>
+    <p class="text-muted-foreground text-sm mt-6">
+      Opt in app-wide instead by putting the meta on the root layout. Keep the
+      transition simple: toggling root attributes mid-nav can cause a one-frame
+      repaint flash on iOS WebKit.
+    </p>
+  `;
+}

--- a/packages/cli/templates/gallery/app/features/view-transitions/second/page.ts
+++ b/packages/cli/templates/gallery/app/features/view-transitions/second/page.ts
@@ -1,0 +1,28 @@
+// The soft-navigation target. It carries the same view-transition opt-in so the
+// cross-fade wraps the swap in BOTH directions, and the same
+// data-webjs-permanent input (same id) so the router regrafts the one live node
+// across the swap: the text you typed on page one is still here.
+import { html } from '@webjsdev/core';
+import type { Metadata } from '@webjsdev/core';
+
+export const metadata: Metadata = {
+  title: 'View transitions: page two | features',
+  other: { 'view-transition': 'same-origin' },
+};
+
+export default function ViewTransitionsSecond() {
+  return html`
+    <h1 class="text-h2 font-bold mb-4">Page two</h1>
+    <div class="rounded-2xl bg-foreground/5 border border-border p-6 mb-6">
+      <p class="text-foreground m-0">You arrived with a cross-fade, no full
+        reload. The input below is the same node from page one, regrafted across
+        the swap.</p>
+    </div>
+    <label class="block mb-6">
+      <span class="text-muted-foreground text-sm">Its value persisted across the transition:</span>
+      <input id="vt-note" data-webjs-permanent type="text" placeholder="type something…"
+        class="mt-2 block w-full max-w-sm rounded-xl border border-border bg-card px-4 py-2 text-foreground" />
+    </label>
+    <a href="/features/view-transitions" class="text-primary no-underline font-medium">&larr; Back to page one</a>
+  `;
+}

--- a/packages/cli/templates/gallery/modules/streaming/actions/stream-tokens.server.ts
+++ b/packages/cli/templates/gallery/modules/streaming/actions/stream-tokens.server.ts
@@ -1,0 +1,17 @@
+'use server';
+// A STREAMING server action (#489). Detection is purely on the RETURN VALUE, no
+// config export: an action that returns a ReadableStream / async iterable /
+// async generator streams its chunks over the single RPC response instead of
+// buffering. Each `yield` is rich-serialized and flushed as it is produced, so
+// the call site sees tokens arrive live. Back-pressure is respected and the
+// generator is cancelled if the client disconnects. A streamed result is never
+// cached / ETagged / seeded. One function per file, like every action.
+export async function* streamTokens(prompt: string): AsyncGenerator<string> {
+  const words = `Streaming ${prompt} one token at a time, straight from the server.`.split(' ');
+  for (const word of words) {
+    // A deliberate per-token delay so the streaming is visible; a real action
+    // would yield as its upstream (an LLM, a DB cursor, a log tail) produces.
+    await new Promise((r) => setTimeout(r, 140));
+    yield word + ' ';
+  }
+}

--- a/packages/cli/templates/gallery/modules/streaming/components/token-stream.ts
+++ b/packages/cli/templates/gallery/modules/streaming/components/token-stream.ts
@@ -1,0 +1,46 @@
+// Consumes a streaming action at the call site with `for await`. The import of
+// a `'use server'` action is rewritten to an RPC stub, so `await streamTokens()`
+// resolves to an async iterable whose chunks arrive as the server yields them.
+// We append each chunk to an instance signal, so the text builds up live as it
+// streams (the built-in SignalWatcher re-renders on each `.set`). With JS off
+// the button is inert and the empty output renders (streaming is inherently a
+// JS behaviour), so nothing here breaks the no-JS first paint.
+import { WebComponent, signal, html } from '@webjsdev/core';
+import { streamTokens } from '../actions/stream-tokens.server.ts';
+
+export class TokenStream extends WebComponent {
+  // Plain instance signals (not reactive props), so a class field is fine here.
+  private output = signal('');
+  private busy = signal(false);
+
+  private async run() {
+    this.output.set('');
+    this.busy.set(true);
+    try {
+      // `await streamTokens(...)` gives the async iterable; `for await` pulls
+      // each token as it arrives instead of waiting for the whole response.
+      for await (const chunk of await streamTokens('webjs')) {
+        this.output.set(this.output.get() + chunk);
+      }
+    } finally {
+      this.busy.set(false);
+    }
+  }
+
+  render() {
+    const busy = this.busy.get();
+    return html`
+      <div class="rounded-2xl border border-border bg-card p-5">
+        <button
+          @click=${() => this.run()}
+          ?disabled=${busy}
+          class="inline-flex items-center px-4 py-2 rounded-xl bg-primary text-primary-foreground font-semibold text-sm transition-all hover:bg-primary/90 active:scale-[0.97] disabled:opacity-60"
+        >
+          ${busy ? 'streaming…' : 'Stream tokens'}
+        </button>
+        <pre class="mt-4 whitespace-pre-wrap font-mono text-sm text-foreground min-h-[3rem]">${this.output.get()}</pre>
+      </div>
+    `;
+  }
+}
+TokenStream.register('token-stream');

--- a/packages/cli/templates/gallery/modules/suspense/components/slow-fact.ts
+++ b/packages/cli/templates/gallery/modules/suspense/components/slow-fact.ts
@@ -1,0 +1,19 @@
+// A bare async-render component whose server data is deliberately SLOW. On its
+// own, async render() BLOCKS the SSR first byte (the resolved value lands in the
+// first paint with no fallback, which is what the async-render demo shows). That
+// is the right default for fast data. Here the data is slow, so the page wraps
+// it in a <webjs-suspense> boundary that flushes its fallback on the first byte
+// and STREAMS this content in when the await settles (progressively on soft
+// navigation too). Same component either way; the boundary is what changes the
+// SSR behaviour from block to stream.
+import { WebComponent, html } from '@webjsdev/core';
+
+export class SlowFact extends WebComponent {
+  async render() {
+    await new Promise((r) => setTimeout(r, 900));
+    return html`<p class="rounded-2xl border border-border bg-card p-5 text-foreground">
+      The answer, after a slow lookup, is <strong>42</strong>.
+    </p>`;
+  }
+}
+SlowFact.register('slow-fact');

--- a/packages/cli/templates/scripts/clear-gallery.mjs
+++ b/packages/cli/templates/scripts/clear-gallery.mjs
@@ -41,7 +41,8 @@ const galleryPaths = [
 const galleryModules = [
   'async-render', 'broadcast', 'caching', 'client-router', 'components',
   'directives', 'file-storage', 'frames', 'optimistic-ui', 'rate-limit',
-  'route-handler', 'server-actions', 'sessions', 'todo', 'websockets',
+  'route-handler', 'server-actions', 'sessions', 'streaming',
+  'todo', 'websockets',
 ].map((m) => `modules/${m}`);
 
 let removed = 0;

--- a/packages/cli/templates/scripts/clear-gallery.mjs
+++ b/packages/cli/templates/scripts/clear-gallery.mjs
@@ -41,7 +41,7 @@ const galleryPaths = [
 const galleryModules = [
   'async-render', 'broadcast', 'caching', 'client-router', 'components',
   'directives', 'file-storage', 'frames', 'optimistic-ui', 'rate-limit',
-  'route-handler', 'server-actions', 'sessions', 'streaming',
+  'route-handler', 'server-actions', 'sessions', 'streaming', 'suspense',
   'todo', 'websockets',
 ].map((m) => `modules/${m}`);
 

--- a/test/scaffolds/scaffold-gallery.test.js
+++ b/test/scaffolds/scaffold-gallery.test.js
@@ -26,15 +26,16 @@ import { scaffoldApp } from '../../packages/cli/lib/create.js';
 // Single-feature demos under app/features/<name>.
 const FEATURES = [
   'routing', 'boundaries', 'components', 'server-actions', 'optimistic-ui',
-  'async-render', 'directives', 'route-handler', 'forms',
-  'metadata', 'caching', 'env', 'client-router', 'service-worker',
-  'websockets', 'broadcast', 'rate-limit', 'file-storage', 'sessions',
+  'async-render', 'streaming', 'suspense', 'directives', 'route-handler', 'forms',
+  'metadata', 'caching', 'env', 'client-router', 'view-transitions', 'frames',
+  'service-worker', 'websockets', 'broadcast', 'rate-limit', 'file-storage', 'sessions',
 ];
 // Whole example apps under app/examples/<name>.
 const EXAMPLE_APPS = ['todo'];
-// Routes whose logic lives in a modules/<name> folder (routing and
-// route-handler are app-only: a pages-only route and a route.ts handler).
-const MODULE_ROUTES = ['components', 'server-actions', 'optimistic-ui', 'async-render', 'directives', 'todo', 'websockets', 'broadcast', 'rate-limit', 'file-storage', 'sessions'];
+// Demos whose logic lives in a modules/<name> folder, spot-checked here. The
+// app-only demos (routing / metadata / env / boundaries / view-transitions,
+// which have no modules/ dir) are excluded.
+const MODULE_ROUTES = ['components', 'server-actions', 'optimistic-ui', 'async-render', 'streaming', 'suspense', 'directives', 'frames', 'todo', 'websockets', 'broadcast', 'rate-limit', 'file-storage', 'sessions'];
 
 async function tempCwd() {
   return mkdtemp(join(tmpdir(), 'webjs-scaffold-gallery-'));
@@ -65,6 +66,8 @@ test('full-stack scaffold ships feature demos and one example app', async () => 
     assert.ok(await exists(join(appDir, 'app', 'features', 'route-handler', 'data', 'route.ts')));
     // Client-router soft-nav target subpage.
     assert.ok(await exists(join(appDir, 'app', 'features', 'client-router', 'second', 'page.ts')));
+    // View-transitions soft-nav target subpage (the cross-fade + permanent-element demo).
+    assert.ok(await exists(join(appDir, 'app', 'features', 'view-transitions', 'second', 'page.ts')));
     // Infra features ship their server endpoints alongside the page.
     assert.ok(await exists(join(appDir, 'app', 'features', 'websockets', 'echo', 'route.ts')));
     assert.ok(await exists(join(appDir, 'app', 'features', 'broadcast', 'feed', 'route.ts')));


### PR DESCRIPTION
Closes #990

Three shipped, browser-facing features had zero demo in the scaffold gallery. This adds one single-concept demo each (three commits), following the gallery conventions (routing-only `app/`, logic in `modules/`, server-only code behind `.server.ts`, light DOM + Tailwind, one action per file).

## 1. Streaming server-action results (#489)
`modules/streaming/actions/stream-tokens.server.ts` is a `'use server'` `async function*`; `modules/streaming/components/token-stream.ts` consumes it at the call site with `for await (const chunk of await streamTokens('webjs'))`, appending each chunk to an instance signal so tokens render as they arrive. Contrasts with the api-template `stream` route, which returns a raw HTTP `ReadableStream` (a different mechanism).

## 2. View Transitions
`app/features/view-transitions/` is a two-page soft-nav pair. Each page opts in with `metadata.other = { 'view-transition': 'same-origin' }` (scoped to the pages, not app-wide), so the swap cross-fades. Both carry the same `data-webjs-permanent` `<input id="vt-note">`, so the router regrafts the one live node across the swap and the typed value survives. App-only (no component needed, since the root layout ships a component so the client router is active app-wide); degrades cleanly where `startViewTransition` is unavailable.

## 3. Component-level `<webjs-suspense>` (#471)
`app/features/suspense/page.ts` wraps a slow async-render component (`modules/suspense/components/slow-fact.ts`, a 900ms await) in `<webjs-suspense .fallback=${...}>`, so the fallback flushes on the first byte and the resolved content streams in. The copy contrasts it with plain async-render (which blocks SSR so the data is in the first paint with no fallback).

All three cards are registered in `FEATURES` (`packages/cli/lib/create.js`); the two with a `modules/` dir (streaming, suspense) are added to the `gallery:clear` prune list (view-transitions is app-only, like metadata/env).

## Definition of done

- **Tests**: `test/scaffolds/*` all green (gallery-coverage, scaffold-gallery, template-validation, integration, runtime). The three features' own mechanisms are already covered by framework tests (#489, #471, view-transitions), so no new framework test; these are template files exercising a documented surface. The gallery-coverage manifest needed no change (all exports were already classified/exempt).
- **Generate + boot + check**: generated a full-stack app, `webjs check` passes, and booting it in prod mode serves `/`, `/features/streaming`, `/features/suspense`, `/features/view-transitions`, `/features/view-transitions/second` all 200 with the expected content (the suspense fallback is in the SSR output, proving the boundary streams).
- **Docs**: N/A. No new API surface. All three features are already documented (client-router page for View Transitions, components / data-fetching for suspense and streaming); the gallery is the scaffold teaching surface and is updated here.
- **Dogfood four-app boot**: N/A. This is a scaffold-template-only change (`packages/cli/templates` + the `FEATURES` list in `create.js`); it does not touch `packages/core` / `packages/server` / the dist build / the importmap, so what the four in-repo apps serve is unchanged. The applicable gate is the fresh-app generate + boot + check above.
- **MCP / editor plugins / marketing**: N/A (no introspected surface, template grammar, or positioning change).
