### PR TITLE
chore: release cli 0.10.45, core 0.7.42

### DIFF
--- a/changelog/cli/0.10.45.md
+++ b/changelog/cli/0.10.45.md
@@ -1,0 +1,17 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.45
+date: 2026-07-22T10:44:04.512Z
+commit_count: 2
+---
+## Features
+
+- **add streaming-action, view-transition, and webjs-suspense gallery demos** ([#1039](https://github.com/webjsdev/webjs/pull/1039)) [`7e523375`](https://github.com/webjsdev/webjs/commit/7e523375)
+  * feat: add streaming-action gallery demo (for await over an async generator)
+  
+  A use-server action returning an async generator, consumed at the call
+  site with for await so tokens render as they arrive. Fills a gallery gap:
+- **fold auth into the default template as a gallery card, drop saas** ([#1040](https://github.com/webjsdev/webjs/pull/1040)) [`94b3b82a`](https://github.com/webjsdev/webjs/commit/94b3b82a)
+  * chore: start auth gallery card work
+  
+  * feat(scaffold): add auth gallery card (login, session, protected route)

--- a/changelog/core/0.7.42.md
+++ b/changelog/core/0.7.42.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/core"
+version: 0.7.42
+date: 2026-07-22T10:44:04.410Z
+commit_count: 1
+---
+## Fixes
+
+- **correct core .d.ts type surface (phantom base + register param)** ([#1038](https://github.com/webjsdev/webjs/pull/1038)) [`2cb78130`](https://github.com/webjsdev/webjs/commit/2cb78130)
+  * fix: stop core overlay leaking WebComponentBase as a value export
+  
+  WebComponentBase is an internal base class the runtime never exports,
+  but the .d.ts declared it as an abstract class. A class is a value as

--- a/package-lock.json
+++ b/package-lock.json
@@ -6975,7 +6975,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.44",
+      "version": "0.10.45",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -6991,7 +6991,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.40",
+      "version": "0.7.42",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.25.0"
@@ -7040,7 +7040,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.54",
+      "version": "0.8.55",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.44",
+  "version": "0.10.45",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.41",
+  "version": "0.7.42",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",


### PR DESCRIPTION
Release bumps for the two packages carrying unreleased work.

## @webjsdev/cli 0.10.44 -> 0.10.45
- feat: fold auth into the default template as a gallery card, drop saas (#1040)
- feat: add streaming-action, view-transition, and webjs-suspense gallery demos (#1039)

These ship the new scaffold to users (`npm create webjs@latest` currently still generates the pre-#1040 saas-era scaffold).

## @webjsdev/core 0.7.41 -> 0.7.42
- fix: correct core .d.ts type surface (phantom base + register param) (#1038)

## Notes
- Patch bumps: dependents pin `@webjsdev/core: ^0.7.1` and `@webjsdev/cli: ^0.10.0`, so no dependent range edits are needed.
- `package-lock.json` regenerated (also reconciled a pre-existing stale server 0.8.54 -> 0.8.55 lock entry to the already-released version).
- Changelogs auto-generated by the pre-commit backfill from the conventional PR titles.
- Merging adds the `changelog/**.md` files to `main`, which triggers `release.yml` to `npm publish` and cut GitHub Releases (idempotent).