### PR TITLE
chore: release core 0.7.46, server 0.8.58, cli 0.10.50

### DIFF
--- a/changelog/cli/0.10.50.md
+++ b/changelog/cli/0.10.50.md
@@ -1,0 +1,23 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.50
+date: 2026-07-31T00:58:50.412Z
+commit_count: 3
+---
+## Features
+
+- **serve the UI gallery at webjs.dev/ui** ([#1126](https://github.com/webjsdev/webjs/pull/1126)) [`d9b2fe1d`](https://github.com/webjsdev/webjs/commit/d9b2fe1d)
+  * refactor(website): extract the docs shell into lib/docs-shell.ts
+  
+  The sidebar, mobile drawer, and .prose-docs typography move out of the
+  docs sub-layout into a shared shell so the component library at /ui
+- **teach HTTP verbs and GET caching on the gallery server-actions card** ([#1152](https://github.com/webjsdev/webjs/pull/1152)) [`5b6b67c1`](https://github.com/webjsdev/webjs/commit/5b6b67c1)
+  * feat: teach HTTP verbs and GET caching on the server-actions card
+  
+  The full-stack gallery used `method = 'GET'` incidentally in two query
+  files and never showed `cache`, `tags`, or `invalidates` at all, so a
+- **add asset() for content-hashed public urls** [`510c32c8`](https://github.com/webjsdev/webjs/commit/510c32c8)
+  * feat: add asset() for content-hashed public urls
+  
+  An app's own asset urls sat at stable paths, so a CDN kept serving the
+  previous bytes after a deploy. That caused two visible regressions on

--- a/changelog/core/0.7.46.md
+++ b/changelog/core/0.7.46.md
@@ -1,0 +1,26 @@
+---
+package: "@webjsdev/core"
+version: 0.7.46
+date: 2026-07-31T00:58:50.293Z
+commit_count: 3
+---
+## Features
+
+- **add asset() for content-hashed public urls** [`510c32c8`](https://github.com/webjsdev/webjs/commit/510c32c8)
+  * feat: add asset() for content-hashed public urls
+  
+  An app's own asset urls sat at stable paths, so a CDN kept serving the
+  previous bytes after a deploy. That caused two visible regressions on
+
+## Fixes
+
+- **stop SSR instantiating a component named inside a comment** ([#1132](https://github.com/webjsdev/webjs/pull/1132)) [`973309af`](https://github.com/webjsdev/webjs/commit/973309af)
+  * fix(core): stop SSR instantiating a component named inside a comment
+  
+  The custom-element walk matched tags with a flat regex over assembled
+  markup, so a registered tag name written inside an HTML comment was
+- **refuse a function in form action=, it leaked server action source** ([#1167](https://github.com/webjsdev/webjs/pull/1167)) [`86605c21`](https://github.com/webjsdev/webjs/commit/86605c21)
+  * fix: refuse a function in form action=, it leaked server source
+  
+  At SSR a `'use server'` import resolves to the REAL function (the RPC stub
+  exists only in the browser), and `action=` is an ordinary escaped attribute

--- a/changelog/server/0.8.58.md
+++ b/changelog/server/0.8.58.md
@@ -1,0 +1,20 @@
+---
+package: "@webjsdev/server"
+version: 0.8.58
+date: 2026-07-31T00:58:50.353Z
+commit_count: 2
+---
+## Features
+
+- **add asset() for content-hashed public urls** [`510c32c8`](https://github.com/webjsdev/webjs/commit/510c32c8)
+  * feat: add asset() for content-hashed public urls
+  
+  An app's own asset urls sat at stable paths, so a CDN kept serving the
+  previous bytes after a deploy. That caused two visible regressions on
+
+## Fixes
+
+- **a partial fragment is never shared-cacheable** ([#1141](https://github.com/webjsdev/webjs/pull/1141)) [`d9a21e8e`](https://github.com/webjsdev/webjs/commit/d9a21e8e)
+  * fix(server): a partial fragment is never shared-cacheable
+  
+  Closes #1140

--- a/package-lock.json
+++ b/package-lock.json
@@ -6975,7 +6975,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.49",
+      "version": "0.10.50",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -6991,7 +6991,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.45",
+      "version": "0.7.46",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.25.0"
@@ -7040,10 +7040,10 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.57",
+      "version": "0.8.58",
       "license": "MIT",
       "dependencies": {
-        "@webjsdev/core": "^0.7.1",
+        "@webjsdev/core": "^0.7.46",
         "ws": "^8.20.0"
       },
       "engines": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.49",
+  "version": "0.10.50",
   "type": "module",
   "description": "webjs CLI - dev, start, create, db",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.45",
+  "version": "0.7.46",
   "type": "module",
   "description": "webjs core runtime - html/css tags, WebComponent base, isomorphic renderers",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.57",
+  "version": "0.8.58",
   "type": "module",
   "description": "webjs dev/prod server: SSR, router, API, server actions, live reload",
   "main": "index.js",
@@ -28,7 +28,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@webjsdev/core": "^0.7.1",
+    "@webjsdev/core": "^0.7.46",
     "ws": "^8.20.0"
   },
   "publishConfig": {


### PR DESCRIPTION
Releases the `asset()` helper (#1194, merged in #1197) across the three packages that carry it.

| package | version | why it moves |
|---|---|---|
| `@webjsdev/core` | 0.7.45 → **0.7.46** | new `asset()` + `setAssetUrlProvider` exports |
| `@webjsdev/server` | 0.8.57 → **0.8.58** | `resolveAssetUrl()`, the dev-server provider install, the elision-fingerprint fix |
| `@webjsdev/cli` | 0.10.49 → **0.10.50** | the scaffold marks its own asset urls |

### Publish order

`core` must publish first, since `server` and `cli` both resolve `asset` from it. The publish loop sorts by the changelog `date:` ASC and tie-breaks on filename DESC, so equal timestamps would publish `server` **before** `core`. The generated timestamps are distinct and ordered `core` → `server` → `cli`:

```
2026-07-31T00:58:50.293Z  changelog/core/0.7.46.md
2026-07-31T00:58:50.353Z  changelog/server/0.8.58.md
2026-07-31T00:58:50.412Z  changelog/cli/0.10.50.md
```

### Dependency range

`packages/server`'s `@webjsdev/core` range moves `^0.7.1` → `^0.7.46`. `dev.js` imports `setAssetUrlProvider` statically, so the old range was satisfied by every published core and none of them carried that export. npm could install a combination that dies at module load, and only publish ORDER was preventing it. This makes the coupling npm's problem instead. A release PR is the only branch where the version-bump hook permits this.

### Verification

- `npm ci` resolves the tightened range against the regenerated lockfile.
- Changelogs are hook-generated by `scripts/backfill-changelog.js`, not hand-written.
- Full `npm test` in a clean worktree install: the only failures are `test/integration/blog-http.test.mjs`, which fail **identically at `origin/main`** in the same worktree (verified by detaching and re-running). No regression from this commit.
