### PR TITLE
chore: capitalize WebJs brand in root package.json description

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "webjs-monorepo",
   "private": true,
   "version": "0.1.0",
-  "description": "webjs - AI-first, web-components-first framework.",
+  "description": "WebJs - AI-first, web-components-first framework.",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
The repo-root `package.json` `description` wrote the brand lowercase as prose. `WebJs` is a proper noun (invariant 11), lowercase only for literal code tokens (a `webjs` command, `@webjsdev` package, `webjs.dev` domain), so the prose description should be capitalized.

One-line, private root manifest (not published), no version bump.