### PR TITLE
chore: release core 0.7.47, server 0.8.59, cli 0.10.51 and five more

### DIFF
--- a/changelog/cli/0.10.51.md
+++ b/changelog/cli/0.10.51.md
@@ -1,0 +1,58 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.51
+date: 2026-08-06T07:41:39.579Z
+commit_count: 11
+---
+## Features
+
+- **`webjs doctor` severity is declarable per check in `webjs.doctor.gate`** ([#1296](https://github.com/webjsdev/webjs/pull/1296)) [`5d286600`](https://github.com/webjsdev/webjs/commit/5d286600)
+  The command was all-or-nothing: the default exit fails on a broken
+  toolchain, and `--strict` makes every warning fatal. A project can now map a
+  stable check code to `off` / `warn` / `error` in the `webjs` config block, so
+  CI gates the subset it cares about and stops treating every advisory as a
+  release blocker. `--json` carries each result's code and effective severity,
+  plus a `configErrors` key on the one path where a rejected `webjs.doctor`
+  config stops any check running.
+
+- **`webjs doctor` warns when a stylesheet link skips `asset()`** ([#1244](https://github.com/webjsdev/webjs/pull/1244)) [`060617ef`](https://github.com/webjsdev/webjs/commit/060617ef)
+  A page or layout that hand-writes `<link rel="stylesheet" href="/public/...">`
+  serves it at an unversioned url, so a CDN keeps the pre-deploy bytes for as
+  long as its TTL says.
+
+- **the scaffold gallery teaches the bound-form shape** [`a22a2995`](https://github.com/webjsdev/webjs/commit/a22a2995)
+  Every gallery form now binds an imported action instead of routing through a
+  per-page adapter, and the actions take the `FormData` directly. The todo
+  example keeps one intent-dispatching action because its rows carry two submit
+  buttons, which is the shape the `formaction` refusal points at. Extended for
+  submitters in [`e4177d95`](https://github.com/webjsdev/webjs/commit/e4177d95),
+  with the caching demo and the conventions doc brought along in
+  [`3838b10a`](https://github.com/webjsdev/webjs/commit/3838b10a) and
+  [`b306cd1e`](https://github.com/webjsdev/webjs/commit/b306cd1e).
+
+- **the npm description says what WebJs is** ([#1248](https://github.com/webjsdev/webjs/pull/1248)) [`175bf443`](https://github.com/webjsdev/webjs/commit/175bf443)
+  Registry metadata only.
+
+## Fixes
+
+- **validate the app name in `webjs create` before writing files** ([#1234](https://github.com/webjsdev/webjs/pull/1234)) [`fe9e58b0`](https://github.com/webjsdev/webjs/commit/fe9e58b0)
+  The name is not only the new directory. It is written verbatim into the
+  generated `package.json` `name` field and interpolated into generated source
+  as a template-literal value, so a name carrying a quote, a backtick, a `${`,
+  or a backslash emitted a file that failed to parse, and the failure surfaced
+  as a syntax error on the fresh app's first boot, far from its cause. The name
+  is now checked against the npm package-name rules before a single file is
+  written. Uppercase is accepted, since the scaffold's manifest is private.
+
+- **the scaffold's `components.json` matches what `webjs ui init` writes** ([#1235](https://github.com/webjsdev/webjs/pull/1235)) [`b0bc2742`](https://github.com/webjsdev/webjs/commit/b0bc2742)
+  `@webjsdev/ui` dropped project detection and moved its defaults to constants
+  in `init`, so `webjs create` now points at that single source. An app that
+  scaffolds and one that runs `webjs ui init` end up with the same config.
+
+- **point the scaffold auth test at the database `db:migrate` prepares** [`03662927`](https://github.com/webjsdev/webjs/commit/03662927)
+  It defaulted `DATABASE_URL` to `./dev.db` while `.env.example` and
+  `drizzle.config.ts` both use `db/dev.db`, so the signup flow found no users
+  table and skipped asking for `db:migrate`, and running `db:migrate` migrated
+  a different file, which made the skip permanent.
+
+- **update the scaffold's action tests for the new identity rules** [`18990a7b`](https://github.com/webjsdev/webjs/commit/18990a7b)

--- a/changelog/core/0.7.47.md
+++ b/changelog/core/0.7.47.md
@@ -1,0 +1,134 @@
+---
+package: "@webjsdev/core"
+version: 0.7.47
+date: 2026-08-06T07:41:39.499Z
+commit_count: 24
+---
+## Breaking
+
+- **`WEBJS_NO_TRUST_PROXY=1` now overrides `rateLimit({ trustProxy: true })`** ([#1272](https://github.com/webjsdev/webjs/pull/1272)) [`afc1170e`](https://github.com/webjsdev/webjs/commit/afc1170e)
+  The kill switch was honoured by every reader of the forwarded host and proto
+  (the URL rewrite, the HSTS scheme gate, the CSRF host resolution) but not by
+  `clientIp`. An operator who set the flag because their container is directly
+  exposed, and who also passed `rateLimit({ trustProxy: true })`, still bucketed
+  rate limits on a header any client can set, so a rotating `X-Forwarded-For`
+  gave every request its own bucket. The switch is now absolute across every
+  forwarded-header read.
+
+  **Migration.** An app that sets both now buckets every visitor behind the
+  proxy onto one key. That combination was always a misconfiguration and is now
+  a visible one. On a genuinely proxied deploy, unset `WEBJS_NO_TRUST_PROXY`.
+  The contradiction warns once per process rather than throwing, because the
+  flag is read per request on the hot path and a throw would take a
+  misconfigured deploy down instead of degrading it.
+
+## Features
+
+- **bind a server action into `<form action=${action}>` and `formaction=${action}`** ([#1210](https://github.com/webjsdev/webjs/pull/1210)) [`429e35e3`](https://github.com/webjsdev/webjs/commit/429e35e3)
+  An unquoted `action=` hole on a `<form>` is now a binding rather than a value.
+  Both renderers resolve the action's identity, omit the `action` attribute so
+  the form posts to the page's own url, supply `method="post"` and an enctype
+  where the template supplies neither, and emit one hidden `__webjs_action`
+  field carrying the identity. A form whose buttons run different actions binds
+  each on its submitter with `formaction=${action}`, where the identity rides
+  the pressed button's own name and value pair. This is the no-JS write path:
+  it works with JS off, and with JS the client router posts the same body to
+  the same url and applies the response in place.
+
+  Every near-miss throws rather than producing a form that posts nowhere. The
+  renderers refuse a quoted `action="${fn}"`, an `action` hole on a tag other
+  than `<form>`, `method="get"` or an unparseable enctype, a `.method` /
+  `.enctype` / `.encoding` property binding, a second `action` hole, a plain
+  `action="/url"` alongside the bound hole, a whitespace-padded `method`, and a
+  function that is not a `'use server'` export. On a submitter they refuse an
+  unbound enclosing form, a control that is not a submit control, an
+  `<input type="image">` or `<input type="submit">`, a submitter carrying its
+  own `name` / `value` / `form` / static `formaction`, and the property
+  spellings of any of those. Where a renderer genuinely cannot tell whether the
+  enclosing form is bound (a component rendering its own template, a
+  `repeat()` row reconciled before its parent form exists) it binds rather than
+  refusing, so an ordinary per-row button is never rejected.
+
+  The full rule set is invariant 12 in `AGENTS.md`. Landed across
+  [`d12c30db`](https://github.com/webjsdev/webjs/commit/d12c30db),
+  [`d4ab6f74`](https://github.com/webjsdev/webjs/commit/d4ab6f74),
+  [`e4177d95`](https://github.com/webjsdev/webjs/commit/e4177d95) and the
+  review fixes that hardened it:
+  [`595826ec`](https://github.com/webjsdev/webjs/commit/595826ec) validates a
+  bound form only after every part is committed, so an attribute written after
+  the action hole is seen;
+  [`f892f5e5`](https://github.com/webjsdev/webjs/commit/f892f5e5) drops a
+  failed render's pending binds instead of leaking them into the next one;
+  [`c09413c3`](https://github.com/webjsdev/webjs/commit/c09413c3),
+  [`65d23bb8`](https://github.com/webjsdev/webjs/commit/65d23bb8),
+  [`d7df9dd9`](https://github.com/webjsdev/webjs/commit/d7df9dd9) and
+  [`b148be61`](https://github.com/webjsdev/webjs/commit/b148be61) re-check the
+  form on every write path, including a removal, the boolean and property
+  branches, and the legacy `form.encoding` alias; and
+  [`573a2f5c`](https://github.com/webjsdev/webjs/commit/573a2f5c) keeps an
+  action's identity resolvable when it is defined in a linked workspace package
+  and re-exported through an in-app barrel.
+
+- **`webjs.doctor.gate` is typed on `WebjsConfig`** ([#1296](https://github.com/webjsdev/webjs/pull/1296)) [`5d286600`](https://github.com/webjsdev/webjs/commit/5d286600)
+  The config block gains a `doctor.gate` map from a stable doctor check code to
+  `off` / `warn` / `error`, so a project can declare which project-health checks
+  are fatal in CI. Typed in `webjs-config.d.ts` and exported from `index.d.ts`.
+
+- **`setHardNavigate()` routes the router's hard navigations through one seam** ([#1290](https://github.com/webjsdev/webjs/pull/1290)) [`92f34de1`](https://github.com/webjsdev/webjs/commit/92f34de1)
+  A hard navigation is unobservable from outside: `preventDefault` cancels a
+  default action rather than a script assignment, and `location.href` is
+  non-configurable on Chromium, Firefox, and WebKit, so its setter cannot be
+  redefined. Every hard navigation now goes through one indirection whose
+  default is byte-identical to the assignment it replaces, so production
+  behaviour is unchanged unless `setHardNavigate` is called. It exists so a
+  router degradation fails one test with its cause slug instead of aborting the
+  whole browser session.
+
+- **the npm description says what WebJs is** ([#1248](https://github.com/webjsdev/webjs/pull/1248)) [`175bf443`](https://github.com/webjsdev/webjs/commit/175bf443)
+  Registry metadata only. The package described what the package does without
+  ever saying what the project is, so a stranger landing on the npm page from a
+  search had no way to place it.
+
+## Fixes
+
+- **close an open redirect in `sameSiteRedirect`** [`b306cd1e`](https://github.com/webjsdev/webjs/commit/b306cd1e)
+  It rejected `//host` and `/\host` but accepted `/<TAB>/host`. The URL parser
+  removes tab, LF, and CR before parsing, so that value reached the redirect as
+  a protocol-relative url pointing off-site.
+
+- **stop a `reflect: true` prop stringifying a function into its attribute** ([#1231](https://github.com/webjsdev/webjs/pull/1231)) [`e303d57c`](https://github.com/webjsdev/webjs/commit/e303d57c)
+  The fall-through branch of `_reflectAttribute` ran `String(value)`, and
+  `String(fn)` is the function's source, so assigning an imported action to a
+  reflected prop wrote the whole function body into the DOM.
+
+- **reactivate a top-level script in a swapped range** ([#1236](https://github.com/webjsdev/webjs/pull/1236)) [`79c6e7e5`](https://github.com/webjsdev/webjs/commit/79c6e7e5)
+  A `<script>` that is a top-level node of a client-router swapped range was
+  never re-executed after a soft navigation.
+
+- **a preserved permanent element keeps its descendant scripts** ([#1279](https://github.com/webjsdev/webjs/pull/1279)) [`8ceda3a4`](https://github.com/webjsdev/webjs/commit/8ceda3a4)
+  `data-webjs-permanent` preserves an element across a swap as the same live
+  DOM node, and the reconciler already treats that as a subtree guarantee. The
+  reactivation pass disagreed and re-emitted every script inside it.
+
+- **make `repeat` / `guard` / `watch` / `until` commits atomic against a throw** ([#1232](https://github.com/webjsdev/webjs/pull/1232)) [`f426edd8`](https://github.com/webjsdev/webjs/commit/f426edd8)
+  Several client-renderer commit paths recorded their bookkeeping before the
+  DOM work that can throw, so a throw part-way through left the renderer's
+  state describing a DOM that was never built.
+
+- **a throw while removing `repeat()` leftovers no longer strands the row** ([#1274](https://github.com/webjsdev/webjs/pull/1274)) [`982d5606`](https://github.com/webjsdev/webjs/commit/982d5606)
+  Rows already disposed and detached stayed registered in `state.map`.
+
+- **a mid-commit throw no longer strands a row in a plain `.map()` array** ([#1284](https://github.com/webjsdev/webjs/pull/1284)) [`df2b6980`](https://github.com/webjsdev/webjs/commit/df2b6980)
+  `reconcileArray` accumulated its replacement slot list locally and committed
+  it only after the whole walk, so a throw part-way discarded the list.
+
+- **a directive inside an `asyncAppend` chunk no longer escapes the error boundary** ([#1285](https://github.com/webjsdev/webjs/pull/1285)) [`cea65748`](https://github.com/webjsdev/webjs/commit/cea65748)
+  A `watch()` or `until()` nested inside a chunk committed by `asyncAppend` or
+  `asyncReplace` never got an error-boundary owner, so a throw from its commit
+  escaped the owning component.
+
+- **hint the core runtime in the head so a pre-boot click is not a full page load** ([#1281](https://github.com/webjsdev/webjs/pull/1281)) [`74dd3ada`](https://github.com/webjsdev/webjs/commit/74dd3ada)
+  Links are clickable from first paint, but the boot is a module script, which
+  the HTML spec defers until parsing finishes, so a click inside that window is
+  a plain browser navigation. The runtime is now hinted in the head, which
+  shortens the window rather than pretending to close it.

--- a/changelog/intellisense/0.5.5.md
+++ b/changelog/intellisense/0.5.5.md
@@ -1,0 +1,12 @@
+---
+package: "@webjsdev/intellisense"
+version: 0.5.5
+date: 2026-08-06T07:41:39.644Z
+commit_count: 1
+---
+## Features
+
+- **the npm description says what WebJs is** ([#1248](https://github.com/webjsdev/webjs/pull/1248)) [`175bf443`](https://github.com/webjsdev/webjs/commit/175bf443)
+  Registry metadata only. The package described what the package does without
+  ever saying what the project is, so a stranger landing on the npm page from a
+  search had no way to place it.

--- a/changelog/mcp/0.1.11.md
+++ b/changelog/mcp/0.1.11.md
@@ -1,0 +1,12 @@
+---
+package: "@webjsdev/mcp"
+version: 0.1.11
+date: 2026-08-06T07:41:39.687Z
+commit_count: 1
+---
+## Features
+
+- **the npm description says what WebJs is** ([#1248](https://github.com/webjsdev/webjs/pull/1248)) [`175bf443`](https://github.com/webjsdev/webjs/commit/175bf443)
+  Registry metadata only. The package described what the package does without
+  ever saying what the project is, so a stranger landing on the npm page from a
+  search had no way to place it.

--- a/changelog/nvim/0.2.4.md
+++ b/changelog/nvim/0.2.4.md
@@ -1,0 +1,16 @@
+---
+package: "webjs.nvim"
+version: 0.2.4
+date: 2026-08-06T07:41:39.725Z
+commit_count: 1
+npm: false
+---
+## Fixes
+
+- **the vendored language service cannot drift from its manifest** ([#1248](https://github.com/webjsdev/webjs/pull/1248)) [`175bf443`](https://github.com/webjsdev/webjs/commit/175bf443)
+  The plugin ships a committed copy of `@webjsdev/intellisense`, and the drift
+  guard now compares that package's `package.json` in full rather than only its
+  sources, so a version bump or a description change that was not re-vendored
+  fails CI instead of shipping a plugin that misreports its own language
+  service version. Carries the refreshed manifest for
+  `@webjsdev/intellisense` 0.5.5.

--- a/changelog/server/0.8.59.md
+++ b/changelog/server/0.8.59.md
@@ -1,0 +1,135 @@
+---
+package: "@webjsdev/server"
+version: 0.8.59
+date: 2026-08-06T07:41:39.539Z
+commit_count: 24
+---
+## Breaking
+
+- **the server HTML cache is keyed by origin, and proxy trust is centralized** ([#1237](https://github.com/webjsdev/webjs/pull/1237)) [`3838b10a`](https://github.com/webjsdev/webjs/commit/3838b10a)
+  The response cache keyed on path plus sorted search only, so a page that
+  opted in with `export const revalidate` could be poisoned through
+  `X-Forwarded-Host`. Neither Cloudflare nor Railway strips a client-supplied
+  one, so a hostile value arrives through the proxy rather than around it, and
+  `ctx.url` is built from it. One request baked an attacker-chosen origin into
+  the shared body and every later visitor to that path was served it: a
+  poisoned `og:image`, canonical link, OAuth callback url, or absolute asset
+  url. The key now carries `url.origin`.
+
+  **Migration.** A single-host deploy has one origin and so one key per url,
+  and its hit rate is unchanged. Because a bare path no longer names one key,
+  `revalidatePath` resolves the origin from the calling request, which is exact
+  for a server action since it runs inside the triggering user's request, and
+  falls back to a bounded first-seen-wins registry of what the process has
+  cached under. A background job that serves no request of its own must pass an
+  absolute url. Separately, `WEBJS_NO_TRUST_PROXY=1` now also governs the CSRF
+  host resolution, so on a genuinely proxied deploy with the flag set the
+  legacy `Origin` fallback compares against the raw `Host` and can reject a
+  legitimate cross-host request, which is what the flag asks for.
+
+- **`WEBJS_NO_TRUST_PROXY=1` now overrides `rateLimit({ trustProxy: true })`** ([#1272](https://github.com/webjsdev/webjs/pull/1272)) [`afc1170e`](https://github.com/webjsdev/webjs/commit/afc1170e)
+  `clientIp` was the one forwarded-header reader the kill switch did not reach,
+  so an operator who set the flag and also passed `rateLimit({ trustProxy: true })`
+  bucketed rate limits on a header any client can set. The switch is now
+  absolute across the package.
+
+  **Migration.** An app that sets both now buckets every visitor behind the
+  proxy onto one key. On a genuinely proxied deploy, unset the env var. The
+  contradiction warns once per process rather than throwing, because the flag
+  is read per request on the hot path.
+
+## Features
+
+- **dispatch a form submission to its bound action** [`4b94680c`](https://github.com/webjsdev/webjs/commit/4b94680c)
+  A non-GET request to a page's own url now runs the server action named by the
+  `__webjs_action` hidden field, replacing the page `action` export. The action
+  receives the `FormData`, and its declared `validate` / `middleware` /
+  `invalidates` config exports run here too, so an action is not protected over
+  RPC and bare over a form post. Success is a 303 (post/redirect/get), failure
+  re-renders the same page at 422 with the result on `ctx.actionData`, and a
+  submission binding nothing is a 405. The renderer half is
+  [`429e35e3`](https://github.com/webjsdev/webjs/commit/429e35e3) in
+  `@webjsdev/core`, extended to submitters in
+  [`e4177d95`](https://github.com/webjsdev/webjs/commit/e4177d95) and narrowed
+  to the shapes both renderers agree on in
+  [`d12c30db`](https://github.com/webjsdev/webjs/commit/d12c30db).
+
+- **`webjs check` flags a form bound to a GET-declared action** [`2fcea211`](https://github.com/webjsdev/webjs/commit/2fcea211)
+  A GET action is CSRF-exempt and rides its arguments in the url, so it cannot
+  answer a form post and the dispatcher returns 405. The rule reads the
+  imported action's own file, so it fires only when the binding really does
+  resolve to one.
+
+- **`webjs.doctor.gate` declares per-check doctor severity** ([#1296](https://github.com/webjsdev/webjs/pull/1296)) [`5d286600`](https://github.com/webjsdev/webjs/commit/5d286600)
+  `webjs doctor` was all-or-nothing: the default exit fails on a broken
+  toolchain, and `--strict` makes every warning fatal. A project can now map a
+  stable check code to `off` / `warn` / `error` in the `webjs` config block, so
+  CI gates the subset it cares about. Each result carries its code and
+  effective severity in `--json`.
+
+- **the npm description says what WebJs is** ([#1248](https://github.com/webjsdev/webjs/pull/1248)) [`175bf443`](https://github.com/webjsdev/webjs/commit/175bf443)
+  Registry metadata only.
+
+## Fixes
+
+- **close an open redirect and stop mislabelling a broken action** [`b306cd1e`](https://github.com/webjsdev/webjs/commit/b306cd1e)
+  `sameSiteRedirect` rejected `//host` and `/\host` but accepted `/<TAB>/host`.
+  The URL parser removes tab, LF, and CR before parsing, so that value reached
+  the redirect as a protocol-relative url pointing off-site.
+
+- **answer a thrown `validate` instead of rethrowing it** [`0192fcc8`](https://github.com/webjsdev/webjs/commit/0192fcc8)
+  Rethrowing reached the handler's last-resort catch, which reported the same
+  error to `onError` a second time and answered a bare 500 with no digest, so
+  the one thing that makes a prod error diagnosable was lost.
+
+- **action identity no longer depends on the seed facade's opinion** [`18990a7b`](https://github.com/webjsdev/webjs/commit/18990a7b)
+  Identity rode the `'use server'` load hook, which only registers a function
+  the facade wrapped. The facade declines to wrap a module containing
+  `export *` and one whose source it cannot rewrite, which used to be harmless
+  (no seeding, RPC unaffected) and became a hard render failure once a bound
+  form needed the identity.
+
+- **keep every action identity, preferring the indexed defining module** [`573a2f5c`](https://github.com/webjsdev/webjs/commit/573a2f5c)
+  The action index only walks the app tree, so an action defined in a linked
+  workspace package and re-exported through an in-app `'use server'` barrel has
+  an indexed name only under the re-exporter. Preferring the defining module
+  unconditionally lost it.
+
+- **the barrel-fallback warning says what it actually knows** [`045b917d`](https://github.com/webjsdev/webjs/commit/045b917d)
+  Five review rounds on one diagnostic. The fallback keeps a page working when
+  the defining module is outside the action index, but the warning asserted the
+  consequence as fact when it could not know it
+  ([`091e24b8`](https://github.com/webjsdev/webjs/commit/091e24b8)), recommended
+  re-exporting the action's config alongside it, which is actively harmful
+  ([`3a090645`](https://github.com/webjsdev/webjs/commit/3a090645)), described
+  the config bypass in one direction when it cuts both ways
+  ([`0deef540`](https://github.com/webjsdev/webjs/commit/0deef540)), and stated
+  the dedicated-module remedy as sufficient when it is conditional on load
+  order among indexed re-exporters
+  ([`bb600659`](https://github.com/webjsdev/webjs/commit/bb600659)).
+
+- **harden the `submitForm` scan against comments and quoted values** [`e56c42eb`](https://github.com/webjsdev/webjs/commit/e56c42eb)
+
+- **wrap exported functions as hoisted declarations in the action seed facade** ([#1208](https://github.com/webjsdev/webjs/pull/1208)) [`420bcdbb`](https://github.com/webjsdev/webjs/commit/420bcdbb)
+
+- **memoize facade action wrapping and refine export classification** ([#1211](https://github.com/webjsdev/webjs/pull/1211)) [`e672d317`](https://github.com/webjsdev/webjs/commit/e672d317)
+  `extractExportNames()` now recognizes non-function variables declared locally
+  in an export list (`export { a, b }`).
+
+- **exit non-zero when a fatal error shuts the server down** ([#1238](https://github.com/webjsdev/webjs/pull/1238)) [`316bfb9b`](https://github.com/webjsdev/webjs/commit/316bfb9b)
+  A crashed server told its supervisor it had stopped cleanly. `makeShutdown`
+  ended every clean drain with `process.exit(0)` no matter what started it, so
+  the exit code carried no information about whether the process was dying from
+  an error.
+
+- **scope the dev error overlay to the URL that produced it** ([#1294](https://github.com/webjsdev/webjs/pull/1294)) [`b355cd8f`](https://github.com/webjsdev/webjs/commit/b355cd8f)
+  In dev, a render error overlay leaked onto pages that render fine, including
+  onto other open tabs, because the frame fans out over the shared reload
+  channel. A `render` frame now carries its url and the browser half decides
+  whether it belongs on the page being viewed, so hovering a link that
+  prefetches a throwing page cannot break the page you are looking at.
+
+- **hint the core runtime in the head so a pre-boot click is not a full page load** ([#1281](https://github.com/webjsdev/webjs/pull/1281)) [`74dd3ada`](https://github.com/webjsdev/webjs/commit/74dd3ada)
+  Links are clickable from first paint, but the boot is a module script, which
+  the HTML spec defers until parsing finishes, so a click inside that window is
+  a plain browser navigation.

--- a/changelog/ui/0.3.11.md
+++ b/changelog/ui/0.3.11.md
@@ -1,0 +1,66 @@
+---
+package: "@webjsdev/ui"
+version: 0.3.11
+date: 2026-08-06T07:41:39.667Z
+commit_count: 7
+---
+## Breaking
+
+- **`@webjsdev/ui` is scoped to WebJs apps, and project detection is gone** ([#1235](https://github.com/webjsdev/webjs/pull/1235)) [`b0bc2742`](https://github.com/webjsdev/webjs/commit/b0bc2742)
+  The package advertised support for Next, Astro, Vite, SvelteKit, and Lit. All
+  that stood behind it was `detectProject()` classifying the host project and
+  `defaultsForProject()` picking two fields for `components.json`. Nothing else
+  branched on project type, and Lit and SvelteKit were never detected at all,
+  so part of the claim was simply false. The concept is deleted rather than
+  narrowed: the defaults are plain constants at the one place that read them
+  (`init`), and `webjsui info` no longer prints a project type.
+
+  **Migration.** `detectProject` and `defaultsForProject` are removed from the
+  published `@webjsdev/ui/utils` specifier with no deprecation shim, so an
+  importer of either must drop the call. `components.json` keeps its shape and
+  nothing recomputes paths on an already-initialised project, so an existing
+  app needs no migration. For a non-WebJs project `init` now writes
+  `styles/globals.css` and the WebJs aliases instead of `app/globals.css` and
+  `@/` aliases. That is the scoping decision, not an oversight, and `--css`
+  plus hand-editing `components.json` still work, they are just no longer a
+  supported or tested path.
+
+  The one remaining `utils` alias default moves to `lib/utils/cn`, matching
+  what `webjs create` has always scaffolded, so `webjs ui init` and
+  `webjs create` now emit the same `components.json`. That also fixes `add`
+  writing a dead second copy of the `cn` and DOM helpers at the manifest's
+  pinned path while every component's import pointed at the configured alias.
+
+## Features
+
+- **the registry is served from `webjs.dev/ui`** ([#1126](https://github.com/webjsdev/webjs/pull/1126)) [`d9b2fe1d`](https://github.com/webjsdev/webjs/commit/d9b2fe1d)
+  The gallery merged into the marketing site, so the CLI now fetches
+  `https://webjs.dev/ui/registry/<name>.json`. The old
+  `ui.webjs.dev/registry/**` urls permanently redirect, because already
+  published CLI versions fetch from them.
+
+- **the npm description says what WebJs is** ([#1248](https://github.com/webjsdev/webjs/pull/1248)) [`175bf443`](https://github.com/webjsdev/webjs/commit/175bf443)
+  Registry metadata only.
+
+## Fixes
+
+- **key `cn()` conflicts on the CSS property, not the class prefix** ([#1247](https://github.com/webjsdev/webjs/pull/1247)) [`dfefe3ec`](https://github.com/webjsdev/webjs/commit/dfefe3ec)
+  Two defects in the shared merger, both from a conflict group that did not
+  match a real CSS property, so classes that cannot conflict cancelled each
+  other and classes that do conflict both survived.
+
+- **close the accessibility gaps found in the kit a11y audit** ([#1230](https://github.com/webjsdev/webjs/pull/1230)) [`f4a6e0cd`](https://github.com/webjsdev/webjs/commit/f4a6e0cd)
+  Menu keyboard activation, focus handling on a delayed hover-card close,
+  popover-open gating, and the ARIA guidance the agent-facing docs stated
+  incorrectly. Two findings marked needs-runtime-check are deliberately not
+  addressed here, since they need a screen-reader pass.
+
+- **stop the dialog scroll lock shifting a fixed header** ([#1146](https://github.com/webjsdev/webjs/pull/1146)) [`f844399d`](https://github.com/webjsdev/webjs/commit/f844399d)
+  Hiding the page scrollbar widens the viewport by its width. The lock
+  compensated by padding the body, which holds in-flow content still but does
+  nothing for a fixed header, so opening a dialog jogged the header sideways.
+
+- **make the accordion trigger hover a state layer** ([#1137](https://github.com/webjsdev/webjs/pull/1137)) [`30b94783`](https://github.com/webjsdev/webjs/commit/30b94783)
+  Replaces the label dim that landed with the gallery move. Reduced prominence
+  is this kit's disabled vocabulary, so reusing it for hover said the wrong
+  thing.

--- a/changelog/vscode/0.2.4.md
+++ b/changelog/vscode/0.2.4.md
@@ -1,0 +1,16 @@
+---
+package: "webjs (VS Code extension)"
+version: 0.2.4
+date: 2026-08-06T07:41:39.707Z
+commit_count: 1
+npm: false
+---
+## Fixes
+
+- **the "webjs create" prompt accepts every name the CLI does** ([#1234](https://github.com/webjsdev/webjs/pull/1234)) [`fe9e58b0`](https://github.com/webjsdev/webjs/commit/fe9e58b0)
+  The input box validated against a lowercase-only regex the CLI had long
+  since dropped, so it refused `MyApp`, `my.app`, and `my_app` while the
+  command it shells out to would have accepted all three. It now mirrors the
+  CLI's rule, including the 214-character cap and the npm-reserved names, and
+  a test cross-checks the two over a name table so the duplication cannot
+  drift again.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6975,7 +6975,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.50",
+      "version": "0.10.51",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -6991,7 +6991,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.46",
+      "version": "0.7.47",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.25.0"
@@ -6999,7 +6999,7 @@
     },
     "packages/editors/intellisense": {
       "name": "@webjsdev/intellisense",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "MIT",
       "peerDependencies": {
         "typescript": ">=5.0.0"
@@ -7007,11 +7007,11 @@
     },
     "packages/editors/nvim": {
       "name": "webjs.nvim",
-      "version": "0.2.3"
+      "version": "0.2.4"
     },
     "packages/editors/vscode": {
       "name": "webjs",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/intellisense": "^0.5.0"
@@ -7025,7 +7025,7 @@
     },
     "packages/mcp": {
       "name": "@webjsdev/mcp",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/server": "^0.8.0",
@@ -7040,10 +7040,10 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.58",
+      "version": "0.8.59",
       "license": "MIT",
       "dependencies": {
-        "@webjsdev/core": "^0.7.46",
+        "@webjsdev/core": "^0.7.47",
         "ws": "^8.20.0"
       },
       "engines": {
@@ -7076,7 +7076,7 @@
     },
     "packages/ui": {
       "name": "@webjsdev/ui",
-      "version": "0.3.10",
+      "version": "0.3.11",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.50",
+  "version": "0.10.51",
   "type": "module",
   "description": "The CLI for WebJs, a full-stack JavaScript framework built on web components with server-side rendering and no build step. Runs the dev and production servers, scaffolds apps, validates conventions, and drives the database. Node 24+ or Bun.",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.46",
+  "version": "0.7.47",
   "type": "module",
   "description": "The runtime for WebJs, a full-stack JavaScript framework built on web components with server-side rendering and no build step. Ships the html and css template tags, the WebComponent base class, signals, directives, and the isomorphic renderers.",
   "types": "./index.d.ts",

--- a/packages/editors/intellisense/package.json
+++ b/packages/editors/intellisense/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/intellisense",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "type": "commonjs",
   "description": "The TypeScript language-service plugin for WebJs, a full-stack JavaScript framework built on web components with server-side rendering and no build step. Adds in-template intelligence with no Lit dependency: go-to-definition on tags, attributes, and CSS classes, binding-aware completions, value and binding diagnostics, and hover.",
   "main": "src/index.js",

--- a/packages/editors/nvim/package.json
+++ b/packages/editors/nvim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webjs.nvim",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "description": "Neovim editor support for webjs apps (html/css/svg template highlighting + in-template intelligence via the bundled @webjsdev/intellisense). NOT an npm package: ships to the webjsdev/webjs.nvim git repo via subtree split, installed by lazy.nvim. This manifest exists only as the version source for the unified changelog (changelog/nvim/<version>.md); see PUBLISHING.md."
 }

--- a/packages/editors/nvim/vendor/node_modules/@webjsdev/intellisense/package.json
+++ b/packages/editors/nvim/vendor/node_modules/@webjsdev/intellisense/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/intellisense",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "type": "commonjs",
   "description": "The TypeScript language-service plugin for WebJs, a full-stack JavaScript framework built on web components with server-side rendering and no build step. Adds in-template intelligence with no Lit dependency: go-to-definition on tags, attributes, and CSS classes, binding-aware completions, value and binding diagnostics, and hover.",
   "main": "src/index.js",

--- a/packages/editors/vscode/package.json
+++ b/packages/editors/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webjs",
   "displayName": "webjs",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "All-in-one webjs support: html/css template highlighting, language-service intelligence, snippets, and commands. No Lit extension required.",
   "publisher": "webjsdev",
   "private": true,

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/mcp",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "type": "module",
   "description": "The Model Context Protocol server for WebJs, a full-stack JavaScript framework built on web components with server-side rendering and no build step. Gives AI coding agents live app introspection over routes, actions, components, and convention checks, plus a knowledge layer of docs, recipes, and framework source.",
   "bin": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.58",
+  "version": "0.8.59",
   "type": "module",
   "description": "The server for WebJs, a full-stack JavaScript framework built on web components with server-side rendering and no build step. Provides the file-based router, SSR, server actions, route handlers, middleware, and live reload on Node 24+ or Bun.",
   "main": "index.js",
@@ -28,7 +28,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@webjsdev/core": "^0.7.46",
+    "@webjsdev/core": "^0.7.47",
     "ws": "^8.20.0"
   },
   "publishConfig": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/ui",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "type": "module",
   "description": "The AI-first component library for WebJs, a full-stack JavaScript framework built on web components with server-side rendering and no build step. Class-helper functions for visuals, custom elements only where state matters, source-copied into your repo so you own it.",
   "bin": {


### PR DESCRIPTION
Clears the whole release backlog. Every tracked package carries unreleased
user-facing work, so this ships all eight rather than a slice.

| Package | From | To | Notes |
|---|---|---|---|
| `@webjsdev/core` | 0.7.46 | 0.7.47 | 1 breaking |
| `@webjsdev/server` | 0.8.58 | 0.8.59 | 2 breaking |
| `@webjsdev/cli` | 0.10.50 | 0.10.51 | |
| `@webjsdev/mcp` | 0.1.10 | 0.1.11 | registry metadata only |
| `@webjsdev/ui` | 0.3.10 | 0.3.11 | 1 breaking |
| `@webjsdev/intellisense` | 0.5.4 | 0.5.5 | registry metadata only |
| `webjs` (VS Code) | 0.2.3 | 0.2.4 | ships via vsce/ovsx, `npm: false` |
| `webjs.nvim` | 0.2.3 | 0.2.4 | ships via the subtree, `npm: false` |

## The headline

The bound-form write path (#1155, #1207). A form binds its action directly,
`<form action=${importedAction}>`, with `formaction=${importedAction}` on a
submitter when one form's buttons run different actions. It works with JS off,
and with JS the client router posts the same body to the same url and applies
the response in place. Every near-miss throws rather than emitting a form that
posts nowhere. This replaces the page `action` export.

## Three breaking changes

Each closes a hole rather than moving an API, and each carries a migration note
in its changelog entry.

- **The server HTML cache is keyed by origin** (#1237). A page opting in with
  `export const revalidate` could be poisoned through `X-Forwarded-Host`, which
  neither Cloudflare nor Railway strips. Callers of `revalidatePath` from a
  background job that serves no request of its own must now pass an absolute
  url.
- **`WEBJS_NO_TRUST_PROXY=1` overrides `rateLimit({ trustProxy: true })`**
  (#1272). `clientIp` was the one forwarded-header reader the kill switch did
  not reach. An app setting both now buckets every visitor behind the proxy
  onto one key, which was always a misconfiguration and is now a visible one.
- **`@webjsdev/ui` drops project detection** (#1235). `detectProject` and
  `defaultsForProject` are removed from the published `@webjsdev/ui/utils`
  specifier with no shim.

## Publish ordering and the core range

`packages/server`'s declared `@webjsdev/core` range moves from `^0.7.46` to
`^0.7.47`. `dev.js` and the action dispatcher now import `FORM_ACTION_FIELD`,
`FORM_ACTION_ID_KEY`, and `setFormActionResolver` statically, and no published
core before 0.7.47 carries them, so the old range would let npm install a pair
that dies at module load. The release PR is the only place that bump is legal.

`changelog/core/0.7.47.md` holds the earliest `date:` of the batch, so the
publish loop ships core first and a failure there stops everything after it.

## Curation

The generated notes were edited before committing, per the flow in
`framework-dev.md`:

- Both server breaking entries and the core one carry hand-written migration
  notes; the generator only excerpts the first lines of a commit message.
- The form-binding epic's review commits are folded into the feature they
  hardened rather than listed as eleven separate entries.
- `changelog/ui/0.3.11.md` is trimmed to the published surface. The generator
  attributes commits from the nested `packages/ui/packages/website` sub-app,
  which is not published; `commit_count` is corrected to match.
- Test-harness and repo-hygiene commits (the browser nav guard, the jspm
  fixture, the dist symlink removal) are dropped from the public notes.

## Verification

- `test/packaging/changelog-editor-packages.test.mjs` and the four release
  repo-health suites: 36 pass.
- `packages/editors/nvim/test/vendor-sync.test.mjs`: 3 pass. The intellisense
  bump was re-vendored in the same commit, as that guard requires.
- `website` server suite (which renders `/changelog`): 443 pass. Browser suite:
  84 pass.
- The lockfile diff is only the eight versions plus the core range.
