### PR TITLE
fix: add cursor-pointer to the gallery streaming demo button

### DIFF
--- a/packages/cli/templates/gallery/modules/streaming/components/token-stream.ts
+++ b/packages/cli/templates/gallery/modules/streaming/components/token-stream.ts
@@ -34,7 +34,7 @@ export class TokenStream extends WebComponent {
         <button
           @click=${() => this.run()}
           ?disabled=${busy}
-          class="inline-flex items-center px-4 py-2 rounded-xl bg-primary text-primary-foreground font-semibold text-sm transition-all hover:bg-primary/90 active:scale-[0.97] disabled:opacity-60"
+          class="inline-flex items-center px-4 py-2 rounded-xl bg-primary text-primary-foreground font-semibold text-sm cursor-pointer transition-all hover:bg-primary/90 active:scale-[0.97] disabled:opacity-60"
         >
           ${busy ? 'streaming…' : 'Stream tokens'}
         </button>


### PR DESCRIPTION
The scaffold gallery's streaming demo ("Stream tokens" button on `/features/streaming`) was missing `cursor-pointer`. Tailwind v4 removed the default `cursor: pointer` on `<button>`, so the gallery sets it per-button, and this one was missed.

## Scope: audited the whole gallery, this was the only gap
Ran a full audit of every `<button>` and every `@click` / `role="button"` element across `packages/cli/templates/gallery/**` (resolving shared class-consts and shadow-DOM `static styles`, and tracking `${...}` depth so arrow-handler `>` does not truncate the tag). Result: the streaming button was the ONLY interactive element missing a pointer cursor. Every other button already has it, via a `cursor-pointer` class, a shared `btn` const, or `cursor: pointer` in a shadow component's `static styles`.

## Approach
Per-button `cursor-pointer`, matching the established gallery convention (Tailwind utility-first, not a global base rule). One-token change.

Found by dogfooding the generated gallery.