### PR TITLE
chore: release cli 0.10.48, ui 0.3.10

### DIFF
--- a/changelog/cli/0.10.48.md
+++ b/changelog/cli/0.10.48.md
@@ -1,0 +1,12 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.48
+date: 2026-07-24T16:16:32.197Z
+commit_count: 1
+---
+## Features
+
+- **template-specific scaffold agent-docs with required app-building playbook** ([#1077](https://github.com/webjsdev/webjs/pull/1077)) [`4a1781f1`](https://github.com/webjsdev/webjs/commit/4a1781f1)
+  * chore: begin scaffold agent-docs context work
+  
+  * feat(cli): template-specific scaffold AGENTS.md with required playbook

--- a/changelog/ui/0.3.10.md
+++ b/changelog/ui/0.3.10.md
@@ -1,0 +1,15 @@
+---
+package: "@webjsdev/ui"
+version: 0.3.10
+date: 2026-07-24T16:16:32.246Z
+commit_count: 2
+---
+## Features
+
+- **Themed class-helper registry: refreshed utils and theme tokens** ([#1060](https://github.com/webjsdev/webjs/pull/1060)) [`a35e1f52`](https://github.com/webjsdev/webjs/commit/a35e1f52)
+  * The registry's `lib/utils.ts` and `themes/index.css` were updated for the own-and-theme class-helper model (`buttonClass` / `cardClass` / `inputClass` and friends), so a copied primitive themes cleanly against the design tokens.
+
+## Fixes
+
+- **tabs arrow-key nav moves focus, not just selection** ([#1079](https://github.com/webjsdev/webjs/pull/1079)) [`e0c6996a`](https://github.com/webjsdev/webjs/commit/e0c6996a)
+  * Arrow / Home / End on a focused tab now moves keyboard focus to the tab it selects, so the focus ring no longer strands on the previously focused tab (roving tabindex a11y).

--- a/package-lock.json
+++ b/package-lock.json
@@ -6975,7 +6975,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.47",
+      "version": "0.10.48",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -7076,7 +7076,7 @@
     },
     "packages/ui": {
       "name": "@webjsdev/ui",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.47",
+  "version": "0.10.48",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/ui",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "type": "module",
   "description": "An AI-first component library - class-helper functions for visuals, custom elements only where state matters. Source-copied into your repo, you own it. Works with any Tailwind v4 project.",
   "bin": {


### PR DESCRIPTION
Release bumps for the two published packages that carry unreleased user-facing commits.

## @webjsdev/cli 0.10.47 -> 0.10.48 (patch)
- feat: template-specific scaffold agent-docs with the required app-building playbook (#1077). The generator now injects a full-stack or api build playbook into the scaffolded `AGENTS.md` and bunifies the copied skill for bun apps.

## @webjsdev/ui 0.3.9 -> 0.3.10 (patch)
- fix: tabs arrow-key nav moves keyboard focus, not just selection (#1079, a11y).
- feat: refreshed registry class-helper utils + theme tokens for the own-and-theme model (#1060).

The `ui` changelog was hand-trimmed to the published surface: #1040's ui touch was a 7-line internal `src/registry/extract.js` edit from a scaffold PR (not a user-facing kit change), so it is excluded and `commit_count` corrected to 2.

## Consistency
- Dependent ranges unchanged: `@webjsdev/cli` is pinned `^0.10.0` and `@webjsdev/ui` `^0.3.1`/`^0.3.9` everywhere, so both patch bumps stay in range (no widening needed).
- `package-lock.json` regenerated (`npm install --package-lock-only`).
- No lockstep wrapper (create-webjs / webjsdev) version set here; the release workflow owns those.

Merging adds the `changelog/**.md` files to `main`, which triggers `release.yml` to `npm publish` cli@0.10.48 and ui@0.3.10 and cut their GitHub Releases (idempotent).