### PR TITLE
docs: replace the README tagline with the site headline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # WebJs
 
-**WebJs is an AI-first, web-components-first framework for building full-stack
-web apps that work before any JavaScript loads.**
+**The web framework for AI agents.**
 
 ## What is WebJs?
 


### PR DESCRIPTION
The README led with two near-duplicate "WebJs is…" definition sentences four lines apart (the tagline under the H1 and the canonical definition under "What is WebJs?"). Within one page that is not a crawler penalty, but it dilutes which sentence a snippet extractor or answer engine quotes, and it reads repetitive.

The tagline is now **The web framework for AI agents.**, matching the webjs.dev `<title>` and home H1, so the repo and the site lead with one voice and the README has exactly one definition sentence, the one under the exact-match "What is WebJs?" heading.