### PR TITLE
docs: make the blog post's optimistic() reducer pure

### DIFF
--- a/blog/optimistic-ui-without-boilerplate.md
+++ b/blog/optimistic-ui-without-boilerplate.md
@@ -2,7 +2,7 @@
 title: "Optimistic UI Without the Boilerplate (React useOptimistic, for Web Components)"
 date: 2026-07-06T10:00:00+05:30
 slug: optimistic-ui-without-boilerplate
-description: "WebJs now ships a declarative optimistic() API with full React 19 useOptimistic parity for Web Components. No try-catch, no manual state caching, no temporary ID bookkeeping. Just add, await, and reconcile."
+description: "WebJs now ships a declarative optimistic() API with full React 19 useOptimistic parity for Web Components. No try-catch, no manual state caching, no temp-id reconciliation. Just add, await, and reconcile."
 tags: optimistic-ui, web-components, react, state-management, ux
 author: Vivek
 ---
@@ -67,9 +67,13 @@ class TodoList extends WebComponent({ todos: prop(Array) }) {
     this.todos = [];
     this.optimisticTodos = optimistic(this, {
       source: () => this.todos,
-      update: (state, title) => [
+      // Pure: the row is derived from the payload, nothing is minted here.
+      // The .value getter re-folds the queue on EVERY read, so a minted id
+      // would differ per render, and a hardcoded 'tmp' would collide across
+      // two concurrent adds. The temp id is minted once in the handler.
+      update: (state, add) => [
         ...state,
-        { id: 'tmp', title, completed: false, pending: true },
+        { id: add.tempId, title: add.title, completed: false, pending: true },
       ],
     });
   }
@@ -77,8 +81,9 @@ class TodoList extends WebComponent({ todos: prop(Array) }) {
   async handleSubmit(e) {
     e.preventDefault();
     const title = getTitle(e);
+    const tempId = crypto.randomUUID();
     const promise = createTodo({ title });
-    this.optimisticTodos.add(title, promise);
+    this.optimisticTodos.add({ tempId, title }, promise);
     const result = await promise;
     if (result.success && result.data) {
       this.todos = [...this.todos, result.data];
@@ -92,15 +97,15 @@ class TodoList extends WebComponent({ todos: prop(Array) }) {
 }
 ```
 
-The difference is structural. Instead of manually caching and reverting, you declare a reducer that says "when a title comes in, append an optimistic item." Then you call `.add(title, promise)` and the wrapper handles the rest. The optimistic update appears immediately. When the promise settles, it disappears. You update `this.todos` on success and the source of truth reconciles naturally.
+The difference is structural. Instead of manually caching and reverting, you declare a pure reducer that builds the optimistic row out of a payload, then call `.add({ tempId, title }, promise)` and let the wrapper handle the rest. The optimistic update appears immediately. When the promise settles, it disappears. You update `this.todos` on success and the source of truth reconciles naturally.
 
-No try-catch. No temp IDs. No previous-state cache. The reducer is the only place the optimistic shape lives, so there is one source of truth for what an optimistic item looks like.
+No try-catch. No previous-state cache. No reconciling a temp id against the real one. Minting the id is one line in the handler, and everything that used to surround it is gone. Nothing tracks the temp row afterwards, because the overlay drops whole when the promise settles and the authoritative row arrives with `result.data`. The reducer is the only place the optimistic shape lives, so there is one source of truth for what an optimistic item looks like.
 
 # How it works under the hood
 
 The `optimistic()` function returns an `OptimisticState` object with two things: a `.value` getter and an `.add(payload, promise?)` method.
 
-**`.value`** reads the current state from your `source()` function and then folds every queued optimistic update through your `update` reducer. If there are no pending updates, it returns the source value directly. If there are three, it applies all three in order. This means the value is always computed, never stored, so it automatically reflects the latest source state.
+**`.value`** reads the current state from your `source()` function and then folds every queued optimistic update through your `update` reducer. If there are no pending updates, it returns the source value directly. If there are three, it applies all three in order. This means the value is always computed, never stored, so it automatically reflects the latest source state. Because the fold re-runs on every read, the reducer has to be pure. Anything it mints is minted again on each render, so a `crypto.randomUUID()` inside `update` hands the pending row a fresh id every time, and a keyed list tears that row down and rebuilds it on each update, losing focus and any in-progress transition. Mint the id once in the handler, pass it in the payload, and it stays stable for the life of the row.
 
 **`.add(payload, promise?)`** pushes the payload onto the internal queue and calls `host.requestUpdate()` so the component re-renders with the new computed value. If you pass a promise, it chains `.finally()` to auto-release the update when the promise settles. For thenables that lack `.finally`, it falls back to `.then(onFulfilled, onRejected)`. The method returns a `release()` function for cases where you want manual control instead.
 
@@ -129,15 +134,16 @@ The exported `optimistic()` function dispatches between them automatically. If t
 The promise-based auto-release is the default pattern and covers most cases:
 
 ```ts
+const tempId = crypto.randomUUID();
 const promise = createTodo({ title });
-this.optimisticTodos.add(title, promise);
+this.optimisticTodos.add({ tempId, title }, promise);
 // The optimistic item disappears when promise settles (resolve or reject).
 ```
 
 When you need explicit control, `.add(payload)` without a promise returns a `release()` function:
 
 ```ts
-const release = this.optimisticTodos.add(title);
+const release = this.optimisticTodos.add({ tempId: crypto.randomUUID(), title });
 try {
   const result = await createTodo({ title });
   if (result.success) this.todos = [...this.todos, result.data];
@@ -171,6 +177,6 @@ If you are building your first full-stack app, optimistic UI is one of those thi
 
 But the boilerplate cost is high enough that many developers skip it entirely, especially when they are learning. The old pattern required understanding temp IDs, state caching, try-catch reconciliation, and concurrent update handling. That is a lot of concepts to hold in your head when you are just trying to make a todo app work.
 
-The new API reduces it to three lines: declare the reducer, call `.add()`, reconcile on success. The concepts are the same (optimistic update, server call, reconciliation), but the code is small enough that you can see the whole thing at once. That is the difference between "I understand this pattern" and "I copied this pattern and hope it works."
+The new API reduces it to three steps: declare the reducer, call `.add()`, reconcile on success. The concepts are the same (optimistic update, server call, reconciliation), but the code is small enough that you can see the whole thing at once. That is the difference between "I understand this pattern" and "I copied this pattern and hope it works."
 
-Optimistic UI should not require a state machine. It should be three things: show the expected result immediately, run the real server action, and release the optimistic overlay when the action settles. WebJs now gives you that directly through `optimistic(host, { source, update })`, with React 19 `useOptimistic` parity, auto-release on promise settlement, concurrent update stacking, and a fallback to the original signal-based API for simple toggles. The boilerplate of temp IDs, try-catch, and manual reconciliation is gone. What remains is the intent: add the item, call the server, fix it up if the server disagrees.
+Optimistic UI should not require a state machine. It should be three things: show the expected result immediately, run the real server action, and release the optimistic overlay when the action settles. WebJs now gives you that directly through `optimistic(host, { source, update })`, with React 19 `useOptimistic` parity, auto-release on promise settlement, concurrent update stacking, and a fallback to the original signal-based API for simple toggles. The boilerplate of state caching, try-catch, and temp-id reconciliation is gone. What remains is the intent: add the item, call the server, fix it up if the server disagrees.


### PR DESCRIPTION
Closes #1258

The blog post was the fifth copy of the declarative `optimistic()` example and the only one still teaching the shape the four reference copies dropped. Its reducer minted the pending row inline with a hardcoded `{ id: 'tmp' }`, and the `.value` getter re-folds the whole queue from `source()` on every read, so that id is handed to every concurrently pending row. Anything downstream that keys on it breaks: a `repeat()` list, a click handler that captured the id, an `aria-activedescendant`, a test selector.

This ports the canonical payload-derived form in its untyped JavaScript variant (the one `website/app/docs/client-router/page.ts` carries, since the post's code is untyped throughout), mints the temp id once in the handler, and copies that page's four-line purity comment across verbatim. The payoff claim is narrowed rather than dropped: what the API removes is the temp-id bookkeeping, not the id itself, which is one line. The purity rule lands in "How it works under the hood", attached to the paragraph that already explains the per-read fold, because that is the mechanism it follows from.

## Changed

`blog/optimistic-ui-without-boilerplate.md` only. Nine edits: the front-matter description, the main snippet, the two paragraphs that described the bare-string payload, the `.value` paragraph, the auto-release and manual-release snippets, and the two closing sentences that claimed temp IDs were gone. The six-step manual walkthrough is untouched, since its temp id is correct there and it is the setup the payoff pays off.

The four reference copies (`AGENTS.md`, `.agents/skills/webjs/references/optimistic-ui.md`, the `packages/core/src/optimistic.js` JSDoc, `website/app/docs/client-router/page.ts`) and the runnable scaffold gallery component are the source of the corrected shape and are deliberately not touched.

## Test plan

- Rendered `/blog/optimistic-ui-without-boilerplate` through the real page module: output contains `add.tempId` and no `id: 'tmp'`.
- `cd website && npm test`.
- No new test. Nothing in the repo reads blog markdown, and a test that string-matches published prose would fail on every legitimate rewording while still missing a semantically wrong example written in different words. The layer that pays already exists: `packages/core/test/signals/optimistic-declarative.test.js` pins the runtime facts the corrected snippet leans on, including a deliberate assertion that a minting reducer yields a different id per read.
- Counterfactual: none owed. Reverting this reds nothing, because no test reads the markdown.

## Doc surfaces

This IS the doc change. Every other surface carrying this snippet was checked and is already correct. Tests N/A per above. Scaffold, MCP, editor plugins, README, changelog, marketing copy, dogfood apps: N/A, no code or generated surface changes.
