### PR TITLE
chore: release cli 0.10.47

### DIFF
--- a/changelog/cli/0.10.47.md
+++ b/changelog/cli/0.10.47.md
@@ -1,0 +1,9 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.47
+date: 2026-07-23T20:25:21.911Z
+commit_count: 1
+---
+## Fixes
+
+- **resolve webjs ui bin via resolveBin, not the blocked exports subpath** ([#1074](https://github.com/webjsdev/webjs/pull/1074)) [`fb7283e8`](https://github.com/webjsdev/webjs/commit/fb7283e8)

--- a/package-lock.json
+++ b/package-lock.json
@@ -6975,7 +6975,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.46",
+      "version": "0.10.47",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.46",
+  "version": "0.10.47",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {


### PR DESCRIPTION
Release `@webjsdev/cli` 0.10.46 -> 0.10.47. Only the cli package changed since the last release (#1068); core / server / mcp / ui / intellisense are untouched and excluded.

## What's in it
| Package | Bump | Change |
|---|---|---|
| @webjsdev/cli | 0.10.46 -> 0.10.47 | fix: `webjs ui` now resolves the @webjsdev/ui bin via resolveBin, so `webjs ui add` / `npx webjsdev ui add` no longer fail with a false 'could not be resolved' (the exports-gate bug, #1074, closes #1073). Also carries the #1071 scaffold-doc update to `templates/AGENTS.md` (docs, not in the changelog). |

## Notes
- Patch bump (a bugfix).
- Changelog auto-generated from the conventional PR title; reviewed (one fix, #1074).
- Lockfile diff is exactly the one cli version field.
- On merge, `release.yml` publishes to npm and cuts the GitHub Release. I will refresh the global CLI once the publish lands.