### PR TITLE
fix(website): make startPara return its paragraph so main typechecks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,12 +455,13 @@ jobs:
       # Nothing in the pipeline typechecked the website before, so a type
       # break landed on main and every branch cut from it inherited a red
       # tsc (#1260). It runs before the tests so a type break names itself
-      # rather than surfacing as a test failure. Two deliberate limits: it
+      # rather than surfacing as a test failure. Two deliberate limits. It
       # covers the website's tsconfig include (app, components, lib, modules)
-      # and NOT test/, whose 23 .ts files carry 30 pre-existing errors; and it
-      # gates website/ only, since examples/blog and
-      # packages/ui/packages/website do not typecheck clean today either.
-      # Widening either is its own fix.
+      # and NOT test/, which would add 17 pre-existing errors across 5 of its
+      # 25 .ts files. And it gates website/ only, which is a scope call rather
+      # than a claim about the others: examples/blog is genuinely red today,
+      # but docs/ and packages/ui/packages/website both typecheck clean, so
+      # adding them is a small separate change. Widening either is its own fix.
       - name: website typecheck
         run: npm run typecheck --workspace=@webjsdev/website
       - name: website tests (node + browser)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,9 +455,12 @@ jobs:
       # Nothing in the pipeline typechecked the website before, so a type
       # break landed on main and every branch cut from it inherited a red
       # tsc (#1260). It runs before the tests so a type break names itself
-      # rather than surfacing as a test failure. Scoped to website/ on
-      # purpose: examples/blog and packages/ui/packages/website do not
-      # typecheck clean today, and wiring them in is its own fix.
+      # rather than surfacing as a test failure. Two deliberate limits: it
+      # covers the website's tsconfig include (app, components, lib, modules)
+      # and NOT test/, whose 23 .ts files carry 30 pre-existing errors; and it
+      # gates website/ only, since examples/blog and
+      # packages/ui/packages/website do not typecheck clean today either.
+      # Widening either is its own fix.
       - name: website typecheck
         run: npm run typecheck --workspace=@webjsdev/website
       - name: website tests (node + browser)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,6 +452,14 @@ jobs:
           cp .env.example .env
           npm run db:migrate
           npm run db:seed
+      # Nothing in the pipeline typechecked the website before, so a type
+      # break landed on main and every branch cut from it inherited a red
+      # tsc (#1260). It runs before the tests so a type break names itself
+      # rather than surfacing as a test failure. Scoped to website/ on
+      # purpose: examples/blog and packages/ui/packages/website do not
+      # typecheck clean today, and wiring them in is its own fix.
+      - name: website typecheck
+        run: npm run typecheck --workspace=@webjsdev/website
       - name: website tests (node + browser)
         run: npm test --workspace=@webjsdev/website
       - name: blog tests (node)

--- a/package-lock.json
+++ b/package-lock.json
@@ -7162,7 +7162,8 @@
         "@types/node": "^24.0.0",
         "@web/test-runner": "^0.20.0",
         "@web/test-runner-playwright": "^0.11.0",
-        "playwright": "^1.59.0"
+        "playwright": "^1.59.0",
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=24.0.0"

--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -366,7 +366,15 @@ calling an action), re-enable it and delete the assertion in
 
 ```sh
 cd website && npm run dev       # http://localhost:5001
+cd website && npm run typecheck # tsc --noEmit, the same gate CI runs
 ```
