### PR TITLE
chore: release core 0.7.45, vscode 0.2.3, nvim 0.2.3

### DIFF
--- a/changelog/core/0.7.45.md
+++ b/changelog/core/0.7.45.md
@@ -1,0 +1,19 @@
+---
+package: "@webjsdev/core"
+version: 0.7.45
+date: 2026-07-26T17:42:19.247Z
+commit_count: 1
+---
+## Fixes
+
+- **a stale hover prefetch no longer degrades a click to a full page load** ([#1115](https://github.com/webjsdev/webjs/pull/1115)) [`f34fa5c9`](https://github.com/webjsdev/webjs/commit/f34fa5c9)
+
+  Clicking a link could intermittently reload the whole document instead of soft-navigating, showing a loading spinner in the browser tab and flashing the entire page including preserved layout chrome.
+
+  A prefetched fragment is a reduced response, anchored at the deepest layout boundary the server short-circuited on, and it can only be applied to a DOM that still offers that boundary. Prefetching any page under a layout while the client already holds that layout therefore yields a fragment that applies from a sibling page but nowhere outside the section. Two ordinary interactions left one cached at the wrong moment: a hover's intent timer resolving after the click it belonged to had already swapped, and a hover on a link that was never clicked before navigating away. Consuming such an entry left the router nothing to swap into, so it correctly degraded to a full page load.
+
+  The prefetch cache now validates a fragment's anchor against the live boundaries and discards it when the anchor is gone, costing one network round-trip instead of a document load. Validation runs against the boundaries captured before the optimistic loading skeleton clears them, so an app with a root-level `loading.{js,ts}` keeps a usable prefetch cache. The router also no longer prefetches the page it is already on, which never helped a later navigation and only occupied a capped cache slot.
+
+- **client-router degradations are now observable in production** ([#1115](https://github.com/webjsdev/webjs/pull/1115)) [`f34fa5c9`](https://github.com/webjsdev/webjs/commit/f34fa5c9)
+
+  When a soft navigation is not safely possible the router degrades to a full page load, which is correct but was previously reported only by a development-mode console warning, leaving deployed apps with no signal at all. Every such path now dispatches a `webjs:navigation-fallback` event on `document` in all environments, with detail `{ cause, href, willReload }`. `willReload` is true only when a document load actually follows, so a listener can count real full loads without also counting the degradations that resolve in place (a dropped background revalidation, or a suppressed cross-deploy reload that proceeds on the stale importmap). The event is not cancelable, and a listener that throws cannot affect the navigation.

--- a/changelog/nvim/0.2.3.md
+++ b/changelog/nvim/0.2.3.md
@@ -1,0 +1,14 @@
+---
+package: "webjs.nvim"
+version: 0.2.3
+date: 2026-07-26T17:55:00.000Z
+commit_count: 2
+npm: false
+---
+## Fixes
+
+- **the vendored `@webjsdev/intellisense` bundle reported the wrong version** ([#1117](https://github.com/webjsdev/webjs/pull/1117))
+
+  The plugin ships a committed copy of `@webjsdev/intellisense` rather than resolving it at install time. That copy still declared 0.5.1 in its own `package.json`, so the published plugin misreported which language-service version it carried. Re-vendored, so the shipped bundle and its stated version agree.
+
+  There is no change to the plugin's own Lua surface. The only other commit touching this package since 0.2.2 was a JSDoc brand-casing pass inside the vendored copy ([#855](https://github.com/webjsdev/webjs/pull/855)) [`f41d105b`](https://github.com/webjsdev/webjs/commit/f41d105b), with no behaviour change.

--- a/changelog/vscode/0.2.3.md
+++ b/changelog/vscode/0.2.3.md
@@ -1,0 +1,18 @@
+---
+package: "webjs (VS Code extension)"
+version: 0.2.3
+date: 2026-07-26T17:55:00.000Z
+commit_count: 3
+npm: false
+---
+## Fixes
+
+- **the "open documentation" command points at the current docs host** ([#1101](https://github.com/webjsdev/webjs/pull/1101)) [`e07ea3a1`](https://github.com/webjsdev/webjs/commit/e07ea3a1)
+
+  The documentation moved from `docs.webjs.dev` onto the main domain, and the command shipped in the extension still opened the old host. This is the extension-side counterpart of the same fix released in `@webjsdev/core` 0.7.44.
+
+- **brand casing corrected in the Marketplace listing** ([#851](https://github.com/webjsdev/webjs/pull/851)) [`28e5be9a`](https://github.com/webjsdev/webjs/commit/28e5be9a)
+
+  The extension README is packaged into the vsix and rendered as the Marketplace listing page, so this is the visible description text.
+
+Also includes a JSDoc-only brand-casing pass over the extension source ([#855](https://github.com/webjsdev/webjs/pull/855)) [`f41d105b`](https://github.com/webjsdev/webjs/commit/f41d105b), with no behaviour change.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6991,7 +6991,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.44",
+      "version": "0.7.45",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.25.0"
@@ -7007,11 +7007,11 @@
     },
     "packages/editors/nvim": {
       "name": "webjs.nvim",
-      "version": "0.2.2"
+      "version": "0.2.3"
     },
     "packages/editors/vscode": {
       "name": "webjs",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/intellisense": "^0.5.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.44",
+  "version": "0.7.45",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/editors/nvim/package.json
+++ b/packages/editors/nvim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webjs.nvim",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "description": "Neovim editor support for webjs apps (html/css/svg template highlighting + in-template intelligence via the bundled @webjsdev/intellisense). NOT an npm package: ships to the webjsdev/webjs.nvim git repo via subtree split, installed by lazy.nvim. This manifest exists only as the version source for the unified changelog (changelog/nvim/<version>.md); see PUBLISHING.md."
 }

--- a/packages/editors/nvim/vendor/node_modules/@webjsdev/intellisense/package.json
+++ b/packages/editors/nvim/vendor/node_modules/@webjsdev/intellisense/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/intellisense",
-  "version": "0.5.1",
+  "version": "0.5.4",
   "type": "commonjs",
   "description": "Standalone TypeScript language-service plugin for webjs (no Lit dependency). Adds in-template intelligence inside html`` templates: go-to-definition on tags / attributes / CSS classes, binding-aware completions, value/binding diagnostics, and hover, all driven by its own template parser and gated on import-graph reachability.",
   "main": "src/index.js",

--- a/packages/editors/vscode/PUBLISHING.md
+++ b/packages/editors/vscode/PUBLISHING.md
@@ -43,8 +43,11 @@ dependencies.
 
 ## Releasing a version
 
-1. Bump `version` in `packages/editors/vscode/package.json` (the pre-commit hook
-   skips this package's changelog, so no changelog file is generated).
+1. Bump `version` in `packages/editors/vscode/package.json`. The pre-commit hook
+   TRACKS this package (#413), so the bump DOES require a `changelog/vscode/<version>.md`
+   and `scripts/backfill-changelog.js` generates one. The entry carries
+   `npm: false`, which makes every publish script skip it, so nothing is
+   published automatically: the `vsce` / `ovsx` steps below are still manual.
 2. Build + package + publish to both registries:
    ```sh
    cd packages/editors/vscode

--- a/packages/editors/vscode/package.json
+++ b/packages/editors/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webjs",
   "displayName": "webjs",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "All-in-one webjs support: html/css template highlighting, language-service intelligence, snippets, and commands. No Lit extension required.",
   "publisher": "webjsdev",
   "private": true,


### PR DESCRIPTION
Releases three packages. `@webjsdev/core` 0.7.45 ships the #1114 fix to the browser bundle: until this publishes, webjs.dev and every app on `latest` keep serving the buggy prefetch path.

## Audit: what is owed, and what is not

Checked every published package against its own latest `changelog/<pkg>/<version>.md`, not just the one the last PR touched.

| Package | Commits since ITS last release | Owed |
|---|---|---|
| **core** | `f34fa5c9` | **yes, patch** |
| **vscode** | `e07ea3a1`, `28e5be9a`, `f41d105b` | **yes, patch** |
| **nvim** | `f41d105b`, plus the re-vendor in this PR | **yes, patch** |
| server | none | no |
| cli | none | no |
| mcp | none | no |
| intellisense | none | no |
| ui | 2 commits, both touching **only** `packages/ui/packages/website` | **no** |

Three rows are worth explaining, because each is a way an audit goes wrong.

**`ui` is not owed, despite `git log -- packages/ui/` showing two commits.** Both are confined to the nested website sub-app, which is not published. The published surface (`src`, `bin`, `registry`, `README`) is untouched, so bumping it would ship a version whose changelog describes changes users never receive.

**The editor plugins ARE owed, and my first pass said they were not.** I dismissed them with "intellisense is unchanged, so neither plugin owes a republish". That is the wrong test: the question is whether each plugin's own shipped bundle changed since THAT PLUGIN's last release. It had. `packages/editors/vscode/src/extension.js` still opened `https://docs.webjs.dev` in its "open documentation" command after the docs moved onto the main domain (#1101), and `packages/editors/vscode/README.md` (packaged into the vsix, rendered as the **Marketplace listing page**) carried a brand-casing fix. Both are user-visible in a published artifact.

**The nvim re-vendor is the reason that plugin has a release at all.** Its vendored `@webjsdev/intellisense` copy had current `src/` but a `package.json` still declaring 0.5.1 against a real 0.5.4, so the published plugin misreported which language-service version it ships. Worth noting the drift guard structurally cannot catch this: `vendor-sync.test.mjs` byte-compares only `src/`, while the vendor script also copies `package.json`.

## What merging actually does

- **core**: `release.yml` publishes 0.7.45 to npm and GitHub Packages with a freshly built `dist/` (gitignored in-repo, built by `prepare`), and cuts a `core@0.7.45` GitHub Release.
- **vscode and nvim**: nothing automated. Both changelogs carry `npm: false`, and all three publish scripts (`publish-npm.js`, `publish-github-packages.js`, `publish-release.js`) skip on that flag, so there is no npm publish, **no GitHub Release and no tag** for either. Their only automated output is the `/changelog` entry.

## Mechanics

- All three are patch bumps. Every `core` dependent pins `^0.7.0` or `^0.7.1`, so 0.7.45 satisfies them all and no dependent `package.json` needs editing. Nothing pins either plugin.
- `package-lock.json` regenerated after all three bumps; `npm ci` verified consistent.

## The core changelog entry is hand-written, deliberately

The pre-commit hook generated it automatically and the output was unusable, for two reasons worth recording:

1. **Truncated.** The entry cut off mid-sentence.
2. **Factually wrong.** A squash of a multi-commit PR concatenates the individual commit messages, so the generated body led with my FIRST commit's explanation, which review later disproved (it claimed a self-prefetch returns a "near-empty fragment", when it returns a normal fragment anchored at the innermost layout). Shipping that would have propagated a retracted diagnosis into the public changelog and the Release notes.

Rewritten to the house style and the final understanding, split into the two user-facing changes: the fix, and the new `webjs:navigation-fallback` event, which is public API worth its own line.

**Process note:** this is a general hazard. Any squash of a multi-commit PR whose early commits were later corrected feeds a stale narrative to the generator. Setting the squash body explicitly at merge time would avoid it.

## Verification

- Changelog frontmatter matches sibling files exactly (field names, order, quoting, ISO date) in all three.
- `/changelog` renders all three versions, their entries, and their change counts.
- `webjs.nvim` vendored-intellisense drift guard passes, and the vendored `package.json` now matches the real one byte for byte.
- `backfill-changelog.js` is `existsSync`-guarded, so a later commit on this branch regenerates nothing and cannot conflict.
- Invariant 11 clean across all three changelog files and this body.

## After merge (not automated)

- **webjs.nvim**: subtree split + force-push to the `webjsdev/webjs.nvim` mirror, then a `v0.2.3` release there. I can do this.
- **VS Code extension**: `vsce publish` to the Marketplace and Open VSX needs credentials I do not have, so that one is yours.
