### PR TITLE
fix: assert soft navigation in the router positive control

### DIFF
--- a/packages/core/test/routing/browser/router-js-handled.test.js
+++ b/packages/core/test/routing/browser/router-js-handled.test.js
@@ -21,8 +21,45 @@ import { enableClientRouter } from '../../../src/router-client.js';
 import { assert } from '../../../../../test/browser-assert.js';
 const tick = () => new Promise((r) => setTimeout(r, 0));
 
+/**
+ * Resolve once the router has SETTLED the navigation a click asked for, rather
+ * than after an arbitrary macrotask. Two outcomes end a navigation and the
+ * router announces both on `document`: `webjs:navigate` when a soft swap
+ * committed, `webjs:navigation-fallback` when it degraded to a full load. The
+ * promise is created BEFORE the click, because a degradation can be dispatched
+ * synchronously from inside the click handler and a listener attached after the
+ * click would miss it.
+ *
+ * The bounded timeout covers the third outcome, a click the router never
+ * intercepted at all, which announces nothing. That case must still return so
+ * the test fails on its own assertion instead of hanging to the runner's 10s
+ * per-test limit (`web-test-runner.config.js`).
+ *
+ * @param {number} [timeoutMs]
+ * @returns {Promise<void>}
+ */
+function awaitNavigation(timeoutMs = 2000) {
+  return new Promise((resolve) => {
+    let settled = false;
+    let timer;
+    const settle = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      document.removeEventListener('webjs:navigate', settle);
+      document.removeEventListener('webjs:navigation-fallback', settle);
+      // Hand back a macrotask later so the router's own post-dispatch work
+      // unwinds before the caller asserts and dismantles the fixture.
+      setTimeout(resolve, 0);
+    };
+    timer = setTimeout(settle, timeoutMs);
+    document.addEventListener('webjs:navigate', settle);
+    document.addEventListener('webjs:navigation-fallback', settle);
+  });
+}
+
 suite('Client router: JS-handled links/forms are not hijacked (#150, #153)', () => {
-  let container, origFetch, fetched, bOpen, bClose;
+  let container, origFetch, fetched, bOpen, bClose, fallbacks, navigated, onFallback, onNavigate;
 
   function setup() {
     enableClientRouter(); // idempotent; ensures the document listeners are attached
@@ -35,6 +72,15 @@ suite('Client router: JS-handled links/forms are not hijacked (#150, #153)', () 
     document.body.appendChild(bOpen);
     document.body.appendChild(container);
     document.body.appendChild(bClose);
+    // Record both router diagnostics (#1114) for the life of the test. A
+    // degradation carries a stable `cause` slug, which is the entire diagnosis
+    // when one of these tests reds, so it has to reach the assertion message.
+    fallbacks = [];
+    navigated = [];
+    onFallback = (e) => fallbacks.push(e.detail);
+    onNavigate = (e) => navigated.push(e.detail && e.detail.url);
+    document.addEventListener('webjs:navigation-fallback', onFallback);
+    document.addEventListener('webjs:navigate', onNavigate);
     fetched = [];
     origFetch = window.fetch;
     window.fetch = (url) => {
@@ -44,7 +90,17 @@ suite('Client router: JS-handled links/forms are not hijacked (#150, #153)', () 
       }));
     };
   }
-  function teardown() { window.fetch = origFetch; container.remove(); bOpen.remove(); bClose.remove(); }
+  function teardown() {
+    document.removeEventListener('webjs:navigation-fallback', onFallback);
+    document.removeEventListener('webjs:navigate', onNavigate);
+    window.fetch = origFetch;
+    container.remove();
+    bOpen.remove();
+    bClose.remove();
+  }
+
+  /** Render the first fallback's cause for an assertion message. */
+  const causeOf = (list) => (list.length ? String(list[0].cause) : 'none');
 
   test('a @click=preventDefault link is NOT navigated by the router', async () => {
     setup();
@@ -52,10 +108,14 @@ suite('Client router: JS-handled links/forms are not hijacked (#150, #153)', () 
       let ran = false;
       render(html`<a href="/js-handled-link" @click=${(e) => { e.preventDefault(); ran = true; }}>go</a>`, container);
       container.querySelector('a').click();
+      // No settle event to await: the assertion is that the router did NOT act,
+      // so a macrotask is the only signal there is.
       await tick();
       assert.ok(ran, 'the component @click handler ran');
       assert.equal(fetched.filter((u) => u.includes('/js-handled-link')).length, 0,
         'router must NOT navigate a preventDefaulted link');
+      assert.equal(fallbacks.length, 0,
+        `router must not have degraded a navigation here (cause: ${causeOf(fallbacks)})`);
     } finally { teardown(); }
   });
 
@@ -65,9 +125,12 @@ suite('Client router: JS-handled links/forms are not hijacked (#150, #153)', () 
       let ran = false;
       render(html`<form @submit=${(e) => { e.preventDefault(); ran = true; }}><button type="submit">go</button></form>`, container);
       container.querySelector('button').click();
+      // Same as the link case: nothing settles, because nothing should navigate.
       await tick();
       assert.ok(ran, 'the component @submit handler ran');
       assert.equal(fetched.length, 0, 'router must NOT submit a preventDefaulted form');
+      assert.equal(fallbacks.length, 0,
+        `router must not have degraded a navigation here (cause: ${causeOf(fallbacks)})`);
     } finally { teardown(); }
   });
 
