### PR TITLE
feat(website): move Why WebJs to the footer and rename it to /why-webjs

### DIFF
--- a/website/app/layout.ts
+++ b/website/app/layout.ts
@@ -22,7 +22,6 @@ const DESCRIPTION = 'A full-stack web framework built on web components, SSR, an
 
 const NAV = [
   { label: 'Docs', href: DOCS_URL + '/docs/getting-started', ext: true },
-  { label: 'Why WebJs', href: '/why', ext: false },
   { label: 'UI', href: UI_URL, ext: true },
   { label: 'Demo', href: EXAMPLE_BLOG_URL, ext: true },
   { label: 'Blog', href: '/blog', ext: false },

--- a/website/app/sitemap.ts
+++ b/website/app/sitemap.ts
@@ -26,7 +26,7 @@ export default async function Sitemap() {
   // that happen to share the name.
   const PRIORITY: Record<string, number> = { '/': 1.0, '/what-is-webjs': 0.9 };
 
-  const staticRoutes = ['/', '/what-is-webjs', '/blog', '/articles', '/compare', '/why', '/changelog'].map((path) => ({
+  const staticRoutes = ['/', '/what-is-webjs', '/blog', '/articles', '/compare', '/why-webjs', '/changelog'].map((path) => ({
     url: `${SITE_URL}${path}`,
     changeFrequency: 'weekly' as const,
     priority: PRIORITY[path] ?? 0.7,

--- a/website/app/what-is-webjs/page.ts
+++ b/website/app/what-is-webjs/page.ts
@@ -8,7 +8,7 @@ import { highlight } from '#lib/highlight.ts';
 /**
  * /what-is-webjs
  *
- * The definitional page for the "what is webjs" query class. Where /why makes
+ * The definitional page for the "what is webjs" query class. Where /why-webjs makes
  * the argument for the framework and /compare positions it against specific
  * alternatives, this page answers the flat question: what IS this thing.
  *
@@ -140,7 +140,7 @@ export function generateMetadata() {
   };
 }
 
-// Shared class strings, kept in lockstep with app/page.ts and app/why/page.ts
+// Shared class strings, kept in lockstep with app/page.ts and app/why-webjs/page.ts
 // so the three render as one design system.
 const KICKER = 'inline-flex flex-wrap justify-center gap-[10px] font-mono font-semibold text-[12px] leading-[1.4] tracking-[0.18em] uppercase text-[var(--accent-text)]';
 const BTN = 'inline-flex items-center gap-2 px-[22px] py-[13px] rounded-full font-semibold text-[15px] leading-none no-underline border cursor-pointer transition-all duration-[140ms]';
@@ -218,12 +218,12 @@ export default function WhatIsWebJs() {
         <h1 class="font-display font-extrabold text-display leading-[1.04] tracking-[-0.035em] mx-auto mt-4 mb-6 max-w-[14ch] text-balance">
           What is WebJs?
         </h1>
-        <p class="text-lede leading-[1.6] text-fg-muted max-w-[62ch] mx-auto mb-6 text-pretty">
+        <p class="text-lede leading-[1.6] text-fg-muted max-w-[56ch] mx-auto mb-6 text-pretty">
           <strong class="text-fg font-semibold">WebJs is a free, open-source, full-stack JavaScript web
           framework built on web components.</strong> It server-renders every page and component to real
           HTML, needs no build step or bundler, and runs on Node 24+ or Bun.
         </p>
-        <p class="text-[1.05rem] leading-[1.7] text-fg-muted max-w-[62ch] mx-auto mb-8 text-pretty">
+        <p class="text-[1.05rem] leading-[1.7] text-fg-muted max-w-[56ch] mx-auto mb-8 text-pretty">
           You write pages, layouts, and components as plain files. WebJs serves that source to the
           browser exactly as you wrote it, so the code you read is the code that runs. Content reads
           and forms submit before any script loads, and JavaScript is added only where an interaction
@@ -234,7 +234,7 @@ export default function WhatIsWebJs() {
             Get started
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>${NEW_TAB}
           </a>
-          <a class="${BTN} text-fg border-border-strong bg-[color-mix(in_oklch,var(--color-bg-elev)_60%,transparent)] hover:border-fg-muted hover:-translate-y-0.5" href="/why">Why WebJs exists</a>
+          <a class="${BTN} text-fg border-border-strong bg-[color-mix(in_oklch,var(--color-bg-elev)_60%,transparent)] hover:border-fg-muted hover:-translate-y-0.5" href="/why-webjs">Why WebJs exists</a>
         </div>
         <div class=${INSTALL}>
           <span class="text-accent select-none" aria-hidden="true">$</span><copy-cmd>npm create webjs@latest my-app</copy-cmd>
@@ -343,7 +343,7 @@ export default function WhatIsWebJs() {
             <a class="${BTN} bg-accent text-accent-fg border-transparent shadow-[var(--shadow-glow)] hover:bg-accent-hover hover:-translate-y-0.5" href=${DOCS_URL + '/docs/getting-started'} target="_blank" rel="noopener noreferrer">Read the docs${NEW_TAB}</a>
             <a class="${BTN} text-fg border-border-strong bg-[color-mix(in_oklch,var(--color-bg-elev)_60%,transparent)] hover:border-fg-muted hover:-translate-y-0.5" href=${GH_URL} target="_blank" rel="noopener noreferrer">View on GitHub${NEW_TAB}</a>
           </div>
-          <p class="mt-10 text-[14px] text-fg-subtle">
+          <p class="mt-14 pt-8 border-t border-border max-w-[52ch] mx-auto text-[14px] leading-[1.7] text-fg-subtle">
             Compare WebJs with <a class="text-fg-muted hover:text-accent underline underline-offset-2" href="/compare/webjs-vs-nextjs">Next.js</a>,
             <a class="text-fg-muted hover:text-accent underline underline-offset-2" href="/compare/webjs-vs-lit">Lit</a>, and
             <a class="text-fg-muted hover:text-accent underline underline-offset-2" href="/compare/webjs-vs-astro">Astro</a>, or read

--- a/website/app/why-webjs/page.ts
+++ b/website/app/why-webjs/page.ts
@@ -3,7 +3,7 @@ import '#components/copy-cmd.ts';
 import { DOCS_URL, GH_URL, EXAMPLE_BLOG_URL, NEW_TAB } from '#lib/links.ts';
 
 /**
- * /why
+ * /why-webjs
  *
  * The developer pitch page. Where the home page shows the framework's shape
  * (progressive enhancement, the three-file stack, the weight stats), this page
@@ -30,7 +30,7 @@ export function generateMetadata(ctx: { url: string }) {
       type: 'article',
       title,
       description,
-      url: `${origin}/why`,
+      url: `${origin}/why-webjs`,
       image,
       'image:width': '1200',
       'image:height': '630',

--- a/website/lib/site-footer.ts
+++ b/website/lib/site-footer.ts
@@ -27,6 +27,7 @@ export function siteFooter() {
           <div class="flex flex-col gap-3">
             <h4 class="text-xs font-bold uppercase tracking-wider text-fg">Resources</h4>
             <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href="/what-is-webjs">What is WebJs?</a>
+            <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href="/why-webjs">Why WebJs</a>
             <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href="/blog">Blog</a>
             <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href="/articles">Articles</a>
             <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href="/changelog">Changelog</a>

--- a/website/package.json
+++ b/website/package.json
@@ -14,8 +14,39 @@
     "css:build": "tailwindcss -i ./public/input.css -o ./public/tailwind.css --minify"
   },
   "webjs": {
-    "dev": { "before": ["npm run css:build"], "regenerate": [{ "output": "public/tailwind.css", "command": "tailwindcss -i ./public/input.css -o ./public/tailwind.css --minify", "inputs": ["app", "components", "lib", "modules", "public/input.css"] }], "watch": ["../blog"] },
-    "start": { "before": ["npm run css:build"] }
+    "redirects": [
+      {
+        "source": "/why",
+        "destination": "/why-webjs",
+        "permanent": true
+      }
+    ],
+    "dev": {
+      "before": [
+        "npm run css:build"
+      ],
+      "regenerate": [
+        {
+          "output": "public/tailwind.css",
+          "command": "tailwindcss -i ./public/input.css -o ./public/tailwind.css --minify",
+          "inputs": [
+            "app",
+            "components",
+            "lib",
+            "modules",
+            "public/input.css"
+          ]
+        }
+      ],
+      "watch": [
+        "../blog"
+      ]
+    },
+    "start": {
+      "before": [
+        "npm run css:build"
+      ]
+    }
   },
   "dependencies": {
     "@webjsdev/cli": "^0.10.0",

--- a/website/test/ssr/nav-and-routes.test.ts
+++ b/website/test/ssr/nav-and-routes.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Guards the header/footer split and the /why to /why-webjs rename (#1094).
+ *
+ * Three things here are easy to half-do and impossible to notice locally:
+ *
+ *  - moving a nav item OUT of the header but forgetting to put it in the
+ *    footer, so the page becomes unreachable from the chrome entirely
+ *  - renaming a route but leaving an internal link, the sitemap entry, or the
+ *    og:url pointing at the old path, which sends crawlers and readers to a
+ *    redirect instead of the page
+ *  - shipping the rename WITHOUT the 301, which silently drops whatever
+ *    ranking equity the old URL had accumulated
+ *
+ * Each is asserted against observable output (rendered HTML, the serialized
+ * sitemap, the config the framework actually reads) rather than source text.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { html } from '@webjsdev/core';
+import { renderToString } from '@webjsdev/core/server';
+import RootLayout from '#app/layout.ts';
+import Sitemap from '#app/sitemap.ts';
+import { siteFooter } from '#lib/site-footer.ts';
+
+const WEBSITE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+const renderLayout = () => renderToString(RootLayout({ children: html`<main>x</main>` }));
+
+test('the header nav no longer carries Why WebJs', async () => {
+  const out = await renderLayout();
+  const header = out.slice(0, out.indexOf('<footer'));
+  assert.ok(!header.includes('href="/why-webjs"'), 'not in the header (desktop or mobile menu)');
+  assert.ok(!header.includes('href="/why"'), 'and not left pointing at the old path either');
+});
+
+test('the footer Resources column carries Why WebJs', async () => {
+  // Moved, not deleted. Without this the page is unreachable from the chrome.
+  const out = await renderToString(siteFooter());
+  assert.ok(out.includes('href="/why-webjs"'), 'linked from the footer');
+  assert.ok(out.includes('href="/what-is-webjs"'), 'still alongside What is WebJs?');
+});
+
+test('the header still carries the rest of the nav', async () => {
+  // Counterweight to the removal assertions: prove we removed ONE entry, not
+  // that the nav failed to render at all.
+  const out = await renderLayout();
+  for (const href of ['/blog', '/compare', '/changelog']) {
+    assert.ok(out.includes(`href="${href}"`), `header still links ${href}`);
+  }
+});
+
+test('the sitemap lists /why-webjs and not the old /why', async () => {
+  const xml = String(await Sitemap());
+  assert.ok(xml.includes('<loc>https://webjs.dev/why-webjs</loc>'), 'lists the new path');
+  assert.ok(!xml.includes('<loc>https://webjs.dev/why</loc>'), 'does not list the redirecting path');
+});
+
+test('a permanent redirect preserves the old /why URL', async () => {
+  // The rename is only safe because the old URL keeps resolving. This reads the
+  // config the framework actually consumes (compileRedirectRules reads
+  // package.json webjs.redirects), so deleting the entry fails here.
+  const pkg = JSON.parse(readFileSync(resolve(WEBSITE_ROOT, 'package.json'), 'utf8'));
+  const rules = pkg.webjs?.redirects ?? [];
+  const rule = rules.find((r: any) => r.source === '/why');
+  assert.ok(rule, 'a redirect rule exists for /why');
+  assert.equal(rule.destination, '/why-webjs', 'points at the new path');
+  assert.ok(rule.permanent === true || rule.statusCode === 301, 'is a PERMANENT redirect, so signals transfer');
+});
+
+test('no internal link still points at the old /why path', async () => {
+  // A link to /why would still work, but every visit would eat a redirect hop.
+  const pages = await Promise.all([renderLayout(), renderToString(siteFooter())]);
+  for (const out of pages) {
+    assert.ok(!/href="\/why"/.test(out), 'no chrome link targets the pre-rename path');
+  }
+});

--- a/website/test/ssr/seo-infra.test.ts
+++ b/website/test/ssr/seo-infra.test.ts
@@ -90,20 +90,20 @@ test('favicon.ico exists so the origin-root fallback resolves', () => {
 });
 
 test('the root layout gives every page a canonical URL', () => {
-  const m = generateMetadata({ url: 'https://webjs.dev/why' });
-  assert.equal(m.alternates.canonical, 'https://webjs.dev/why', 'canonical tracks the current path');
+  const m = generateMetadata({ url: 'https://webjs.dev/why-webjs' });
+  assert.equal(m.alternates.canonical, 'https://webjs.dev/why-webjs', 'canonical tracks the current path');
 });
 
 test('the canonical collapses query strings and trailing slashes', () => {
   // The counterfactual for the whole point of a canonical: three addresses for
   // one page must resolve to ONE canonical, or they split ranking signals.
   const variants = [
-    'https://webjs.dev/why?utm_source=twitter&utm_campaign=launch',
-    'https://webjs.dev/why/',
-    'https://webjs.dev/why',
+    'https://webjs.dev/why-webjs?utm_source=twitter&utm_campaign=launch',
+    'https://webjs.dev/why-webjs/',
+    'https://webjs.dev/why-webjs',
   ];
   const canonicals = variants.map((url) => generateMetadata({ url }).alternates.canonical);
-  assert.deepEqual(new Set(canonicals), new Set(['https://webjs.dev/why']), 'all variants collapse to one canonical');
+  assert.deepEqual(new Set(canonicals), new Set(['https://webjs.dev/why-webjs']), 'all variants collapse to one canonical');
 });
 
 test('the home page canonical has no trailing slash', () => {

--- a/website/test/ssr/why-webjs-ssr.test.ts
+++ b/website/test/ssr/why-webjs-ssr.test.ts
@@ -1,17 +1,17 @@
 /**
- * SSR smoke test for the /why pitch page (app/why/page.ts).
+ * SSR smoke test for the /why-webjs pitch page (app/why-webjs/page.ts).
  *
  * The page is pure marketing markup (no components of its own), so this guards
  * the things that would only otherwise surface at dogfood boot: a render crash,
  * a malformed html`` template, a stray-backtick (invariant 9) regression, a
  * dropped install command, or the missing main landmark. It also pins the
  * page's own metadata as self-consistent across the title, og, and twitter tags
- * and pointed at the dedicated /why social card.
+ * and pointed at the dedicated /why-webjs social card.
  */
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { renderToString } from '@webjsdev/core/server';
-import Why, { generateMetadata } from '#app/why/page.ts';
+import Why, { generateMetadata } from '#app/why-webjs/page.ts';
 
 test('the pitch page SSRs with its headline, terminals, reason cards, and a main landmark', async () => {
   const out = await renderToString(Why());
@@ -24,21 +24,21 @@ test('the pitch page SSRs with its headline, terminals, reason cards, and a main
   assert.ok(out.includes('<main id="main"'), 'wraps content in a main landmark');
 });
 
-test('why metadata is self-consistent and points at the dedicated /why social card', () => {
-  const m = generateMetadata({ url: 'https://webjs.dev/why' });
+test('why metadata is self-consistent and points at the dedicated /why-webjs social card', () => {
+  const m = generateMetadata({ url: 'https://webjs.dev/why-webjs' });
   assert.equal(m.openGraph.title, m.title, 'og:title matches the <title>');
   assert.equal(m.twitter.title, m.title, 'twitter:title matches the <title>');
   assert.equal(m.openGraph.description, m.description, 'og:description matches the meta description');
   assert.equal(m.twitter.description, m.description, 'twitter:description matches the meta description');
-  assert.equal(m.openGraph.url, 'https://webjs.dev/why', 'og:url is the canonical /why URL');
+  assert.equal(m.openGraph.url, 'https://webjs.dev/why-webjs', 'og:url is the canonical /why-webjs URL');
   assert.match(m.openGraph.image, /\/public\/og-why\.png$/, 'og:image is the dedicated /why card');
   assert.equal(m.twitter.image, m.openGraph.image, 'twitter image matches the og image');
 });
 
-test('the /why title uses a clean hyphen form, not a colon', () => {
+test('the /why-webjs title uses a clean hyphen form, not a colon', () => {
   // Guards the regression that shipped the title as "Why WebJs: the framework
   // ...". This is a marketing page, so it takes the brand-first hyphen title
   // like the home page, not a colon-label form.
-  const { title } = generateMetadata({ url: 'https://webjs.dev/why' });
+  const { title } = generateMetadata({ url: 'https://webjs.dev/why-webjs' });
   assert.ok(!title.includes(':'), 'title uses no colon-label form');
 });


### PR DESCRIPTION
Closes #1094

## What changed

**1. "Why WebJs" out of the top navbar, into the footer.** The header carried eight items, and it now carries seven. The entry moves to the footer Resources column beside "What is WebJs?", so the two explainers sit together.

**2. `/why` renamed to `/why-webjs`,** so both explainer pages are self-describing. A **308 permanent redirect** (via `webjs.redirects`, #254) keeps the old URL working, so no accumulated ranking signal is lost. Sitemap, `og:url`, canonical, internal links, and the test file all follow.

**3. Two alignment fixes on `/what-is-webjs`:** the hero lede now uses the same `56ch` measure as the home page and the pitch page, and the closing "Compare WebJs with..." line sits behind a rule instead of crowding the CTA row.

## Important: the production page is broken by stale CSS, not by this markup

You reported `/what-is-webjs` as "broken entirely" in production. That is **not a markup bug**, and this PR is not what fixes it.

`tailwind.css` is served at an **un-versioned URL** (`<link rel="stylesheet" href="/public/tailwind.css">`), so a deploy never invalidates the Cloudflare copy:

```
cache-control: public, max-age=14400
cf-cache-status: HIT
age: 3146
```

The cached body is **missing** `max-w-[62ch]`, `max-w-[14ch]`, `min-[700px]:grid-cols-2`, `min-[1000px]:grid-cols-3`, `marker:content-none`. The same URL with a cache-busting query returns a body **containing** all of them. That exactly explains the three symptoms you saw: content edge to edge, capability cards collapsing to one column, and unpadded FAQ rows.

It self-heals within 4h but **recurs on every deploy**. It hit this page hardest only because the page is new, so none of its arbitrary-value utilities existed in the previously-built CSS. **Tracked as #1095** (fingerprint author-written `<link>` hrefs the way #243 already fingerprints framework-emitted URLs). That is a framework change with wider blast radius, so it is deliberately not bundled here.

A local screenshot against a freshly built stylesheet confirms the page renders correctly today.

## Verified locally

```
/why        308 -> /why-webjs
/why-webjs  200, <title>Why WebJs - ...</title>, canonical /why-webjs
header      0 occurrences of href="/why"
footer      1 occurrence of href="/why-webjs"
```

## Tests

75 website server tests pass, `webjs check` clean. New `test/ssr/nav-and-routes.test.ts` covers the header removal, the footer addition, the sitemap swap, the redirect config, and a guard that no chrome link still eats a redirect hop. It also asserts the rest of the nav still renders, so the removal assertions cannot pass by the nav failing to render at all.

**Counterfactuals verified.** Dropping the footer link, the redirect, and the sitemap update each fail:

```
x the footer Resources column carries Why WebJs
x the sitemap lists /why-webjs and not the old /why
x a permanent redirect preserves the old /why URL
```
