### PR TITLE
fix(cli): resolve webjs ui bin via resolveBin, not the blocked exports subpath

### DIFF
--- a/packages/cli/bin/webjs.js
+++ b/packages/cli/bin/webjs.js
@@ -497,28 +497,31 @@ async function main() {
       break;
     }
     case 'ui': {
-      // Delegate to @webjsdev/ui. Bundled as a hard dependency of
-      // @webjsdev/cli, so `npm install -g webjsdev` pulls it in
-      // automatically, and `webjs ui add button` works out of the box
-      // without an extra install in user projects.
-      const { createRequire } = await import('node:module');
-      const req = createRequire(import.meta.url);
+      // Delegate to @webjsdev/ui's bin. It is a hard dependency of
+      // @webjsdev/cli, so `npm install -g webjsdev` pulls it in automatically
+      // and `webjs ui add button` works without an extra install.
+      //
+      // Resolve via resolveBin, NOT req.resolve('@webjsdev/ui/bin/webjsui.js'):
+      // the ui package's `exports` map does not list the bin subpath, so a
+      // direct subpath resolve throws ERR_PACKAGE_PATH_NOT_EXPORTED even though
+      // the file exists, which surfaced as a misleading "could not be resolved"
+      // (#1073). resolveBin resolves the `.` export, walks to the package root,
+      // and reads the `bin` map, exactly as `db` / `test --browser` do.
       let entry;
       try {
-        entry = req.resolve('@webjsdev/ui/bin/webjsui.js');
+        // Hard-dep path: @webjsdev/ui in the CLI's own node_modules.
+        entry = resolveBin(join(__dirname, '..'), '@webjsdev/ui', 'webjsui');
       } catch {
-        // Fallback: try resolving from the user's cwd in case of weird
-        // workspace setups.
+        // Fallback: the user installed @webjsdev/ui directly in their project.
         try {
-          const userReq = createRequire(join(process.cwd(), 'package.json'));
-          entry = userReq.resolve('@webjsdev/ui/bin/webjsui.js');
+          entry = resolveBin(process.cwd(), '@webjsdev/ui', 'webjsui');
         } catch {
           console.error('@webjsdev/ui could not be resolved.');
           console.error('Reinstall the CLI:  npm install -g webjsdev');
           process.exit(1);
         }
       }
-      const child = spawn('node', [entry, ...rest], { stdio: 'inherit', cwd: process.cwd() });
+      const child = spawn(process.execPath, [entry, ...rest], { stdio: 'inherit', cwd: process.cwd() });
       child.on('exit', (code) => process.exit(code ?? 0));
       break;
     }

--- a/packages/cli/test/resolve-bin/resolve-bin.test.mjs
+++ b/packages/cli/test/resolve-bin/resolve-bin.test.mjs
@@ -7,10 +7,12 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
 
 import { resolveBin } from '../../lib/resolve-bin.js';
 
 const repoRoot = fileURLToPath(new URL('../../../../', import.meta.url));
+const cliDir = fileURLToPath(new URL('../../', import.meta.url));
 // Resolve each tool from a cwd that genuinely DECLARES it (not via hoist luck):
 // drizzle-kit is a devDependency of examples/blog; @web/test-runner is a root
 // devDependency. Both packages block their bin subpath + ./package.json in
@@ -27,6 +29,27 @@ test('resolves @web/test-runner via the wtr bin key', () => {
   const p = resolveBin(repoRoot, '@web/test-runner', 'wtr');
   assert.match(p, /@web[/\\]test-runner[/\\].*bin\.js$/);
   assert.ok(existsSync(p), 'the resolved wtr bin exists on disk');
+});
+
+test('resolves the @webjsdev/ui webjsui bin despite its exports gate (#1073)', () => {
+  // @webjsdev/ui is a hard dependency of @webjsdev/cli, so resolve from the CLI
+  // package dir the way `webjs ui` does.
+  const p = resolveBin(cliDir, '@webjsdev/ui', 'webjsui');
+  // Path tail only: the monorepo resolves the workspace `packages/ui/`, an
+  // installed app resolves `node_modules/@webjsdev/ui/`; both end the same way.
+  assert.match(p, /ui[/\\]bin[/\\]webjsui\.js$/);
+  assert.ok(existsSync(p), 'the resolved webjsui bin exists on disk');
+});
+
+test('counterfactual: the raw bin subpath resolve is blocked by exports (#1073)', () => {
+  // This is exactly the resolve the `ui` dispatch used to do, and why it failed
+  // even with @webjsdev/ui installed: the exports map does not list ./bin/*, so
+  // Node refuses the subpath though the file exists. resolveBin bypasses this.
+  const req = createRequire(new URL('../../package.json', import.meta.url));
+  assert.throws(
+    () => req.resolve('@webjsdev/ui/bin/webjsui.js'),
+    /ERR_PACKAGE_PATH_NOT_EXPORTED|is not defined by "exports"/,
+  );
 });
 
 test('throws a clear error when the package is not installed', () => {


### PR DESCRIPTION
Closes #1073

## Bug
`webjs ui <subcmd>` / `npx webjsdev ui add <name>` printed a misleading `@webjsdev/ui could not be resolved. Reinstall the CLI` even with `@webjsdev/ui` installed. Root cause is a resolver gate, not a missing package: the `ui` dispatch resolved the bin by SUBPATH (`req.resolve('@webjsdev/ui/bin/webjsui.js')`), but the ui package's `exports` map lists only `.` / `./registry/*` / `./utils`, so Node blocks the unlisted `./bin/*` subpath with `ERR_PACKAGE_PATH_NOT_EXPORTED` even though the file exists. Found dogfooding (an agent assumed the kit was unavailable and hand-wrote UI instead, compounding #1070).

## Fix
Use the CLI's existing `resolveBin` helper (`lib/resolve-bin.js`, #570), which resolves the `.` export, walks to the package root, and reads the `bin` map, bypassing the exports gate. `db` and `test --browser` already use it; the `ui` dispatch was simply missed. Kept the CLI-root-first (hard-dep) then cwd fallback order, and switched `spawn('node', ...)` to `spawn(process.execPath, ...)` to match the sibling paths (works under Bun / a Node-less image). Considered adding `./bin/webjsui.js` to the ui package's `exports` instead, but reusing `resolveBin` is the single consistent fix and needs no second package change.

## Tests
Extended `packages/cli/test/resolve-bin/resolve-bin.test.mjs`: asserts `resolveBin` resolves the `webjsui` bin, plus a COUNTERFACTUAL proving `require.resolve('@webjsdev/ui/bin/webjsui.js')` throws `ERR_PACKAGE_PATH_NOT_EXPORTED` (the exact old failure). Full CLI suite green (25/25).

## Verified
`node packages/cli/bin/webjs.js ui list` now launches and lists the kit (exit 0), where before it printed the reinstall error.