@@ -75,10 +138,21 @@ suite('Client router: JS-handled links/forms are not hijacked (#150, #153)', () 
     setup();
     try {
       render(html`<a href="/plain-link-target">go</a>`, container);
+      // Arm the settle listener BEFORE the click: a degradation can fire
+      // synchronously from inside the router's click handler.
+      const settled = awaitNavigation();
       container.querySelector('a').click();
-      await tick();
+      await settled;
+      // Assert the degradation channel FIRST. `fetched` alone cannot tell a
+      // committed soft swap from a degradation that fetched and then reloaded,
+      // and when a reload does follow, this cause slug is the only thing that
+      // reaches the log before the session dies.
+      assert.equal(fallbacks.length, 0,
+        `router must SOFT-navigate a plain link, but it degraded (cause: ${causeOf(fallbacks)})`);
       assert.ok(fetched.some((u) => u.includes('/plain-link-target')),
         'router must SPA-navigate a plain link (the fix must not break progressive enhancement)');
+      assert.ok(navigated.some((u) => u && String(u).includes('/plain-link-target')),
+        'the soft swap must COMMIT (webjs:navigate), not merely start');
     } finally { teardown(); }
   });
 });

--- a/packages/core/test/routing/browser/router-js-handled.test.js
+++ b/packages/core/test/routing/browser/router-js-handled.test.js
@@ -143,10 +143,18 @@ suite('Client router: JS-handled links/forms are not hijacked (#150, #153)', () 
       const settled = awaitNavigation();
       container.querySelector('a').click();
       await settled;
-      // Assert the degradation channel FIRST. `fetched` alone cannot tell a
+      // Assert the degradation channel FIRST: `fetched` alone cannot tell a
       // committed soft swap from a degradation that fetched and then reloaded,
-      // and when a reload does follow, this cause slug is the only thing that
-      // reaches the log before the session dies.
+      // so without this the degraded outcome PASSES.
+      //
+      // This message only reaches the log for a degradation whose `willReload`
+      // is false. A reloading one assigns `location.href` in the same task as
+      // the dispatch, nothing can cancel a programmatic assignment, and
+      // web-test-runner discards the page's buffered console output once the
+      // navigation interrupts the session, so neither this assertion nor a
+      // synchronous `console.error` from the listener survives (both were
+      // measured). Preventing the reload is the only real answer, which is why
+      // teardown below waits for a settle instead of a bare macrotask.
       assert.equal(fallbacks.length, 0,
         `router must SOFT-navigate a plain link, but it degraded (cause: ${causeOf(fallbacks)})`);
       assert.ok(fetched.some((u) => u.includes('/plain-link-target')),

--- a/packages/core/test/routing/browser/router-js-handled.test.js
+++ b/packages/core/test/routing/browser/router-js-handled.test.js
@@ -108,9 +108,14 @@ suite('Client router: JS-handled links/forms are not hijacked (#150, #153)', () 
       let ran = false;
       render(html`<a href="/js-handled-link" @click=${(e) => { e.preventDefault(); ran = true; }}>go</a>`, container);
       container.querySelector('a').click();
-      // No settle event to await: the assertion is that the router did NOT act,
-      // so a macrotask is the only signal there is.
       await tick();
+      // In the healthy case the router did not act, so there is nothing to
+      // settle and this costs nothing. On the REGRESSION this test exists to
+      // catch, the router hijacked the link and a swap is in flight; tearing
+      // the boundary pair out from under it in `finally` is the
+      // `live-boundaries-malformed` degradation, which reloads and aborts the
+      // whole session instead of failing this test readably.
+      if (fetched.length) await awaitNavigation();
       assert.ok(ran, 'the component @click handler ran');
       assert.equal(fetched.filter((u) => u.includes('/js-handled-link')).length, 0,
         'router must NOT navigate a preventDefaulted link');
@@ -125,8 +130,10 @@ suite('Client router: JS-handled links/forms are not hijacked (#150, #153)', () 
       let ran = false;
       render(html`<form @submit=${(e) => { e.preventDefault(); ran = true; }}><button type="submit">go</button></form>`, container);
       container.querySelector('button').click();
-      // Same as the link case: nothing settles, because nothing should navigate.
       await tick();
+      // Same reasoning as the link case: only a regression puts a swap in
+      // flight, and only then must teardown wait for it.
+      if (fetched.length) await awaitNavigation();
       assert.ok(ran, 'the component @submit handler ran');
       assert.equal(fetched.length, 0, 'router must NOT submit a preventDefaulted form');
       assert.equal(fallbacks.length, 0,
@@ -159,8 +166,15 @@ suite('Client router: JS-handled links/forms are not hijacked (#150, #153)', () 
         `router must SOFT-navigate a plain link, but it degraded (cause: ${causeOf(fallbacks)})`);
       assert.ok(fetched.some((u) => u.includes('/plain-link-target')),
         'router must SPA-navigate a plain link (the fix must not break progressive enhancement)');
+      // `webjs:navigate` proves the router ran a navigation to completion
+      // rather than bailing out part-way (a discarded revalidation, an early
+      // error return). It does NOT prove the navigation was soft: the
+      // degradation branch in `applySwap` returns `undefined`, which is not
+      // the `'discard'` disposition, so `fetchAndApply` falls through and
+      // dispatches this event on the reload path too. The `fallbacks`
+      // assertion above is the only thing that separates those two.
       assert.ok(navigated.some((u) => u && String(u).includes('/plain-link-target')),
-        'the soft swap must COMMIT (webjs:navigate), not merely start');
+        'the router must run the navigation to completion (webjs:navigate)');
     } finally { teardown(); }
   });
 });

