### PR TITLE
chore: release cli 0.10.46, core 0.7.43, server 0.8.56

### DIFF
--- a/changelog/cli/0.10.46.md
+++ b/changelog/cli/0.10.46.md
@@ -1,0 +1,21 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.46
+date: 2026-07-23T18:50:49.171Z
+commit_count: 2
+---
+## Features
+
+- **refactor the scaffold gallery onto a @webjsdev/ui class-helper design system** ([#1060](https://github.com/webjsdev/webjs/pull/1060)) [`a35e1f52`](https://github.com/webjsdev/webjs/commit/a35e1f52)
+  * feat: ship @webjsdev/ui class-helper primitives into the gallery scaffold
+  
+  Add components/ui/{button,card,input,textarea,badge}.ts (the ui tier-1 class
+  helpers buttonClass/cardClass/inputClass/textareaClass/badgeClass) to the
+
+## Fixes
+
+- **add cursor-pointer to the gallery streaming demo button** ([#1057](https://github.com/webjsdev/webjs/pull/1057)) [`af638b94`](https://github.com/webjsdev/webjs/commit/af638b94)
+  The streaming demo's 'Stream tokens' button was the one gallery button missing
+  cursor-pointer (Tailwind v4 dropped the default button cursor, and every other
+  gallery button already sets it per-button). A full audit of every button and
+  @click element in the gallery found this was the only gap.

--- a/changelog/core/0.7.43.md
+++ b/changelog/core/0.7.43.md
@@ -1,0 +1,18 @@
+---
+package: "@webjsdev/core"
+version: 0.7.43
+date: 2026-07-23T18:50:49.061Z
+commit_count: 2
+---
+## Fixes
+
+- **view-transition soft-nav meta leak and stuck Suspense skeleton** ([#1049](https://github.com/webjsdev/webjs/pull/1049)) [`e9af348b`](https://github.com/webjsdev/webjs/commit/e9af348b)
+  * fix: view-transition soft-nav meta leak and stuck Suspense skeleton
+  
+  Two related client-router defects, both triggered by view transitions
+  during a soft navigation.
+- **preserve csp-nonce on mergeHead, warn on dropped streamed resolve** ([#1052](https://github.com/webjsdev/webjs/pull/1052)) [`a32353e2`](https://github.com/webjsdev/webjs/commit/a32353e2)
+  * fix: preserve csp-nonce on mergeHead, warn on dropped streamed resolve
+  
+  #1050: mergeHead (the background full-body swap path) treated the live
+  csp-nonce meta as stale whenever the incoming response carried a different

--- a/changelog/server/0.8.56.md
+++ b/changelog/server/0.8.56.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/server"
+version: 0.8.56
+date: 2026-07-23T18:50:49.116Z
+commit_count: 1
+---
+## Features
+
+- **refactor the scaffold gallery onto a @webjsdev/ui class-helper design system** ([#1060](https://github.com/webjsdev/webjs/pull/1060)) [`a35e1f52`](https://github.com/webjsdev/webjs/commit/a35e1f52)
+  * feat: ship @webjsdev/ui class-helper primitives into the gallery scaffold
+  
+  Add components/ui/{button,card,input,textarea,badge}.ts (the ui tier-1 class
+  helpers buttonClass/cardClass/inputClass/textareaClass/badgeClass) to the

--- a/package-lock.json
+++ b/package-lock.json
@@ -6975,7 +6975,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.45",
+      "version": "0.10.46",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -6991,7 +6991,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.42",
+      "version": "0.7.43",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.25.0"
@@ -7040,7 +7040,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.55",
+      "version": "0.8.56",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.45",
+  "version": "0.10.46",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.42",
+  "version": "0.7.43",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.55",
+  "version": "0.8.56",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",


### PR DESCRIPTION
Release the three packages with unreleased changes since `cli 0.10.45, core 0.7.42` (#1043). mcp / ui / intellisense are unchanged and excluded.

## Packages

| Package | Bump | What landed |
|---|---|---|
| @webjsdev/core | 0.7.42 -> 0.7.43 | view-transition soft-nav meta leak + stuck Suspense skeleton (#1049); preserve csp-nonce on mergeHead, warn on dropped streamed resolve (#1052) |
| @webjsdev/server | 0.8.55 -> 0.8.56 | the `no-shadowed-native-member` check rule + the quote-aware head-hoist ssr fix (#1060) |
| @webjsdev/cli | 0.10.45 -> 0.10.46 | scaffold gallery on the @webjsdev/ui class-helper design system (#1060); streaming-demo button cursor-pointer (#1057). Bundles the corrected `no-shadowed-native-member` skill docs (#1067) |

## Notes

- Patch bumps, matching the recent cadence.
- Changelogs auto-generated by the pre-commit hook from conventional PR titles; reviewed for correct per-package attribution (all server/src changes trace to #1060, core to #1049/#1052).
- Lockfile diff is exactly the three version fields.
- On merge, `release.yml` publishes to npm and cuts the GitHub Releases. I will refresh the global CLI once the publish lands.