### PR TITLE
feat(website): link X and Bluesky from the footer community column

### DIFF
--- a/website/lib/links.ts
+++ b/website/lib/links.ts
@@ -34,6 +34,8 @@ export const DOCS_START_PATH = '/docs/getting-started';
 export const UI_PATH = '/ui';
 export const GH_URL = 'https://github.com/webjsdev/webjs';
 export const DISCORD_URL = 'https://discord.gg/qZScjWWNA8';
+export const X_URL = 'https://x.com/webjsdev';
+export const BLUESKY_URL = 'https://bsky.app/profile/webjs.bsky.social';
 
 // Visually-hidden cue appended inside target="_blank" links so a screen reader
 // announces the new-tab context change.

--- a/website/lib/ui/site-footer.ts
+++ b/website/lib/ui/site-footer.ts
@@ -1,5 +1,5 @@
 import { html } from '@webjsdev/core';
-import { DOCS_START_PATH, UI_PATH, GH_URL, DISCORD_URL, NEW_TAB } from '#lib/links.ts';
+import { DOCS_START_PATH, UI_PATH, GH_URL, DISCORD_URL, X_URL, BLUESKY_URL, NEW_TAB } from '#lib/links.ts';
 import { brandLockup } from '#lib/design/brand.ts';
 
 /**
@@ -53,6 +53,8 @@ export function siteFooter() {
             <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href=${GH_URL} target="_blank" rel="noopener noreferrer">GitHub${NEW_TAB}</a>
             <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href=${GH_URL + '/discussions'} target="_blank" rel="noopener noreferrer">Discussions${NEW_TAB}</a>
             <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href=${DISCORD_URL} target="_blank" rel="noopener noreferrer">Discord${NEW_TAB}</a>
+            <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href=${X_URL} target="_blank" rel="noopener noreferrer">X${NEW_TAB}</a>
+            <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href=${BLUESKY_URL} target="_blank" rel="noopener noreferrer">Bluesky${NEW_TAB}</a>
           </div>
           <div class="flex flex-col gap-3">
             <a href="/" aria-label="WebJs home" class="no-underline text-fg inline-flex w-fit transition-opacity duration-150 hover:opacity-80">${brandLockup('ftr', { height: 26 })}</a>

--- a/website/test/ssr/nav-and-routes.test.ts
+++ b/website/test/ssr/nav-and-routes.test.ts
@@ -43,6 +43,22 @@ test('the footer Resources column carries Why WebJs', async () => {
   assert.ok(out.includes('href="/what-is-webjs"'), 'still alongside What is WebJs?');
 });
 
+test('the footer Community column carries the social profiles', async () => {
+  // The footer is the only chrome that links the social accounts, so a dropped
+  // entry here is the account becoming unreachable from the site. Each opens in
+  // a new tab, which needs the noopener/noreferrer pair and the screen-reader
+  // cue that the rest of the column already carries.
+  const out = await renderToString(siteFooter());
+  for (const href of ['https://x.com/webjsdev', 'https://bsky.app/profile/webjs.bsky.social']) {
+    const anchor = out.slice(out.indexOf(`href="${href}"`));
+    assert.ok(out.includes(`href="${href}"`), `footer links ${href}`);
+    assert.ok(anchor.startsWith(`href="${href}" target="_blank" rel="noopener noreferrer"`), `${href} opens safely in a new tab`);
+    assert.ok(anchor.slice(0, 400).includes('opens in a new tab'), `${href} announces the new-tab context`);
+  }
+  assert.ok(out.includes('>X<'), 'the X link is labelled');
+  assert.ok(out.includes('>Bluesky<'), 'the Bluesky link is labelled');
+});
+
 test('the header still carries the rest of the nav', async () => {
   // Counterweight to the removal assertions: prove we removed ONE entry, not
   // that the nav failed to render at all.


### PR DESCRIPTION
Adds X (https://x.com/webjsdev) and Bluesky (https://bsky.app/profile/webjs.bsky.social) to the footer's Community column, alongside GitHub, Discussions, and Discord.

- `lib/links.ts` gains `X_URL` / `BLUESKY_URL` so the URLs are declared once with the rest of the chrome links.
- Both anchors follow the column's existing shape: `target="_blank"`, `rel="noopener noreferrer"`, and the `NEW_TAB` screen-reader cue.
- `test/ssr/nav-and-routes.test.ts` asserts the rendered hrefs, the new-tab safety attributes, and the labels. Verified it fails when the two anchors are removed.