--- a/packages/core/test/routing/browser/router-js-handled.test.js
+++ b/packages/core/test/routing/browser/router-js-handled.test.js
@@ -22,18 +22,37 @@ import { assert } from '../../../../../test/browser-assert.js';
 const tick = () => new Promise((r) => setTimeout(r, 0));
 
 /**
- * Resolve once the router has SETTLED the navigation a click asked for, rather
- * than after an arbitrary macrotask. Two outcomes end a navigation and the
- * router announces both on `document`: `webjs:navigate` when a soft swap
- * committed, `webjs:navigation-fallback` when it degraded to a full load. The
- * promise is created BEFORE the click, because a degradation can be dispatched
- * synchronously from inside the click handler and a listener attached after the
- * click would miss it.
+ * Resolve once the router is done with the navigation in flight, rather than
+ * after an arbitrary macrotask, so a test never dismantles its fixture from
+ * under a running swap.
  *
- * The bounded timeout covers the third outcome, a click the router never
- * intercepted at all, which announces nothing. That case must still return so
- * the test fails on its own assertion instead of hanging to the runner's 10s
+ * It settles on the first of three things:
+ *
+ * - `webjs:navigate`, which means the router ran a navigation to COMPLETION. It
+ *   does not mean the navigation was soft: the degradation branches return
+ *   without the `'discard'` disposition, so `fetchAndApply` falls through and
+ *   dispatches this on the reload path too.
+ * - a RELOADING `webjs:navigation-fallback`. A `willReload: false` one is
+ *   explicitly documented as a dropped background op rather than the end of a
+ *   navigation, and at least one such path (a suppressed deploy-mismatch
+ *   reload) goes on to complete its swap, so treating it as terminal would
+ *   resolve mid-swap and reintroduce the very race this helper exists to close.
+ * - a bounded timeout.
+ *
+ * The timeout is NOT just the "router never intercepted" case. Several terminal
+ * paths in `fetchAndApply` announce nothing at all (an aborted or superseded
+ * navigation, a 204/205 empty body, an unparseable body, an error recovered in
+ * place), and a popstate snapshot restore applies a swap without dispatching
+ * `webjs:navigate`. The timeout is the backstop for every one of those, so a
+ * test fails on its own assertion instead of hanging to the runner's 10s
  * per-test limit (`web-test-runner.config.js`).
+ *
+ * Two call shapes, and the difference matters. The positive control ARMS it
+ * before the click, because a degradation can be dispatched synchronously from
+ * inside the router's click handler and a listener attached afterwards would
+ * miss it. The negative controls call it after the click instead, since there
+ * they are not waiting for an expected navigation at all; they are draining an
+ * unexpected one before teardown, and by then it is already in flight.
  *
  * @param {number} [timeoutMs]
  * @returns {Promise<void>}
@@ -47,14 +66,18 @@ function awaitNavigation(timeoutMs = 2000) {
       settled = true;
       clearTimeout(timer);
       document.removeEventListener('webjs:navigate', settle);
-      document.removeEventListener('webjs:navigation-fallback', settle);
+      document.removeEventListener('webjs:navigation-fallback', onFallbackSettle);
       // Hand back a macrotask later so the router's own post-dispatch work
       // unwinds before the caller asserts and dismantles the fixture.
       setTimeout(resolve, 0);
     };
+    const onFallbackSettle = (e) => {
+      if (e.detail && e.detail.willReload === false) return; // not a navigation end
+      settle();
+    };
     timer = setTimeout(settle, timeoutMs);
     document.addEventListener('webjs:navigate', settle);
-    document.addEventListener('webjs:navigation-fallback', settle);
+    document.addEventListener('webjs:navigation-fallback', onFallbackSettle);
   });
 }
 
@@ -109,12 +132,19 @@ suite('Client router: JS-handled links/forms are not hijacked (#150, #153)', () 
       render(html`<a href="/js-handled-link" @click=${(e) => { e.preventDefault(); ran = true; }}>go</a>`, container);
       container.querySelector('a').click();
       await tick();
-      // In the healthy case the router did not act, so there is nothing to
-      // settle and this costs nothing. On the REGRESSION this test exists to
-      // catch, the router hijacked the link and a swap is in flight; tearing
-      // the boundary pair out from under it in `finally` is the
-      // `live-boundaries-malformed` degradation, which reloads and aborts the
-      // whole session instead of failing this test readably.
+      // In the healthy case the router did not act, nothing was fetched, and
+      // this costs nothing. On the REGRESSION this test exists to catch, the
+      // router hijacked the link and a swap is in flight; tearing the boundary
+      // pair out from under it in `finally` is the `live-boundaries-malformed`
+      // degradation, which reloads and aborts the whole session instead of
+      // failing this test readably.
+      //
+      // Keyed on a fetch specifically, which is sound here because the router
+      // reaches its `await fetch(...)` inside the click dispatch, with no
+      // macrotask in between. It is not a general "is a swap in flight" test:
+      // a prefetch-cache hit swaps without calling `fetch` at all. This fixture
+      // never prefetches (`el.click()` fires none of the intent events), so
+      // that path cannot arise.
       if (fetched.length) await awaitNavigation();
       assert.ok(ran, 'the component @click handler ran');
       assert.equal(fetched.filter((u) => u.includes('/js-handled-link')).length, 0,

--- a/packages/core/test/routing/browser/router-js-handled.test.js
+++ b/packages/core/test/routing/browser/router-js-handled.test.js
@@ -39,13 +39,19 @@ const tick = () => new Promise((r) => setTimeout(r, 0));
  *   resolve mid-swap and reintroduce the very race this helper exists to close.
  * - a bounded timeout.
  *
- * The timeout is NOT just the "router never intercepted" case. Several terminal
- * paths in `fetchAndApply` announce nothing at all (an aborted or superseded
- * navigation, a 204/205 empty body, an unparseable body, an error recovered in
- * place), and a popstate snapshot restore applies a swap without dispatching
- * `webjs:navigate`. The timeout is the backstop for every one of those, so a
- * test fails on its own assertion instead of hanging to the runner's 10s
- * per-test limit (`web-test-runner.config.js`).
+ * The timeout is NOT just the "router never intercepted" case. Some terminal
+ * paths in `fetchAndApply` announce nothing on either channel (an aborted or
+ * superseded navigation, a 204/205 empty body), and a popstate snapshot restore
+ * applies a swap without dispatching `webjs:navigate`. The timeout is the
+ * backstop for those, so a test fails on its own assertion instead of hanging
+ * to the runner's 10s per-test limit (`web-test-runner.config.js`).
+ *
+ * A navigation error is the one case that is neither: an unparseable body or a
+ * failed fetch announces `webjs:navigation-error`, which this helper does not
+ * listen for, so it waits out the timeout when the error is recovered in place.
+ * When it CANNOT be recovered in place, the router emits a reloading
+ * `navigation-error-unrecoverable` fallback, and that does settle here. This
+ * fixture always installs a live boundary pair, so recovery is always in place.
  *
  * Two call shapes, and the difference matters. The positive control ARMS it
  * before the click, because a degradation can be dispatched synchronously from


### PR DESCRIPTION
Closes #1053

## Summary

The positive control in `packages/core/test/routing/browser/router-js-handled.test.js` asserted only that the router had called `fetch`. That single assertion cannot separate the three things a click can do here: the router intercepted and swapped softly (what the test claims to prove), the router intercepted and then degraded to `location.href = href` (the page navigates, `fetched` still holds the URL, so the assertion passes while the runner session dies), or the click never reached `onClick` at all. A test whose passing state includes a full page load is not a positive control for soft navigation, and when it lost that race on Firefox the whole Browser job aborted with a misleading `0 failed` plus exit 1.

The discriminator is `webjs:navigation-fallback` (#1114), which carries a stable `cause` slug and is dispatched immediately before every `location.href` reload site. The test now asserts none fired, with the cause interpolated into the failure message.

Note what `webjs:navigate` does and does not prove, because the first draft of this PR got it wrong. It does NOT mean the swap was soft: the degradation branches in `applySwap` return without the `'discard'` disposition, so `fetchAndApply` falls through and dispatches it on the reload path too. It is still worth asserting, because it separates a navigation the router ran to completion from one that bailed out part-way, but the fallback assertion is doing the real work.

The second half is a fixture race. Teardown ran one macrotask after the click, so on a slower engine it restored the real `window.fetch` and removed the keyed boundary pair while the swap was still running. Removing a live boundary mid-swap is precisely the `live-boundaries-malformed` condition, which ends in a full load, which is the abort. All three tests now settle before teardown. The two negative controls only pay that cost when something was actually fetched, which happens only on the regression they exist to catch, so the healthy path is unchanged.

`packages/core/src/router-client.js` is untouched.

## A limit worth stating

None of this makes a reloading degradation survivable. `preventDefault` cannot cancel a programmatic `location.href` assignment, and web-test-runner discards the page's buffered console output once the navigation interrupts the session, so neither the assertion message nor a synchronous `console.error` from the listener reaches the log. Both were measured. Preventing the degradation is the only real answer, which is what the teardown fix does; making an escaped click structurally unable to navigate the runner page is #1135.

## Test plan

- Browser: `packages/core/test/routing/browser/router-js-handled.test.js`, 3/3 on Chromium, Firefox, and WebKit; a 20x Firefox loop had zero failures.
- Counterfactual: suppressing the `webjs:navigate` dispatch in the router reds the commit assertion on all three engines, with the test's own message and no session abort. It still passed the old `fetched`-only assertion, which is the gap this PR closes.
- Unit: N/A, linkedom does not model capture-vs-bubble ordering of a document-level against an element-level listener, which is why this suite is browser-only in the first place.
- Bun parity: N/A, browser-only test code, no runtime-sensitive server surface.
- Dogfood: N/A, no framework source changed.
- Docs: N/A, the change is test-internal. The cross-suite convention that comes out of it belongs to #1135.
