### PR TITLE
docs: make the canonical optimistic() reducer snippets pure

### DIFF
--- a/.agents/skills/webjs/references/optimistic-ui.md
+++ b/.agents/skills/webjs/references/optimistic-ui.md
@@ -78,7 +78,7 @@ class TodoList extends WebComponent({
 TodoList.register('todo-list');
 ```
 
-**Auto-release is the whole point.** Pass the action's promise as the second argument to `.add(payload, promise)`, and the update auto-releases the moment that promise settles (resolve OR reject). It uses `.finally()`, with a `.then()` fallback for thenables that lack `.finally`. No try-catch, no manual rollback, no temp-ID bookkeeping. On success you reconcile the authoritative row from `result.data` (as above); on failure the optimistic entry simply drops when the promise rejects.
+**Auto-release is the whole point.** Pass the action's promise as the second argument to `.add(payload, promise)`, and the update auto-releases the moment that promise settles (resolve OR reject). It uses `.finally()`, with a `.then()` fallback for thenables that lack `.finally`. No try-catch, no manual rollback, no reconciling a temp id against the real one. The handler mints a temp id for the pending row, but nothing tracks it afterwards: the overlay drops whole when the promise settles, and the authoritative row arrives from `result.data`. On failure the optimistic entry simply drops when the promise rejects.
 
 - Multiple `.add()` calls stack independently. Each carries its own release by ID, so overlapping in-flight mutations do not clobber one another.
 - When `update` is omitted, the payload REPLACES the state directly (`Action = State`), matching the simple `useOptimistic(setState)` pattern.

--- a/.agents/skills/webjs/references/optimistic-ui.md
+++ b/.agents/skills/webjs/references/optimistic-ui.md
@@ -17,6 +17,8 @@ Read this when a mutation should feel instant, when the client can predict the r
 
 `optimistic(host, { source, update })` returns an `OptimisticState<State, Action>` with a `.value` getter and an `.add(payload, promise?)` method. The `source` reads the authoritative state (usually a reactive prop). The `update` reducer transforms that state with each payload. Calling `.add()` pushes an update and schedules a re-render, so `.value` reflects the optimistic state on the next paint.
 
+**The reducer must be pure.** `.value` re-folds the whole queue on every read, so `update` runs again on each render rather than once per `.add()`. Anything it MINTS is therefore minted per render. Mint a temp id in the handler and pass it in the payload. A `crypto.randomUUID()` inside the reducer gives the pending row a different id on every read, which breaks a keyed list and anything else treating that id as stable.
+
 ```ts
 import { WebComponent, prop, optimistic, html } from '@webjsdev/core';
 import { createTodo } from '#modules/todos/actions/create-todo.server.ts';
@@ -26,15 +28,18 @@ class TodoList extends WebComponent({
 }) {
   private optimisticTodos = optimistic(this, {
     source: () => this.todos,
-    update: (state, title: string) => [
+    // KEEP THIS REDUCER PURE. `.value` re-folds every queued update on EVERY
+    // read, not once per `.add()`, so anything minted in here is minted again
+    // on each render. A `crypto.randomUUID()` here would hand the pending row
+    // a NEW id per render, and a keyed list (`repeat(todos, t => t.id, ...)`)
+    // would tear the row down and rebuild it every update, losing focus, any
+    // in-progress transition, and DOM state. Mint the temp id in the handler
+    // and carry it in the payload, so it is stable for the life of the row.
+    update: (state, add: { tempId: string; title: string }) => [
       ...state,
-      // A client-only placeholder id for the pending row. The real id arrives
-      // from the server on reconcile, when this row is dropped. No cast is
-      // needed because `Todo['id']` is a string here (the schema uses a uuid
-      // primary key). Against an auto-increment integer id there is no honest
-      // client-side value, so model the temp row instead (an optional id, or a
-      // `tempId` the reducer keys on) rather than casting one in.
-      { id: crypto.randomUUID(), title, completed: false, createdAt: new Date(), pending: true },
+      // `createdAt` is rebuilt per read too. That is tolerable only because
+      // nothing keys on it; put it in the payload as well if anything does.
+      { id: add.tempId, title: add.title, completed: false, createdAt: new Date(), pending: true },
     ],
   });
 
@@ -44,8 +49,13 @@ class TodoList extends WebComponent({
     if (!title) return;
     (e.target as HTMLFormElement).reset();
 
+    // Minted ONCE here, not in the reducer. `Todo['id']` is a string (a uuid
+    // primary key), so no cast is needed. Against an auto-increment integer
+    // id there is no honest client-side value, so model the temp row instead
+    // (an optional id, or a `tempId` the row keys on) rather than casting.
+    const tempId = crypto.randomUUID();
     const promise = createTodo({ title });
-    this.optimisticTodos.add(title, promise);
+    this.optimisticTodos.add({ tempId, title }, promise);
 
     const result = await promise;
     if (result.success && result.data) {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -377,11 +377,15 @@ class TodoList extends WebComponent({
 }) {
   private optimisticTodos = optimistic(this, {
     source: () => this.todos,
-    update: (state, title: string) => [
+    // KEEP THIS REDUCER PURE. `.value` re-folds every queued update on EVERY
+    // read, so a `crypto.randomUUID()` here would mint a NEW id per render and
+    // a keyed list would tear the pending row down on each update. Mint the
+    // temp id in the handler and carry it in the payload.
+    update: (state, add: { tempId: string; title: string }) => [
       ...state,
-      // No cast needed: `Todo['id']` is a string (a uuid primary key). Against
-      // an auto-increment integer id, model the temp row instead of casting.
-      { id: crypto.randomUUID(), title, completed: false, createdAt: new Date(), pending: true },
+      // `createdAt` is rebuilt per read too, tolerable only because nothing
+      // keys on it. Put it in the payload as well if anything does.
+      { id: add.tempId, title: add.title, completed: false, createdAt: new Date(), pending: true },
     ],
   });
 
@@ -391,8 +395,12 @@ class TodoList extends WebComponent({
     if (!title) return;
     (e.target as HTMLFormElement).reset();
 
+    // Minted ONCE here, not in the reducer. No cast needed: `Todo['id']` is a
+    // string (a uuid primary key). Against an auto-increment integer id, model
+    // the temp row instead of casting.
+    const tempId = crypto.randomUUID();
     const promise = createTodo({ title });
-    this.optimisticTodos.add(title, promise);
+    this.optimisticTodos.add({ tempId, title }, promise);
 
     const result = await promise;
     if (result.success && result.data) {
@@ -413,7 +421,9 @@ class TodoList extends WebComponent({
 TodoList.register('todo-list');
 ```
 
-`.add(payload, promise)` auto-releases when the promise settles (resolve or reject). No try-catch, no manual rollback, no temp-ID bookkeeping.
+`.add(payload, promise)` auto-releases when the promise settles (resolve or reject). No try-catch, no manual rollback, no reconciling a temp id against the real one.
+
+**Keep `update` pure.** `.value` re-folds the whole queue on every read, so the reducer runs again on each render rather than once per `.add()`, and anything it mints is minted per render. Mint a temp id in the handler and pass it in the payload, as above. A `crypto.randomUUID()` inside the reducer hands the pending row a fresh id every read, which breaks `repeat()` keying and anything else treating that id as stable.
 
 ### Simple flips: imperative API
 

--- a/packages/core/src/optimistic.js
+++ b/packages/core/src/optimistic.js
@@ -76,13 +76,18 @@ async function runLegacyOptimistic(signal, value, action) {
  *   class TodoList extends WebComponent({ todos: prop(Array) }) {
  *     optimisticTodos = optimistic(this, {
  *       source: () => this.todos,
- *       update: (state, title) => [...state, { id: 'tmp', title, pending: true }]
+ *       // PURE: the row is derived from the payload, nothing is minted here.
+ *       // `.value` re-folds the queue on every read (see Behaviour 1), so a
+ *       // minted id would differ per render and a hardcoded 'tmp' would
+ *       // collide across two concurrent adds.
+ *       update: (state, add) => [...state, { id: add.tempId, title: add.title, pending: true }]
  *     });
  *
  *     async handleSubmit(e) {
  *       const title = e.target.querySelector('input').value;
+ *       const tempId = crypto.randomUUID();
  *       const promise = createTodo({ title });
- *       this.optimisticTodos.add(title, promise);
+ *       this.optimisticTodos.add({ tempId, title }, promise);
  *       const result = await promise;
  *       if (result.success) this.todos = [...this.todos, result.data];
  *     }

--- a/packages/core/test/signals/optimistic-declarative.test.js
+++ b/packages/core/test/signals/optimistic-declarative.test.js
@@ -188,8 +188,9 @@ test('declarative optimistic: handles thenables lacking finally method', async (
 // canonical docs snippets used to do exactly that (`crypto.randomUUID()` inside
 // `update`), which silently breaks a keyed list: `repeat(todos, t => t.id, ...)`
 // sees a brand-new key every update and rebuilds the row, losing focus, any
-// in-progress transition, and DOM state. These pin the contract the docs now
-// teach: derive the row from the payload, mint the temp id in the handler.
+// in-progress transition, and DOM state. These pin the RUNTIME fact the docs
+// now rely on (the reducer re-runs per read); the doc snippets themselves have
+// no test coverage, so a doc revert would not red these.
 test('declarative optimistic: .value is stable across repeated reads for one queued update', () => {
   const host = new MockHost();
   const todos = [{ id: 'real-1', title: 'existing' }];
@@ -237,12 +238,21 @@ test('declarative optimistic: two concurrent adds get distinct ids from their pa
     update: (state, add) => [...state, { id: add.tempId, title: add.title }],
   });
 
-  // The old `{ id: 'tmp' }` snippet collided here: both pending rows shared one
-  // id, defeating the "multiple .add() calls stack independently" guarantee.
-  opt.add({ tempId: 'tmp-1', title: 'first' });
+  // The old `{ id: 'tmp' }` snippet gave both pending rows the SAME id. Queue
+  // stacking and release survive that (`add()` keys its entry on an internal
+  // `opt-N`, never on the row's id), so what breaks is downstream: a keyed
+  // list, a handler capturing the id, an `aria-activedescendant`, a selector.
+  const releaseFirst = opt.add({ tempId: 'tmp-1', title: 'first' });
   opt.add({ tempId: 'tmp-2', title: 'second' });
 
-  const ids = opt.value.map(t => t.id);
-  assert.deepEqual(ids, ['tmp-1', 'tmp-2']);
-  assert.equal(new Set(ids).size, 2, 'concurrent pending rows must not share an id');
+  // Both queued updates must fold, so a payload-derived id yields two rows.
+  // Under the old hardcoded `{ id: 'tmp' }` the SAME two folds produced two
+  // rows sharing one id, which is what broke keyed rendering downstream.
+  assert.equal(opt.value.length, 2, 'both queued updates must fold into .value');
+  assert.equal(new Set(opt.value.map(t => t.id)).size, 2, 'concurrent pending rows must not share an id');
+
+  // Releasing the FIRST must drop only its row, which is what proves the queue
+  // is keyed independently of whatever id the reducer wrote.
+  releaseFirst();
+  assert.deepEqual(opt.value.map(t => t.title), ['second']);
 });

--- a/packages/core/test/signals/optimistic-declarative.test.js
+++ b/packages/core/test/signals/optimistic-declarative.test.js
@@ -182,3 +182,67 @@ test('declarative optimistic: handles thenables lacking finally method', async (
   assert.equal(opt.value, 'a', 'auto-released using fallback then()');
 });
 
+
+// The reducer runs on EVERY `.value` read, not once per `.add()`, so a reducer
+// that MINTS a value hands the pending row a different one on each render. The
+// canonical docs snippets used to do exactly that (`crypto.randomUUID()` inside
+// `update`), which silently breaks a keyed list: `repeat(todos, t => t.id, ...)`
+// sees a brand-new key every update and rebuilds the row, losing focus, any
+// in-progress transition, and DOM state. These pin the contract the docs now
+// teach: derive the row from the payload, mint the temp id in the handler.
+test('declarative optimistic: .value is stable across repeated reads for one queued update', () => {
+  const host = new MockHost();
+  const todos = [{ id: 'real-1', title: 'existing' }];
+  const opt = optimistic(host, {
+    source: () => todos,
+    // PURE: everything comes off the payload.
+    update: (state, add) => [...state, { id: add.tempId, title: add.title, pending: true }],
+  });
+
+  opt.add({ tempId: 'tmp-abc', title: 'new' });
+
+  const first = opt.value;
+  const second = opt.value;
+  const third = opt.value;
+
+  assert.equal(first.at(-1).id, 'tmp-abc');
+  assert.equal(second.at(-1).id, first.at(-1).id, 'a second read must not change the pending id');
+  assert.equal(third.at(-1).id, first.at(-1).id, 'a third read must not change the pending id');
+  // The confirmed rows are untouched by the overlay on every read.
+  assert.equal(second[0].id, 'real-1');
+});
+
+test('declarative optimistic: a minting reducer is what instability looks like', () => {
+  const host = new MockHost();
+  let n = 0;
+  const opt = optimistic(host, {
+    source: () => [],
+    // IMPURE, the shape the docs must never teach: a fresh id per read.
+    update: (state, title) => [...state, { id: `minted-${++n}`, title }],
+  });
+
+  opt.add('new');
+
+  assert.notEqual(
+    opt.value.at(-1).id,
+    opt.value.at(-1).id,
+    'a minting reducer yields a different id on each read, which is the bug the pure shape avoids',
+  );
+});
+
+test('declarative optimistic: two concurrent adds get distinct ids from their payloads', () => {
+  const host = new MockHost();
+  const opt = optimistic(host, {
+    source: () => [],
+    update: (state, add) => [...state, { id: add.tempId, title: add.title }],
+  });
+
+  // The old `{ id: 'tmp' }` snippet collided here: both pending rows shared one
+  // id, defeating the "multiple .add() calls stack independently" guarantee.
+  opt.add({ tempId: 'tmp-1', title: 'first' });
+  opt.add({ tempId: 'tmp-2', title: 'second' });
+
+  const ids = opt.value.map(t => t.id);
+  assert.deepEqual(ids, ['tmp-1', 'tmp-2']);
+  assert.equal(new Set(ids).size, 2, 'concurrent pending rows must not share an id');
+});

--- a/website/app/docs/client-router/page.ts
+++ b/website/app/docs/client-router/page.ts
@@ -69,9 +69,9 @@ class TodoList extends WebComponent({ todos: prop(Array) }) {
     this.optTodos = optimistic(this, {
       source: () => this.todos,
       // Pure: the row is derived from the payload, nothing is minted here.
-      // `.value` re-folds the queue on EVERY read, so a minted id would differ
-      // per render, and a hardcoded 'tmp' would collide across two concurrent
-      // adds. The temp id is minted once in the handler and passed in.
+      // The .value getter re-folds the queue on EVERY read, so a minted id
+      // would differ per render, and a hardcoded 'tmp' would collide across
+      // two concurrent adds. The temp id is minted once in the handler.
       update: (state, add) => [...state, { id: add.tempId, title: add.title, pending: true }],
     });
   }

--- a/website/app/docs/client-router/page.ts
+++ b/website/app/docs/client-router/page.ts
@@ -68,19 +68,24 @@ class TodoList extends WebComponent({ todos: prop(Array) }) {
     this.todos = [];
     this.optTodos = optimistic(this, {
       source: () => this.todos,
-      update: (state, title) => [...state, { id: 'tmp', title, pending: true }],
+      // Pure: the row is derived from the payload, nothing is minted here.
+      // `.value` re-folds the queue on EVERY read, so a minted id would differ
+      // per render, and a hardcoded 'tmp' would collide across two concurrent
+      // adds. The temp id is minted once in the handler and passed in.
+      update: (state, add) => [...state, { id: add.tempId, title: add.title, pending: true }],
     });
   }
   async handleSubmit(e) {
     const title = e.target.querySelector('input').value;
+    const tempId = crypto.randomUUID();
     const promise = createTodo({ title });
-    this.optTodos.add(title, promise);  // auto-releases on settle
+    this.optTodos.add({ tempId, title }, promise);  // auto-releases on settle
     const result = await promise;
     if (result.success) this.todos = [...this.todos, result.data];
   }
   render() {
     return html\`&lt;ul&gt;\${this.optTodos.value.map(t =>
-      html\`&lt;li class=\${t.pending ? 'opacity-50' : ''}&gt;\${t.title}&lt;/li&gt;\`)\}\`;
+      html\`&lt;li class=\${t.pending ? 'opacity-50' : ''}&gt;\${t.title}&lt;/li&gt;\`)\}&lt;/ul&gt;\`;
   }
 }</pre>
     <p><strong>Imperative:</strong> <code>optimistic(signal, value, action)</code> sets the signal to <code>value</code> immediately, runs <code>action()</code>, and rolls back on a thrown error or <code>{ success: false }</code> envelope.</p>


### PR DESCRIPTION
Closes #1203

## Summary

`optimistic()`'s reducer runs on every `.value` read, not once per `.add()`. The getter re-folds the whole queue from `source()` each time, rebuilding the optimistic row from its stored payload. So a reducer that MINTS a value mints it per render.

The canonical snippet in `AGENTS.md` and `.agents/skills/webjs/references/optimistic-ui.md` did exactly that, with `crypto.randomUUID()` inside `update`. Nothing breaks in the snippet as written because its `render()` uses an unkeyed `.map()`. It breaks the moment an author keys the list with `repeat(todos, t => t.id, ...)`, which is what the rest of the docs recommend: every render sees a brand-new key for the pending row, so `repeat` tears the `<li>` down and rebuilds it on each update, losing focus, any in-progress transition, and DOM state.

The other two copies (the `optimistic.js` JSDoc and the client-router docs page) used a hardcoded `{ id: 'tmp' }`. That is stable per read, so it has no `repeat` bug, but both pending rows collide when two adds are in flight, which is precisely the case `optimistic()` advertises support for.

All four copies now converge on the shape `packages/cli/templates/gallery/modules/todo/components/todo-app.ts` already ships: the temp id is minted once in the handler and carried in the payload, so the reducer is pure and the id is stable for the life of the pending row.

## Decisions

- **`createdAt: new Date()` stays in the reducer**, matching the gallery component, with a comment saying it is rebuilt per read and that this is tolerable only because nothing keys on it. Decided once and applied to all four copies rather than left inconsistent.
- **The payload stops being a bare `title` string**, so the prose explaining `.add(payload, promise?)` and the reducer's second parameter type moved with it. No sentence still describes the bare-string payload.
- **Rejected:** leaving the snippets alone and adding a "the reducer must be pure" warning. That keeps a broken example on the page, and #1200 established that an agent copies the example far more reliably than it follows the prose. The prose note is added *as well*, not instead.

## Test plan

- [x] New unit test asserts `.value` is stable across repeated reads for one queued update
- [x] **Counterfactual proven at [`7f0acaca`](https://github.com/webjsdev/webjs/commit/7f0acaca):** swapped the fixture reducer back to a minting `crypto.randomUUID()`, the stability test went red (10 pass / 1 fail), restored through `git checkout`, green again (11/11)
- [x] Two further tests pin the collision case (two concurrent adds get distinct ids) and encode the minting behaviour permanently
- [x] `node --test "packages/core/test/signals/*.test.js"`: 53/53 pass
- [x] `website` boots in prod mode, `/docs/client-router` 200 with balanced `<pre>` markup and no broken preloads
- [x] `webjs check` on `website`: all checks pass
- [x] Diffed `AGENTS.md` against the skill copy: the load-bearing code lines are byte-identical

One regression caught and fixed in-branch: the first version of the docs-page comment used backticks to name `.value`, which is invariant 9 (a backtick inside an `html` template body closes the literal at parse time) and 500'd `/docs/client-router`. The comment names the getter in plain prose now, fixed in [`1bff68f9`](https://github.com/webjsdev/webjs/commit/1bff68f9).

## Doc surfaces

- **Updated:** `AGENTS.md`, `.agents/skills/webjs/references/optimistic-ui.md`, `packages/core/src/optimistic.js` (JSDoc), `website/app/docs/client-router/page.ts` (snippet plus the pre-existing unbalanced `<ul>` the issue flagged).
- **Reference, not a target:** `packages/cli/templates/gallery/modules/todo/components/todo-app.ts` was already correct and is what the others were copied from.
- **N/A:** MCP, editor plugins, marketing copy, scaffold generators, changelog. This is example correctness in docs, no public surface changed, and per the issue it is deliberately NOT a `webjs check` rule.