### PR TITLE
test(e2e): make the elision block report its real failure, not an off-by-one

### DIFF
--- a/test/e2e/e2e.test.mjs
+++ b/test/e2e/e2e.test.mjs
@@ -2017,36 +2017,51 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
      * Wait until the page has actually hydrated, instead of sleeping and hoping.
      *
      * The counter is the readiness signal because it is the one thing on this
-     * page that is interactive in BOTH builds, so it is the last thing to come
-     * up and it must come up on either side. `whenDefined` alone is not enough:
-     * the custom element can be registered a tick before the instance is
-     * upgraded and its buttons rendered, and it is the buttons the assertions
-     * need. `my-counter` is a LIGHT-DOM component, so its children sit on the
-     * element itself and there is no shadow root to look inside.
+     * page that is interactive in BOTH builds, so it must come up on either side.
+     *
+     * The signal is that the ELEMENT INSTANCE has been upgraded, tested with
+     * `instanceof` against the registered constructor. Nothing weaker works
+     * here, because SSR already emits the counter's full inner markup:
+     *
+     *     <my-counter count="3" data-wj-host><!--webjs-hydrate-->
+     *       <button aria-label="Decrement">...<output>3</output>
+     *       <button aria-label="Increment">...
+     *
+     * So the host, the output and both buttons exist before a single line of
+     * JavaScript has run. Waiting on any of them is waiting on the server's
+     * HTML, which is always already true, and a click at that point lands on a
+     * real button with no listener attached and is silently swallowed. Before
+     * upgrade the element is a plain HTMLElement; only after it is an instance
+     * of the registered class, which is the first moment the `@click` binding
+     * exists. `my-counter` is a LIGHT-DOM component, so there is no shadow root
+     * to look inside for a different answer.
      * @param {import('puppeteer-core').Page} p
+     * @param {string} which  'ON' or 'OFF', named in the failure message
      */
     const waitForHydration = async (p, which) => {
       try {
         await p.waitForFunction(() => {
-          if (!customElements.get('my-counter')) return false;
-          const c = document.querySelector('my-counter');
-          return !!(c && c.querySelector('output') && c.querySelector('button[aria-label="Increment"]'));
+          const C = customElements.get('my-counter');
+          return !!(C && document.querySelector('my-counter') instanceof C);
         }, { timeout: 15000, polling: 50 });
       } catch {
         // Say what failed and what it most likely means. A bare puppeteer
         // "Waiting failed: 15000ms exceeded" names neither the page nor the
         // condition, which is the same diagnostic dead end the old off-by-one
         // counter assertion was. Report what is actually on the page.
-        const state = await p.evaluate(() => ({
-          defined: !!customElements.get('my-counter'),
-          host: !!document.querySelector('my-counter'),
-          button: !!document.querySelector('my-counter')?.querySelector('button[aria-label="Increment"]'),
-        })).catch(() => null);
+        const state = await p.evaluate(() => {
+          const C = customElements.get('my-counter');
+          return {
+            defined: !!C,
+            host: !!document.querySelector('my-counter'),
+            upgraded: !!(C && document.querySelector('my-counter') instanceof C),
+          };
+        }).catch(() => null);
         throw new Error(
-          `${which} page never hydrated <my-counter> within 15s `
+          `${which} page never upgraded <my-counter> within 15s `
           + `(customElements.define ${state?.defined ? 'ran' : 'DID NOT run'}, `
           + `host ${state?.host ? 'present' : 'absent'}, `
-          + `increment button ${state?.button ? 'present' : 'absent'}). `
+          + `instance ${state?.upgraded ? 'upgraded' : 'NOT upgraded'}). `
           + 'If define never ran, the component module was not served: elision may have wrongly dropped it.',
         );
       }

--- a/test/e2e/e2e.test.mjs
+++ b/test/e2e/e2e.test.mjs
@@ -1999,35 +1999,52 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
     });
 
     // Snapshot the observable content of <main>: visible text and the ordered
-    // tag structure. Only the wall-clock and the chat participant COUNT are
-    // normalised away, and the distinction matters, so it is worth stating.
+    // tag structure, with the two sources that are not a function of elision
+    // held out. Getting this boundary right took several passes, so the reasons
+    // are written down rather than left to be rediscovered.
     //
-    // <chat-box> sits inside <main> and it is NOT independent of what this
-    // block tests. It calls connectWS from connectedCallback, so leaving its
-    // SSR 'Connecting…' state requires its module to have shipped and the
-    // element to have upgraded. Its rendered state is therefore a real signal
-    // that chat-box hydrated on both sides, and erasing it would throw away
-    // coverage in the exact test that exists to compare hydration.
+    // 1. The wall-clock, which ticks between the two snapshots. Both the
+    //    12-hour and 24-hour renderings are matched, since which one appears
+    //    depends on the runner's default locale, not on anything under test.
     //
-    // What is genuinely not a function of elision is the participant count:
-    // each page talks to its own server, so `Live · N others online` counts
-    // whoever happens to be connected to THAT server. The digits are
-    // normalised; the 'Live' that proves hydration is kept.
+    // 2. <chat-box>'s INNER content. The element itself is still compared (it
+    //    must be present and in the same position on both sides), but its pane
+    //    is a live socket feed and cannot be made equal across the two servers:
     //
-    // The socket handshake is handled by waiting (waitForChatLive below), not
-    // by normalising. Waiting is what makes both sides comparable: the open
-    // also broadcasts a join to every client including the joiner, which adds
-    // a 'someone joined' line and its own element, changing BOTH the text and
-    // the tags. A regex over the status line alone would have left that race
-    // untouched in the tags half.
+    //      - The server broadcasts every join and leave to all clients
+    //        including the joiner, and the handler appends a line per event, so
+    //        the pane accumulates entries and each adds elements to the tag
+    //        list. The count of those events is a property of the SERVER's
+    //        client population.
+    //      - Those populations are not comparable by construction. The OFF
+    //        server is created fresh and privately in this block's before();
+    //        the ON server is shared with the whole suite and outlives it, so
+    //        anyone else connecting to or leaving it during the window adds a
+    //        line on the ON side with no OFF counterpart.
+    //      - A reconnect re-opens the socket and appends a SECOND join line, so
+    //        even a single page's pane is not a function of its own history.
+    //
+    //    Waiting cannot fix any of that, which an earlier revision of this test
+    //    assumed it could: the two sides are genuinely independent populations,
+    //    not one lagging the other. So the pane is held out of the comparison.
+    //
+    // Holding it out does NOT drop the coverage, because the thing worth
+    // checking about chat-box is that it HYDRATED, not what its feed happened
+    // to say. It connects from connectedCallback, so reaching its connected
+    // state proves its module shipped and the element upgraded, and that is
+    // asserted directly on both sides by waitForChatLive below.
     const observableMain = (pg) => pg.evaluate(() => {
       const main = document.querySelector('main') || document.body;
-      const text = (main.textContent || '')
+      // Work on a clone so the live DOM is untouched and a later snapshot of
+      // the same page still sees the real thing.
+      const copy = /** @type {HTMLElement} */ (main.cloneNode(true));
+      for (const box of copy.querySelectorAll('chat-box')) box.replaceChildren();
+      const text = (copy.textContent || '')
         .replace(/\d{1,2}:\d{2}:\d{2}\s?[AP]M/gi, 'TIME')
-        .replace(/Live · \d+ others? online/g, 'Live · CHAT-COUNT online')
+        .replace(/\d{1,2}:\d{2}:\d{2}/g, 'TIME')
         .replace(/\s+/g, ' ')
         .trim();
-      const tags = [...main.querySelectorAll('*')].map((el) => el.tagName.toLowerCase());
+      const tags = [...copy.querySelectorAll('*')].map((el) => el.tagName.toLowerCase());
       return { text, tags };
     });
 
@@ -2099,20 +2116,23 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
     };
 
     /**
-     * Wait until <chat-box> has settled into its connected state.
+     * Assert that <chat-box> HYDRATED, by waiting for it to leave its
+     * server-rendered state.
      *
-     * The socket open is what makes the two pages comparable, and it changes
-     * more than the status line: the server broadcasts the join to every
-     * client INCLUDING the joiner, so the message pane flips from its empty
-     * placeholder to a 'someone joined' entry, adding an element. Both the text
-     * and the tag structure move. Snapshotting before that has landed on both
-     * sides compares one settled page against one unsettled page.
+     * This is a hydration check, not a settle barrier, and the difference
+     * matters. It keys on the status line reaching 'Live ·', which `onOpen`
+     * sets before the join message arrives, so it deliberately does NOT
+     * guarantee the message pane has stopped moving. That guarantee is not
+     * available at all: the pane accumulates a line per join and leave on that
+     * page's own server, a reconnect appends another, and the two servers have
+     * different client populations by construction. The pane is therefore held
+     * out of the snapshot (see observableMain) instead of waited on.
      *
-     * This is a wait rather than a normalisation on purpose: chat-box connects
-     * from connectedCallback, so reaching this state proves it hydrated, which
-     * is a signal this block exists to check. Only the participant count is
-     * normalised out of the snapshot, since that counts whoever is connected to
-     * that page's own server.
+     * What this DOES establish is the part worth asserting. chat-box calls
+     * connectWS from connectedCallback, so leaving the SSR state at all proves
+     * its module shipped and the element upgraded. Running it against both
+     * pages keeps the on-vs-off hydration coverage that holding the pane out of
+     * the snapshot would otherwise have lost.
      * @param {import('puppeteer-core').Page} p
      * @param {string} which  'ON' or 'OFF', named in the failure message
      */
@@ -2138,9 +2158,10 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
       await offPage.goto(`${offBaseUrl}/`, { waitUntil: 'domcontentloaded', timeout: 30000 });
       await waitForHydration(page, 'ON');
       await waitForHydration(offPage, 'OFF');
-      // <chat-box> renders inside <main>, so its connected state has to land on
-      // BOTH sides before the snapshot, or this compares a settled page against
-      // an unsettled one.
+      // chat-box's pane is held out of the snapshot (it is a live socket feed
+      // over two independent servers), so assert its hydration directly on both
+      // sides instead. Without this the held-out pane would mean an un-hydrated
+      // chat-box went unnoticed.
       await waitForChatLive(page, 'ON');
       await waitForChatLive(offPage, 'OFF');
       const onSnap = await observableMain(page);

--- a/test/e2e/e2e.test.mjs
+++ b/test/e2e/e2e.test.mjs
@@ -2045,34 +2045,14 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
         // "Waiting failed: 15000ms exceeded" names neither the page nor the
         // condition, which is the same diagnostic dead end the old off-by-one
         // counter assertion was. Report what is actually on the page.
