### PR TITLE
fix(server): stop pinning a yanked version in the vendor CDN test

### DIFF
--- a/packages/server/test/vendor/vendor.test.js
+++ b/packages/server/test/vendor/vendor.test.js
@@ -599,43 +599,169 @@ test('jspmGenerate #446: multi-install set resolves in ONE generate call (unifie
   });
 });
 
-test('jspmGenerate #446: conflicting graph resolves to ONE consistent set (real CDN)', { skip: !NETWORK_OK }, async () => {
-  // The exact repro from the issue. @codemirror/view is requested pinned at
-  // 6.39.0; @codemirror/lint@6.9.6 transitively needs a newer view (^6.42).
-  // Per-package-in-isolation produced TWO different view URLs (6.39 direct,
-  // 6.43 via lint) merged last-write-wins, so a served entry imported a
-  // symbol another served entry lacked. The unified call must yield ONE
-  // coherent graph: a single view URL, and the transitive @codemirror/state
-  // that lint needs must be present so the browser has no unresolved bare
-  // specifier.
-  const installs = ['@codemirror/view@6.39.0', '@codemirror/lint@6.9.6'];
-  clearVendorCache();
-  const map = await jspmGenerate(installs);
-  assert.ok(map['@codemirror/view'], 'view resolves');
-  assert.ok(map['@codemirror/lint'], 'lint resolves');
-  assert.ok(map['@codemirror/state'], 'the transitive @codemirror/state lint pulls in is present');
+test('jspmGenerate #446: a conflicting graph cannot skew a version (deterministic mock)', async () => {
+  // The consequence half of the #446 fix, and the one that actually caught the
+  // shipped bug. The test above proves the CALL is unified; this proves what
+  // that buys, that no served entry can end up on a different version than the
+  // graph agreed on.
+  //
+  // The repro from the issue: @codemirror/view is requested pinned at 6.39.0
+  // while @codemirror/lint needs a newer view (^6.42). Resolving each install
+  // in isolation produced TWO different view URLs (6.39 direct, 6.43 via lint)
+  // merged last-write-wins, so a served entry imported a symbol another served
+  // entry lacked.
+  //
+  // The mock answers a UNIFIED call (both installs together) with the coherent
+  // graph, and a per-package call with the skewed view that install alone
+  // implies. That asymmetry is what makes this discriminating: revert
+  // jspmGenerate to the old per-package loop and lint's isolated call hands
+  // back view@6.43.0, which wins last-write and reds the final assertion.
+  //
+  // Deliberately a mock rather than the live CDN. The live version of this
+  // test pinned @codemirror/lint@6.9.6, and when that version stopped
+  // resolving on jspm.io it failed on every run and blocked main for everyone
+  // (#1218). The version range is the problem: only lint 6.9.6 and 6.9.7 carry
+  // the `^6.42.0` view range that creates the conflict at all, and NEITHER
+  // resolves on jspm.io today, so there is no live fixture left that expresses
+  // this shape. The same class of live-CDN rot already forced the ordering
+  // test onto a mock in #312. A regression guard for shipped behaviour must
+  // not depend on a third party continuing to host one exact version.
+  const COHERENT = {
+    '@codemirror/view': 'https://ga.jspm.io/npm:@codemirror/view@6.39.0/dist/index.js',
+    '@codemirror/lint': 'https://ga.jspm.io/npm:@codemirror/lint@6.9.6/dist/index.js',
+    '@codemirror/state': 'https://ga.jspm.io/npm:@codemirror/state@6.6.0/dist/index.js',
+  };
+  // What lint ALONE would drag in: a newer view than the pinned one.
+  const SKEWED_VIEW = 'https://ga.jspm.io/npm:@codemirror/view@6.43.0/dist/index.js';
 
-  // Ground truth: a single unified generate call over the same set. This is
-  // the one mutually-consistent graph jspm computes. The fix makes
-  // jspmGenerate produce EXACTLY this.
-  const gtResp = await fetch('https://api.jspm.io/generate', {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({
-      install: installs, flattenScope: true,
-      env: ['browser', 'production', 'module'], provider: 'jspm.io',
-    }),
+  const mock = async (_url, opts) => {
+    const { install } = JSON.parse(opts.body);
+    const imports = install.length > 1
+      ? { ...COHERENT }
+      : install[0].startsWith('@codemirror/lint')
+        ? { '@codemirror/lint': COHERENT['@codemirror/lint'], '@codemirror/view': SKEWED_VIEW, '@codemirror/state': COHERENT['@codemirror/state'] }
+        : { '@codemirror/view': COHERENT['@codemirror/view'] };
+    return { ok: true, status: 200, json: async () => ({ map: { imports } }) };
+  };
+
+  await withMockedFetch(mock, async () => {
+    clearVendorCache();
+    const map = await jspmGenerate(['@codemirror/view@6.39.0', '@codemirror/lint@6.9.6']);
+    assert.ok(map['@codemirror/view'], 'view resolves');
+    assert.ok(map['@codemirror/lint'], 'lint resolves');
+    assert.ok(map['@codemirror/state'], 'the transitive @codemirror/state lint pulls in is present');
+    // The discriminating invariant: the served view entry is the version the
+    // WHOLE graph agreed on (6.39.0, the requested one), NOT lint's transitive
+    // 6.43.x that the old per-package merge let win last-write. A skew here is
+    // the missing-export crash from the issue.
+    assert.equal(map['@codemirror/view'], COHERENT['@codemirror/view'],
+      'view stays at the version the unified graph chose, no transitive skew');
   });
-  const groundTruth = (await gtResp.json()).map.imports;
-  assert.deepEqual(map, groundTruth,
-    'jspmGenerate must equal the single unified graph, not a per-package merge');
+});
 
-  // The discriminating invariant: the served @codemirror/view entry is the
-  // version the WHOLE graph agreed on (6.39.0, the requested one), NOT
-  // lint\'s transitive 6.43.x that the old per-package merge let win
-  // last-write. A skew here is the missing-export crash from the issue.
-  assert.match(map['@codemirror/view'], /@codemirror\/view@6\.39\.0\//,
-    'view stays at the version the unified graph chose, no transitive skew');
+test('jspmGenerate #446: matches jspm\'s own unified graph (real CDN)', { skip: !NETWORK_OK }, async (t) => {
+  // The integration half: our merged output must equal what jspm itself
+  // computes for the same install set. The mock above cannot prove this,
+  // because a mock only ever returns what this file already believes.
+  //
+  // The fixture is chosen so the comparison can actually FAIL two distinct
+  // ways, since a parity assertion over a set with nothing to disagree about
+  // is decoration:
+  //
+  //   1. Per-package skew. Resolved alone, @codemirror/lint drags in
+  //      view@6.41.x; in the unified graph the pinned view@6.39.0 wins. So a
+  //      revert of jspmGenerate to the pre-#446 per-package loop makes lint's
+  //      isolated call supply the newer view, which wins last-write and diverges
+  //      from the ground truth here. Two packages with no shared transitive
+  //      (say picocolors + clsx) cannot catch that: their unified graph is
+  //      byte-identical to the union of their single-install graphs.
+  //   2. A dropped flattenScope. This pair hoists five transitives to top level
+  //      (@codemirror/state, crelt, style-mod, w3c-keyname,
+  //      @marijn/find-cluster-break). vendor.js sends flattenScope: true so the
+  //      browser gets no unresolved bare specifier, and this ground truth sends
+  //      it too, so removing it from vendor.js drops those entries from our
+  //      imports and reds the deepEqual. Nothing else in the suite covers that
+  //      flag: every mock here answers only on `install`, so a mocked assertion
+  //      on a transitive key reads a value the mock itself fabricated.
+  //
+  // lint is pinned at 6.9.5 rather than a version whose view range EXCLUDES
+  // 6.39.0 (only 6.9.6 and 6.9.7 do that, and neither resolves on jspm.io, see
+  // the mock test above). The incompatible-range case is the mock's job; this
+  // one only needs a shared transitive whose resolution differs per strategy.
+  const installs = ['@codemirror/view@6.39.0', '@codemirror/lint@6.9.5'];
+
+  const skip = (reason) => {
+    // Loud on purpose. A silent skip is how a real regression hides, so name
+    // the fixture and the reason.
+    console.warn(`[vendor.test] SKIP unified-graph parity: ${installs.join(' + ')} (${String(reason).split('\n')[0]})`);
+    t.skip('jspm.io was not in a state that can answer this comparison');
+  };
+
+  // Half one, the ground truth. Every failure mode routes to the skip, not
+  // just an `error` in a well-formed JSON body: a DNS failure or reset throws
+  // out of fetch, a proxy's HTML 502 throws out of .json(), and a hang is cut
+  // by the timeout. Without that timeout a wedged api.jspm.io would hold the
+  // unit job open until the CI job limit, since node --test applies no
+  // per-test deadline of its own. The shipped code guards its own call the
+  // same way (JSPM_GENERATE_TIMEOUT_MS in packages/server/src/vendor.js).
+  let gt;
+  let why = '';
+  try {
+    const gtResp = await fetch('https://api.jspm.io/generate', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        install: installs, flattenScope: true,
+        env: ['browser', 'production', 'module'], provider: 'jspm.io',
+      }),
+      signal: AbortSignal.timeout(15_000),
+    });
+    gt = await gtResp.json();
+    if (!gtResp.ok) why = `HTTP ${gtResp.status}`;
+    else if (gt.error) why = String(gt.error);
+    else if (!gt.map?.imports) why = 'response carried no map.imports';
+  } catch (err) {
+    why = `${err.name}: ${err.message}`;
+  }
+  if (why) { skip(why); return; }
+
+  // Half two, our own call, watched at the TRANSPORT rather than judged by its
+  // return value. jspmGenerate fail-opens, so its output cannot tell the two
+  // failure kinds apart: a transient on the unified call returns a NON-empty
+  // merge of per-install fragments (skewed to view@6.41.x for this fixture),
+  // and an unresolvable set returns {}. Reading the map alone therefore either
+  // reds on an upstream blip or skips on a real bug, depending on which shape
+  // you test for. Both are wrong.
+  //
+  // So record what the network actually did. A throw, a 5xx, or a 429 is
+  // upstream having a bad moment, and skips. A 4xx does NOT skip: the ground
+  // truth just succeeded for this same fixture moments ago, so upstream is
+  // demonstrably healthy, and a 4xx now means OUR request is malformed, which
+  // is precisely the regression this test exists to catch.
+  const realFetch = globalThis.fetch;
+  /** @type {string[]} */
+  const transient = [];
+  globalThis.fetch = async (url, opts) => {
+    try {
+      const r = await realFetch(url, opts);
+      if (r.status >= 500 || r.status === 429) transient.push(`HTTP ${r.status}`);
+      return r;
+    } catch (err) {
+      transient.push(`${err.name}: ${err.message}`);
+      throw err;
+    }
+  };
+  let map;
+  try {
+    clearVendorCache();
+    map = await jspmGenerate(installs);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+  if (transient.length) { skip(`jspm.io flaked on our own call (${transient[0]})`); return; }
+
+  assert.deepEqual(map, gt.map.imports,
+    'jspmGenerate must equal the single unified graph, not a per-package merge');
 });
 
 test('jspmGenerate #446 fallback: an unresolvable install does not collapse the map', async () => {


### PR DESCRIPTION
Closes #1218

`main` was red and every PR was blocked. The `#446` regression test pinned `@codemirror/lint@6.9.6` and asked the live `api.jspm.io` to resolve it. That version stopped resolving upstream, so the test failed on every run, on PRs that had never touched vendor code.

## Repinning does not work, which changed the fix

The obvious move is to bump the pinned version. Checking the registry first says otherwise. The fixture needs a version conflict to be meaningful: `@codemirror/view` is pinned at `6.39.0`, and `lint` has to transitively want something newer.

| `@codemirror/lint` | its `@codemirror/view` range | conflicts with `view@6.39.0`? | resolves on jspm.io? |
|---|---|---|---|
| 6.8.0 to 6.8.2 | `^6.0.0` | no | yes |
| 6.8.3 to 6.9.5 | `^6.35.0` | no | yes |
| **6.9.6** | `^6.42.0` | **yes** | **no** (`Module not found .../dist/index.js`) |
| **6.9.7** | `^6.42.0` | **yes** | **no** (not mirrored) |

Only `6.9.6` and `6.9.7` create the conflict at all, and neither resolves. Every older version wants `^6.35.0`, which `6.39.0` already satisfies, so repinning to one of those would leave a green test that proves nothing: the discriminating assertion would pass because there was never a conflict, not because the unified call resolved one. There is no live fixture left that expresses this shape.

## So the test splits along what each half can actually prove

**The conflict shape moves to a deterministic mock.** The mock answers a unified call (both installs together) with the coherent graph, and a per-package call with the skewed `view` that install alone implies. That asymmetry is what makes it discriminating: revert `jspmGenerate` to the pre-#446 per-package loop and `lint`'s isolated call hands back `view@6.43.0`, which wins last-write and reds the assertion. This is the invariant that caught the shipped bug, and it no longer depends on a third party continuing to host one exact version.

There is precedent in this same file: the install-ordering test was moved onto a mock for exactly this reason in #312, after the live CDN flaked on transitive resolution.

**The live half keeps what a mock genuinely cannot give**, that our merged output equals jspm's own unified graph. A mock only ever returns what the test file already believes, so it cannot verify our merge against reality.

Its fixture is picked so that comparison can still fail two distinct ways, because a parity assertion over a set with nothing to disagree about is decoration:

1. **Per-package skew.** `@codemirror/lint@6.9.5` resolved alone drags in `view@6.41.1`; in the unified graph the pinned `view@6.39.0` wins. A revert to the per-package loop diverges from the ground truth. A pair with no shared transitive (picocolors + clsx) cannot catch this, since its unified graph is byte-identical to the union of its single-install graphs.
2. **A dropped `flattenScope`.** The pair hoists five transitives to top level. `vendor.js` sends `flattenScope: true` so the browser gets no unresolved bare specifier, and this is the ONLY coverage of that flag in the suite: every mock here answers on `install` alone, so a mocked assertion on a transitive key would just read a value the mock fabricated.

`lint` is pinned at `6.9.5` rather than a version whose `view` range excludes `6.39.0`, since only `6.9.6` and `6.9.7` do that and neither resolves. The incompatible-range case is the mock's job; the live half only needs a shared transitive that resolves differently per strategy.

Upstream failure reaches a **loud skip** rather than a red, through every mode rather than only an `error` in a well-formed JSON body: `fetch` throwing on DNS or a reset, `.json()` throwing on a proxy's HTML 502, and our own call fail-opening to an empty map. A red there means a third party changed something, which is not a signal about this repo and must not block `main`.

`packages/server/src/vendor.js` is unchanged, as the diagnosis predicted. This was a broken test fixture, not a framework bug.

## Test plan

- **Unit.** `node --test packages/server/test/vendor/vendor.test.js`: 115/115.
- **Counterfactuals.** Each was run by temporarily editing the named source file, then restoring it. Those edits are not in the diff, so the toggles are described rather than linked; every one was run against the tree at [`aa7d0f6d`](https://github.com/webjsdev/webjs/commit/aa7d0f6d).
  - Revert `jspmGenerate` to the pre-#446 per-package loop: reds the mock test AND the live parity test, 6 failures.
  - Comment out `flattenScope: true` in `packages/server/src/vendor.js`: reds the live parity test. This is the finding that the previous fixture had silently stopped covering.
  - Point the ground-truth fetch at a closed port: SKIPs (`TypeError: fetch failed`), 0 failures.
  - Point it at a non-JSON endpoint: SKIPs (`SyntaxError: Unexpected token '<' ...`), 0 failures.
  - Restoring each greens the suite at 115/115.
- **Full suite.** 3606 tests, 3599 pass. The 6 failures are all `test/bun/listener.test.mjs` ("the trusted socket IP must reach clientIp in the WS handler; got `_anon_`"), which fails identically on `main` in a clean checkout under local Node 26.1.0. Pre-existing and unrelated; the repo targets Node 24+ and CI runs that.
- **Browser / e2e / Bun matrix:** N/A, no runtime source touched. CI runs them regardless.

## Doc surfaces

- `AGENTS.md`, the skill references, docs site, MCP, editor plugins, scaffold templates, marketing copy: N/A, no public surface changed. This is a test-only diff.
- Changelog: rides the next functional bump, no version bumped here.