+
+`npm run typecheck` mirrors the kit sources in before it runs `tsc`, because
+without that gitignored mirror `tsc` reports a wall of unrelated `TS2882`
+side-effect-import errors that bury any real one. The CI `apps` job runs the
+same script, so a type break in `website/` reds the build instead of riding
+onto `main` unnoticed (#1260). It gates `website/` only: `examples/blog` and
+`packages/ui/packages/website` do not typecheck clean today.
 
 `npm run dev` and `webjs dev` behave identically (#550): `webjs.dev.before`
 mirrors the kit sources in and compiles `public/tailwind.css`, and

--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -369,12 +369,20 @@ cd website && npm run dev       # http://localhost:5001
 cd website && npm run typecheck # tsc --noEmit, the same gate CI runs
 ```
 
-`npm run typecheck` mirrors the kit sources in before it runs `tsc`, because
-without that gitignored mirror `tsc` reports a wall of unrelated `TS2882`
-side-effect-import errors that bury any real one. The CI `apps` job runs the
-same script, so a type break in `website/` reds the build instead of riding
-onto `main` unnoticed (#1260). It gates `website/` only: `examples/blog` and
-`packages/ui/packages/website` do not typecheck clean today.
+`npm run typecheck` mirrors the kit sources in before it runs `webjs typecheck`,
+because without that gitignored mirror `tsc` reports a wall of unrelated
+`TS2882` side-effect-import errors that bury any real one. The CI `apps` job
+runs the same script, so a type break reds the build instead of riding onto
+`main` unnoticed (#1260).
+
+What it covers is exactly the tsconfig `include`: `app/`, `components/`,
+`lib/`, and `modules/`. **`test/` is deliberately outside it.** The 23
+TypeScript files under `test/` carry 30 pre-existing type errors (a `never`
+argument in the sitemap test, `LayoutProps` calls missing `params` /
+`searchParams` / `url`), so including them would red the gate on day one.
+Fixing those is its own task. Across apps the gate covers `website/` only, for
+the same reason: `examples/blog` and `packages/ui/packages/website` do not
+typecheck clean today either.
 
 `npm run dev` and `webjs dev` behave identically (#550): `webjs.dev.before`
 mirrors the kit sources in and compiles `public/tailwind.css`, and

--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -370,19 +370,24 @@ cd website && npm run typecheck # tsc --noEmit, the same gate CI runs
 ```
 
 `npm run typecheck` mirrors the kit sources in before it runs `webjs typecheck`,
-because without that gitignored mirror `tsc` reports a wall of unrelated
-`TS2882` side-effect-import errors that bury any real one. The CI `apps` job
-runs the same script, so a type break reds the build instead of riding onto
-`main` unnoticed (#1260).
+because the mirror is gitignored and without it `tsc` reports 45 errors that
+have nothing to do with your change (17 unresolved-module, 19 implicit-any, 9
+side-effect-import) and bury any real one. The CI `apps` job runs the same
+script, so a type break reds the build instead of riding onto `main` unnoticed
+(#1260).
 
 What it covers is exactly the tsconfig `include`: `app/`, `components/`,
-`lib/`, and `modules/`. **`test/` is deliberately outside it.** The 23
-TypeScript files under `test/` carry 30 pre-existing type errors (a `never`
-argument in the sitemap test, `LayoutProps` calls missing `params` /
-`searchParams` / `url`), so including them would red the gate on day one.
-Fixing those is its own task. Across apps the gate covers `website/` only, for
-the same reason: `examples/blog` and `packages/ui/packages/website` do not
-typecheck clean today either.
+`lib/`, and `modules/`. **`test/` is deliberately outside it.** Adding
+`test/**/*` surfaces 17 pre-existing errors across 5 of its 25 TypeScript
+files (a `never` argument in the sitemap test, `LayoutProps` calls missing
+`params` / `searchParams` / `url`, and an `unknown` not assignable to
+`TemplateResult` in the determinism test), so including it would red the gate
+on day one. Fixing those is its own task.
+
+Across apps the gate covers `website/` only, which is a SCOPE decision rather
+than a claim about the others. Measured: `examples/blog` is genuinely red (13
+errors), but `docs/` and `packages/ui/packages/website` both typecheck clean
+today, so gating them is a small, separate change and not a blocked one.
 
 `npm run dev` and `webjs dev` behave identically (#550): `webjs.dev.before`
 mirrors the kit sources in and compiles `public/tailwind.css`, and

--- a/website/modules/changelog/utils/render-entry.ts
+++ b/website/modules/changelog/utils/render-entry.ts
@@ -101,7 +101,6 @@ export function renderEntryBody(md: string): string {
       startList();
       itemOpen = true;
       paras = [];
-      open = null;
       open = startPara(line.slice(2).trim());
     } else if (itemOpen && /^ {2,}[-*] /.test(line)) {
       // Its own paragraph, marker dropped. Depth is not read, so a deeper

--- a/website/modules/changelog/utils/render-entry.ts
+++ b/website/modules/changelog/utils/render-entry.ts
@@ -53,7 +53,13 @@ export function renderEntryBody(md: string): string {
   let paras: Para[] = [];
   let open: Para | null = null;
 
-  function startPara(text: string) { open = [text]; paras.push(open); }
+  // Returns the paragraph rather than assigning `open` itself. TypeScript's
+  // control-flow analysis ignores a write made inside a nested function when
+  // it narrows a `let` read in the enclosing scope, so an assigning version
+  // leaves `open` narrowed to `null` at the read below and the truthiness
+  // guard there narrows it to `never`. Assigning at each call site keeps the
+  // write in the enclosing function's own control-flow graph.
+  function startPara(text: string): Para { const p: Para = [text]; paras.push(p); return p; }
 
   function renderParas(ps: Para[]): string {
     // The overwhelmingly common entry is a single line with no body. Emit it
@@ -96,17 +102,17 @@ export function renderEntryBody(md: string): string {
       itemOpen = true;
       paras = [];
       open = null;
-      startPara(line.slice(2).trim());
+      open = startPara(line.slice(2).trim());
     } else if (itemOpen && /^ {2,}[-*] /.test(line)) {
       // Its own paragraph, marker dropped. Depth is not read, so a deeper
       // run groups exactly like a 2-space one instead of nesting.
-      startPara(line.trim().slice(2).trim());
+      open = startPara(line.trim().slice(2).trim());
     } else if (itemOpen && /^ {2,}\S/.test(line)) {
       const text = line.trim();
       // Soft-wrapped continuation of the open paragraph, or the start of a
       // fresh one when a blank line closed the last.
       if (open) open.push(text);
-      else startPara(text);
+      else open = startPara(text);
     } else if (line.trim() === '') {
       if (itemOpen) open = null;
       else flushItem();

--- a/website/package.json
+++ b/website/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev": "webjs dev --port ${PORT:-5001}",
     "start": "webjs start",
+    "typecheck": "node scripts/copy-registry.mjs && tsc --noEmit",
     "pretest": "node scripts/copy-registry.mjs",
     "test": "webjs test",
     "pretest:browser": "node scripts/copy-registry.mjs",

--- a/website/package.json
+++ b/website/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "webjs dev --port ${PORT:-5001}",
     "start": "webjs start",
-    "typecheck": "node scripts/copy-registry.mjs && tsc --noEmit",
+    "typecheck": "node scripts/copy-registry.mjs && webjs typecheck",
     "pretest": "node scripts/copy-registry.mjs",
     "test": "webjs test",
     "pretest:browser": "node scripts/copy-registry.mjs",
@@ -70,7 +70,8 @@
     "@types/node": "^24.0.0",
     "@web/test-runner": "^0.20.0",
     "@web/test-runner-playwright": "^0.11.0",
-    "playwright": "^1.59.0"
+    "playwright": "^1.59.0",
+    "typescript": "^6.0.3"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -13,6 +13,6 @@
     "skipLibCheck": true,
     "erasableSyntaxOnly": true
   },
-  "include": ["app/**/*", "components/**/*"],
+  "include": ["app/**/*", "components/**/*", "lib/**/*", "modules/**/*"],
   "exclude": ["node_modules", ".webjs"]
 }


### PR DESCRIPTION
Closes #1260

## Summary

`main` did not pass the website typecheck. `cd website && npx tsc --noEmit` reported `modules/changelog/utils/render-entry.ts(108,22): error TS2339: Property 'push' does not exist on type 'never'`, so every branch cut from `main` inherited a red `tsc` and could not use a clean one as evidence that its own change was sound.

The cause is where the assignment lives, not what the type holds. `startPara` wrote the enclosing `let open` from inside a nested function, and TypeScript's control-flow analysis ignores such a write when narrowing a `let` read in the enclosing scope. The analysis therefore saw only the three `open = null` writes, narrowed `open` to `null` at the read, and the `if (open)` truthiness guard narrowed that to `never`. `startPara` now returns the paragraph and each of the three call sites assigns the result, which puts the write back in the enclosing function's own control-flow graph. No assertion, no cast, no `any`.

It landed unnoticed because nothing in the pipeline typechecks the website: the CI `Conventions` job runs `webjs check`, which is a different tool. That is the part worth fixing beyond the one line, so the `apps` job now runs the typecheck too.

## What changed

- `website/modules/changelog/utils/render-entry.ts`: `startPara` returns `Para`; the three call sites (the column-0 entry branch, the indented-bullet branch, and the continuation branch's `else`) assign it. Those three assignments are what fix the read: `null` is in the union from the declaration initializer and from the blank-line branch, so no `open = null` write is doing that work. The one that sat immediately above the column-0 `startPara` call was load-bearing only while `startPara` assigned `open` itself, so it is gone.
- `website/package.json`: new `typecheck` script, `node scripts/copy-registry.mjs && webjs typecheck`, plus a `typescript` devDependency so the gate owns its compiler. The registry mirror prestep is not optional: without the gitignored kit mirror in place, `tsc` reports a wall of unrelated `TS2882` side-effect-import errors that bury the real one.
- `website/tsconfig.json`: `include` widened to `lib/` and `modules/`, which is clean today. Without it a `modules/` or `lib/` file that no page imports was invisible to the gate.
- `.github/workflows/ci.yml`: the `apps` job runs `npm run typecheck --workspace=@webjsdev/website` before the website tests, so a type break names itself rather than surfacing as a test failure.
- `website/AGENTS.md`: `npm run typecheck` documented under `## Run`, with what it does and does not cover.

## Deliberately excluded

**`website/test/` is outside the gate.** Adding `test/**/*` surfaces 17 pre-existing errors across 5 of its 25 TypeScript files (a `never` argument in the sitemap test, `LayoutProps` calls missing `params` / `searchParams` / `url`, and an `unknown` not assignable to `TemplateResult` in the determinism test), so including it would red the gate on day one. Both the AGENTS.md prose and the CI comment say so rather than implying full coverage.

**Across apps the gate covers `website/` only, and that is a scope call rather than a claim about the others.** Measured on this checkout: `examples/blog` is genuinely red (13 errors), but `docs/` and `packages/ui/packages/website` both typecheck clean today. Adding those two is a small separate change, deliberately not folded into a one-line typing fix. The issue said the UI website does not complete a `tsc` run at all; that is not what it does, and the prose in the diff says the measured thing instead.

Also rejected: a non-null assertion (`open!.push(text)`), an `as Para` cast or `any` (both barred by the derive-the-type rule), a local annotated copy whose only purpose is to defeat the analysis, inlining `startPara` at all three call sites (which duplicates the `paras.push` bookkeeping three ways, the exact shape #1233 factored out), and rewriting the loop as a class or a reducer.

## Test plan

- `npm run typecheck --workspace=@webjsdev/website` exits 0. Reverting the `render-entry.ts` change alone reds it with the original `TS2339`, and reverting the script and CI step alone makes the failure invisible again, which is the recurrence this closes.
- Widening the `include` to `test/**` as well was measured, not assumed: it surfaces 30 pre-existing errors, so it stays out. `lib/` and `modules/` were measured clean, so they went in.
- Rendering all 229 `changelog/<pkg>/*.md` entry files through the pre-change and post-change renderer gives byte-identical HTML (0 diffs of 229), which confirms this is a typing gap and not a live bug.
- `npm test --workspace=@webjsdev/website`: 436 node tests pass, 84 browser tests pass. The 9 changelog rendering tests from #1233 are unchanged and still green.
- No new unit test. The defect is invisible to a runtime assertion by construction, since the shipped renderer already behaves correctly; the new CI step is the harness that catches it.
- Browser / e2e / Bun parity: N/A. `renderEntryBody` is a pure server-side string function with no client, wire, listener, serializer, stream, or `node:*` surface.
- Dogfood: N/A for the four-app boot check. No framework package changed, and the one app touched here is the website, whose own full suite (node + browser) runs above.

## Doc surfaces

- **Updated**: `website/AGENTS.md`.
- **N/A**: the framework docs, the skill at `.agents/skills/webjs/`, the scaffold templates, the docs site, `README.md`, the MCP inventory, and the editor plugins. `render-entry.ts` is website-internal with no public API.
- **N/A**: changelog and version bumps. No published package changed.

## Follow-on

#1267 edits this same file and this same paragraph machinery, and its PR is stacked on this branch.