-        const state = await p.evaluate(async () => {
+        const state = await p.evaluate(() => {
           const C = customElements.get('my-counter');
-          // Ask the page what actually happened to the module: whether the
-          // browser ever fetched it, and what the server says if we ask again.
-          // Guessing at this from outside has been unproductive.
-          const res = performance.getEntriesByType('resource')
-            .filter((e) => /counter\.ts/.test(e.name))
-            .map((e) => `${e.name.replace(/^https?:\/\/[^/]+/, '')} dur=${Math.round(e.duration)}ms size=${e.transferSize}`);
-          let refetch = 'not attempted';
-          try {
-            const r = await fetch('/components/counter.ts', { cache: 'no-store' });
-            const body = await r.text();
-            refetch = `HTTP ${r.status}, ${body.length} bytes, defines=${/customElements|register\(/.test(body)}`;
-          } catch (e) { refetch = `threw ${e.name}: ${e.message}`; }
-          const boot = [...document.querySelectorAll('script[type="module"]')]
-            .map((s) => (s.src ? `src=${s.src.replace(/^https?:\/\/[^/]+/, '')}` : `inline(${s.textContent.length}b) mentionsCounter=${/counter/.test(s.textContent)}`));
           return {
             defined: !!C,
             host: !!document.querySelector('my-counter'),
             upgraded: !!(C && document.querySelector('my-counter') instanceof C),
-            resourceEntries: res.length ? res : ['(the browser never fetched counter.ts)'],
-            refetch,
-            bootScripts: boot,
-            definedTags: customElements.get ? ['my-counter', 'build-stamp', 'vendor-badge', 'muted-text'].filter((t) => customElements.get(t)) : [],
           };
-        }).catch((e) => ({ evalFailed: String(e && e.message) }));
-        // eslint-disable-next-line no-console
-        console.error(`[e2e diag] ${which} hydration timeout state:`, JSON.stringify(state, null, 2));
+        }).catch(() => null);
         throw new Error(
           `${which} page never upgraded <my-counter> within 15s `
           + `(customElements.define ${state?.defined ? 'ran' : 'DID NOT run'}, `

--- a/test/e2e/e2e.test.mjs
+++ b/test/e2e/e2e.test.mjs
@@ -2025,17 +2025,38 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
      * element itself and there is no shadow root to look inside.
      * @param {import('puppeteer-core').Page} p
      */
-    const waitForHydration = (p) => p.waitForFunction(() => {
-      if (!customElements.get('my-counter')) return false;
-      const c = document.querySelector('my-counter');
-      return !!(c && c.querySelector('output') && c.querySelector('button[aria-label="Increment"]'));
-    }, { timeout: 30000, polling: 50 });
+    const waitForHydration = async (p, which) => {
+      try {
+        await p.waitForFunction(() => {
+          if (!customElements.get('my-counter')) return false;
+          const c = document.querySelector('my-counter');
+          return !!(c && c.querySelector('output') && c.querySelector('button[aria-label="Increment"]'));
+        }, { timeout: 15000, polling: 50 });
+      } catch {
+        // Say what failed and what it most likely means. A bare puppeteer
+        // "Waiting failed: 15000ms exceeded" names neither the page nor the
+        // condition, which is the same diagnostic dead end the old off-by-one
+        // counter assertion was. Report what is actually on the page.
+        const state = await p.evaluate(() => ({
+          defined: !!customElements.get('my-counter'),
+          host: !!document.querySelector('my-counter'),
+          button: !!document.querySelector('my-counter')?.querySelector('button[aria-label="Increment"]'),
+        })).catch(() => null);
+        throw new Error(
+          `${which} page never hydrated <my-counter> within 15s `
+          + `(customElements.define ${state?.defined ? 'ran' : 'DID NOT run'}, `
+          + `host ${state?.host ? 'present' : 'absent'}, `
+          + `increment button ${state?.button ? 'present' : 'absent'}). `
+          + 'If define never ran, the component module was not served: elision may have wrongly dropped it.',
+        );
+      }
+    };
 
     test('the mixed page renders identically on vs off', async () => {
       await page.goto(`${baseUrl}/`, { waitUntil: 'domcontentloaded', timeout: 30000 });
       await offPage.goto(`${offBaseUrl}/`, { waitUntil: 'domcontentloaded', timeout: 30000 });
-      await waitForHydration(page);
-      await waitForHydration(offPage);
+      await waitForHydration(page, 'ON');
+      await waitForHydration(offPage, 'OFF');
       const onSnap = await observableMain(page);
       const offSnap = await observableMain(offPage);
       // The display-only badges (build-stamp, vendor-badge, muted-text) are
@@ -2054,8 +2075,8 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
       // guard for the dangerous direction.
       await page.goto(`${baseUrl}/`, { waitUntil: 'domcontentloaded', timeout: 30000 });
       await offPage.goto(`${offBaseUrl}/`, { waitUntil: 'domcontentloaded', timeout: 30000 });
-      await waitForHydration(page);
-      await waitForHydration(offPage);
+      await waitForHydration(page, 'ON');
+      await waitForHydration(offPage, 'OFF');
 
       const onSeed = await getCounterValue(page);
       assert.equal(onSeed, await getCounterValue(offPage),

--- a/test/e2e/e2e.test.mjs
+++ b/test/e2e/e2e.test.mjs
@@ -2045,14 +2045,34 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
         // "Waiting failed: 15000ms exceeded" names neither the page nor the
         // condition, which is the same diagnostic dead end the old off-by-one
         // counter assertion was. Report what is actually on the page.
-        const state = await p.evaluate(() => {
+        const state = await p.evaluate(async () => {
           const C = customElements.get('my-counter');
+          // Ask the page what actually happened to the module: whether the
+          // browser ever fetched it, and what the server says if we ask again.
+          // Guessing at this from outside has been unproductive.
+          const res = performance.getEntriesByType('resource')
+            .filter((e) => /counter\.ts/.test(e.name))
+            .map((e) => `${e.name.replace(/^https?:\/\/[^/]+/, '')} dur=${Math.round(e.duration)}ms size=${e.transferSize}`);
+          let refetch = 'not attempted';
+          try {
+            const r = await fetch('/components/counter.ts', { cache: 'no-store' });
+            const body = await r.text();
+            refetch = `HTTP ${r.status}, ${body.length} bytes, defines=${/customElements|register\(/.test(body)}`;
+          } catch (e) { refetch = `threw ${e.name}: ${e.message}`; }
+          const boot = [...document.querySelectorAll('script[type="module"]')]
+            .map((s) => (s.src ? `src=${s.src.replace(/^https?:\/\/[^/]+/, '')}` : `inline(${s.textContent.length}b) mentionsCounter=${/counter/.test(s.textContent)}`));
           return {
             defined: !!C,
             host: !!document.querySelector('my-counter'),
             upgraded: !!(C && document.querySelector('my-counter') instanceof C),
+            resourceEntries: res.length ? res : ['(the browser never fetched counter.ts)'],
+            refetch,
+            bootScripts: boot,
+            definedTags: customElements.get ? ['my-counter', 'build-stamp', 'vendor-badge', 'muted-text'].filter((t) => customElements.get(t)) : [],
           };
-        }).catch(() => null);
+        }).catch((e) => ({ evalFailed: String(e && e.message) }));
+        // eslint-disable-next-line no-console
+        console.error(`[e2e diag] ${which} hydration timeout state:`, JSON.stringify(state, null, 2));
         throw new Error(
           `${which} page never upgraded <my-counter> within 15s `
           + `(customElements.define ${state?.defined ? 'ran' : 'DID NOT run'}, `

--- a/test/e2e/e2e.test.mjs
+++ b/test/e2e/e2e.test.mjs
@@ -2007,9 +2007,11 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
     //    12-hour and 24-hour renderings are matched, since which one appears
     //    depends on the runner's default locale, not on anything under test.
     //
-    // 2. <chat-box>'s INNER content. The element itself is still compared (it
-    //    must be present and in the same position on both sides), but its pane
-    //    is a live socket feed and cannot be made equal across the two servers:
+    // 2. <chat-box>'s MESSAGE PANE, and only that. The element, its status
+    //    header and its form (input, Send button) are all still compared, so a
+    //    structural difference in chat-box's rendering is still caught; what is
+    //    dropped is the list of chat lines, which is a live socket feed and
+    //    cannot be made equal across the two servers:
     //
     //      - The server broadcasts every join and leave to all clients
     //        including the joiner, and the handler appends a line per event, so
@@ -2028,25 +2030,45 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
     //    assumed it could: the two sides are genuinely independent populations,
     //    not one lagging the other. So the pane is held out of the comparison.
     //
-    // Holding it out does NOT drop the coverage, because the thing worth
-    // checking about chat-box is that it HYDRATED, not what its feed happened
-    // to say. It connects from connectedCallback, so reaching its connected
-    // state proves its module shipped and the element upgraded, and that is
-    // asserted directly on both sides by waitForChatLive below.
+    //    The participant count in the status header is environmental for the
+    //    same reason and is normalised, while the 'Live ·' around it stays.
+    //
+    // Dropping the pane does not drop the hydration coverage: chat-box connects
+    // from connectedCallback, so reaching its connected state proves its module
+    // shipped and the element upgraded, and waitForChatLive asserts that on
+    // both sides directly.
     const observableMain = (pg) => pg.evaluate(() => {
       const main = document.querySelector('main') || document.body;
       // Work on a clone so the live DOM is untouched and a later snapshot of
       // the same page still sees the real thing.
       const copy = /** @type {HTMLElement} */ (main.cloneNode(true));
-      for (const box of copy.querySelectorAll('chat-box')) box.replaceChildren();
+      // The pane is the middle child of chat-box's wrapper: header div, pane
+      // div, form. Positional because the markup carries no id or data hook.
+      // The count below is asserted so a markup change surfaces as a loud
+      // failure here rather than silently restoring the raw comparison, which
+      // would put the flake back invisibly.
+      const boxes = [...copy.querySelectorAll('chat-box')];
+      const panes = boxes.map((b) => b.querySelector(':scope > div > div:nth-child(2)')).filter(Boolean);
+      if (panes.length !== boxes.length) {
+        return { error: `expected one message pane per <chat-box>, found ${panes.length} for ${boxes.length}; chat-box markup changed and this snapshot no longer excludes its feed` };
+      }
+      for (const pane of panes) pane.replaceChildren();
       const text = (copy.textContent || '')
         .replace(/\d{1,2}:\d{2}:\d{2}\s?[AP]M/gi, 'TIME')
         .replace(/\d{1,2}:\d{2}:\d{2}/g, 'TIME')
+        .replace(/Live · \d+ others? online/g, 'Live · CHAT-COUNT online')
         .replace(/\s+/g, ' ')
         .trim();
       const tags = [...copy.querySelectorAll('*')].map((el) => el.tagName.toLowerCase());
       return { text, tags };
     });
+
+    /** Fail loudly if observableMain could not find what it needs to exclude. */
+    const snapshot = async (pg, which) => {
+      const snap = await observableMain(pg);
+      if (snap.error) throw new Error(`${which} snapshot: ${snap.error}`);
+      return snap;
+    };
 
     /**
      * Wait until the page has actually hydrated, instead of sleeping and hoping.
@@ -2116,23 +2138,25 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
     };
 
     /**
-     * Assert that <chat-box> HYDRATED, by waiting for it to leave its
-     * server-rendered state.
+     * Wait for <chat-box> to reach its connected state.
      *
-     * This is a hydration check, not a settle barrier, and the difference
-     * matters. It keys on the status line reaching 'Live ·', which `onOpen`
-     * sets before the join message arrives, so it deliberately does NOT
-     * guarantee the message pane has stopped moving. That guarantee is not
-     * available at all: the pane accumulates a line per join and leave on that
-     * page's own server, a reconnect appends another, and the two servers have
-     * different client populations by construction. The pane is therefore held
-     * out of the snapshot (see observableMain) instead of waited on.
+     * Precisely what this proves, since an overclaim here would be the same
+     * misattribution this block exists to remove: it keys on the status line
+     * reaching 'Live ·', which `onOpen` sets, so passing means BOTH that the
+     * component hydrated AND that its websocket opened against that page's own
+     * server. Hydration is the necessary half (chat-box calls connectWS from
+     * connectedCallback, so the SSR state cannot be left until its module
+     * shipped and the element upgraded), but a red here is not proof of a
+     * hydration failure on its own: a dev server that never completed the WS
+     * upgrade produces the same timeout with hydration perfectly healthy. The
+     * failure message says both.
      *
-     * What this DOES establish is the part worth asserting. chat-box calls
-     * connectWS from connectedCallback, so leaving the SSR state at all proves
-     * its module shipped and the element upgraded. Running it against both
-     * pages keeps the on-vs-off hydration coverage that holding the pane out of
-     * the snapshot would otherwise have lost.
+     * It is NOT a settle barrier. `onOpen` fires before the join message
+     * arrives, so the message pane is still moving when this returns. That
+     * guarantee is not available at all (the pane accumulates a line per join
+     * and leave on that page's own server, a reconnect appends another, and the
+     * two servers have different client populations by construction), which is
+     * why the pane is held out of the snapshot instead of waited on.
      * @param {import('puppeteer-core').Page} p
      * @param {string} which  'ON' or 'OFF', named in the failure message
      */
@@ -2158,14 +2182,14 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
       await offPage.goto(`${offBaseUrl}/`, { waitUntil: 'domcontentloaded', timeout: 30000 });
       await waitForHydration(page, 'ON');
       await waitForHydration(offPage, 'OFF');
-      // chat-box's pane is held out of the snapshot (it is a live socket feed
-      // over two independent servers), so assert its hydration directly on both
-      // sides instead. Without this the held-out pane would mean an un-hydrated
-      // chat-box went unnoticed.
+      // chat-box's message pane is held out of the snapshot (a live socket feed
+      // over two independent servers), so check its connected state directly on
+      // both sides. Without this an un-hydrated chat-box would go unnoticed,
+      // since the excluded pane is where that would otherwise have shown.
       await waitForChatLive(page, 'ON');
       await waitForChatLive(offPage, 'OFF');
-      const onSnap = await observableMain(page);
-      const offSnap = await observableMain(offPage);
+      const onSnap = await snapshot(page, 'ON');
+      const offSnap = await snapshot(offPage, 'OFF');
       // The display-only badges (build-stamp, vendor-badge, muted-text) are
       // elided ON and shipped OFF, yet their rendered output must match: that
       // identity is exactly why they are safe to elide.
@@ -2238,8 +2262,8 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
       // settled) is the real condition the old sleep stood in for.
       await page.goto(`${baseUrl}/static-info`, { waitUntil: 'load', timeout: 30000 });
       await offPage.goto(`${offBaseUrl}/static-info`, { waitUntil: 'load', timeout: 30000 });
-      const onSnap = await observableMain(page);
-      const offSnap = await observableMain(offPage);
+      const onSnap = await snapshot(page, 'ON');
+      const offSnap = await snapshot(offPage, 'OFF');
       assert.deepEqual(onSnap.tags, offSnap.tags, 'static route tag structure must match on vs off');
       assert.equal(onSnap.text, offSnap.text, 'static route visible text must match on vs off');
     });

--- a/test/e2e/e2e.test.mjs
+++ b/test/e2e/e2e.test.mjs
@@ -2036,11 +2036,14 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
     //    'Reconnecting…' after the socket opened. 'Connecting…', the
     //    never-connected state, is left alone so it still diverges.
     //
-    // Dropping the pane does not drop the hydration coverage, twice over. The
-    // status header stays in the snapshot, so an un-hydrated side reading
-    // 'Connecting…' against a connected side diverges here and fails. And
-    // waitForChatLive checks the connected state on both sides before the
-    // snapshot is taken at all.
+    // Dropping the pane does not drop the hydration coverage, but be precise
+    // about where that coverage actually lives: it is waitForChatLive, which
+    // runs on both sides BEFORE either snapshot and throws if a side is still
+    // in its server-rendered state. The status header is kept in the snapshot,
+    // but it does not add coverage on top of that, because by the time a
+    // snapshot is taken both sides are necessarily connected and chat-box has
+    // no path back, so the header's contribution is the same constant on both
+    // sides.
     const observableMain = (pg) => pg.evaluate(() => {
       const main = document.querySelector('main') || document.body;
       // Work on a clone so the live DOM is untouched and a later snapshot of
@@ -2049,22 +2052,28 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
       // The pane is the middle child of chat-box's wrapper (header div, pane
       // div, form), positional because the markup carries no id or data hook.
       //
-      // The whole SHAPE is asserted, not merely that something was found.
-      // Checking only "did the selector match" is the weaker guard, and it is
-      // green in the likelier failure: insert an element above the header, or
-      // swap header and pane, and a positional selector happily returns the
-      // WRONG element. The count still matches, the header gets emptied, and
-      // the live feed is compared raw again, which is the flake restored
-      // invisibly. Pinning the child tag sequence catches an insertion or a
-      // reorder, not just a deletion.
+      // The pane is identified by CONTENT, not by position. Position cannot do
+      // it: the header and the pane are both plain divs, so neither an index
+      // nor a tag sequence can tell them apart, and swapping the two would
+      // leave any positional guard green while the header got emptied and the
+      // live feed went back into the comparison. That is the flake restored
+      // invisibly, so the identification has to key on something that actually
+      // distinguishes them. The header is the div carrying the status line; the
+      // pane is the other one. Both are asserted, so a markup change fails
+      // loudly here rather than silently reverting the exclusion.
+      const STATUS = /Connecting…|Reconnecting…|Live ·/;
       const panes = [];
       for (const box of copy.querySelectorAll('chat-box')) {
         const wrapper = box.firstElementChild;
-        const shape = wrapper ? [...wrapper.children].map((el) => el.tagName.toLowerCase()) : [];
-        if (!wrapper || shape.join(',') !== 'div,div,form') {
-          return { error: `<chat-box>'s wrapper should hold [div, div, form] (header, message pane, form), found [${shape.join(', ') || 'no wrapper'}]; its markup changed, so this snapshot can no longer identify the live feed to exclude it` };
+        if (!wrapper) return { error: '<chat-box> rendered no wrapper element; its markup changed, so this snapshot can no longer identify the live feed to exclude it' };
+        const divs = [...wrapper.children].filter((el) => el.tagName.toLowerCase() === 'div');
+        const headers = divs.filter((el) => STATUS.test(el.textContent || ''));
+        const rest = divs.filter((el) => !headers.includes(el));
+        if (headers.length !== 1 || rest.length !== 1) {
+          const shape = [...wrapper.children].map((el) => el.tagName.toLowerCase()).join(', ');
+          return { error: `expected <chat-box>'s wrapper to hold exactly one status div and one message pane div, found ${headers.length} status and ${rest.length} other div(s) among [${shape}]; its markup changed, so this snapshot can no longer identify the live feed to exclude it` };
         }
-        panes.push(wrapper.children[1]);
+        panes.push(rest[0]);
       }
       for (const pane of panes) pane.replaceChildren();
       const text = (copy.textContent || '')
@@ -2075,8 +2084,9 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
         // like the participant count: the two pages hold sockets to two
         // independent servers, so one can drop between the wait and the
         // snapshot with no counterpart on the other side. 'Connecting…' is
-        // deliberately NOT collapsed, because that is the never-connected
-        // state and it should still diverge loudly.
+        // left uncollapsed only so this regex says what it means; it is not
+        // reachable here, since waitForChatLive has already failed the test on
+        // any side still showing it.
         .replace(/Live · \d+ others? online|Reconnecting…/g, 'CHAT-CONNECTED')
         .replace(/\s+/g, ' ')
         .trim();
@@ -2205,10 +2215,9 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
       await waitForHydration(offPage, 'OFF');
       // chat-box's message pane is held out of the snapshot (a live socket feed
       // over two independent servers), so check its connected state directly on
-      // both sides. This is belt and braces rather than the only guard: the
-      // status header is still compared, so an un-hydrated side would also
-      // diverge there. Checking it here fails at the point of the problem
-      // instead of as a text mismatch further down.
+      // both sides. This IS the guard for chat-box hydration, not a redundant
+      // one: the snapshot below cannot catch an un-hydrated chat-box, because
+      // reaching it at all means this check already passed on both sides.
       await waitForChatLive(page, 'ON');
       await waitForChatLive(offPage, 'OFF');
       const onSnap = await snapshot(page, 'ON');

--- a/test/e2e/e2e.test.mjs
+++ b/test/e2e/e2e.test.mjs
@@ -1999,123 +1999,56 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
     });
 
     // Snapshot the observable content of <main>: visible text and the ordered
-    // tag structure, with the two sources that are not a function of elision
-    // held out. Getting this boundary right took several passes, so the reasons
-    // are written down rather than left to be rediscovered.
+    // tag structure, with the two things that are not a function of elision
+    // held out.
     //
     // 1. The wall-clock, which ticks between the two snapshots. Both the
     //    12-hour and 24-hour renderings are matched, since which one appears
-    //    depends on the runner's default locale, not on anything under test.
+    //    depends on the runner's default locale.
     //
-    // 2. <chat-box>'s MESSAGE PANE, and only that. The element, its status
-    //    header and its form (input, Send button) are all still compared, so a
-    //    structural difference in chat-box's rendering is still caught; what is
-    //    dropped is the list of chat lines, which is a live socket feed and
-    //    cannot be made equal across the two servers:
+    // 2. Everything INSIDE <chat-box>. The element itself stays in the tag
+    //    list, so a chat-box that failed to render at all is still caught, but
+    //    its contents are dropped wholesale.
     //
-    //      - The server broadcasts every join and leave to all clients
-    //        including the joiner, and the handler appends a line per event, so
-    //        the pane accumulates entries and each adds elements to the tag
-    //        list. The count of those events is a property of the SERVER's
-    //        client population.
-    //      - Those populations are not comparable by construction. The OFF
-    //        server is created fresh and privately in this block's before();
-    //        the ON server is shared with the whole suite and outlives it, so
-    //        anyone else connecting to or leaving it during the window adds a
-    //        line on the ON side with no OFF counterpart.
-    //      - A reconnect re-opens the socket and appends a SECOND join line, so
-    //        even a single page's pane is not a function of its own history.
+    //    That is a blunt cut and it is deliberate. chat-box's pane is a live
+    //    websocket feed, and the two pages hold sockets to two DIFFERENT
+    //    servers: the OFF server is created privately in this block, the ON
+    //    server is shared with the whole suite. Every join and leave on either
+    //    appends a line with no counterpart on the other, and a reconnect
+    //    appends another. Those are independent populations, so no amount of
+    //    waiting converges them. Earlier revisions tried to keep the status
+    //    header while excluding just the pane, which needs the pane identified
+    //    by content or position inside markup that carries neither an id nor a
+    //    data hook; that machinery went wrong repeatedly under review and is
+    //    not worth its weight for a widget this block is not testing.
     //
-    //    Waiting cannot fix any of that, which an earlier revision of this test
-    //    assumed it could: the two sides are genuinely independent populations,
-    //    not one lagging the other. So the pane is held out of the comparison.
-    //
-    //    The status header is kept, but its two CONNECTED renderings are
-    //    collapsed to one token: the participant count is environmental (it
-    //    counts whoever is on that page's own server) and so is a drop to
-    //    'Reconnecting…' after the socket opened. 'Connecting…', the
-    //    never-connected state, is left alone so it still diverges.
-    //
-    // Dropping the pane does not drop the hydration coverage, but be precise
-    // about where that coverage actually lives: it is waitForChatLive, which
-    // the mixed-page test runs on both sides before either snapshot and which
-    // throws if a side is still in its server-rendered state. The status header
-    // is kept in the snapshot but adds nothing on top of that, because once
-    // that wait has passed both sides are connected and chat-box has no path
-    // back, so the header contributes the same constant to each. (The other
-    // caller, the static-route test, runs no such wait and needs none: that
-    // route renders no <chat-box> at all, so none of this applies there.)
+    //    The cost is explicit: chat-box's own hydration and its header/form
+    //    structure are no longer covered here. The counter still covers
+    //    hydration on both sides, which is what this block is for.
     const observableMain = (pg) => pg.evaluate(() => {
       const main = document.querySelector('main') || document.body;
-      // Work on a clone so the live DOM is untouched and a later snapshot of
-      // the same page still sees the real thing.
+      // Clone so the live DOM is untouched and a later snapshot of the same
+      // page still sees the real thing.
       const copy = /** @type {HTMLElement} */ (main.cloneNode(true));
-      // The pane is identified by CONTENT, not by position. Position cannot do
-      // it: the header and the pane are both plain divs, so neither an index
-      // nor a tag sequence can tell them apart, and swapping the two would
-      // leave any positional guard green while the header got emptied and the
-      // live feed went back into the comparison. That is the flake restored
-      // invisibly, so the identification has to key on something that actually
-      // distinguishes them. The header is the div carrying the status line; the
-      // pane is the other one. Both are asserted, so a markup change fails
-      // loudly here rather than silently reverting the exclusion.
-      // Anchored and whole-string: the header renders exactly one status and
-      // nothing else (its dot is an empty span). A substring test would let a
-      // chat MESSAGE containing 'Live ·' look like a header, since message text
-      // is user-supplied and echoed back verbatim by the say broadcast. That
-      // would not mis-select (the real header always matches too, so the guard
-      // below trips on two headers rather than picking wrong) but it would be a
-      // spurious red in the block whose whole point is not producing those.
-      const STATUS = /^(Connecting…|Reconnecting…|Live · \d+ others? online)$/;
-      const panes = [];
-      for (const box of copy.querySelectorAll('chat-box')) {
-        const wrapper = box.firstElementChild;
-        if (!wrapper) return { error: '<chat-box> rendered no wrapper element; its markup changed, so this snapshot can no longer identify the live feed to exclude it' };
-        const divs = [...wrapper.children].filter((el) => el.tagName.toLowerCase() === 'div');
-        const headers = divs.filter((el) => STATUS.test((el.textContent || '').replace(/\s+/g, ' ').trim()));
-        const rest = divs.filter((el) => !headers.includes(el));
-        if (headers.length !== 1 || rest.length !== 1) {
-          const shape = [...wrapper.children].map((el) => el.tagName.toLowerCase()).join(', ');
-          return { error: `expected <chat-box>'s wrapper to hold exactly one status div and one message pane div, found ${headers.length} status and ${rest.length} other div(s) among [${shape}]. Either its markup changed or a chat message's text matched the status line exactly; either way this snapshot can no longer identify the live feed to exclude it` };
-        }
-        panes.push(rest[0]);
-      }
-      for (const pane of panes) pane.replaceChildren();
+      for (const box of copy.querySelectorAll('chat-box')) box.replaceChildren();
       const text = (copy.textContent || '')
         .replace(/\d{1,2}:\d{2}:\d{2}\s?[AP]M/gi, 'TIME')
         .replace(/\d{1,2}:\d{2}:\d{2}/g, 'TIME')
-        // Both CONNECTED states collapse to one token. 'Reconnecting…' is a
-        // socket that dropped after opening, which is environmental exactly
-        // like the participant count: the two pages hold sockets to two
-        // independent servers, so one can drop between the wait and the
-        // snapshot with no counterpart on the other side. 'Connecting…' is
-        // left uncollapsed only so this regex says what it means. It is not
-        // reachable from either caller: the mixed-page test has already failed
-        // in waitForChatLive on any side still showing it, and the static route
-        // renders no <chat-box>.
-        .replace(/Live · \d+ others? online|Reconnecting…/g, 'CHAT-CONNECTED')
         .replace(/\s+/g, ' ')
         .trim();
       const tags = [...copy.querySelectorAll('*')].map((el) => el.tagName.toLowerCase());
       return { text, tags };
     });
 
-    /** Fail loudly if observableMain could not find what it needs to exclude. */
-    const snapshot = async (pg, which) => {
-      const snap = await observableMain(pg);
-      if (snap.error) throw new Error(`${which} snapshot: ${snap.error}`);
-      return snap;
-    };
 
     /**
      * Wait until the page has actually hydrated, instead of sleeping and hoping.
      *
      * The counter is ONE of the page's interactive components, not all of
      * them: <chat-box> is inside <main> too, and <theme-toggle> is in the root
-     * layout. So this alone is not a whole-page hydration barrier, and the
-     * snapshot test pairs it with waitForChatLive below to cover the other
-     * component whose rendering lands inside <main>. Callers that only drive
-     * the counter need this one on its own.
+     * layout. So this is a wait for the component the assertions drive, not a
+     * whole-page hydration barrier. chat-box is not waited on because its
+     * contents are excluded from the snapshot entirely (see observableMain).
      *
      * The signal is that the ELEMENT INSTANCE has been upgraded, tested with
      * `instanceof` against the registered constructor. Nothing weaker works
@@ -2174,60 +2107,13 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
       }
     };
 
-    /**
-     * Wait for <chat-box> to reach its connected state.
-     *
-     * Precisely what this proves, since an overclaim here would be the same
-     * misattribution this block exists to remove: it keys on the status line
-     * reaching 'Live ·', which `onOpen` sets, so passing means BOTH that the
-     * component hydrated AND that its websocket opened against that page's own
-     * server. Hydration is the necessary half (chat-box calls connectWS from
-     * connectedCallback, so the SSR state cannot be left until its module
-     * shipped and the element upgraded), but a red here is not proof of a
-     * hydration failure on its own: a dev server that never completed the WS
-     * upgrade produces the same timeout with hydration perfectly healthy. The
-     * failure message says both.
-     *
-     * It is NOT a settle barrier. `onOpen` fires before the join message
-     * arrives, so the message pane is still moving when this returns. That
-     * guarantee is not available at all (the pane accumulates a line per join
-     * and leave on that page's own server, a reconnect appends another, and the
-     * two servers have different client populations by construction), which is
-     * why the pane is held out of the snapshot instead of waited on.
-     * @param {import('puppeteer-core').Page} p
-     * @param {string} which  'ON' or 'OFF', named in the failure message
-     */
-    const waitForChatLive = async (p, which) => {
-      try {
-        await p.waitForFunction(
-          () => /Live ·/.test(document.querySelector('chat-box')?.textContent || ''),
-          { timeout: 15000, polling: 50 },
-        );
-      } catch (err) {
-        if (!/timeout|Waiting failed/i.test(String(err && err.message))) throw err;
-        const seen = await p.evaluate(() => document.querySelector('chat-box')?.textContent?.trim().slice(0, 80) ?? '(no <chat-box> on the page)').catch(() => null);
-        throw new Error(
-          `${which} page's <chat-box> never reached its connected state within 15s `
-          + `(showing ${seen === null ? 'an unprobeable page' : JSON.stringify(seen)}). `
-          + 'It connects from connectedCallback, so this is either a hydration failure or a websocket that never opened.',
-        );
-      }
-    };
-
     test('the mixed page renders identically on vs off', async () => {
       await page.goto(`${baseUrl}/`, { waitUntil: 'domcontentloaded', timeout: 30000 });
       await offPage.goto(`${offBaseUrl}/`, { waitUntil: 'domcontentloaded', timeout: 30000 });
       await waitForHydration(page, 'ON');
       await waitForHydration(offPage, 'OFF');
-      // chat-box's message pane is held out of the snapshot (a live socket feed
-      // over two independent servers), so check its connected state directly on
-      // both sides. This IS the guard for chat-box hydration, not a redundant
-      // one: the snapshot below cannot catch an un-hydrated chat-box, because
-      // reaching it at all means this check already passed on both sides.
-      await waitForChatLive(page, 'ON');
-      await waitForChatLive(offPage, 'OFF');
-      const onSnap = await snapshot(page, 'ON');
-      const offSnap = await snapshot(offPage, 'OFF');
+      const onSnap = await observableMain(page);
+      const offSnap = await observableMain(offPage);
       // The display-only badges (build-stamp, vendor-badge, muted-text) are
       // elided ON and shipped OFF, yet their rendered output must match: that
       // identity is exactly why they are safe to elide.
@@ -2300,8 +2186,8 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
       // settled) is the real condition the old sleep stood in for.
       await page.goto(`${baseUrl}/static-info`, { waitUntil: 'load', timeout: 30000 });
       await offPage.goto(`${offBaseUrl}/static-info`, { waitUntil: 'load', timeout: 30000 });
-      const onSnap = await snapshot(page, 'ON');
-      const offSnap = await snapshot(offPage, 'OFF');
+      const onSnap = await observableMain(page);
+      const offSnap = await observableMain(offPage);
       assert.deepEqual(onSnap.tags, offSnap.tags, 'static route tag structure must match on vs off');
       assert.equal(onSnap.text, offSnap.text, 'static route visible text must match on vs off');
     });

--- a/test/e2e/e2e.test.mjs
+++ b/test/e2e/e2e.test.mjs
@@ -2038,20 +2038,18 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
     //
     // Dropping the pane does not drop the hydration coverage, but be precise
     // about where that coverage actually lives: it is waitForChatLive, which
-    // runs on both sides BEFORE either snapshot and throws if a side is still
-    // in its server-rendered state. The status header is kept in the snapshot,
-    // but it does not add coverage on top of that, because by the time a
-    // snapshot is taken both sides are necessarily connected and chat-box has
-    // no path back, so the header's contribution is the same constant on both
-    // sides.
+    // the mixed-page test runs on both sides before either snapshot and which
+    // throws if a side is still in its server-rendered state. The status header
+    // is kept in the snapshot but adds nothing on top of that, because once
+    // that wait has passed both sides are connected and chat-box has no path
+    // back, so the header contributes the same constant to each. (The other
+    // caller, the static-route test, runs no such wait and needs none: that
+    // route renders no <chat-box> at all, so none of this applies there.)
     const observableMain = (pg) => pg.evaluate(() => {
       const main = document.querySelector('main') || document.body;
       // Work on a clone so the live DOM is untouched and a later snapshot of
       // the same page still sees the real thing.
       const copy = /** @type {HTMLElement} */ (main.cloneNode(true));
-      // The pane is the middle child of chat-box's wrapper (header div, pane
-      // div, form), positional because the markup carries no id or data hook.
-      //
       // The pane is identified by CONTENT, not by position. Position cannot do
       // it: the header and the pane are both plain divs, so neither an index
       // nor a tag sequence can tell them apart, and swapping the two would
@@ -2061,17 +2059,24 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
       // distinguishes them. The header is the div carrying the status line; the
       // pane is the other one. Both are asserted, so a markup change fails
       // loudly here rather than silently reverting the exclusion.
-      const STATUS = /Connecting…|Reconnecting…|Live ·/;
+      // Anchored and whole-string: the header renders exactly one status and
+      // nothing else (its dot is an empty span). A substring test would let a
+      // chat MESSAGE containing 'Live ·' look like a header, since message text
+      // is user-supplied and echoed back verbatim by the say broadcast. That
+      // would not mis-select (the real header always matches too, so the guard
+      // below trips on two headers rather than picking wrong) but it would be a
+      // spurious red in the block whose whole point is not producing those.
+      const STATUS = /^(Connecting…|Reconnecting…|Live · \d+ others? online)$/;
       const panes = [];
       for (const box of copy.querySelectorAll('chat-box')) {
         const wrapper = box.firstElementChild;
         if (!wrapper) return { error: '<chat-box> rendered no wrapper element; its markup changed, so this snapshot can no longer identify the live feed to exclude it' };
         const divs = [...wrapper.children].filter((el) => el.tagName.toLowerCase() === 'div');
-        const headers = divs.filter((el) => STATUS.test(el.textContent || ''));
+        const headers = divs.filter((el) => STATUS.test((el.textContent || '').replace(/\s+/g, ' ').trim()));
         const rest = divs.filter((el) => !headers.includes(el));
         if (headers.length !== 1 || rest.length !== 1) {
           const shape = [...wrapper.children].map((el) => el.tagName.toLowerCase()).join(', ');
-          return { error: `expected <chat-box>'s wrapper to hold exactly one status div and one message pane div, found ${headers.length} status and ${rest.length} other div(s) among [${shape}]; its markup changed, so this snapshot can no longer identify the live feed to exclude it` };
+          return { error: `expected <chat-box>'s wrapper to hold exactly one status div and one message pane div, found ${headers.length} status and ${rest.length} other div(s) among [${shape}]. Either its markup changed or a chat message's text matched the status line exactly; either way this snapshot can no longer identify the live feed to exclude it` };
         }
         panes.push(rest[0]);
       }
@@ -2084,9 +2089,10 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
         // like the participant count: the two pages hold sockets to two
         // independent servers, so one can drop between the wait and the
         // snapshot with no counterpart on the other side. 'Connecting…' is
-        // left uncollapsed only so this regex says what it means; it is not
-        // reachable here, since waitForChatLive has already failed the test on
-        // any side still showing it.
+        // left uncollapsed only so this regex says what it means. It is not
+        // reachable from either caller: the mixed-page test has already failed
+        // in waitForChatLive on any side still showing it, and the static route
+        // renders no <chat-box>.
         .replace(/Live · \d+ others? online|Reconnecting…/g, 'CHAT-CONNECTED')
         .replace(/\s+/g, ' ')
         .trim();

--- a/test/e2e/e2e.test.mjs
+++ b/test/e2e/e2e.test.mjs
@@ -1981,11 +1981,13 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
       // module graph and there is no residual for a warmup to remove (measured
       // with a 4s delay injected on the counter module, goto took 4076ms and
       // the element was upgraded by the time it returned). And it correlated
-      // with a deterministic CI failure on all three pushes that carried it,
-      // where the OFF page reported customElements.define never running, while
-      // main without it stayed green. Driving extra navigations through the
-      // page under test buys nothing and changes browser-side state the
-      // assertions then depend on.
+      // with CI failures on the pushes that carried it. That attribution did
+      // NOT hold up: the same failure recurs without the warmup, and the cause
+      // is tracked separately as #1228 (the elision-OFF boot intermittently
+      // 404s a module, leaving components inert). What stands is the narrower
+      // point, that driving extra navigations through the page under test buys
+      // nothing measurable and changes browser-side state the assertions then
+      // depend on.
     });
 
     after(async () => {
@@ -1997,12 +1999,25 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
     });
 
     // Snapshot the observable content of <main>: visible text and the ordered
-    // tag structure, with framework hydration internals (comment markers, the
-    // live wall-clock) normalised away, since those are not observable output.
+    // tag structure, with content that is not a function of elision normalised
+    // away, since a difference there says nothing about the property under test.
+    //
+    // Two such sources. The live wall-clock, which ticks between the two
+    // snapshots. And <chat-box>, which sits inside <main> and whose status line
+    // is driven by a WEBSOCKET handshake rather than by hydration: it reads
+    // 'Connecting…' until the socket opens, then 'Live · N others online', and
+    // 'Reconnecting…' after a drop. The two pages talk to two independent
+    // servers, so their sockets open independently and the count is a function
+    // of who is connected, not of what shipped. Comparing that raw makes the
+    // assertion a race on the handshake in one direction and a masked
+    // divergence in the other, and no readiness wait fixes it because the two
+    // sides are genuinely independent. Normalise it for the same reason the
+    // clock is normalised.
     const observableMain = (pg) => pg.evaluate(() => {
       const main = document.querySelector('main') || document.body;
       const text = (main.textContent || '')
         .replace(/\d{1,2}:\d{2}:\d{2}\s?[AP]M/gi, 'TIME')
+        .replace(/Live · \d+ others? online|Connecting…|Reconnecting…/g, 'CHAT-STATUS')
         .replace(/\s+/g, ' ')
         .trim();
       const tags = [...main.querySelectorAll('*')].map((el) => el.tagName.toLowerCase());
@@ -2012,8 +2027,13 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
     /**
      * Wait until the page has actually hydrated, instead of sleeping and hoping.
      *
-     * The counter is the readiness signal because it is the one thing on this
-     * page that is interactive in BOTH builds, so it must come up on either side.
+     * The counter is the readiness signal because it is the component the
+     * assertions below actually drive. It is not the only interactive element
+     * on the page (<chat-box> is here too, and <theme-toggle> is in the root
+     * layout), so this is a wait for the thing under test, not a whole-page
+     * hydration barrier. Content that is not a function of elision, including
+     * chat-box's socket-driven status line, is normalised out of the snapshot
+     * above rather than waited on.
      *
      * The signal is that the ELEMENT INSTANCE has been upgraded, tested with
      * `instanceof` against the registered constructor. Nothing weaker works
@@ -2040,11 +2060,17 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
           const C = customElements.get('my-counter');
           return !!(C && document.querySelector('my-counter') instanceof C);
         }, { timeout: 15000, polling: 50 });
-      } catch {
+      } catch (waitErr) {
         // Say what failed and what it most likely means. A bare puppeteer
         // "Waiting failed: 15000ms exceeded" names neither the page nor the
         // condition, which is the same diagnostic dead end the old off-by-one
         // counter assertion was. Report what is actually on the page.
+        //
+        // Only a genuine timeout is evidence about hydration. waitForFunction
+        // also rejects for reasons that say nothing about it (a detached frame,
+        // a target crash, a navigation mid-wait), so those are rethrown as
+        // themselves rather than relabelled as a suspected elision defect.
+        if (!/timeout|Waiting failed/i.test(String(waitErr && waitErr.message))) throw waitErr;
         const state = await p.evaluate(() => {
           const C = customElements.get('my-counter');
           return {
@@ -2053,13 +2079,16 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
             upgraded: !!(C && document.querySelector('my-counter') instanceof C),
           };
         }).catch(() => null);
-        throw new Error(
-          `${which} page never upgraded <my-counter> within 15s `
-          + `(customElements.define ${state?.defined ? 'ran' : 'DID NOT run'}, `
-          + `host ${state?.host ? 'present' : 'absent'}, `
-          + `instance ${state?.upgraded ? 'upgraded' : 'NOT upgraded'}). `
-          + 'If define never ran, the component module was not served: elision may have wrongly dropped it.',
-        );
+        // Never print an unobserved state as a fact. When the probe itself
+        // fails there is nothing to report, and asserting "define DID NOT run"
+        // from a null reading would send the next reader after the wrong bug.
+        const detail = state
+          ? `customElements.define ${state.defined ? 'ran' : 'DID NOT run'}, `
+            + `host ${state.host ? 'present' : 'absent'}, `
+            + `instance ${state.upgraded ? 'upgraded' : 'NOT upgraded'}`
+            + (state.defined ? '' : '. If define never ran, the component module was not served: elision may have wrongly dropped it')
+          : 'the page could not be probed for its state, so nothing is known beyond the timeout';
+        throw new Error(`${which} page never upgraded <my-counter> within 15s (${detail}).`);
       }
     };
 
@@ -2097,13 +2126,31 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
       // The click sets a reactive property, and that re-render is batched to a
       // microtask, so the new value is NOT readable synchronously. Wait for it
       // to land on both sides rather than sleeping a guessed interval.
-      const settled = (p) => p.waitForFunction(
-        (want) => parseInt(document.querySelector('my-counter')?.querySelector('output')?.textContent.trim(), 10) === want,
-        { timeout: 10000, polling: 25 },
-        onSeed + 1,
-      ).catch(() => {});
-      await settled(page);
-      await settled(offPage);
+      //
+      // A failure here is REPORTED, not swallowed. Discarding it would leave
+      // the run to fall through to the on-vs-off assertion below and fail as
+      // `on=4, off=3`, which is precisely the misleading message this block is
+      // supposed to stop producing: it names a counter mismatch when what
+      // actually happened is that one side never applied its click. This wait
+      // knows which side it was and what the value got stuck on, so it says so.
+      const settled = async (p, which) => {
+        try {
+          await p.waitForFunction(
+            (want) => parseInt(document.querySelector('my-counter')?.querySelector('output')?.textContent.trim(), 10) === want,
+            { timeout: 10000, polling: 25 },
+            onSeed + 1,
+          );
+        } catch (err) {
+          if (!/timeout|Waiting failed/i.test(String(err && err.message))) throw err;
+          const got = await getCounterValue(p).catch(() => null);
+          throw new Error(
+            `${which} counter never reached ${onSeed + 1} within 10s of the click (still ${got}). `
+            + 'The click did not take effect on that side.',
+          );
+        }
+      };
+      await settled(page, 'ON');
+      await settled(offPage, 'OFF');
       const onAfter = await getCounterValue(page);
       const offAfter = await getCounterValue(offPage);
       assert.equal(onAfter, offAfter, `counter increments identically on vs off (on=${onAfter}, off=${offAfter})`);
@@ -2111,9 +2158,13 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
     });
 
     test('the fully-static route renders identically on vs off', async () => {
-      // This route is fully static, so there is no component to hydrate and
-      // nothing to poll for. `load` (every subresource settled) is the real
-      // condition the old sleep was standing in for.
+      // This route ships no component of its OWN (its page module is dropped),
+      // but it is not JS-free: the boot re-emits the root layout's
+      // theme-toggle, which loads @webjsdev/core and enables the client router
+      // (see the docstring on examples/blog/app/static-info/page.ts). Nothing
+      // inside <main> depends on that, which is the scope this asserts on, so
+      // there is no component here to poll for and `load` (every subresource
+      // settled) is the real condition the old sleep stood in for.
       await page.goto(`${baseUrl}/static-info`, { waitUntil: 'load', timeout: 30000 });
       await offPage.goto(`${offBaseUrl}/static-info`, { waitUntil: 'load', timeout: 30000 });
       const onSnap = await observableMain(page);
@@ -3175,20 +3226,30 @@ async function getCounterValue(p) {
  * @param {'Increment'|'Decrement'} label
  */
 async function clickCounterButton(p, label) {
-  // Throw rather than optional-chain into a no-op. A `btn?.click()` on a
-  // not-yet-hydrated page silently does nothing, the counter stays on its seed,
-  // and the failure surfaces one assertion later as a baffling off-by-one
-  // (`on=4, off=3`) instead of naming its own cause. That cost a real
-  // investigation, so make the miss say what it is.
-  const clicked = await p.evaluate((lbl) => {
+  // Refuse to click an element that cannot respond, and say so.
+  //
+  // Checking the BUTTON exists is not that check, which is the trap worth
+  // spelling out: SSR emits the counter's buttons and output, so on a page that
+  // has not hydrated the button is present, `click()` runs, and nothing at all
+  // happens. A helper that only guards `!btn` therefore reports success for the
+  // one failure it was written to catch, and the miss resurfaces an assertion
+  // later as a baffling off-by-one (`on=4, off=3`).
+  //
+  // The element being UPGRADED is the real precondition: before upgrade it is a
+  // plain HTMLElement, after it is an instance of the registered class, and
+  // that is the first moment the `@click` binding exists.
+  const problem = await p.evaluate((lbl) => {
     const counter = document.querySelector('my-counter');
     if (!counter) return 'no <my-counter> on the page';
+    const C = customElements.get('my-counter');
+    if (!C) return 'my-counter is not registered (its module never ran), so the SSR buttons have no listener';
+    if (!(counter instanceof C)) return 'my-counter is registered but this instance is not upgraded yet, so its buttons have no listener';
     const btn = counter.querySelector(`button[aria-label="${lbl}"]`);
-    if (!btn) return `<my-counter> has no button[aria-label="${lbl}"] yet (not hydrated?)`;
+    if (!btn) return `<my-counter> has no button[aria-label="${lbl}"] (SSR markup changed?)`;
     btn.click();
     return null;
   }, label);
-  if (clicked) throw new Error(`clickCounterButton(${label}): ${clicked}`);
+  if (problem) throw new Error(`clickCounterButton(${label}): ${problem}`);
 }
 
 /**

--- a/test/e2e/e2e.test.mjs
+++ b/test/e2e/e2e.test.mjs
@@ -1999,25 +1999,32 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
     });
 
     // Snapshot the observable content of <main>: visible text and the ordered
-    // tag structure, with content that is not a function of elision normalised
-    // away, since a difference there says nothing about the property under test.
+    // tag structure. Only the wall-clock and the chat participant COUNT are
+    // normalised away, and the distinction matters, so it is worth stating.
     //
-    // Two such sources. The live wall-clock, which ticks between the two
-    // snapshots. And <chat-box>, which sits inside <main> and whose status line
-    // is driven by a WEBSOCKET handshake rather than by hydration: it reads
-    // 'Connecting…' until the socket opens, then 'Live · N others online', and
-    // 'Reconnecting…' after a drop. The two pages talk to two independent
-    // servers, so their sockets open independently and the count is a function
-    // of who is connected, not of what shipped. Comparing that raw makes the
-    // assertion a race on the handshake in one direction and a masked
-    // divergence in the other, and no readiness wait fixes it because the two
-    // sides are genuinely independent. Normalise it for the same reason the
-    // clock is normalised.
+    // <chat-box> sits inside <main> and it is NOT independent of what this
+    // block tests. It calls connectWS from connectedCallback, so leaving its
+    // SSR 'Connecting…' state requires its module to have shipped and the
+    // element to have upgraded. Its rendered state is therefore a real signal
+    // that chat-box hydrated on both sides, and erasing it would throw away
+    // coverage in the exact test that exists to compare hydration.
+    //
+    // What is genuinely not a function of elision is the participant count:
+    // each page talks to its own server, so `Live · N others online` counts
+    // whoever happens to be connected to THAT server. The digits are
+    // normalised; the 'Live' that proves hydration is kept.
+    //
+    // The socket handshake is handled by waiting (waitForChatLive below), not
+    // by normalising. Waiting is what makes both sides comparable: the open
+    // also broadcasts a join to every client including the joiner, which adds
+    // a 'someone joined' line and its own element, changing BOTH the text and
+    // the tags. A regex over the status line alone would have left that race
+    // untouched in the tags half.
     const observableMain = (pg) => pg.evaluate(() => {
       const main = document.querySelector('main') || document.body;
       const text = (main.textContent || '')
         .replace(/\d{1,2}:\d{2}:\d{2}\s?[AP]M/gi, 'TIME')
-        .replace(/Live · \d+ others? online|Connecting…|Reconnecting…/g, 'CHAT-STATUS')
+        .replace(/Live · \d+ others? online/g, 'Live · CHAT-COUNT online')
         .replace(/\s+/g, ' ')
         .trim();
       const tags = [...main.querySelectorAll('*')].map((el) => el.tagName.toLowerCase());
@@ -2027,13 +2034,12 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
     /**
      * Wait until the page has actually hydrated, instead of sleeping and hoping.
      *
-     * The counter is the readiness signal because it is the component the
-     * assertions below actually drive. It is not the only interactive element
-     * on the page (<chat-box> is here too, and <theme-toggle> is in the root
-     * layout), so this is a wait for the thing under test, not a whole-page
-     * hydration barrier. Content that is not a function of elision, including
-     * chat-box's socket-driven status line, is normalised out of the snapshot
-     * above rather than waited on.
+     * The counter is ONE of the page's interactive components, not all of
+     * them: <chat-box> is inside <main> too, and <theme-toggle> is in the root
+     * layout. So this alone is not a whole-page hydration barrier, and the
+     * snapshot test pairs it with waitForChatLive below to cover the other
+     * component whose rendering lands inside <main>. Callers that only drive
+     * the counter need this one on its own.
      *
      * The signal is that the ELEMENT INSTANCE has been upgraded, tested with
      * `instanceof` against the registered constructor. Nothing weaker works
@@ -2092,11 +2098,51 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
       }
     };
 
+    /**
+     * Wait until <chat-box> has settled into its connected state.
+     *
+     * The socket open is what makes the two pages comparable, and it changes
+     * more than the status line: the server broadcasts the join to every
+     * client INCLUDING the joiner, so the message pane flips from its empty
+     * placeholder to a 'someone joined' entry, adding an element. Both the text
+     * and the tag structure move. Snapshotting before that has landed on both
+     * sides compares one settled page against one unsettled page.
+     *
+     * This is a wait rather than a normalisation on purpose: chat-box connects
+     * from connectedCallback, so reaching this state proves it hydrated, which
+     * is a signal this block exists to check. Only the participant count is
+     * normalised out of the snapshot, since that counts whoever is connected to
+     * that page's own server.
+     * @param {import('puppeteer-core').Page} p
+     * @param {string} which  'ON' or 'OFF', named in the failure message
+     */
+    const waitForChatLive = async (p, which) => {
+      try {
+        await p.waitForFunction(
+          () => /Live ·/.test(document.querySelector('chat-box')?.textContent || ''),
+          { timeout: 15000, polling: 50 },
+        );
+      } catch (err) {
+        if (!/timeout|Waiting failed/i.test(String(err && err.message))) throw err;
+        const seen = await p.evaluate(() => document.querySelector('chat-box')?.textContent?.trim().slice(0, 80) ?? '(no <chat-box> on the page)').catch(() => null);
+        throw new Error(
+          `${which} page's <chat-box> never reached its connected state within 15s `
+          + `(showing ${seen === null ? 'an unprobeable page' : JSON.stringify(seen)}). `
+          + 'It connects from connectedCallback, so this is either a hydration failure or a websocket that never opened.',
+        );
+      }
+    };
+
     test('the mixed page renders identically on vs off', async () => {
       await page.goto(`${baseUrl}/`, { waitUntil: 'domcontentloaded', timeout: 30000 });
       await offPage.goto(`${offBaseUrl}/`, { waitUntil: 'domcontentloaded', timeout: 30000 });
       await waitForHydration(page, 'ON');
       await waitForHydration(offPage, 'OFF');
+      // <chat-box> renders inside <main>, so its connected state has to land on
+      // BOTH sides before the snapshot, or this compares a settled page against
+      // an unsettled one.
+      await waitForChatLive(page, 'ON');
+      await waitForChatLive(offPage, 'OFF');
       const onSnap = await observableMain(page);
       const offSnap = await observableMain(offPage);
       // The display-only badges (build-stamp, vendor-badge, muted-text) are
@@ -2136,7 +2182,11 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
       const settled = async (p, which) => {
         try {
           await p.waitForFunction(
-            (want) => parseInt(document.querySelector('my-counter')?.querySelector('output')?.textContent.trim(), 10) === want,
+            // Every hop optional-chained: a missing <output> must make the
+            // predicate FALSE (so the wait times out and reports which side
+            // stalled), not throw a TypeError that the handler below cannot
+            // recognise as a timeout and rethrows raw, unlabelled.
+            (want) => parseInt(document.querySelector('my-counter')?.querySelector('output')?.textContent?.trim() ?? '', 10) === want,
             { timeout: 10000, polling: 25 },
             onSeed + 1,
           );
@@ -3205,7 +3255,8 @@ describe('E2E: form actions (no-JS + enhanced)', { skip: !process.env.WEBJS_E2E 
 
 /**
  * Get the current counter display value.
- * The counter is a shadow DOM component: <my-counter> → shadowRoot → <output>.
+ * The counter is a LIGHT DOM component, so its <output> is a child of the host
+ * itself and there is no shadow root in the path.
  * @param {import('puppeteer-core').Page} p
  * @returns {Promise<number|null>}
  */

--- a/test/e2e/e2e.test.mjs
+++ b/test/e2e/e2e.test.mjs
@@ -1973,23 +1973,19 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
       offServerProcess = await startBlog(offPort, { WEBJS_ELIDE: '0' });
       offPage = await browser.newPage();
 
-      // WARM the OFF server before anything is timed against it.
-      //
-      // This is the whole reason the block used to flake, and the asymmetry is
-      // easy to miss: the ON server has been serving the rest of this suite for
-      // ~100 tests, so its dev-mode on-demand module transformation was paid
-      // long ago, while the OFF server is brand new here and its very FIRST
-      // request is the assertion. Measured on this machine, that first request
-      // costs 11.5s against 610ms once warm, and OFF is the expensive side
-      // because WEBJS_ELIDE=0 ships 13 modulepreloads to the ON build's 6. So
-      // the OFF page could still be fetching modules when a timed wait expired,
-      // leaving it un-hydrated, which is why OFF was always the failing side.
-      //
-      // Pay that cost here, where nothing is being measured. `waitForHydration`
-      // below then guards the residual, so neither the warmup nor the waits are
-      // load-bearing on their own.
-      await offPage.goto(`${offBaseUrl}/`, { waitUntil: 'load', timeout: 60000 });
-      await offPage.goto(`${offBaseUrl}/about`, { waitUntil: 'load', timeout: 60000 });
+      // No browser-side warmup here on purpose. An earlier revision navigated
+      // offPage twice before the tests, to pay the cold dev server's on-demand
+      // transform cost off the clock. Two things killed that idea. Its premise
+      // was wrong: module scripts are deferred and DOMContentLoaded waits for
+      // deferred scripts, so goto(domcontentloaded) already absorbs the whole
+      // module graph and there is no residual for a warmup to remove (measured
+      // with a 4s delay injected on the counter module, goto took 4076ms and
+      // the element was upgraded by the time it returned). And it correlated
+      // with a deterministic CI failure on all three pushes that carried it,
+      // where the OFF page reported customElements.define never running, while
+      // main without it stayed green. Driving extra navigations through the
+      // page under test buys nothing and changes browser-side state the
+      // assertions then depend on.
     });
 
     after(async () => {

--- a/test/e2e/e2e.test.mjs
+++ b/test/e2e/e2e.test.mjs
@@ -2030,33 +2030,54 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
     //    assumed it could: the two sides are genuinely independent populations,
     //    not one lagging the other. So the pane is held out of the comparison.
     //
-    //    The participant count in the status header is environmental for the
-    //    same reason and is normalised, while the 'Live ·' around it stays.
+    //    The status header is kept, but its two CONNECTED renderings are
+    //    collapsed to one token: the participant count is environmental (it
+    //    counts whoever is on that page's own server) and so is a drop to
+    //    'Reconnecting…' after the socket opened. 'Connecting…', the
+    //    never-connected state, is left alone so it still diverges.
     //
-    // Dropping the pane does not drop the hydration coverage: chat-box connects
-    // from connectedCallback, so reaching its connected state proves its module
-    // shipped and the element upgraded, and waitForChatLive asserts that on
-    // both sides directly.
+    // Dropping the pane does not drop the hydration coverage, twice over. The
+    // status header stays in the snapshot, so an un-hydrated side reading
+    // 'Connecting…' against a connected side diverges here and fails. And
+    // waitForChatLive checks the connected state on both sides before the
+    // snapshot is taken at all.
     const observableMain = (pg) => pg.evaluate(() => {
       const main = document.querySelector('main') || document.body;
       // Work on a clone so the live DOM is untouched and a later snapshot of
       // the same page still sees the real thing.
       const copy = /** @type {HTMLElement} */ (main.cloneNode(true));
-      // The pane is the middle child of chat-box's wrapper: header div, pane
-      // div, form. Positional because the markup carries no id or data hook.
-      // The count below is asserted so a markup change surfaces as a loud
-      // failure here rather than silently restoring the raw comparison, which
-      // would put the flake back invisibly.
-      const boxes = [...copy.querySelectorAll('chat-box')];
-      const panes = boxes.map((b) => b.querySelector(':scope > div > div:nth-child(2)')).filter(Boolean);
-      if (panes.length !== boxes.length) {
-        return { error: `expected one message pane per <chat-box>, found ${panes.length} for ${boxes.length}; chat-box markup changed and this snapshot no longer excludes its feed` };
+      // The pane is the middle child of chat-box's wrapper (header div, pane
+      // div, form), positional because the markup carries no id or data hook.
+      //
+      // The whole SHAPE is asserted, not merely that something was found.
+      // Checking only "did the selector match" is the weaker guard, and it is
+      // green in the likelier failure: insert an element above the header, or
+      // swap header and pane, and a positional selector happily returns the
+      // WRONG element. The count still matches, the header gets emptied, and
+      // the live feed is compared raw again, which is the flake restored
+      // invisibly. Pinning the child tag sequence catches an insertion or a
+      // reorder, not just a deletion.
+      const panes = [];
+      for (const box of copy.querySelectorAll('chat-box')) {
+        const wrapper = box.firstElementChild;
+        const shape = wrapper ? [...wrapper.children].map((el) => el.tagName.toLowerCase()) : [];
+        if (!wrapper || shape.join(',') !== 'div,div,form') {
+          return { error: `<chat-box>'s wrapper should hold [div, div, form] (header, message pane, form), found [${shape.join(', ') || 'no wrapper'}]; its markup changed, so this snapshot can no longer identify the live feed to exclude it` };
+        }
+        panes.push(wrapper.children[1]);
       }
       for (const pane of panes) pane.replaceChildren();
       const text = (copy.textContent || '')
         .replace(/\d{1,2}:\d{2}:\d{2}\s?[AP]M/gi, 'TIME')
         .replace(/\d{1,2}:\d{2}:\d{2}/g, 'TIME')
-        .replace(/Live · \d+ others? online/g, 'Live · CHAT-COUNT online')
+        // Both CONNECTED states collapse to one token. 'Reconnecting…' is a
+        // socket that dropped after opening, which is environmental exactly
+        // like the participant count: the two pages hold sockets to two
+        // independent servers, so one can drop between the wait and the
+        // snapshot with no counterpart on the other side. 'Connecting…' is
+        // deliberately NOT collapsed, because that is the never-connected
+        // state and it should still diverge loudly.
+        .replace(/Live · \d+ others? online|Reconnecting…/g, 'CHAT-CONNECTED')
         .replace(/\s+/g, ' ')
         .trim();
       const tags = [...copy.querySelectorAll('*')].map((el) => el.tagName.toLowerCase());
@@ -2184,8 +2205,10 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
       await waitForHydration(offPage, 'OFF');
       // chat-box's message pane is held out of the snapshot (a live socket feed
       // over two independent servers), so check its connected state directly on
-      // both sides. Without this an un-hydrated chat-box would go unnoticed,
-      // since the excluded pane is where that would otherwise have shown.
+      // both sides. This is belt and braces rather than the only guard: the
+      // status header is still compared, so an un-hydrated side would also
+      // diverge there. Checking it here fails at the point of the problem
+      // instead of as a text mismatch further down.
       await waitForChatLive(page, 'ON');
       await waitForChatLive(offPage, 'OFF');
       const onSnap = await snapshot(page, 'ON');

--- a/test/e2e/e2e.test.mjs
+++ b/test/e2e/e2e.test.mjs
@@ -1972,6 +1972,24 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
       offBaseUrl = `http://localhost:${offPort}`;
       offServerProcess = await startBlog(offPort, { WEBJS_ELIDE: '0' });
       offPage = await browser.newPage();
+
+      // WARM the OFF server before anything is timed against it.
+      //
+      // This is the whole reason the block used to flake, and the asymmetry is
+      // easy to miss: the ON server has been serving the rest of this suite for
+      // ~100 tests, so its dev-mode on-demand module transformation was paid
+      // long ago, while the OFF server is brand new here and its very FIRST
+      // request is the assertion. Measured on this machine, that first request
+      // costs 11.5s against 610ms once warm, and OFF is the expensive side
+      // because WEBJS_ELIDE=0 ships 13 modulepreloads to the ON build's 6. So
+      // the OFF page could still be fetching modules when a timed wait expired,
+      // leaving it un-hydrated, which is why OFF was always the failing side.
+      //
+      // Pay that cost here, where nothing is being measured. `waitForHydration`
+      // below then guards the residual, so neither the warmup nor the waits are
+      // load-bearing on their own.
+      await offPage.goto(`${offBaseUrl}/`, { waitUntil: 'load', timeout: 60000 });
+      await offPage.goto(`${offBaseUrl}/about`, { waitUntil: 'load', timeout: 60000 });
     });
 
     after(async () => {
@@ -1995,10 +2013,29 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
       return { text, tags };
     });
 
+    /**
+     * Wait until the page has actually hydrated, instead of sleeping and hoping.
+     *
+     * The counter is the readiness signal because it is the one thing on this
+     * page that is interactive in BOTH builds, so it is the last thing to come
+     * up and it must come up on either side. `whenDefined` alone is not enough:
+     * the custom element can be registered a tick before the instance is
+     * upgraded and its buttons rendered, and it is the buttons the assertions
+     * need. `my-counter` is a LIGHT-DOM component, so its children sit on the
+     * element itself and there is no shadow root to look inside.
+     * @param {import('puppeteer-core').Page} p
+     */
+    const waitForHydration = (p) => p.waitForFunction(() => {
+      if (!customElements.get('my-counter')) return false;
+      const c = document.querySelector('my-counter');
+      return !!(c && c.querySelector('output') && c.querySelector('button[aria-label="Increment"]'));
+    }, { timeout: 30000, polling: 50 });
+
     test('the mixed page renders identically on vs off', async () => {
-      await page.goto(`${baseUrl}/`, { waitUntil: 'domcontentloaded', timeout: 15000 });
-      await offPage.goto(`${offBaseUrl}/`, { waitUntil: 'domcontentloaded', timeout: 15000 });
-      await sleep(2500); // allow hydration on both
+      await page.goto(`${baseUrl}/`, { waitUntil: 'domcontentloaded', timeout: 30000 });
+      await offPage.goto(`${offBaseUrl}/`, { waitUntil: 'domcontentloaded', timeout: 30000 });
+      await waitForHydration(page);
+      await waitForHydration(offPage);
       const onSnap = await observableMain(page);
       const offSnap = await observableMain(offPage);
       // The display-only badges (build-stamp, vendor-badge, muted-text) are
@@ -2015,15 +2052,26 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
       // in both. If elision ever wrongly dropped its module on the ON side,
       // the ON counter would not increment and this assertion fails: the live
       // guard for the dangerous direction.
-      await page.goto(`${baseUrl}/`, { waitUntil: 'domcontentloaded', timeout: 15000 });
-      await offPage.goto(`${offBaseUrl}/`, { waitUntil: 'domcontentloaded', timeout: 15000 });
-      await sleep(2500);
+      await page.goto(`${baseUrl}/`, { waitUntil: 'domcontentloaded', timeout: 30000 });
+      await offPage.goto(`${offBaseUrl}/`, { waitUntil: 'domcontentloaded', timeout: 30000 });
+      await waitForHydration(page);
+      await waitForHydration(offPage);
 
-      assert.equal(await getCounterValue(page), await getCounterValue(offPage),
+      const onSeed = await getCounterValue(page);
+      assert.equal(onSeed, await getCounterValue(offPage),
         'counter seeds to the same value on vs off');
       await clickCounterButton(page, 'Increment');
       await clickCounterButton(offPage, 'Increment');
-      await sleep(300);
+      // The click sets a reactive property, and that re-render is batched to a
+      // microtask, so the new value is NOT readable synchronously. Wait for it
+      // to land on both sides rather than sleeping a guessed interval.
+      const settled = (p) => p.waitForFunction(
+        (want) => parseInt(document.querySelector('my-counter')?.querySelector('output')?.textContent.trim(), 10) === want,
+        { timeout: 10000, polling: 25 },
+        onSeed + 1,
+      ).catch(() => {});
+      await settled(page);
+      await settled(offPage);
       const onAfter = await getCounterValue(page);
       const offAfter = await getCounterValue(offPage);
       assert.equal(onAfter, offAfter, `counter increments identically on vs off (on=${onAfter}, off=${offAfter})`);
@@ -2031,9 +2079,11 @@ describe('E2E: Blog example', { skip: !process.env.WEBJS_E2E && 'set WEBJS_E2E=1
     });
 
     test('the fully-static route renders identically on vs off', async () => {
-      await page.goto(`${baseUrl}/static-info`, { waitUntil: 'domcontentloaded', timeout: 15000 });
-      await offPage.goto(`${offBaseUrl}/static-info`, { waitUntil: 'domcontentloaded', timeout: 15000 });
-      await sleep(1500);
+      // This route is fully static, so there is no component to hydrate and
+      // nothing to poll for. `load` (every subresource settled) is the real
+      // condition the old sleep was standing in for.
+      await page.goto(`${baseUrl}/static-info`, { waitUntil: 'load', timeout: 30000 });
+      await offPage.goto(`${offBaseUrl}/static-info`, { waitUntil: 'load', timeout: 30000 });
       const onSnap = await observableMain(page);
       const offSnap = await observableMain(offPage);
       assert.deepEqual(onSnap.tags, offSnap.tags, 'static route tag structure must match on vs off');
@@ -3093,11 +3143,20 @@ async function getCounterValue(p) {
  * @param {'Increment'|'Decrement'} label
  */
 async function clickCounterButton(p, label) {
-  await p.evaluate((lbl) => {
+  // Throw rather than optional-chain into a no-op. A `btn?.click()` on a
+  // not-yet-hydrated page silently does nothing, the counter stays on its seed,
+  // and the failure surfaces one assertion later as a baffling off-by-one
+  // (`on=4, off=3`) instead of naming its own cause. That cost a real
+  // investigation, so make the miss say what it is.
+  const clicked = await p.evaluate((lbl) => {
     const counter = document.querySelector('my-counter');
-    const btn = counter?.querySelector(`button[aria-label="${lbl}"]`);
-    btn?.click();
+    if (!counter) return 'no <my-counter> on the page';
+    const btn = counter.querySelector(`button[aria-label="${lbl}"]`);
+    if (!btn) return `<my-counter> has no button[aria-label="${lbl}"] yet (not hydrated?)`;
+    btn.click();
+    return null;
   }, label);
+  if (clicked) throw new Error(`clickCounterButton(${label}): ${clicked}`);
 }
 
 /**


### PR DESCRIPTION
Closes #1220

The `differential elision (#181)` block reported its failures in a way that pointed away from the cause, and several of its guards could not observe the thing they named. This makes the block honest. **It does not stop the block going red**, see "What this does not do".

## The misdirection

The block failed with:

```
counter increments identically on vs off (on=4, off=3)
```

which reads as a counting bug. Nothing counted wrong. SSR emits the counter's full inner markup before any JavaScript runs:

```html
<my-counter count="3" data-wj-host><!--webjs-hydrate-->
  <button aria-label="Decrement">...<output>3</output>
  <button aria-label="Increment">...
```

So a click landing before the component's module executes hits a real button with **no listener attached**, and the counter stays on its seed. The seed is 3. Hence `off=3`, three assertions away from the actual problem.

## Changes

1. **Wait for the element to be UPGRADED** (`instanceof` against the registered constructor) rather than for markup the server already sent. Anything weaker is satisfied before hydration begins.
2. **`clickCounterButton` refuses to click an element that cannot respond**, and says which of registered / upgraded failed. Checking the button exists is NOT that check, for the reason above; an earlier revision of this PR made exactly that mistake.
3. **The post-click wait reports its own failure** instead of swallowing it and letting the run fall through to the `on=4, off=3` message.
4. **Everything inside `<chat-box>` is dropped from the snapshot**, in one line. The element stays in the tag list, so a chat-box that failed to render at all is still caught. This is deliberately blunt: its pane is a live websocket feed and the two pages hold sockets to two DIFFERENT servers (the OFF server is private to this block, the ON server is shared with the whole suite), so joins and leaves land on one side with no counterpart and no wait converges them. Earlier revisions tried to keep the status header and exclude only the pane; that needs the pane identified inside markup carrying neither an id nor a data hook, and it went wrong repeatedly under review. The cost is stated in the code: chat-box's own hydration and its header/form structure are not covered here. The counter still covers hydration on both sides, which is what this block is for.
5. **The hydration diagnostic no longer states unobserved facts.** When its probe fails it says so rather than printing "define DID NOT run"; and a non-timeout rejection (detached frame, target crash) is rethrown as itself rather than relabelled a suspected elision defect.
6. Every fixed `sleep()` in the block is replaced by the condition it stood in for.

## What this does NOT do

**It does not make CI green.** By this PR's own measurement, module scripts are deferred and DOMContentLoaded waits for them, so on a healthy run the upgrade wait is already satisfied when `goto` resolves. The only run it changes is the one where the module never executes at all, which is **#1228** (the elision-OFF boot intermittently 404s a module, leaving components inert) and is unfixed.

So the block still reds at the same rate. What changes is that it now reds with

```
OFF page never upgraded <my-counter> within 15s
(customElements.define DID NOT run, host present, instance NOT upgraded)
```

instead of an off-by-one. That diagnosis is what led to #1228 being findable at all.

An earlier revision also warmed the OFF server in `before()`; it was removed (its premise was disproved by the DOMContentLoaded measurement) and the current `before()` documents why.

## Test plan

- Counterfactual: with the counter module blocked, the old fixed wait reports `counter 3 -> 3` silently, and this version fails naming the cause.
- `WEBJS_E2E=1 node --test test/e2e/e2e.test.mjs`: the elision block is 3/3, repeatedly, including pinned to two cores.
- All five other `clickCounterButton` callers pass; the new throw is a no-op where the counter is already hydrated.
- Note: 5 unrelated `submitter` tests fail in my local worktree on `main`'s own copy of this file too (verified by running `origin/main:test/e2e/e2e.test.mjs` in the same tree), so they are environmental here, not from this diff. They pass on CI.

## Doc surfaces

- `AGENTS.md`, skill references, docs site, MCP, editor plugins, scaffold templates, marketing copy: N/A, test-only diff with no public surface change.
- Bun parity: N/A, no runtime-sensitive source touched.
- Changelog: prefixed `test:` on purpose, so it generates no entry.
