### PR TITLE
fix: darken the dark-mode CTA text for crisp contrast on the amber

### DIFF
--- a/examples/blog/app/layout.ts
+++ b/examples/blog/app/layout.ts
@@ -151,7 +151,7 @@ export default function RootLayout({ children }: LayoutProps) {
         --popover:                oklch(0.135 0 0);
         --popover-foreground:     oklch(0.96 0 0);
         --primary:                oklch(0.7 0.16 52);
-        --primary-foreground:     oklch(0.17 0.02 52);
+        --primary-foreground:     oklch(0.1 0.01 52);
         --secondary:              oklch(0 0 0);
         --secondary-foreground:   oklch(0.96 0 0);
         --muted:                  oklch(0.09 0 0);

--- a/packages/ui/packages/website/app/layout.ts
+++ b/packages/ui/packages/website/app/layout.ts
@@ -170,7 +170,7 @@ export default function Layout({ children }: { children: any }) {
           --border-strong: oklch(0.44 0 0 / 0.92);
           --accent:        oklch(0.7 0.16 52);
           --accent-hover:  oklch(0.75 0.16 52);
-          --accent-fg:     oklch(0.17 0.02 52);
+          --accent-fg:     oklch(0.1 0.01 52);
           --logo-from:     oklch(0.8 0.16 58);
           --logo-to:       oklch(0.62 0.18 44);
           --glow-strength: 0.16;
@@ -201,7 +201,7 @@ export default function Layout({ children }: { children: any }) {
         --border-strong: oklch(0.44 0 0 / 0.92);
         --accent:        oklch(0.7 0.16 52);
         --accent-hover:  oklch(0.75 0.16 52);
-        --accent-fg:     oklch(0.17 0.02 52);
+        --accent-fg:     oklch(0.1 0.01 52);
         --logo-from:     oklch(0.8 0.16 58);
         --logo-to:       oklch(0.62 0.18 44);
         --glow-strength: 0.16;

--- a/website/app/layout.ts
+++ b/website/app/layout.ts
@@ -214,7 +214,7 @@ export default function RootLayout({ children }: { children: unknown }) {
           --fg: oklch(0.96 0 0); --fg-muted: oklch(0.74 0 0); --fg-subtle: oklch(0.62 0 0);
           --bg: oklch(0 0 0); --bg-elev: oklch(0.135 0 0); --bg-subtle: oklch(0.09 0 0); --bg-sunken: oklch(0 0 0);
           --border: oklch(0.32 0 0 / 0.9); --border-strong: oklch(0.44 0 0 / 0.92);
-          --accent: oklch(0.7 0.16 52); --accent-hover: oklch(0.75 0.16 52); --accent-fg: oklch(0.17 0.02 52); --logo-from: oklch(0.8 0.16 58); --logo-to: oklch(0.62 0.18 44);
+          --accent: oklch(0.7 0.16 52); --accent-hover: oklch(0.75 0.16 52); --accent-fg: oklch(0.1 0.01 52); --logo-from: oklch(0.8 0.16 58); --logo-to: oklch(0.62 0.18 44);
           --glow-strength: 0.16;
           --shadow-sm: 0 1px 2px oklch(0 0 0 / 0.4);
           --shadow: 0 10px 40px oklch(0 0 0 / 0.5), 0 2px 6px oklch(0 0 0 / 0.35);
@@ -226,7 +226,7 @@ export default function RootLayout({ children }: { children: unknown }) {
         --fg: oklch(0.96 0 0); --fg-muted: oklch(0.74 0 0); --fg-subtle: oklch(0.62 0 0);
         --bg: oklch(0 0 0); --bg-elev: oklch(0.135 0 0); --bg-subtle: oklch(0.09 0 0); --bg-sunken: oklch(0 0 0);
         --border: oklch(0.32 0 0 / 0.9); --border-strong: oklch(0.44 0 0 / 0.92);
-        --accent: oklch(0.7 0.16 52); --accent-hover: oklch(0.75 0.16 52); --accent-fg: oklch(0.17 0.02 52); --logo-from: oklch(0.8 0.16 58); --logo-to: oklch(0.62 0.18 44);
+        --accent: oklch(0.7 0.16 52); --accent-hover: oklch(0.75 0.16 52); --accent-fg: oklch(0.1 0.01 52); --logo-from: oklch(0.8 0.16 58); --logo-to: oklch(0.62 0.18 44);
         --glow-strength: 0.16;
         --shadow-sm: 0 1px 2px oklch(0 0 0 / 0.4);
         --shadow: 0 10px 40px oklch(0 0 0 / 0.5), 0 2px 6px oklch(0 0 0 / 0.35);


### PR DESCRIPTION
Closes #1124

## Summary

The dark-mode primary CTA ("Get started" on the landing page and the same `bg-accent text-accent-fg` button across the marketing site) rendered its label in `oklch(0.17 0.02 52)`, a warm dark brown in the same hue as the amber accent, so the text read muddy against `--accent: oklch(0.7 0.16 52)` even though the pair measured 6.81:1 WCAG. This darkens the dark-mode `--accent-fg` token to `oklch(0.1 0.01 52)`, near black with a trace of warmth: 7.32:1 on the base amber and 8.82:1 on the hover amber (`oklch(0.75 0.16 52)`). Light mode is untouched (white on the burnt orange, 5.35:1, already crisp).

The fix is at the token level, edited identically in both dark blocks (the `prefers-color-scheme: dark` media query and `:root[data-theme='dark']`), in the three apps that ship the same pairing:

- `website/app/layout.ts`, covering every `text-accent-fg` consumer: the landing hero and footer CTAs, the what-is-webjs and why-webjs CTAs, and the skip-to-content link.
- `packages/ui/packages/website/app/layout.ts`, whose hero renders the same button via `bg-brand text-brand-fg` (`--color-brand-fg` maps to `var(--accent-fg)`).
- `examples/blog/app/layout.ts`, which mirrors the same warm-orange stops under its own names (`--primary` / `--primary-foreground`, rendered by the kit button, badge, and input). The blog is dark-by-default, so its single `:root` declaration is the dark value; the light overrides stay white.

Considered and rejected: matching the light-mode look with white text (2.81:1 on the bright amber, clearly worse) and darkening the dark-mode amber itself (out of scope; `--accent` also feeds `--accent-text`, `--accent-live`, and the glow, and the bright amber against the near-black background is the design direction).

## Test plan

- [x] `webjs check` passes in `website/`, `packages/ui/packages/website/`, and `examples/blog/`
- [x] Contrast computed via oklch to sRGB conversion + WCAG relative luminance: 7.32:1 base, 8.82:1 hover (target was at least 7:1)
- [x] Visual verification with Playwright against all three apps' dev servers: system-dark (`prefers-color-scheme: dark`), explicit `data-theme='dark'` (waiting out the 240ms token transition), and light mode all render the expected computed color/background pairs; screenshots eyeballed
- [x] All dark token blocks remain byte-identical for the changed line within each app

## Doc surfaces

- Tests: N/A because none of the three apps has a CSS-token test layer; verification is the visual + computed-contrast pass above.
- Markdown / docs site / scaffold / MCP / editor plugins / README: N/A because this is a design-token value change in the three apps with no framework surface, API, or convention change.
- Marketing copy: N/A, no copy changed.
- Dogfood apps: `website/`, `packages/ui/packages/website/`, and `examples/blog/` are the affected apps; all three boot and serve with the change (verified live on worktree dev servers).
