### PR TITLE
feat(website): sell what a WebJs prompt no longer has to specify

### DIFF
--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -200,20 +200,13 @@ calling an action), re-enable it and delete the assertion in
 - Each section in `page.ts` is a `<section>` wrapper for predictable
   scroll anchors.
 - **Code blocks follow three accessibility rules.** `test/ssr/pre-block-a11y.test.ts`
-  enforces them on the three MARKETING pages (`/`, `/what-is-webjs`,
-  `/why-webjs`). The `/docs/**` and `/ui/**` pages are NOT covered yet: their
-  `<pre>` blocks scroll via `.prose-docs pre { overflow-x: auto }` in
-  `lib/ui/docs-shell.ts` and carry no `tabindex`, so rule 3 is currently
-  violated there. Follow the rules in any new markup, and extend the test's
-  `PAGES` list when you bring a section into line.
-  A `<pre>` maps to ARIA role `generic`, where ARIA prohibits an
-  author-supplied name, so a named block carries `role="region"` to make
-  the name legal. A named region is a landmark, so no two blocks on a
-  page may share a name (`aria-label="Example files"` on two cards is
-  the mistake to avoid; name each for what it shows). And a block with
-  `overflow-x-auto` is a scroll container at some viewport width, so it
-  carries `tabindex="0"`, since a scroll container no keyboard can reach
-  is unusable without a pointer.
+  enforces them, but only on the pages in its `PAGES` list, currently the three
+  marketing pages. Coverage is PARTIAL and the rest of the site is not clean:
+  sections outside that list still render a `<pre>` with no `tabindex`, whether
+  the scroll comes from an `overflow-x-auto` utility or from
+  `.prose-docs pre { overflow-x: auto }` in `lib/ui/docs-shell.ts`. Do not read
+  the list as an inventory of what is left. Follow the rules in any new markup,
+  and add a page to `PAGES` once its section satisfies them.
 
 ## Run
 

--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -199,6 +199,16 @@ calling an action), re-enable it and delete the assertion in
   (same palette / type scale as the blog and docs).
 - Each section in `page.ts` is a `<section>` wrapper for predictable
   scroll anchors.
+- **Code blocks follow three accessibility rules**, enforced by
+  `test/ssr/pre-block-a11y.test.ts` across every page that renders one.
+  A `<pre>` maps to ARIA role `generic`, where ARIA prohibits an
+  author-supplied name, so a named block carries `role="region"` to make
+  the name legal. A named region is a landmark, so no two blocks on a
+  page may share a name (`aria-label="Example files"` on two cards is
+  the mistake to avoid; name each for what it shows). And a block with
+  `overflow-x-auto` is a scroll container at some viewport width, so it
+  carries `tabindex="0"`, since a scroll container no keyboard can reach
+  is unusable without a pointer.
 
 ## Run
 

--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -199,8 +199,13 @@ calling an action), re-enable it and delete the assertion in
   (same palette / type scale as the blog and docs).
 - Each section in `page.ts` is a `<section>` wrapper for predictable
   scroll anchors.
-- **Code blocks follow three accessibility rules**, enforced by
-  `test/ssr/pre-block-a11y.test.ts` across every page that renders one.
+- **Code blocks follow three accessibility rules.** `test/ssr/pre-block-a11y.test.ts`
+  enforces them on the three MARKETING pages (`/`, `/what-is-webjs`,
+  `/why-webjs`). The `/docs/**` and `/ui/**` pages are NOT covered yet: their
+  `<pre>` blocks scroll via `.prose-docs pre { overflow-x: auto }` in
+  `lib/ui/docs-shell.ts` and carry no `tabindex`, so rule 3 is currently
+  violated there. Follow the rules in any new markup, and extend the test's
+  `PAGES` list when you bring a section into line.
   A `<pre>` maps to ARIA role `generic`, where ARIA prohibits an
   author-supplied name, so a named block carries `role="region"` to make
   the name legal. A named region is a landmark, so no two blocks on a

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -232,7 +232,7 @@ export default function LandingPage() {
             <div class="flex-1 grid place-items-center px-6 py-10 group-has-[:checked]/stage:hidden">
               <like-button count="3"></like-button>
             </div>
-            <pre class="hidden group-has-[:checked]/stage:block flex-1 m-0 p-5 overflow-x-auto font-mono text-xs leading-[1.72] text-left"><code>${highlight(USAGE_SAMPLE)}</code></pre>
+            <pre class="hidden group-has-[:checked]/stage:block flex-1 m-0 p-5 overflow-x-auto font-mono text-xs leading-[1.72] text-left" role="region" tabindex="0" aria-label="like-button usage"><code>${highlight(USAGE_SAMPLE)}</code></pre>
             <div class="px-4 py-3 border-t border-border text-center font-mono text-xs leading-[1.5] text-fg-subtle">
               Server-rendered first, then upgraded. Click it.
             </div>

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -232,7 +232,7 @@ export default function LandingPage() {
             <div class="flex-1 grid place-items-center px-6 py-10 group-has-[:checked]/stage:hidden">
               <like-button count="3"></like-button>
             </div>
-            <pre class="hidden group-has-[:checked]/stage:block flex-1 m-0 p-5 overflow-x-auto font-mono text-xs leading-[1.72] text-left"><code>${highlight(USAGE_SAMPLE)}</code></pre>
+            <pre class="hidden group-has-[:checked]/stage:block flex-1 m-0 p-5 overflow-x-auto font-mono text-xs leading-[1.72] text-left" role="region" tabindex="0" aria-label="like-button usage"><code>${highlight(USAGE_SAMPLE)}</code></pre>
             <div class="px-4 py-3 border-t border-border text-center font-mono text-xs leading-[1.5] text-fg-subtle">
               Server-rendered first, then upgraded. Click it.
             </div>
@@ -384,7 +384,7 @@ export default function LandingPage() {
             <span class="text-xs font-medium leading-none text-accent">Full-stack</span>
             <h3 class="font-display font-bold text-lg leading-[1.25] m-0">Pages + API + components</h3>
             <p class="m-0 text-sm leading-[1.6] text-fg-muted">SSR pages, web components, server actions, Drizzle, streaming, and a browsable feature gallery. Auth (login, sessions, a protected route) ships as a gallery card. The default.</p>
-            <pre class="scroll-thin m-0 px-3.5 py-3 overflow-x-auto rounded-lg border border-border bg-bg-subtle font-mono text-xs leading-[1.6] text-fg-muted" role="region" tabindex="0" aria-label="Example files">app/page.ts
+            <pre class="scroll-thin m-0 px-3.5 py-3 overflow-x-auto rounded-lg border border-border bg-bg-subtle font-mono text-xs leading-[1.6] text-fg-muted" role="region" tabindex="0" aria-label="Example files in a full-stack app">app/page.ts
 components/counter.ts
 actions/posts.server.ts</pre>
             <div class="cmd-foot pt-2 mt-auto font-mono text-xs leading-[1.6] text-fg-muted max-w-full min-w-0"><copy-cmd>npm create webjs@latest my-app</copy-cmd></div>
@@ -393,7 +393,7 @@ actions/posts.server.ts</pre>
             <span class="text-xs font-medium leading-none text-accent">Backend (API)</span>
             <h3 class="font-display font-bold text-lg leading-[1.25] m-0">Route handlers + Database</h3>
             <p class="m-0 text-sm leading-[1.6] text-fg-muted">A backend-only app, no UI or SSR. File-based route handlers, modules, middleware, rate limiting, WebSockets, a database, and a backend-features gallery.</p>
-            <pre class="scroll-thin m-0 px-3.5 py-3 overflow-x-auto rounded-lg border border-border bg-bg-subtle font-mono text-xs leading-[1.6] text-fg-muted" role="region" tabindex="0" aria-label="Example files">app/api/users/route.ts
+            <pre class="scroll-thin m-0 px-3.5 py-3 overflow-x-auto rounded-lg border border-border bg-bg-subtle font-mono text-xs leading-[1.6] text-fg-muted" role="region" tabindex="0" aria-label="Example files in an API app">app/api/users/route.ts
 app/api/chat/route.ts
 middleware.ts</pre>
             <div class="cmd-foot pt-2 mt-auto font-mono text-xs leading-[1.6] text-fg-muted max-w-full min-w-0"><copy-cmd>npm create webjs@latest my-api -- --template api</copy-cmd></div>

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -232,7 +232,7 @@ export default function LandingPage() {
             <div class="flex-1 grid place-items-center px-6 py-10 group-has-[:checked]/stage:hidden">
               <like-button count="3"></like-button>
             </div>
-            <pre class="hidden group-has-[:checked]/stage:block flex-1 m-0 p-5 overflow-x-auto font-mono text-xs leading-[1.72] text-left" role="region" tabindex="0" aria-label="like-button usage"><code>${highlight(USAGE_SAMPLE)}</code></pre>
+            <pre class="hidden group-has-[:checked]/stage:block flex-1 m-0 p-5 overflow-x-auto font-mono text-xs leading-[1.72] text-left"><code>${highlight(USAGE_SAMPLE)}</code></pre>
             <div class="px-4 py-3 border-t border-border text-center font-mono text-xs leading-[1.5] text-fg-subtle">
               Server-rendered first, then upgraded. Click it.
             </div>

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -103,7 +103,7 @@ function codeWindow(title: string, sample: string) {
   return html`
     <figure class=${WIN}>
       <figcaption class=${WINBAR}>${DOTS}<span class=${WINNAME}>${title}</span></figcaption>
-      <pre class="scroll-thin m-0 p-4 overflow-x-auto font-mono text-sm leading-[1.7] [tab-size:2] flex-1" tabindex="0" aria-label=${title + ' code sample'}><code>${highlight(sample)}</code></pre>
+      <pre class="scroll-thin m-0 p-4 overflow-x-auto font-mono text-sm leading-[1.7] [tab-size:2] flex-1" role="region" tabindex="0" aria-label=${title + ' code sample'}><code>${highlight(sample)}</code></pre>
     </figure>
   `;
 }
@@ -216,7 +216,7 @@ export default function LandingPage() {
         <div class="hero-stage max-w-5xl mx-auto grid grid-cols-1 wide:grid-cols-2 rounded-2xl overflow-hidden border border-border-strong bg-bg-sunken shadow-[var(--shadow)]">
           <div class="min-w-0 border-b wide:border-b-0 wide:border-r border-border bg-bg-subtle">
             <div class=${WINBAR}>${DOTS}<span class=${WINNAME}>components/like-button.ts</span></div>
-            <pre class="scroll-thin m-0 p-5 overflow-x-auto font-mono text-xs leading-[1.72] [tab-size:2] text-left" tabindex="0" aria-label="like-button component source"><code>${highlight(HERO_SAMPLE)}</code></pre>
+            <pre class="scroll-thin m-0 p-5 overflow-x-auto font-mono text-xs leading-[1.72] [tab-size:2] text-left" role="region" tabindex="0" aria-label="like-button component source"><code>${highlight(HERO_SAMPLE)}</code></pre>
           </div>
           <div class="group/stage flex flex-col min-w-0 bg-bg">
             <input type="checkbox" id="stage-usage" class="sr-only peer" />
@@ -232,7 +232,7 @@ export default function LandingPage() {
             <div class="flex-1 grid place-items-center px-6 py-10 group-has-[:checked]/stage:hidden">
               <like-button count="3"></like-button>
             </div>
-            <pre class="hidden group-has-[:checked]/stage:block flex-1 m-0 p-5 overflow-x-auto font-mono text-xs leading-[1.72] text-left" aria-label="like-button usage"><code>${highlight(USAGE_SAMPLE)}</code></pre>
+            <pre class="hidden group-has-[:checked]/stage:block flex-1 m-0 p-5 overflow-x-auto font-mono text-xs leading-[1.72] text-left"><code>${highlight(USAGE_SAMPLE)}</code></pre>
             <div class="px-4 py-3 border-t border-border text-center font-mono text-xs leading-[1.5] text-fg-subtle">
               Server-rendered first, then upgraded. Click it.
             </div>
@@ -384,7 +384,7 @@ export default function LandingPage() {
             <span class="text-xs font-medium leading-none text-accent">Full-stack</span>
             <h3 class="font-display font-bold text-lg leading-[1.25] m-0">Pages + API + components</h3>
             <p class="m-0 text-sm leading-[1.6] text-fg-muted">SSR pages, web components, server actions, Drizzle, streaming, and a browsable feature gallery. Auth (login, sessions, a protected route) ships as a gallery card. The default.</p>
-            <pre class="scroll-thin m-0 px-3.5 py-3 overflow-x-auto rounded-lg border border-border bg-bg-subtle font-mono text-xs leading-[1.6] text-fg-muted" tabindex="0" aria-label="Example files">app/page.ts
+            <pre class="scroll-thin m-0 px-3.5 py-3 overflow-x-auto rounded-lg border border-border bg-bg-subtle font-mono text-xs leading-[1.6] text-fg-muted" role="region" tabindex="0" aria-label="Example files">app/page.ts
 components/counter.ts
 actions/posts.server.ts</pre>
             <div class="cmd-foot pt-2 mt-auto font-mono text-xs leading-[1.6] text-fg-muted max-w-full min-w-0"><copy-cmd>npm create webjs@latest my-app</copy-cmd></div>
@@ -393,7 +393,7 @@ actions/posts.server.ts</pre>
             <span class="text-xs font-medium leading-none text-accent">Backend (API)</span>
             <h3 class="font-display font-bold text-lg leading-[1.25] m-0">Route handlers + Database</h3>
             <p class="m-0 text-sm leading-[1.6] text-fg-muted">A backend-only app, no UI or SSR. File-based route handlers, modules, middleware, rate limiting, WebSockets, a database, and a backend-features gallery.</p>
-            <pre class="scroll-thin m-0 px-3.5 py-3 overflow-x-auto rounded-lg border border-border bg-bg-subtle font-mono text-xs leading-[1.6] text-fg-muted" tabindex="0" aria-label="Example files">app/api/users/route.ts
+            <pre class="scroll-thin m-0 px-3.5 py-3 overflow-x-auto rounded-lg border border-border bg-bg-subtle font-mono text-xs leading-[1.6] text-fg-muted" role="region" tabindex="0" aria-label="Example files">app/api/users/route.ts
 app/api/chat/route.ts
 middleware.ts</pre>
             <div class="cmd-foot pt-2 mt-auto font-mono text-xs leading-[1.6] text-fg-muted max-w-full min-w-0"><copy-cmd>npm create webjs@latest my-api -- --template api</copy-cmd></div>

--- a/website/app/what-is-webjs/page.ts
+++ b/website/app/what-is-webjs/page.ts
@@ -161,7 +161,7 @@ const PROSE = 'text-fg-muted text-base leading-[1.7] m-0';
 const CAPABILITIES = [
   {
     title: 'AI-first, readable end to end',
-    body: 'Predictable file conventions, one server function per file, and an explicit .server.ts boundary keep the context a change needs small, so an agent can edit one route without reading the whole app. Because those conventions decide the shape, a non-technical request in ordinary words still produces a well-structured app, and the result holds up across models of very different sizes. Every app ships an AGENTS.md contract that Claude Code, Cursor, Copilot, Gemini, and opencode read from one source, and the framework itself is plain JavaScript with JSDoc in node_modules rather than a compiled bundle.',
+    body: 'Predictable file conventions, one server function per file, and an explicit .server.ts boundary keep the context small, so an agent edits one route without reading the whole app, and a request written in ordinary words still lands in the right shape. Every app ships one AGENTS.md contract that Claude Code, Cursor, Copilot, Gemini, and opencode all read, and the framework is plain JavaScript rather than a compiled bundle.',
   },
   {
     title: 'Web components, server-rendered',

--- a/website/app/what-is-webjs/page.ts
+++ b/website/app/what-is-webjs/page.ts
@@ -161,7 +161,7 @@ const PROSE = 'text-fg-muted text-base leading-[1.7] m-0';
 const CAPABILITIES = [
   {
     title: 'AI-first, readable end to end',
-    body: 'Predictable file conventions and an explicit .server.ts boundary decide the shape of an app, so an agent edits one route without reading the whole app, and ordinary words are enough to ask for a new one. Every app ships an AGENTS.md contract that Claude Code, Cursor, Copilot, Gemini, and opencode read from one source, and the framework itself sits in node_modules as plain JavaScript with JSDoc you can open and read.',
+    body: 'Predictable file conventions and an explicit .server.ts boundary decide the shape of an app, so an agent edits one route without reading the whole app, and ordinary words are enough to ask for a new one. Every app ships an AGENTS.md contract that Claude Code, Cursor, Copilot, Gemini, and opencode read from one source, and the framework itself is plain JavaScript with JSDoc in node_modules rather than a compiled bundle.',
   },
   {
     title: 'Web components, server-rendered',

--- a/website/app/what-is-webjs/page.ts
+++ b/website/app/what-is-webjs/page.ts
@@ -161,7 +161,7 @@ const PROSE = 'text-fg-muted text-base leading-[1.7] m-0';
 const CAPABILITIES = [
   {
     title: 'AI-first, readable end to end',
-    body: 'Predictable file conventions, one server function per file, and an explicit .server.ts boundary keep the context small, so an agent edits one route without reading the whole app, and a request written in ordinary words still lands in the right shape. Every app ships one AGENTS.md contract that Claude Code, Cursor, Copilot, Gemini, and opencode all read, and the framework is plain JavaScript rather than a compiled bundle.',
+    body: 'Predictable file conventions and an explicit .server.ts boundary decide the shape of an app, so an agent edits one route without reading the whole app, and ordinary words are enough to ask for a new one. Every app ships an AGENTS.md contract that Claude Code, Cursor, Copilot, Gemini, and opencode read from one source, and the framework itself is plain JavaScript with JSDoc in node_modules rather than a compiled bundle.',
   },
   {
     title: 'Web components, server-rendered',
@@ -207,7 +207,7 @@ function codeWindow(title: string, sample: string, label: string) {
   return html`
     <figure class=${WIN}>
       <figcaption class=${WINBAR}>${DOTS}<span class=${WINNAME}>${title}</span></figcaption>
-      <pre class="scroll-thin m-0 p-4 overflow-x-auto font-mono text-sm leading-[1.7] [tab-size:2] flex-1" tabindex="0" aria-label=${label}><code>${highlight(sample)}</code></pre>
+      <pre class="scroll-thin m-0 p-4 overflow-x-auto font-mono text-sm leading-[1.7] [tab-size:2] flex-1" role="region" tabindex="0" aria-label=${label}><code>${highlight(sample)}</code></pre>
     </figure>
   `;
 }

--- a/website/app/what-is-webjs/page.ts
+++ b/website/app/what-is-webjs/page.ts
@@ -161,7 +161,7 @@ const PROSE = 'text-fg-muted text-base leading-[1.7] m-0';
 const CAPABILITIES = [
   {
     title: 'AI-first, readable end to end',
-    body: 'Predictable file conventions, one server function per file, and an explicit .server.ts boundary keep the context a change needs small, so an agent can edit one route without reading the whole app. Every app ships an AGENTS.md contract that Claude Code, Cursor, Copilot, Gemini, and opencode read from one source, and the framework itself is plain JavaScript with JSDoc in node_modules rather than a compiled bundle.',
+    body: 'Predictable file conventions, one server function per file, and an explicit .server.ts boundary keep the context a change needs small, so an agent can edit one route without reading the whole app. Because those conventions decide the shape, a non-technical request in ordinary words still produces a well-structured app, and the result holds up across models of very different sizes. Every app ships an AGENTS.md contract that Claude Code, Cursor, Copilot, Gemini, and opencode read from one source, and the framework itself is plain JavaScript with JSDoc in node_modules rather than a compiled bundle.',
   },
   {
     title: 'Web components, server-rendered',

--- a/website/app/what-is-webjs/page.ts
+++ b/website/app/what-is-webjs/page.ts
@@ -161,7 +161,7 @@ const PROSE = 'text-fg-muted text-base leading-[1.7] m-0';
 const CAPABILITIES = [
   {
     title: 'AI-first, readable end to end',
-    body: 'Predictable file conventions and an explicit .server.ts boundary decide the shape of an app, so an agent edits one route without reading the whole app, and ordinary words are enough to ask for a new one. Every app ships an AGENTS.md contract that Claude Code, Cursor, Copilot, Gemini, and opencode read from one source, and the framework itself is plain JavaScript with JSDoc in node_modules rather than a compiled bundle.',
+    body: 'Predictable file conventions and an explicit .server.ts boundary decide the shape of an app, so an agent edits one route without reading the whole app, and the things nobody thinks to ask for arrive anyway. Every app ships an AGENTS.md contract that Claude Code, Cursor, Copilot, Gemini, and opencode read from one source, and the framework itself is plain JavaScript with JSDoc in node_modules rather than a compiled bundle.',
   },
   {
     title: 'Web components, server-rendered',

--- a/website/app/what-is-webjs/page.ts
+++ b/website/app/what-is-webjs/page.ts
@@ -161,7 +161,7 @@ const PROSE = 'text-fg-muted text-base leading-[1.7] m-0';
 const CAPABILITIES = [
   {
     title: 'AI-first, readable end to end',
-    body: 'Predictable file conventions and an explicit .server.ts boundary decide the shape of an app, so an agent edits one route without reading the whole app, and the things nobody thinks to ask for arrive anyway. Every app ships an AGENTS.md contract that Claude Code, Cursor, Copilot, Gemini, and opencode read from one source, and the framework itself is plain JavaScript with JSDoc in node_modules rather than a compiled bundle.',
+    body: 'Predictable file conventions and an explicit .server.ts boundary decide the shape of an app, so an agent edits one route without reading the whole app, and Build me an app is the whole prompt. Every app ships an AGENTS.md contract that Claude Code, Cursor, Copilot, Gemini, and opencode read from one source, and the framework itself is plain JavaScript with JSDoc in node_modules rather than a compiled bundle.',
   },
   {
     title: 'Web components, server-rendered',

--- a/website/app/what-is-webjs/page.ts
+++ b/website/app/what-is-webjs/page.ts
@@ -161,7 +161,7 @@ const PROSE = 'text-fg-muted text-base leading-[1.7] m-0';
 const CAPABILITIES = [
   {
     title: 'AI-first, readable end to end',
-    body: 'Predictable file conventions and an explicit .server.ts boundary decide the shape of an app, so an agent edits one route without reading the whole app, and ordinary words are enough to ask for a new one. Every app ships an AGENTS.md contract that Claude Code, Cursor, Copilot, Gemini, and opencode read from one source, and the framework itself is plain JavaScript with JSDoc in node_modules rather than a compiled bundle.',
+    body: 'Predictable file conventions and an explicit .server.ts boundary decide the shape of an app, so an agent edits one route without reading the whole app, and ordinary words are enough to ask for a new one. Every app ships an AGENTS.md contract that Claude Code, Cursor, Copilot, Gemini, and opencode read from one source, and the framework itself sits in node_modules as plain JavaScript with JSDoc you can open and read.',
   },
   {
     title: 'Web components, server-rendered',

--- a/website/app/why-webjs/page.ts
+++ b/website/app/why-webjs/page.ts
@@ -79,11 +79,11 @@ const REASONS = [
 const ARRIVES = [
   {
     title: 'Architecture',
-    body: 'Where a page lives, where a form submission is handled, and which code is allowed to touch the server are settled by the framework, not improvised per app. Every app also ships the conventions an agent works to, so the habits come with the project rather than out of your prompt.',
+    body: 'Where a page lives, where a form submission is handled, and which code is allowed to touch the server are settled by the framework, not improvised per app. The result comes out in the shape a reviewer expects.',
   },
   {
     title: 'Code',
-    body: 'Types run the whole way through. A server function keeps its argument and return types at the call site in the browser, and the route table becomes a typed union of every path and its params, so an agent has the real types to hand rather than a reason to reach for any. Nobody had to ask it to keep the types honest.',
+    body: 'Server-rendered pages that work before any script loads, and no build step in between. Types run the whole way through, so a server function keeps its argument and return types at the call site and an agent has no reason to reach for any. Running webjs check catches what is outright wrong before it ships.',
   },
   {
     title: 'Database',

--- a/website/app/why-webjs/page.ts
+++ b/website/app/why-webjs/page.ts
@@ -79,11 +79,11 @@ const REASONS = [
 const ARRIVES = [
   {
     title: 'Architecture',
-    body: 'Where a page lives, where a form submission is handled, and which code is allowed to touch the server are settled by the framework, not improvised per app. The result comes out in the shape a reviewer expects.',
+    body: 'Where a page lives, where a form submission is handled, and which code is allowed to touch the server are settled by the framework, not improvised per app. Every app also ships the conventions an agent works to, so the habits come with the project rather than out of your prompt.',
   },
   {
     title: 'Code',
-    body: 'Server-rendered pages that work before any script loads, typed calls from the browser to the server, and no build step in between. Running webjs check catches what is outright wrong before it ships.',
+    body: 'Types run the whole way through. A server function keeps its argument and return types at the call site in the browser, and the route table becomes a typed union of every path and its params, so an agent has the real types to hand rather than a reason to reach for any. Nobody had to ask it to keep the types honest.',
   },
   {
     title: 'Database',

--- a/website/app/why-webjs/page.ts
+++ b/website/app/why-webjs/page.ts
@@ -211,7 +211,7 @@ Counter.register('counter');
               <pre class="scroll-thin m-0 p-4 overflow-x-auto font-mono text-sm leading-[1.7] [tab-size:2] flex-1" role="region" tabindex="0" aria-label="A prompt that has to specify the architecture as well as the app"><code><span class="text-accent">&gt;</span> Build me a table booking app
 
 <span class="text-fg-subtle">  and put the data in a real database,</span>
-<span class="text-fg-subtle">  and use a design system, and write</span>
+<span class="text-fg-subtle">  use a design system, and write</span>
 <span class="text-fg-subtle">  production ready code and architecture</span></code></pre>
             </figure>
           </div>

--- a/website/app/why-webjs/page.ts
+++ b/website/app/why-webjs/page.ts
@@ -24,7 +24,7 @@ export function generateMetadata(ctx: { url: string }) {
   const image = `${origin}/public/og-why.png`;
   const title = 'Why WebJs - The Framework Your AI Agent Already Understands';
   const description =
-    'WebJs is a full-stack JavaScript framework you describe in plain language, because the file conventions land an app in the right shape whatever model you use. Nothing is hidden behind a build step, so any AI model reads the framework source from node_modules, reasons about the whole stack, and debugs it. No training data required, no single blessed model, on the web components and HTML every model already knows.';
+    'WebJs gives an AI-built app what nobody thinks to ask for: real storage, pages that work before scripts load, one design system, security by default. Nothing is hidden behind a build step either, so any AI model reads the framework source from node_modules, reasons about the whole stack, and debugs it. No training data required, no single blessed model, on the web components and HTML every model already knows.';
   return {
     title,
     description,
@@ -69,6 +69,29 @@ const REASONS = [
   {
     title: 'Standard HTML and JavaScript',
     body: 'WebJs is built on web components, custom elements, SSR, and forms. Every model, small or large, is already trained on the platform primitives, so the muscle memory transfers instead of fighting a bespoke abstraction.',
+  },
+];
+
+// The things an experienced developer adds without being asked, and that a
+// person outside the field has no reason to know they should ask for. Each is a
+// DEFAULT of the framework or of what `webjs create` scaffolds, not an outcome
+// the prompt has to request, which is the whole claim of the section.
+const UNASKED = [
+  {
+    title: 'The information is really kept',
+    body: 'Not a list living inside the code that empties every time the app restarts. A scaffolded app arrives wired to a real database with a schema and migrations, and the conventions point an agent at it rather than at a temporary stand-in. Swap in whichever database you prefer later. The point is that one is there from the first command, without anybody asking.',
+  },
+  {
+    title: 'It works when the code does not load',
+    body: 'Every page and component is rendered to finished HTML on the server, so text reads, links work, and forms submit before a single script arrives. Scripts are added for the parts that genuinely need to react, so a bad connection degrades the app instead of emptying it.',
+  },
+  {
+    title: 'It looks like one product',
+    body: 'Colour, type, and spacing come from a small set of design tokens the layout sets once, so every screen the app grows shares them instead of each being styled from scratch. Change the palette in that one place and the whole app follows.',
+  },
+  {
+    title: 'Strangers cannot walk in',
+    body: 'Sessions and sign-in are part of the framework rather than something bolted on later, a request that tries to act on your app from another site is refused, and the security headers browsers look for are set for you. None of it is a step somebody has to remember.',
   },
 ];
 
@@ -168,45 +191,41 @@ Counter.register('counter');
 
     <section class="py-16">
       <div class="max-w-6xl mx-auto px-6">
-        <div class="max-w-3xl mx-auto mb-12 text-center">
-          <h2 class="font-display font-bold text-h2 leading-[1.12] tracking-[-0.03em] my-3 text-balance">Describe what you want in plain language</h2>
+        <div class="max-w-3xl mx-auto mb-10 text-center">
+          <h2 class="font-display font-bold text-h2 leading-[1.12] tracking-[-0.03em] my-3 text-balance">You should not have to know what to ask for</h2>
           <p class="text-fg-muted text-base leading-[1.6] m-0">
-            You do not have to know what a route handler or a server action is
-            to ask for one. Say what the app should do, the way you would say it
-            out loud, and the agent still lands on the right structure, because
-            the structure was decided before the prompt was written. Where a
-            page lives, where a form submission is handled, and where database
-            code is allowed to run are all answered by file and folder
-            convention, so the model fills in a shape instead of inventing an
-            architecture from a sentence.
+            The hard part of asking for software is not describing what you
+            want. It is knowing the dozen things an experienced developer would
+            add without being asked, and never thinking to say them. Somebody
+            asking for their first app does not say keep the information
+            somewhere it survives a restart, or make sure the pages still work
+            when the code fails to load, or keep every screen looking like the
+            same product. Those are the difference between a demo and something
+            you can put in front of customers, and they are exactly what a
+            person outside the field has no reason to know exists.
           </p>
         </div>
-        <div class="grid grid-cols-1 wide:grid-cols-2 gap-4 items-stretch max-w-3xl mx-auto">
-          <div class="flex flex-col min-w-0">
-            <p class="font-mono font-semibold text-xs leading-[1.4] tracking-widest uppercase text-fg-subtle mb-2.5 ml-1">What you ask for</p>
-            <figure class=${WIN}>
-              <figcaption class=${WINBAR}>${DOTS}<span class=${WINNAME}>prompt</span></figcaption>
-              <pre class="scroll-thin m-0 p-4 overflow-x-auto font-mono text-sm leading-[1.7] [tab-size:2] flex-1" role="region" tabindex="0" aria-label="A plain-language prompt with no technical terms in it"><code><span class="text-accent">&gt;</span> Let customers book a table, save the
-  bookings, and give staff today's list.
-
-<span class="text-fg-subtle"># no framework terms, no file names, no</span>
-<span class="text-fg-subtle"># architecture. just the thing you want.</span></code></pre>
-            </figure>
-          </div>
-          <div class="flex flex-col min-w-0">
-            <p class="font-mono font-semibold text-xs leading-[1.4] tracking-widest uppercase text-fg-subtle mb-2.5 ml-1">Where the conventions put it</p>
-            <figure class=${WIN}>
-              <figcaption class=${WINBAR}>${DOTS}<span class=${WINNAME}>files</span></figcaption>
-              <pre class="scroll-thin m-0 p-4 overflow-x-auto font-mono text-sm leading-[1.7] [tab-size:2] flex-1" role="region" tabindex="0" aria-label="The files a WebJs app grows for that request"><code>app/book/page.ts
-<span class="text-fg-subtle">  the page, server-rendered to real HTML</span>
-app/staff/bookings/page.ts
-<span class="text-fg-subtle">  the staff view, its own route</span>
-modules/bookings/actions/create.server.ts
-<span class="text-fg-subtle">  the write, server-side by extension</span>
-db/schema.server.ts
-<span class="text-fg-subtle">  the table it all reads and writes</span></code></pre>
-            </figure>
-          </div>
+        <div class="max-w-xl mx-auto mb-10">
+          <figure class=${WIN}>
+            <figcaption class=${WINBAR}>${DOTS}<span class=${WINNAME}>prompt</span></figcaption>
+            <pre class="scroll-thin m-0 p-4 overflow-x-auto font-mono text-sm leading-[1.7] [tab-size:2]" role="region" tabindex="0" aria-label="A prompt written the way somebody would say it out loud"><code><span class="text-accent">&gt;</span> Let customers book a table, and let my
+  staff see who is coming in today.</code></pre>
+          </figure>
+        </div>
+        <div class="max-w-3xl mx-auto mb-8 text-center">
+          <p class="text-fg-muted text-base leading-[1.6] m-0">
+            Nothing in that sentence asks for any of the following. All of it
+            arrives anyway, because it is what WebJs does by default rather than
+            something the prompt has to request.
+          </p>
+        </div>
+        <div class="grid gap-px overflow-hidden rounded-2xl border border-border bg-border grid-cols-1 xs:grid-cols-2 shadow-[var(--shadow-sm)] max-w-3xl mx-auto">
+          ${UNASKED.map(u => html`
+            <div class="${CARD}">
+              <h3 class="font-display font-bold text-lg leading-[1.3] tracking-[-0.02em] mt-0 mb-2">${u.title}</h3>
+              <p class="m-0 text-sm leading-[1.65] text-fg-muted">${u.body}</p>
+            </div>
+          `)}
         </div>
       </div>
     </section>

--- a/website/app/why-webjs/page.ts
+++ b/website/app/why-webjs/page.ts
@@ -91,7 +91,7 @@ const ARRIVES = [
   },
   {
     title: 'Design system',
-    body: 'A palette, type scale, and spacing live as design tokens the layout sets once, so every screen the app grows shares them, and changing how the whole thing looks stays a single edit.',
+    body: 'A palette and a type scale ship as design tokens rather than values scattered through components, so every screen the app grows shares them and restyling the whole thing means editing the tokens, not hunting through the markup.',
   },
 ];
 

--- a/website/app/why-webjs/page.ts
+++ b/website/app/why-webjs/page.ts
@@ -24,7 +24,7 @@ export function generateMetadata(ctx: { url: string }) {
   const image = `${origin}/public/og-why.png`;
   const title = 'Why WebJs - The Framework Your AI Agent Already Understands';
   const description =
-    'WebJs gives an AI-built app what nobody thinks to ask for: real storage, pages that work before scripts load, one design system, security by default. Nothing is hidden behind a build step either, so any AI model reads the framework source from node_modules, reasons about the whole stack, and debugs it. No training data required, no single blessed model, on the web components and HTML every model already knows.';
+    'WebJs is a full-stack JavaScript framework where Build me an app is the whole prompt. The architecture, the code, a real database, and a design system arrive without being specified, because the framework already made those calls rather than leaving them for your prompt to close. Nothing is hidden behind a build step either, so any AI model reads the framework source from node_modules and reasons about the whole stack. No training data required, no single blessed model.';
   return {
     title,
     description,
@@ -72,26 +72,26 @@ const REASONS = [
   },
 ];
 
-// The things an experienced developer adds without being asked, and that a
-// person outside the field has no reason to know they should ask for. Each is a
-// DEFAULT of the framework or of what `webjs create` scaffolds, not an outcome
-// the prompt has to request, which is the whole claim of the section.
-const UNASKED = [
+// What comes back from the one-sentence prompt. These are the four things the
+// prompt would otherwise have had to specify, so each must stay a genuine
+// DEFAULT of the framework or of what `webjs create` scaffolds. If one ever
+// becomes something the prompt has to request, the section's claim is gone.
+const ARRIVES = [
   {
-    title: 'The information is really kept',
-    body: 'Not a list living inside the code that empties every time the app restarts. A scaffolded app arrives wired to a real database with a schema and migrations, and the conventions point an agent at it rather than at a temporary stand-in. Swap in whichever database you prefer later. The point is that one is there from the first command, without anybody asking.',
+    title: 'Architecture',
+    body: 'Where a page lives, where a form submission is handled, and which code is allowed to touch the server are settled by the framework, not improvised per app. The result comes out in the shape a reviewer expects.',
   },
   {
-    title: 'It works when the code does not load',
-    body: 'Every page and component is rendered to finished HTML on the server, so text reads, links work, and forms submit before a single script arrives. Scripts are added for the parts that genuinely need to react, so a bad connection degrades the app instead of emptying it.',
+    title: 'Code',
+    body: 'Server-rendered pages that work before any script loads, typed calls from the browser to the server, and no build step in between. Running webjs check catches what is outright wrong before it ships.',
   },
   {
-    title: 'It looks like one product',
-    body: 'Colour, type, and spacing come from a small set of design tokens the layout sets once, so every screen the app grows shares them instead of each being styled from scratch. Change the palette in that one place and the whole app follows.',
+    title: 'Database',
+    body: 'A scaffolded app is wired to a real database with a schema and migrations from the first command, so an agent reaches for that rather than a list of items living in the code. Swap the database later if you want a different one.',
   },
   {
-    title: 'Strangers cannot walk in',
-    body: 'Sessions and sign-in are part of the framework rather than something bolted on later, a request that tries to act on your app from another site is refused, and the security headers browsers look for are set for you. None of it is a step somebody has to remember.',
+    title: 'Design system',
+    body: 'A palette, type scale, and spacing live as design tokens the layout sets once, so every screen the app grows shares them, and changing how the whole thing looks stays a single edit.',
   },
 ];
 
@@ -191,39 +191,56 @@ Counter.register('counter');
 
     <section class="py-16">
       <div class="max-w-6xl mx-auto px-6">
-        <div class="max-w-3xl mx-auto mb-10 text-center">
-          <h2 class="font-display font-bold text-h2 leading-[1.12] tracking-[-0.03em] my-3 text-balance">You should not have to know what to ask for</h2>
+        <div class="max-w-3xl mx-auto mb-12 text-center">
+          <h2 class="font-display font-bold text-h2 leading-[1.12] tracking-[-0.03em] my-3 text-balance">The prompt does not have to carry the architecture</h2>
           <p class="text-fg-muted text-base leading-[1.6] m-0">
-            The hard part of asking for software is not describing what you
-            want. It is knowing the dozen things an experienced developer would
-            add without being asked, and never thinking to say them. Somebody
-            asking for their first app does not say keep the information
-            somewhere it survives a restart, or make sure the pages still work
-            when the code fails to load, or keep every screen looking like the
-            same product. Those are the difference between a demo and something
-            you can put in front of customers, and they are exactly what a
-            person outside the field has no reason to know exists.
+            Most frameworks leave the big decisions open, and that flexibility
+            is the point of them. But an open decision has to be closed by
+            somebody, and when an agent is writing the code, that somebody is
+            whoever wrote the prompt. So the request grows an appendix of
+            technical instructions, and every one of them is a thing you had to
+            know to ask for. WebJs has already made those calls, so the request
+            stays the request.
           </p>
         </div>
-        <div class="max-w-xl mx-auto mb-10">
-          <figure class=${WIN}>
-            <figcaption class=${WINBAR}>${DOTS}<span class=${WINNAME}>prompt</span></figcaption>
-            <pre class="scroll-thin m-0 p-4 overflow-x-auto font-mono text-sm leading-[1.7] [tab-size:2]" role="region" tabindex="0" aria-label="A prompt written the way somebody would say it out loud"><code><span class="text-accent">&gt;</span> Let customers book a table, and let my
-  staff see who is coming in today.</code></pre>
-          </figure>
+        <div class="grid grid-cols-1 wide:grid-cols-2 gap-4 items-stretch max-w-3xl mx-auto mb-12">
+          <div class="flex flex-col min-w-0">
+            <p class="font-mono font-semibold text-xs leading-[1.4] tracking-widest uppercase text-fg-subtle mb-2.5 ml-1">Where the decisions are still open</p>
+            <figure class=${WIN}>
+              <figcaption class=${WINBAR}>${DOTS}<span class=${WINNAME}>prompt</span></figcaption>
+              <pre class="scroll-thin m-0 p-4 overflow-x-auto font-mono text-sm leading-[1.7] [tab-size:2] flex-1" role="region" tabindex="0" aria-label="A prompt that has to specify the architecture as well as the app"><code><span class="text-accent">&gt;</span> Build me a table booking app
+
+<span class="text-fg-subtle">  and put the data in a real database,</span>
+<span class="text-fg-subtle">  and render the pages on the server,</span>
+<span class="text-fg-subtle">  and set up design tokens for the look,</span>
+<span class="text-fg-subtle">  and add sessions and a login,</span>
+<span class="text-fg-subtle">  and keep the server code off the client,</span>
+<span class="text-fg-subtle">  and make it production ready</span></code></pre>
+            </figure>
+          </div>
+          <div class="flex flex-col min-w-0">
+            <p class="font-mono font-semibold text-xs leading-[1.4] tracking-widest uppercase text-fg-subtle mb-2.5 ml-1">Where they are already made</p>
+            <figure class=${WIN}>
+              <figcaption class=${WINBAR}>${DOTS}<span class=${WINNAME}>prompt</span></figcaption>
+              <pre class="scroll-thin m-0 p-4 overflow-x-auto font-mono text-sm leading-[1.7] [tab-size:2] flex-1" role="region" tabindex="0" aria-label="The same request on WebJs, with no architecture appended"><code><span class="text-accent">&gt;</span> Build me a table booking app
+
+<span class="text-fg-subtle">  # that is the whole prompt. the rest</span>
+<span class="text-fg-subtle">  # is not left to the model to guess,</span>
+<span class="text-fg-subtle">  # so it is not yours to specify.</span></code></pre>
+            </figure>
+          </div>
         </div>
         <div class="max-w-3xl mx-auto mb-8 text-center">
           <p class="text-fg-muted text-base leading-[1.6] m-0">
-            Nothing in that sentence asks for any of the following. All of it
-            arrives anyway, because it is what WebJs does by default rather than
-            something the prompt has to request.
+            Both prompts should produce something you can put in front of
+            customers. Only one of them made that your job to spell out.
           </p>
         </div>
         <div class="grid gap-px overflow-hidden rounded-2xl border border-border bg-border grid-cols-1 xs:grid-cols-2 shadow-[var(--shadow-sm)] max-w-3xl mx-auto">
-          ${UNASKED.map(u => html`
+          ${ARRIVES.map(a => html`
             <div class="${CARD}">
-              <h3 class="font-display font-bold text-lg leading-[1.3] tracking-[-0.02em] mt-0 mb-2">${u.title}</h3>
-              <p class="m-0 text-sm leading-[1.65] text-fg-muted">${u.body}</p>
+              <h3 class="font-display font-bold text-lg leading-[1.3] tracking-[-0.02em] mt-0 mb-2">${a.title}</h3>
+              <p class="m-0 text-sm leading-[1.65] text-fg-muted">${a.body}</p>
             </div>
           `)}
         </div>

--- a/website/app/why-webjs/page.ts
+++ b/website/app/why-webjs/page.ts
@@ -211,11 +211,8 @@ Counter.register('counter');
               <pre class="scroll-thin m-0 p-4 overflow-x-auto font-mono text-sm leading-[1.7] [tab-size:2] flex-1" role="region" tabindex="0" aria-label="A prompt that has to specify the architecture as well as the app"><code><span class="text-accent">&gt;</span> Build me a table booking app
 
 <span class="text-fg-subtle">  and put the data in a real database,</span>
-<span class="text-fg-subtle">  and render the pages on the server,</span>
-<span class="text-fg-subtle">  and set up design tokens for the look,</span>
-<span class="text-fg-subtle">  and add sessions and a login,</span>
-<span class="text-fg-subtle">  and keep the server code off the client,</span>
-<span class="text-fg-subtle">  and make it production ready</span></code></pre>
+<span class="text-fg-subtle">  and use a design system, and write</span>
+<span class="text-fg-subtle">  production ready code and architecture</span></code></pre>
             </figure>
           </div>
           <div class="flex flex-col min-w-0">

--- a/website/app/why-webjs/page.ts
+++ b/website/app/why-webjs/page.ts
@@ -24,7 +24,7 @@ export function generateMetadata(ctx: { url: string }) {
   const image = `${origin}/public/og-why.png`;
   const title = 'Why WebJs - The Framework Your AI Agent Already Understands';
   const description =
-    'WebJs is a full-stack JavaScript framework that serves the framework source and your app code exactly as written, so any AI model can read the whole stack from node_modules, reason about it, and debug it. No training data required, no single blessed model. Built on the web components, HTML, and JavaScript every model already knows.';
+    'WebJs is a full-stack JavaScript framework that serves the framework source and your app code exactly as written, so any AI model can read the whole stack from node_modules, reason about it, and debug it. No training data required, no single blessed model. Describe an app in plain language and the file conventions land it in the right shape, whatever model you use. Built on the web components, HTML, and JavaScript every model already knows.';
   return {
     title,
     description,
@@ -168,6 +168,52 @@ Counter.register('counter');
 
     <section class="py-16">
       <div class="max-w-6xl mx-auto px-6">
+        <div class="max-w-3xl mx-auto mb-12 text-center">
+          <h2 class="font-display font-bold text-h2 leading-[1.12] tracking-[-0.03em] my-3 text-balance">Describe what you want in plain language</h2>
+          <p class="text-fg-muted text-base leading-[1.6] m-0">
+            You do not have to know what a route handler or a server action is
+            to ask for one. Say what the app should do, the way you would say it
+            out loud, and the agent still lands on the right structure, because
+            the structure was decided before the prompt was written. Where a
+            page lives, where a form submission is handled, and where database
+            code is allowed to run are all answered by file and folder
+            convention, so the model fills in a shape instead of inventing an
+            architecture from a sentence.
+          </p>
+        </div>
+        <div class="grid grid-cols-1 wide:grid-cols-2 gap-4 items-stretch max-w-3xl mx-auto">
+          <div class="flex flex-col min-w-0">
+            <p class="font-mono font-semibold text-xs leading-[1.4] tracking-widest uppercase text-fg-subtle mb-2.5 ml-1">What you ask for</p>
+            <figure class=${WIN}>
+              <figcaption class=${WINBAR}>${DOTS}<span class=${WINNAME}>prompt</span></figcaption>
+              <pre class="scroll-thin m-0 p-4 overflow-x-auto font-mono text-sm leading-[1.7] [tab-size:2] flex-1" tabindex="0" aria-label="A plain-language prompt with no technical terms in it"><code><span class="text-accent">&gt;</span> Build a page where customers can book a
+  table, save the bookings, and let staff
+  see today's list.
+
+<span class="text-fg-subtle"># no framework terms, no file names, no</span>
+<span class="text-fg-subtle"># architecture. just the thing you want.</span></code></pre>
+            </figure>
+          </div>
+          <div class="flex flex-col min-w-0">
+            <p class="font-mono font-semibold text-xs leading-[1.4] tracking-widest uppercase text-fg-subtle mb-2.5 ml-1">Where the conventions put it</p>
+            <figure class=${WIN}>
+              <figcaption class=${WINBAR}>${DOTS}<span class=${WINNAME}>terminal</span></figcaption>
+              <pre class="scroll-thin m-0 p-4 overflow-x-auto font-mono text-sm leading-[1.7] [tab-size:2] flex-1" tabindex="0" aria-label="The files a WebJs app grows for that request"><code>app/book/page.ts
+<span class="text-fg-subtle">  the page, server-rendered to real HTML</span>
+app/staff/bookings/page.ts
+<span class="text-fg-subtle">  the list, behind the session check</span>
+modules/bookings/actions/create.server.ts
+<span class="text-fg-subtle">  the write, server-side by extension</span>
+db/schema.server.ts
+<span class="text-fg-subtle">  the table it all reads and writes</span></code></pre>
+            </figure>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="py-16">
+      <div class="max-w-6xl mx-auto px-6">
         <div class="max-w-3xl mx-auto text-center">
           <h2 class="font-display font-bold text-h2 leading-[1.12] tracking-[-0.03em] my-3 text-balance">Experiment with any model, freely</h2>
           <p class="text-fg-muted text-base leading-[1.6] m-0 mb-4">
@@ -176,6 +222,15 @@ Counter.register('counter');
             model or a small one at a WebJs project and it fits the source into
             context and gets to work. Switch models between tasks and the output
             stays reliable, because they are all reading the same readable code.
+          </p>
+          <p class="text-fg-muted text-base leading-[1.6] m-0 mb-4">
+            That shows up in the quality of what comes back, not just in whether
+            a model can work at all. Large or small, every model is reading the
+            same source and following the same conventions, so the architecture
+            it reaches for, the code it writes, and the design system it applies
+            come out looking like one project rather than three. You still read
+            what an agent hands you. What you stop doing is re-deciding the
+            shape of the app every time you change model.
           </p>
           <p class="text-fg-muted text-base leading-[1.6] m-0">
             Human developers get the same deal. There is no hidden compiler

--- a/website/app/why-webjs/page.ts
+++ b/website/app/why-webjs/page.ts
@@ -24,7 +24,7 @@ export function generateMetadata(ctx: { url: string }) {
   const image = `${origin}/public/og-why.png`;
   const title = 'Why WebJs - The Framework Your AI Agent Already Understands';
   const description =
-    'WebJs is a full-stack JavaScript framework that serves the framework source and your app code exactly as written, so any AI model can read the whole stack from node_modules, reason about it, and debug it. No training data required, no single blessed model. Describe an app in plain language and the file conventions land it in the right shape, whatever model you use. Built on the web components, HTML, and JavaScript every model already knows.';
+    'WebJs is a full-stack JavaScript framework you can describe in plain language, because the file conventions land an app in the right shape whatever model you use. Nothing is hidden behind a build step, so any AI model reads the framework source from node_modules, reasons about the whole stack, and debugs it. No training data required, no single blessed model, on the web components and HTML every model already knows.';
   return {
     title,
     description,
@@ -118,7 +118,7 @@ export default function Why() {
             <p class="font-mono font-semibold text-xs leading-[1.4] tracking-widest uppercase text-fg-subtle mb-2.5 ml-1">The framework, readable in node_modules</p>
             <figure class=${WIN}>
               <figcaption class=${WINBAR}>${DOTS}<span class=${WINNAME}>terminal</span></figcaption>
-              <pre class="scroll-thin m-0 p-4 overflow-x-auto font-mono text-sm leading-[1.7] [tab-size:2] flex-1" tabindex="0" aria-label="Listing and grepping the framework source in node_modules"><code><span class="text-accent">$</span> ls node_modules/@webjsdev/core/src
+              <pre class="scroll-thin m-0 p-4 overflow-x-auto font-mono text-sm leading-[1.7] [tab-size:2] flex-1" role="region" tabindex="0" aria-label="Listing and grepping the framework source in node_modules"><code><span class="text-accent">$</span> ls node_modules/@webjsdev/core/src
 component.js    html.js         render-client.js
 css.js          directives.js   render-server.js
 serialize.js    router-client.js
@@ -134,7 +134,7 @@ server/src/ssr.js: const html = await renderToString(tree)
             <p class="font-mono font-semibold text-xs leading-[1.4] tracking-widest uppercase text-fg-subtle mb-2.5 ml-1">Your app code, served to the browser as written</p>
             <figure class=${WIN}>
               <figcaption class=${WINBAR}>${DOTS}<span class=${WINNAME}>terminal</span></figcaption>
-              <pre class="scroll-thin m-0 p-4 overflow-x-auto font-mono text-sm leading-[1.7] [tab-size:2] flex-1" tabindex="0" aria-label="Fetching an app module served unbundled"><code><span class="text-accent">$</span> curl localhost:5001/components/counter.ts
+              <pre class="scroll-thin m-0 p-4 overflow-x-auto font-mono text-sm leading-[1.7] [tab-size:2] flex-1" role="region" tabindex="0" aria-label="Fetching an app module served unbundled"><code><span class="text-accent">$</span> curl localhost:5001/components/counter.ts
 import { WebComponent } from '@webjsdev/core';
 
 class Counter extends WebComponent({ count: Number }) {
@@ -186,9 +186,8 @@ Counter.register('counter');
             <p class="font-mono font-semibold text-xs leading-[1.4] tracking-widest uppercase text-fg-subtle mb-2.5 ml-1">What you ask for</p>
             <figure class=${WIN}>
               <figcaption class=${WINBAR}>${DOTS}<span class=${WINNAME}>prompt</span></figcaption>
-              <pre class="scroll-thin m-0 p-4 overflow-x-auto font-mono text-sm leading-[1.7] [tab-size:2] flex-1" tabindex="0" aria-label="A plain-language prompt with no technical terms in it"><code><span class="text-accent">&gt;</span> Build a page where customers can book a
-  table, save the bookings, and let staff
-  see today's list.
+              <pre class="scroll-thin m-0 p-4 overflow-x-auto font-mono text-sm leading-[1.7] [tab-size:2] flex-1" role="region" tabindex="0" aria-label="A plain-language prompt with no technical terms in it"><code><span class="text-accent">&gt;</span> Let customers book a table, save the
+  bookings, and give staff today's list.
 
 <span class="text-fg-subtle"># no framework terms, no file names, no</span>
 <span class="text-fg-subtle"># architecture. just the thing you want.</span></code></pre>
@@ -197,8 +196,8 @@ Counter.register('counter');
           <div class="flex flex-col min-w-0">
             <p class="font-mono font-semibold text-xs leading-[1.4] tracking-widest uppercase text-fg-subtle mb-2.5 ml-1">Where the conventions put it</p>
             <figure class=${WIN}>
-              <figcaption class=${WINBAR}>${DOTS}<span class=${WINNAME}>terminal</span></figcaption>
-              <pre class="scroll-thin m-0 p-4 overflow-x-auto font-mono text-sm leading-[1.7] [tab-size:2] flex-1" tabindex="0" aria-label="The files a WebJs app grows for that request"><code>app/book/page.ts
+              <figcaption class=${WINBAR}>${DOTS}<span class=${WINNAME}>files</span></figcaption>
+              <pre class="scroll-thin m-0 p-4 overflow-x-auto font-mono text-sm leading-[1.7] [tab-size:2] flex-1" role="region" tabindex="0" aria-label="The files a WebJs app grows for that request"><code>app/book/page.ts
 <span class="text-fg-subtle">  the page, server-rendered to real HTML</span>
 app/staff/bookings/page.ts
 <span class="text-fg-subtle">  the list, behind the session check</span>
@@ -224,13 +223,13 @@ db/schema.server.ts
             stays reliable, because they are all reading the same readable code.
           </p>
           <p class="text-fg-muted text-base leading-[1.6] m-0 mb-4">
-            That shows up in the quality of what comes back, not just in whether
-            a model can work at all. Large or small, every model is reading the
-            same source and following the same conventions, so the architecture
-            it reaches for, the code it writes, and the design system it applies
-            come out looking like one project rather than three. You still read
-            what an agent hands you. What you stop doing is re-deciding the
-            shape of the app every time you change model.
+            That shows up in the quality of what comes back, not only in whether
+            a model can participate. Routing, the server boundary, and the file
+            layout are settled by convention, and the palette lives in design
+            tokens the root layout sets once, so a smaller model is filling
+            those in rather than inventing them. Taste is still yours to
+            direct, and you still read what an agent hands you. What you stop
+            doing is re-deciding the shape of the app every time you switch.
           </p>
           <p class="text-fg-muted text-base leading-[1.6] m-0">
             Human developers get the same deal. There is no hidden compiler

--- a/website/app/why-webjs/page.ts
+++ b/website/app/why-webjs/page.ts
@@ -24,7 +24,7 @@ export function generateMetadata(ctx: { url: string }) {
   const image = `${origin}/public/og-why.png`;
   const title = 'Why WebJs - The Framework Your AI Agent Already Understands';
   const description =
-    'WebJs is a full-stack JavaScript framework you can describe in plain language, because the file conventions land an app in the right shape whatever model you use. Nothing is hidden behind a build step, so any AI model reads the framework source from node_modules, reasons about the whole stack, and debugs it. No training data required, no single blessed model, on the web components and HTML every model already knows.';
+    'WebJs is a full-stack JavaScript framework you describe in plain language, because the file conventions land an app in the right shape whatever model you use. Nothing is hidden behind a build step, so any AI model reads the framework source from node_modules, reasons about the whole stack, and debugs it. No training data required, no single blessed model, on the web components and HTML every model already knows.';
   return {
     title,
     description,
@@ -200,7 +200,7 @@ Counter.register('counter');
               <pre class="scroll-thin m-0 p-4 overflow-x-auto font-mono text-sm leading-[1.7] [tab-size:2] flex-1" role="region" tabindex="0" aria-label="The files a WebJs app grows for that request"><code>app/book/page.ts
 <span class="text-fg-subtle">  the page, server-rendered to real HTML</span>
 app/staff/bookings/page.ts
-<span class="text-fg-subtle">  the list, behind the session check</span>
+<span class="text-fg-subtle">  the staff view, its own route</span>
 modules/bookings/actions/create.server.ts
 <span class="text-fg-subtle">  the write, server-side by extension</span>
 db/schema.server.ts

--- a/website/test/ssr/pre-block-a11y.test.ts
+++ b/website/test/ssr/pre-block-a11y.test.ts
@@ -1,0 +1,71 @@
+/**
+ * The accessible name on every code block the marketing pages render.
+ *
+ * A <pre> maps to ARIA role `generic`, and ARIA prohibits an author-supplied
+ * name on `generic`, so a bare <pre aria-label="..."> gives a spec-following
+ * screen reader a name it will not announce. Every block that carries a name
+ * therefore carries an explicit `role="region"` to make that name one ARIA
+ * permits, and because a named region is a landmark, the names have to be
+ * unique per page or they collapse into an ambiguous pair in the landmark list.
+ *
+ * This lives in its own file rather than inside each page's test because the
+ * rule is a property of the SITE, not of one page. The pages here were fixed
+ * together, and pinning them together is what stops the next one from drifting
+ * back: the sweep that fixed them originally covered one page, and the other
+ * two went unobserved until a review caught it.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { renderToString } from '@webjsdev/core/server';
+import Home from '#app/page.ts';
+import WhatIsWebJs from '#app/what-is-webjs/page.ts';
+import Why from '#app/why-webjs/page.ts';
+
+/** Every `<pre …>` open tag in the rendered HTML, attribute order as authored. */
+function preTags(html: string) {
+  return html.match(/<pre\b[^>]*>/g) ?? [];
+}
+
+function nameOf(tag: string) {
+  return tag.match(/aria-label="([^"]*)"/)?.[1];
+}
+
+const PAGES = [
+  { name: '/', render: () => Home() },
+  { name: '/what-is-webjs', render: () => WhatIsWebJs() },
+  { name: '/why-webjs', render: () => Why() },
+];
+
+for (const page of PAGES) {
+  test(`every named code block on ${page.name} carries a role that permits the name`, async () => {
+    const tags = preTags(await renderToString(page.render()));
+    assert.ok(tags.length > 0, 'the page renders at least one code block');
+    const named = tags.filter(nameOf);
+    assert.ok(named.length > 0, 'the page renders at least one NAMED code block, so this test has something to check');
+    for (const tag of named) {
+      // Read the role by attribute, not by position: an order-sensitive regex
+      // would red on correct markup that simply wrote the attributes the other
+      // way round.
+      assert.match(tag, /\brole="region"/, `a named pre is missing role=region, so its name is one ARIA prohibits: ${nameOf(tag)}`);
+    }
+  });
+
+  test(`no two code blocks on ${page.name} share a landmark name`, async () => {
+    const named = preTags(await renderToString(page.render())).map(nameOf).filter(Boolean);
+    assert.deepEqual([...new Set(named)], named, `duplicate landmark names on ${page.name}: ${named.join(', ')}`);
+  });
+}
+
+test('a code block with no name needs no role, so it adds no landmark', async () => {
+  // The home page's toggled usage block holds one short line that never becomes
+  // a scroll container at a real viewport width. It carries no name and no
+  // focus stop on purpose, and promoting it would add an empty-ish landmark and
+  // a permanent tab stop on content nothing can interact with.
+  const tags = preTags(await renderToString(Home()));
+  const unnamed = tags.filter((t) => !nameOf(t));
+  assert.ok(unnamed.length > 0, 'the home page still renders an unnamed code block');
+  for (const tag of unnamed) {
+    assert.doesNotMatch(tag, /\brole="region"/, 'an unnamed block claims a landmark role it has no name for');
+    assert.doesNotMatch(tag, /\btabindex=/, 'an unnamed, non-scrolling block takes a tab stop for nothing');
+  }
+});

--- a/website/test/ssr/pre-block-a11y.test.ts
+++ b/website/test/ssr/pre-block-a11y.test.ts
@@ -1,18 +1,20 @@
 /**
- * The accessible name on every code block the marketing pages render.
+ * The accessibility rules every code block on the marketing pages follows.
  *
- * A <pre> maps to ARIA role `generic`, and ARIA prohibits an author-supplied
- * name on `generic`, so a bare <pre aria-label="..."> gives a spec-following
- * screen reader a name it will not announce. Every block that carries a name
- * therefore carries an explicit `role="region"` to make that name one ARIA
- * permits, and because a named region is a landmark, the names have to be
- * unique per page or they collapse into an ambiguous pair in the landmark list.
+ * Three rules, each checkable from the rendered markup alone:
  *
- * This lives in its own file rather than inside each page's test because the
- * rule is a property of the SITE, not of one page. The pages here were fixed
- * together, and pinning them together is what stops the next one from drifting
- * back: the sweep that fixed them originally covered one page, and the other
- * two went unobserved until a review caught it.
+ *  1. A named block carries `role="region"`. A <pre> maps to ARIA role
+ *     `generic`, and ARIA prohibits an author-supplied name on `generic`, so a
+ *     bare <pre aria-label="..."> hands a spec-following screen reader a name
+ *     it will not announce.
+ *  2. No two blocks on a page share a name. A named region is a landmark, and
+ *     duplicates collapse into an ambiguous pair in the landmark list.
+ *  3. A block that can scroll carries `tabindex="0"`. `overflow-x-auto` makes
+ *     it a scroll container at some viewport width, and a scroll container no
+ *     keyboard can reach is unusable without a pointer.
+ *
+ * This lives in its own file, and loops over every page that renders code
+ * blocks, because the rules belong to the site rather than to any one page.
  */
 import test from 'node:test';
 import assert from 'node:assert/strict';
@@ -26,9 +28,9 @@ function preTags(html: string) {
   return html.match(/<pre\b[^>]*>/g) ?? [];
 }
 
-function nameOf(tag: string) {
-  return tag.match(/aria-label="([^"]*)"/)?.[1];
-}
+const nameOf = (tag: string) => tag.match(/aria-label="([^"]*)"/)?.[1];
+/** Read attributes by name, never by position: order is not a defect. */
+const has = (tag: string, attr: RegExp) => attr.test(tag);
 
 const PAGES = [
   { name: '/', render: () => Home() },
@@ -39,14 +41,10 @@ const PAGES = [
 for (const page of PAGES) {
   test(`every named code block on ${page.name} carries a role that permits the name`, async () => {
     const tags = preTags(await renderToString(page.render()));
-    assert.ok(tags.length > 0, 'the page renders at least one code block');
     const named = tags.filter(nameOf);
-    assert.ok(named.length > 0, 'the page renders at least one NAMED code block, so this test has something to check');
+    assert.ok(named.length > 0, 'the page renders at least one named code block, so this test has something to check');
     for (const tag of named) {
-      // Read the role by attribute, not by position: an order-sensitive regex
-      // would red on correct markup that simply wrote the attributes the other
-      // way round.
-      assert.match(tag, /\brole="region"/, `a named pre is missing role=region, so its name is one ARIA prohibits: ${nameOf(tag)}`);
+      assert.ok(has(tag, /\brole="region"/), `a named pre is missing role=region, so its name is one ARIA prohibits: ${nameOf(tag)}`);
     }
   });
 
@@ -54,18 +52,12 @@ for (const page of PAGES) {
     const named = preTags(await renderToString(page.render())).map(nameOf).filter(Boolean);
     assert.deepEqual([...new Set(named)], named, `duplicate landmark names on ${page.name}: ${named.join(', ')}`);
   });
-}
 
-test('a code block with no name needs no role, so it adds no landmark', async () => {
-  // The home page's toggled usage block holds one short line that never becomes
-  // a scroll container at a real viewport width. It carries no name and no
-  // focus stop on purpose, and promoting it would add an empty-ish landmark and
-  // a permanent tab stop on content nothing can interact with.
-  const tags = preTags(await renderToString(Home()));
-  const unnamed = tags.filter((t) => !nameOf(t));
-  assert.ok(unnamed.length > 0, 'the home page still renders an unnamed code block');
-  for (const tag of unnamed) {
-    assert.doesNotMatch(tag, /\brole="region"/, 'an unnamed block claims a landmark role it has no name for');
-    assert.doesNotMatch(tag, /\btabindex=/, 'an unnamed, non-scrolling block takes a tab stop for nothing');
-  }
-});
+  test(`every scrollable code block on ${page.name} can be reached by keyboard`, async () => {
+    const scrollable = preTags(await renderToString(page.render())).filter((t) => has(t, /\boverflow-x-auto\b/));
+    assert.ok(scrollable.length > 0, 'the page renders at least one scrollable code block');
+    for (const tag of scrollable) {
+      assert.ok(has(tag, /\btabindex="0"/), `a scrollable pre has no focus stop, so only a pointer can scroll it: ${nameOf(tag) ?? tag.slice(0, 80)}`);
+    }
+  });
+}

--- a/website/test/ssr/pre-block-a11y.test.ts
+++ b/website/test/ssr/pre-block-a11y.test.ts
@@ -13,8 +13,11 @@
  *     it a scroll container at some viewport width, and a scroll container no
  *     keyboard can reach is unusable without a pointer.
  *
- * This lives in its own file, and loops over every page that renders code
- * blocks, because the rules belong to the site rather than to any one page.
+ * This lives in its own file, and loops over the pages in PAGES, because the
+ * rules belong to the site rather than to any one page. PAGES is the three
+ * marketing pages, NOT every page that renders a code block: the /docs and /ui
+ * pages scroll their blocks through a stylesheet rule and do not satisfy rule 3
+ * yet. Add a page here as it is brought into line.
  */
 import test from 'node:test';
 import assert from 'node:assert/strict';
@@ -53,7 +56,10 @@ for (const page of PAGES) {
     assert.deepEqual([...new Set(named)], named, `duplicate landmark names on ${page.name}: ${named.join(', ')}`);
   });
 
-  test(`every scrollable code block on ${page.name} can be reached by keyboard`, async () => {
+  test(`every code block marked scrollable on ${page.name} can be reached by keyboard`, async () => {
+    // Detected by the utility class, so a block made scrollable only by a
+    // stylesheet rule is out of scope here. Every block on these three pages
+    // carries the class, which is why that is sufficient for them.
     const scrollable = preTags(await renderToString(page.render())).filter((t) => has(t, /\boverflow-x-auto\b/));
     assert.ok(scrollable.length > 0, 'the page renders at least one scrollable code block');
     for (const tag of scrollable) {

--- a/website/test/ssr/pre-block-a11y.test.ts
+++ b/website/test/ssr/pre-block-a11y.test.ts
@@ -14,10 +14,10 @@
  *     keyboard can reach is unusable without a pointer.
  *
  * This lives in its own file, and loops over the pages in PAGES, because the
- * rules belong to the site rather than to any one page. PAGES is the three
- * marketing pages, NOT every page that renders a code block: the /docs and /ui
- * pages scroll their blocks through a stylesheet rule and do not satisfy rule 3
- * yet. Add a page here as it is brought into line.
+ * rules belong to the site rather than to any one page. PAGES is NOT every page
+ * that renders a code block: coverage is partial, other sections do not satisfy
+ * rule 3 yet, and this list is not an inventory of which. Add a page here once
+ * its section satisfies the rules.
  */
 import test from 'node:test';
 import assert from 'node:assert/strict';
@@ -57,9 +57,10 @@ for (const page of PAGES) {
   });
 
   test(`every code block marked scrollable on ${page.name} can be reached by keyboard`, async () => {
-    // Detected by the utility class, so a block made scrollable only by a
-    // stylesheet rule is out of scope here. Every block on these three pages
-    // carries the class, which is why that is sufficient for them.
+    // Scrollability is read from the utility class, which is sufficient here
+    // because every block on these pages carries it. A block scrolled only by a
+    // stylesheet rule would not be seen, so this detector suits the PAGES list
+    // rather than the site.
     const scrollable = preTags(await renderToString(page.render())).filter((t) => has(t, /\boverflow-x-auto\b/));
     assert.ok(scrollable.length > 0, 'the page renders at least one scrollable code block');
     for (const tag of scrollable) {

--- a/website/test/ssr/why-webjs-ssr.test.ts
+++ b/website/test/ssr/why-webjs-ssr.test.ts
@@ -35,6 +35,35 @@ test('the pitch page makes the plain-language prompt and cross-model quality arg
   assert.ok(out.includes('quality of what comes back'), 'ties model-agnosticism to output quality, not just to whether a model works');
 });
 
+test('the plain-language section pairs a prompt against the files the conventions produce', async () => {
+  // The prose above the demo carries the argument, but the two windows are what
+  // SHOW it, and they were previously unasserted: the whole grid could be
+  // deleted with every test in this file still green. These pin both panels,
+  // their correspondence, and the accessible name each scrollable block needs.
+  const out = await renderToString(Why());
+  assert.ok(out.includes('Let customers book a table'), 'the prompt panel carries a request written in ordinary words');
+  assert.ok(!/&gt; Build a page/.test(out), 'the prompt does not name a page, which the file panel would then have to match one for one');
+  for (const file of ['app/book/page.ts', 'app/staff/bookings/page.ts', 'modules/bookings/actions/create.server.ts', 'db/schema.server.ts']) {
+    assert.ok(out.includes(file), `the file panel answers the prompt with ${file}`);
+  }
+  assert.ok(out.includes('<span class="ml-2 font-mono font-medium text-xs leading-none text-fg-subtle">files</span>'), 'the file listing is labelled files, not terminal');
+  // <pre> maps to role generic, where ARIA prohibits an author-supplied name,
+  // so every named scrollable block on this page carries an explicit role.
+  const named = out.match(/<pre[^>]*aria-label=/g) ?? [];
+  const region = out.match(/<pre[^>]*role="region"[^>]*aria-label=/g) ?? [];
+  assert.equal(named.length, 4, 'the page renders its four named code blocks');
+  assert.equal(region.length, named.length, 'every named pre carries role=region, so the name is one ARIA permits');
+});
+
+test('the /why-webjs description answers in the snippet window a SERP actually shows', async () => {
+  // Mirrors the assertion on /what-is-webjs. The claim this page leads with is
+  // only worth adding if it survives truncation, and nothing pinned that here.
+  const { description } = generateMetadata({ url: 'https://webjs.dev/why-webjs' });
+  const firstSentence = description.slice(0, description.indexOf('. ') + 1);
+  assert.ok(firstSentence.length <= 160, `first sentence is ${firstSentence.length} chars, over the 160-char snippet window`);
+  assert.ok(firstSentence.includes('plain language'), 'the plain-language claim is inside the snippet window, not past it');
+});
+
 test('why metadata is self-consistent and points at the dedicated /why-webjs social card', () => {
   const m = generateMetadata({ url: 'https://webjs.dev/why-webjs' });
   assert.equal(m.openGraph.title, m.title, 'og:title matches the <title>');

--- a/website/test/ssr/why-webjs-ssr.test.ts
+++ b/website/test/ssr/why-webjs-ssr.test.ts
@@ -24,6 +24,17 @@ test('the pitch page SSRs with its headline, terminals, reason cards, and a main
   assert.ok(out.includes('<main id="main"'), 'wraps content in a main landmark');
 });
 
+test('the pitch page makes the plain-language prompt and cross-model quality argument', async () => {
+  // The page used to argue model-agnosticism only from the model side (any
+  // model CAN read the source). These two claims are the reader-side half: a
+  // non-technical prompt still lands on the right structure, and the quality
+  // of the output does not swing with the size of the model.
+  const out = await renderToString(Why());
+  assert.ok(out.includes('Describe what you want in plain language'), 'includes the plain-language section heading');
+  assert.ok(out.includes('architecture from a sentence'), 'says the conventions decide the shape, not the prompt');
+  assert.ok(out.includes('quality of what comes back'), 'ties model-agnosticism to output quality, not just to whether a model works');
+});
+
 test('why metadata is self-consistent and points at the dedicated /why-webjs social card', () => {
   const m = generateMetadata({ url: 'https://webjs.dev/why-webjs' });
   assert.equal(m.openGraph.title, m.title, 'og:title matches the <title>');

--- a/website/test/ssr/why-webjs-ssr.test.ts
+++ b/website/test/ssr/why-webjs-ssr.test.ts
@@ -24,36 +24,40 @@ test('the pitch page SSRs with its headline, terminals, reason cards, and a main
   assert.ok(out.includes('<main id="main"'), 'wraps content in a main landmark');
 });
 
-test('the pitch page makes the plain-language prompt and cross-model quality argument', async () => {
+test('the pitch page argues the defaults arrive unasked, and that quality holds across models', async () => {
   // The page used to argue model-agnosticism only from the model side (any
-  // model CAN read the source). These two claims are the reader-side half: a
-  // non-technical prompt still lands on the right structure, and the quality
-  // of the output does not swing with the size of the model.
+  // model CAN read the source). These are the reader-side half. The first claim
+  // is deliberately NOT "you need not know the framework's vocabulary", which
+  // is a non-claim: an agent resolves internals for a technical and a
+  // non-technical prompter alike. It is that the things nobody thinks to ask
+  // for arrive anyway, which is a property of the defaults rather than of the
+  // wording of the prompt.
   const out = await renderToString(Why());
-  assert.ok(out.includes('Describe what you want in plain language'), 'includes the plain-language section heading');
-  assert.ok(out.includes('architecture from a sentence'), 'says the conventions decide the shape, not the prompt');
+  assert.ok(out.includes('You should not have to know what to ask for'), 'includes the unasked-for section heading');
+  assert.ok(out.includes('no reason to know exists'), 'names the gap as not knowing a thing exists, not as not knowing its name');
   assert.ok(out.includes('quality of what comes back'), 'ties model-agnosticism to output quality, not just to whether a model works');
 });
 
-test('the plain-language section pairs a prompt against the files the conventions produce', async () => {
-  // The prose above the demo carries the argument, but the two windows are what
-  // SHOW it, and they were previously unasserted: the whole grid could be
-  // deleted with every test in this file still green. These pin both panels,
-  // their correspondence, and the accessible name each scrollable block needs.
+test('the section names defaults the prompt never asked for', async () => {
+  // The prose carries the argument, but these four cards are what make it
+  // concrete, and an unasserted card grid could be deleted with the rest of the
+  // file still green. Each card must also stay a genuine DEFAULT: if one is
+  // ever reworded into something the prompt has to request, the section's claim
+  // is gone while every other assertion here still passes.
   const out = await renderToString(Why());
-  assert.ok(out.includes('Let customers book a table'), 'the prompt panel carries a request written in ordinary words');
-  for (const file of ['app/book/page.ts', 'app/staff/bookings/page.ts', 'modules/bookings/actions/create.server.ts', 'db/schema.server.ts']) {
-    assert.ok(out.includes(file), `the file panel answers the prompt with ${file}`);
-  }
-  assert.ok(out.includes('<span class="ml-2 font-mono font-medium text-xs leading-none text-fg-subtle">files</span>'), 'the file listing is labelled files, not terminal');
+  const prompt = out.slice(out.indexOf('aria-label="A prompt written the way'), out.indexOf('Nothing in that sentence'));
+  assert.ok(prompt.includes('Let customers book a table'), 'the prompt is a request written the way somebody would say it out loud');
+  assert.ok(prompt.includes('staff see who is coming in'), 'the slice really is the whole prompt panel');
 
-  // The section's whole claim is that the prompt needs no framework vocabulary,
-  // so assert that property of the prompt panel itself rather than tripwiring
-  // one historical phrasing, which any reworded regression would walk past.
-  const prompt = out.slice(out.indexOf('aria-label="A plain-language prompt'), out.indexOf('Where the conventions put it'));
-  assert.ok(prompt.includes('Let customers'), 'the slice really is the prompt panel');
-  for (const jargon of ['page.ts', '.server.ts', 'route', 'component', 'schema', 'action']) {
-    assert.ok(!prompt.includes(jargon), `the prompt says nothing about ${jargon}, so it reads as a request rather than a spec`);
+  for (const claim of ['The information is really kept', 'It works when the code does not load', 'It looks like one product', 'Strangers cannot walk in']) {
+    assert.ok(out.includes(claim), `the section names ${claim} among what arrives unasked`);
+  }
+  assert.ok(out.includes('arrives anyway'), 'says outright that these arrive without being requested');
+
+  // None of the four may appear in the prompt, or the section is demonstrating
+  // the opposite of what it claims.
+  for (const asked of ['database', 'design system', 'session', 'secure', 'production']) {
+    assert.ok(!prompt.includes(asked), `the prompt never asks for ${asked}, which is the entire point of the four cards below it`);
   }
 });
 
@@ -63,7 +67,7 @@ test('the /why-webjs description answers in the snippet window a SERP actually s
   const { description } = generateMetadata({ url: 'https://webjs.dev/why-webjs' });
   const firstSentence = description.slice(0, description.indexOf('. ') + 1);
   assert.ok(firstSentence.length <= 160, `first sentence is ${firstSentence.length} chars, over the 160-char snippet window`);
-  assert.ok(firstSentence.includes('plain language'), 'the plain-language claim is inside the snippet window, not past it');
+  assert.ok(firstSentence.includes('nobody thinks to ask for'), 'the unasked-for claim is inside the snippet window, not past it');
 });
 
 test('why metadata is self-consistent and points at the dedicated /why-webjs social card', () => {

--- a/website/test/ssr/why-webjs-ssr.test.ts
+++ b/website/test/ssr/why-webjs-ssr.test.ts
@@ -24,40 +24,44 @@ test('the pitch page SSRs with its headline, terminals, reason cards, and a main
   assert.ok(out.includes('<main id="main"'), 'wraps content in a main landmark');
 });
 
-test('the pitch page argues the defaults arrive unasked, and that quality holds across models', async () => {
+test('the pitch page argues the prompt carries no architecture, and that quality holds across models', async () => {
   // The page used to argue model-agnosticism only from the model side (any
-  // model CAN read the source). These are the reader-side half. The first claim
-  // is deliberately NOT "you need not know the framework's vocabulary", which
-  // is a non-claim: an agent resolves internals for a technical and a
-  // non-technical prompter alike. It is that the things nobody thinks to ask
-  // for arrive anyway, which is a property of the defaults rather than of the
-  // wording of the prompt.
+  // model CAN read the source). This is the reader-side half, and the claim is
+  // deliberately NOT "you need not know the framework's vocabulary", which is
+  // a non-claim: an agent resolves internals for a technical and a
+  // non-technical prompter alike, so nobody needed that vocabulary either way.
+  // The claim is comparative and about WHO CLOSES THE OPEN DECISIONS. Where
+  // they are open, the prompt closes them. Here the framework already did.
   const out = await renderToString(Why());
-  assert.ok(out.includes('You should not have to know what to ask for'), 'includes the unasked-for section heading');
-  assert.ok(out.includes('no reason to know exists'), 'names the gap as not knowing a thing exists, not as not knowing its name');
+  assert.ok(out.includes('The prompt does not have to carry the architecture'), 'includes the section heading');
+  assert.ok(out.includes('has to be closed by'), 'names the mechanism as an open decision someone must close');
   assert.ok(out.includes('quality of what comes back'), 'ties model-agnosticism to output quality, not just to whether a model works');
 });
 
-test('the section names defaults the prompt never asked for', async () => {
-  // The prose carries the argument, but these four cards are what make it
-  // concrete, and an unasserted card grid could be deleted with the rest of the
-  // file still green. Each card must also stay a genuine DEFAULT: if one is
-  // ever reworded into something the prompt has to request, the section's claim
-  // is gone while every other assertion here still passes.
+test('the two prompts differ only by the architecture one of them has to spell out', async () => {
+  // The contrast IS the argument, so both panels are pinned, and so is the
+  // property that makes the contrast real: the appended instructions appear in
+  // one prompt and in neither the other prompt nor as something WebJs asks for.
   const out = await renderToString(Why());
-  const prompt = out.slice(out.indexOf('aria-label="A prompt written the way'), out.indexOf('Nothing in that sentence'));
-  assert.ok(prompt.includes('Let customers book a table'), 'the prompt is a request written the way somebody would say it out loud');
-  assert.ok(prompt.includes('staff see who is coming in'), 'the slice really is the whole prompt panel');
+  const open = out.slice(out.indexOf('aria-label="A prompt that has to specify'), out.indexOf('Where they are already made'));
+  const made = out.slice(out.indexOf('aria-label="The same request on WebJs'), out.indexOf('Both prompts should produce'));
 
-  for (const claim of ['The information is really kept', 'It works when the code does not load', 'It looks like one product', 'Strangers cannot walk in']) {
-    assert.ok(out.includes(claim), `the section names ${claim} among what arrives unasked`);
+  const ask = 'Build me a table booking app';
+  assert.ok(open.includes(ask), 'both panels open on the same request');
+  assert.ok(made.includes(ask), 'both panels open on the same request');
+  assert.ok(made.includes('that is the whole prompt'), 'the WebJs panel says the request is the whole prompt');
+
+  // Every instruction the other prompt has to append must be absent here, or
+  // the two panels are not actually showing a difference.
+  for (const appended of ['real database', 'render the pages on the server', 'design tokens', 'sessions and a login', 'production ready']) {
+    assert.ok(open.includes(appended), `the open-decision prompt has to append ${appended}`);
+    assert.ok(!made.includes(appended), `the WebJs prompt never appends ${appended}, which is the whole contrast`);
   }
-  assert.ok(out.includes('arrives anyway'), 'says outright that these arrive without being requested');
 
-  // None of the four may appear in the prompt, or the section is demonstrating
-  // the opposite of what it claims.
-  for (const asked of ['database', 'design system', 'session', 'secure', 'production']) {
-    assert.ok(!prompt.includes(asked), `the prompt never asks for ${asked}, which is the entire point of the four cards below it`);
+  // And each appended instruction has to correspond to something the section
+  // then claims arrives anyway, so the contrast resolves instead of dangling.
+  for (const arrives of ['Architecture', 'Code', 'Database', 'Design system']) {
+    assert.ok(out.includes(`>${arrives}</h3>`), `the section names ${arrives} among what arrives without being asked`);
   }
 });
 
@@ -67,7 +71,7 @@ test('the /why-webjs description answers in the snippet window a SERP actually s
   const { description } = generateMetadata({ url: 'https://webjs.dev/why-webjs' });
   const firstSentence = description.slice(0, description.indexOf('. ') + 1);
   assert.ok(firstSentence.length <= 160, `first sentence is ${firstSentence.length} chars, over the 160-char snippet window`);
-  assert.ok(firstSentence.includes('nobody thinks to ask for'), 'the unasked-for claim is inside the snippet window, not past it');
+  assert.ok(firstSentence.includes('the whole prompt'), 'the whole-prompt claim is inside the snippet window, not past it');
 });
 
 test('why metadata is self-consistent and points at the dedicated /why-webjs social card', () => {

--- a/website/test/ssr/why-webjs-ssr.test.ts
+++ b/website/test/ssr/why-webjs-ssr.test.ts
@@ -42,7 +42,10 @@ test('the plain-language section pairs a prompt against the files the convention
   // their correspondence, and the accessible name each scrollable block needs.
   const out = await renderToString(Why());
   assert.ok(out.includes('Let customers book a table'), 'the prompt panel carries a request written in ordinary words');
-  assert.ok(!/&gt; Build a page/.test(out), 'the prompt does not name a page, which the file panel would then have to match one for one');
+  // Plain substring, not a regex spanning the chevron: the prompt's > lives in
+  // its own span, so anything asserting the two are adjacent can never match
+  // and would sit here green while the regression it names is fully present.
+  assert.ok(!out.includes('Build a page'), 'the prompt does not name a page, which the file panel would then have to match one for one');
   for (const file of ['app/book/page.ts', 'app/staff/bookings/page.ts', 'modules/bookings/actions/create.server.ts', 'db/schema.server.ts']) {
     assert.ok(out.includes(file), `the file panel answers the prompt with ${file}`);
   }

--- a/website/test/ssr/why-webjs-ssr.test.ts
+++ b/website/test/ssr/why-webjs-ssr.test.ts
@@ -53,7 +53,7 @@ test('the two prompts differ only by the architecture one of them has to spell o
 
   // Every instruction the other prompt has to append must be absent here, or
   // the two panels are not actually showing a difference.
-  for (const appended of ['real database', 'render the pages on the server', 'design tokens', 'sessions and a login', 'production ready']) {
+  for (const appended of ['real database', 'design system', 'production ready code and architecture']) {
     assert.ok(open.includes(appended), `the open-decision prompt has to append ${appended}`);
     assert.ok(!made.includes(appended), `the WebJs prompt never appends ${appended}, which is the whole contrast`);
   }

--- a/website/test/ssr/why-webjs-ssr.test.ts
+++ b/website/test/ssr/why-webjs-ssr.test.ts
@@ -42,20 +42,19 @@ test('the plain-language section pairs a prompt against the files the convention
   // their correspondence, and the accessible name each scrollable block needs.
   const out = await renderToString(Why());
   assert.ok(out.includes('Let customers book a table'), 'the prompt panel carries a request written in ordinary words');
-  // Plain substring, not a regex spanning the chevron: the prompt's > lives in
-  // its own span, so anything asserting the two are adjacent can never match
-  // and would sit here green while the regression it names is fully present.
-  assert.ok(!out.includes('Build a page'), 'the prompt does not name a page, which the file panel would then have to match one for one');
   for (const file of ['app/book/page.ts', 'app/staff/bookings/page.ts', 'modules/bookings/actions/create.server.ts', 'db/schema.server.ts']) {
     assert.ok(out.includes(file), `the file panel answers the prompt with ${file}`);
   }
   assert.ok(out.includes('<span class="ml-2 font-mono font-medium text-xs leading-none text-fg-subtle">files</span>'), 'the file listing is labelled files, not terminal');
-  // <pre> maps to role generic, where ARIA prohibits an author-supplied name,
-  // so every named scrollable block on this page carries an explicit role.
-  const named = out.match(/<pre[^>]*aria-label=/g) ?? [];
-  const region = out.match(/<pre[^>]*role="region"[^>]*aria-label=/g) ?? [];
-  assert.equal(named.length, 4, 'the page renders its four named code blocks');
-  assert.equal(region.length, named.length, 'every named pre carries role=region, so the name is one ARIA permits');
+
+  // The section's whole claim is that the prompt needs no framework vocabulary,
+  // so assert that property of the prompt panel itself rather than tripwiring
+  // one historical phrasing, which any reworded regression would walk past.
+  const prompt = out.slice(out.indexOf('aria-label="A plain-language prompt'), out.indexOf('Where the conventions put it'));
+  assert.ok(prompt.includes('Let customers'), 'the slice really is the prompt panel');
+  for (const jargon of ['page.ts', '.server.ts', 'route', 'component', 'schema', 'action']) {
+    assert.ok(!prompt.includes(jargon), `the prompt says nothing about ${jargon}, so it reads as a request rather than a spec`);
+  }
 });
 
 test('the /why-webjs description answers in the snippet window a SERP actually shows', async () => {


### PR DESCRIPTION
Closes #1201

The `/why-webjs` page argued model-agnosticism only from the model side: any model can read the whole framework from `node_modules`, so no training data and no single blessed model are required. That leaves out the half a reader cares about. Most frameworks leave the big decisions open, which is their flexibility rather than a fault, but an open decision still has to be closed by somebody, and when an agent writes the code that somebody is whoever wrote the prompt. So "Build me an app" grows an appendix of technical instructions, and every line of it is something you had to know to ask for. WebJs has already made those calls, so the request stays the request.

## What changed

- `website/app/why-webjs/page.ts`: a new section, "The prompt does not have to carry the architecture", between the reason grid and the any-model section. It shows the same request twice, once with the architecture appended and once without, then names what comes back regardless: architecture, code, a real database, and a design system. The any-model section gains a paragraph tying model-agnosticism to output quality rather than only to whether a model can participate, and the meta description leads with the whole-prompt claim.
- `website/app/what-is-webjs/page.ts`: one short echo folded into the existing "AI-first, readable end to end" capability rather than a seventh card, which would leave the three-column grid ragged. Worded differently from `/why-webjs` so the two pages do not chase the same phrasing.
- `website/app/page.ts`: an accessibility fix review pulled in, unrelated to the copy. A `<pre>` maps to ARIA role `generic`, where ARIA prohibits an author-supplied name, so the `aria-label` these code blocks already carried was a name no spec-following screen reader announces. Every `<pre>` that already carried such a name now takes `role="region"`, and the two that shared a label are named apart so they do not collapse into an ambiguous landmark pair. Purely additive against main.
- `website/AGENTS.md`: states the three code-block rules, and says plainly that the test covers only the pages in its `PAGES` list. Coverage is partial and the rest of the site is not clean, which is now filed as #1204.
- Tests: `why-webjs-ssr.test.ts` pins the contrast rather than either panel alone, so a future edit that quietly erases the difference fails. `pre-block-a11y.test.ts` pins the three rules across the marketing pages.

## Deliberately excluded

- The home page's copy. #1087 already led it with the model-agnostic benefit, and a third telling is the cannibalization the site's SEO conventions warn against. The `app/page.ts` change is the accessibility fix, not positioning.
- Any claim that models produce identical code, or that this removes the need to read what an agent writes. The copy says the opposite on the second point.
- Any claim that the framework makes design converge. AGENTS.md is explicit that there is no design gate and taste is the agent's job, so the copy credits design tokens and says taste is the reader's to direct.
- The accessibility gap outside the marketing pages. Real and pre-existing, separate from a copy change, filed as #1204.

## Test plan

- Website server suite 141/141, browser suite 35/35, `webjs check` clean
- Counterfactuals: deleting the demo panels reds the contrast test; duplicating the two card labels reds the landmark-uniqueness test; dropping the role from the `codeWindow` helper reds the role test
- Rendered at 1440 and 390 wide, light and dark, no console errors
- Rebased onto main after #1200

Doc surfaces: website copy plus one accessibility fix. No `packages/*/src` change, so the framework doc surfaces, the scaffold, the MCP, the editor plugins, and the changelog are N/A.
