### PR TITLE
fix: decode llms.txt entities once, after every tag strip

### DIFF
--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -121,7 +121,15 @@ website/
                        path `webjs ui add` writes them to in a real app
     links.ts           cross-app URLs + in-app paths for the header and footer
     samples.ts         the code samples shown on the marketing pages
-    docs-llms.server.ts  enumerates the doc pages on disk (sitemap, llms.txt)
+    docs-llms.server.ts  enumerates the doc pages on disk (sitemap, llms.txt).
+                       Strips tags at every stage and decodes entities exactly
+                       ONCE, at the end. Decoding earlier puts a bare `<` in
+                       front of a later tag strip, which then matches to the
+                       next `>` anywhere in the document and deletes
+                       everything between the two. That once cost
+                       `/docs/metadata-routes` 5 of its 9 code samples and
+                       deleted an escaped tag from 253 prose lines across the
+                       corpus.
   modules/
     ui/components/     GITIGNORED mirror of the @webjsdev/ui registry sources,
                        written by scripts/copy-registry.mjs. NEVER hand-write

--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -129,7 +129,14 @@ website/
                        everything between the two. That once cost
                        `/docs/metadata-routes` 5 of its 9 code samples and
                        deleted an escaped tag from 253 prose lines across the
-                       corpus.
+                       corpus. It also keeps the template holes a reader
+                       actually sees: `\${x}` is ESCAPED (literal text, not an
+                       interpolation) and `${"lit"}` interpolates a known
+                       literal, so both are preserved, while only a bare
+                       `${x}` is render-time and gets dropped. Treating all
+                       three alike printed `<form action=\>` on 12 corpus
+                       lines, teaching an LLM the one shape invariant 12
+                       exists to rule out.
   modules/
     ui/components/     GITIGNORED mirror of the @webjsdev/ui registry sources,
                        written by scripts/copy-registry.mjs. NEVER hand-write

--- a/website/lib/docs-llms.server.ts
+++ b/website/lib/docs-llms.server.ts
@@ -258,13 +258,21 @@ export function bodyToMarkdown(raw: string): string {
     // The kept text is parked behind a sentinel so the dynamic-hole strip
     // below cannot eat what these two just preserved, and it is restored
     // before `decodeEntities` so entities inside it decode like any prose.
-    .replace(/\\\$\{((?:[^{}]|\{[^}]*\})*)\}/g, (_m, inner) => keepHole('${' + inner + '}'))
-    .replace(/\$\{"((?:[^"\\]|\\.)*)"\}/g, (_m, lit) => keepHole(lit))
+    .replace(/\\\$\{((?:[^{}]|\{[^}]*\})*)\}/g, (_m, inner) => keepHole('${' + unescapeJs(inner) + '}'))
+    .replace(/\$\{"((?:[^"\\]|\\.)*)"\}/g, (_m, lit) => keepHole(unescapeJs(lit)))
     // Brace-aware: `[^}]*` would stop at the FIRST `}`, leaving `"}` debris
     // behind a nested hole.
     .replace(/\$\{(?:[^{}]|\{[^}]*\})*\}/g, '');
 
-  body = body.replace(/\uE001HOLE(\d+)\uE001/g, (_m, i) => heldHoles[Number(i)]);
+  // Restore kept holes. A kept hole can itself contain a parked sentinel (an
+  // escaped hole nested inside a string-literal one), so this repeats until
+  // none is left. Replacing once emitted the inner sentinel verbatim, which
+  // would ship a private-use codepoint in a text/plain response and into the
+  // search index. Bounded: a hole can only contain sentinels parked before
+  // it, so each pass resolves at least one.
+  for (let pass = 0; pass <= heldHoles.length && /\uE001HOLE\d+\uE001/.test(body); pass++) {
+    body = body.replace(/\uE001HOLE(\d+)\uE001/g, (_m, i) => heldHoles[Number(i)]);
+  }
 
   body = decodeEntities(body);
 

--- a/website/lib/docs-llms.server.ts
+++ b/website/lib/docs-llms.server.ts
@@ -140,7 +140,8 @@ function oneLine(s: string): string {
  * decode. Exported for the same reason `bodyToMarkdown` is, so a unit test
  * can drive it on a fixture instead of planting scaffolding in a real docs
  * page. The whitespace collapse is re-run after decoding because `&nbsp;`
- * and `&hellip;` only become whitespace-relevant once decoded.
+ * decodes to a literal space, so a run of them is only collapsible once the
+ * decode has happened.
  */
 export function plainText(s: string): string {
   return decodeEntities(oneLine(s)).replace(/\s+/g, ' ').trim();

--- a/website/lib/docs-llms.server.ts
+++ b/website/lib/docs-llms.server.ts
@@ -216,6 +216,13 @@ export function bodyToMarkdown(raw: string): string {
     return `\uE000CODE${codeBlocks.length - 1}\uE000`;
   });
 
+  // Prose template holes that survive rather than being dropped, parked
+  // behind a sentinel while the dynamic-hole strip runs. Same U+E001
+  // escape-not-literal rule as the code-block sentinel above, so the
+  // file stays diffable text.
+  const heldHoles: string[] = [];
+  const keepHole = (text: string) => `\uE001HOLE${heldHoles.push(text) - 1}\uE001`;
+
   body = body
     // Headings -> markdown
     .replace(/<h1[^>]*>([\s\S]*?)<\/h1>/g, (_m, t) => `\n# ${oneLine(t)}\n`)
@@ -231,11 +238,33 @@ export function bodyToMarkdown(raw: string): string {
     .replace(/<\/?(ul|ol)[^>]*>/g, '\n')
     // Strip every remaining tag
     .replace(/<[^>]+>/g, ' ')
-    // Drop template-interpolation holes. Brace-aware: `[^}]*` stops at the
-    // FIRST `}`, so a nested hole like ${"${createPost}"} (docs/architecture
-    // authors one) left `"}` behind as debris in the prose. Invisible until
-    // the decode ordering above was fixed, and reader-visible after.
+    // Template holes in prose. Three shapes, and only one is dynamic:
+    //
+    //   \${x}      an ESCAPED hole. The `\$` means the page is not
+    //              interpolating at all, so the reader sees the literal text
+    //              `${x}`. Keep it, minus the escape.
+    //   ${"lit"}   a hole whose value is a string literal, so the reader sees
+    //              that literal. Keep the literal.
+    //   ${x}       a real hole. What it renders is known only at render time,
+    //              so there is nothing to put in the corpus. Drop it.
+    //
+    // All three used to be dropped alike, which deleted the binding out of
+    // every sentence teaching `<form action=${action}>` and stranded the
+    // escape backslash. On main that damage was hidden, because the runaway
+    // strip had already eaten those fragments whole; restoring them exposed
+    // 12 corpus lines reading `<form action=\>`, in the one surface whose
+    // reader is an LLM and about the exact shape invariant 12 governs.
+    //
+    // The kept text is parked behind a sentinel so the dynamic-hole strip
+    // below cannot eat what these two just preserved, and it is restored
+    // before `decodeEntities` so entities inside it decode like any prose.
+    .replace(/\\\$\{((?:[^{}]|\{[^}]*\})*)\}/g, (_m, inner) => keepHole('${' + inner + '}'))
+    .replace(/\$\{"((?:[^"\\]|\\.)*)"\}/g, (_m, lit) => keepHole(lit))
+    // Brace-aware: `[^}]*` would stop at the FIRST `}`, leaving `"}` debris
+    // behind a nested hole.
     .replace(/\$\{(?:[^{}]|\{[^}]*\})*\}/g, '');
+
+  body = body.replace(/\uE001HOLE(\d+)\uE001/g, (_m, i) => heldHoles[Number(i)]);
 
   body = decodeEntities(body);
 

--- a/website/lib/docs-llms.server.ts
+++ b/website/lib/docs-llms.server.ts
@@ -117,19 +117,33 @@ function metadataBlock(raw: string): string {
   return raw.slice(startIdx, end);
 }
 
-/** Collapse a fragment to a single trimmed line of plain text. */
+/**
+ * Collapse a fragment to a single trimmed line of plain text.
+ *
+ * Deliberately does NOT decode entities. Entities are decoded exactly once,
+ * at the END of the pipeline (`decodeEntities(body)`), because a decoded `<`
+ * re-entering a later tag strip matches from there to the next `>` anywhere
+ * in the document and deletes everything between the two. That is what cost
+ * /docs/metadata-routes 5 of its 9 samples: one 935-character match that ran
+ * from a decoded `&lt;` in one paragraph to a decoded `&lt;title&gt;` sixty
+ * lines further down. Decoding belongs after every strip, never before one.
+ */
 function oneLine(s: string): string {
   return s
     .replace(/<[^>]+>/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&#123;/g, '{')
-    .replace(/&#125;/g, '}')
-    .replace(/&#39;|&apos;/g, "'")
-    .replace(/&quot;/g, '"')
     .replace(/\s+/g, ' ')
     .trim();
+}
+
+/**
+ * `oneLine` plus the decode, in the one order that is safe: strip, THEN
+ * decode. Exported for the same reason `bodyToMarkdown` is, so a unit test
+ * can drive it on a fixture instead of planting scaffolding in a real docs
+ * page. The whitespace collapse is re-run after decoding because `&nbsp;`
+ * and `&hellip;` only become whitespace-relevant once decoded.
+ */
+export function plainText(s: string): string {
+  return decodeEntities(oneLine(s)).replace(/\s+/g, ' ').trim();
 }
 
 /** Truncate at a word boundary, appending an ellipsis when cut. */
@@ -190,16 +204,11 @@ export function bodyToMarkdown(raw: string): string {
   // had the decoded tags deleted out of it, silently, in the one pipeline
   // whose silent losses this function exists to avoid.
   //
-  // A related loss is still live and is NOT fixed here: oneLine() below
-  // decodes `&lt;` to a bare `<` while rewriting a <p>, and the generic tag
-  // strip further down then matches from that stray `<` to the next `>` and
-  // swallows what lies between, including these sentinels. On
-  // /docs/metadata-routes that costs 5 of its 9 samples and the paragraphs
-  // among them. Not fixed here: the repair reorders this pipeline for every
-  // page, and the decode is what makes prose about markup readable, so it
-  // needs its own before-and-after across all 43. test/ssr/docs-llms.test.ts
-  // pins that page at its exact counts, so it cannot decay further and a
-  // repair fails the test rather than passing unnoticed.
+  // The pipeline invariant, and the reason the stages are ordered this way:
+  // tags are stripped at EVERY stage, entities are decoded exactly ONCE, at
+  // the end. A captured sample decodes on its own path below; prose decodes
+  // at `decodeEntities(body)` after the generic strip. Decoding earlier puts
+  // a bare `<` in front of a strip that then eats to the next `>`.
   const codeBlocks: string[] = [];
   body = body.replace(/<(?:pre|code-block)(?=[\s>])[^>]*>([\s\S]*?)<\/(?:pre|code-block)>/g, (_m, code) => {
     codeBlocks.push(decodeEntities(String(code)).replace(/\n+$/, ''));
@@ -221,8 +230,11 @@ export function bodyToMarkdown(raw: string): string {
     .replace(/<\/?(ul|ol)[^>]*>/g, '\n')
     // Strip every remaining tag
     .replace(/<[^>]+>/g, ' ')
-    // Drop template-interpolation holes
-    .replace(/\$\{[^}]*\}/g, '');
+    // Drop template-interpolation holes. Brace-aware: `[^}]*` stops at the
+    // FIRST `}`, so a nested hole like ${"${createPost}"} (docs/architecture
+    // authors one) left `"}` behind as debris in the prose. Invisible until
+    // the decode ordering above was fixed, and reader-visible after.
+    .replace(/\$\{(?:[^{}]|\{[^}]*\})*\}/g, '');
 
   body = decodeEntities(body);
 
@@ -287,11 +299,11 @@ async function extractPage(file: string): Promise<DocPage> {
   let description = '';
   const descMatch = meta.match(/description:\s*(?:'((?:\\.|[^'\\])*)'|"((?:\\.|[^"\\])*)"|`((?:\\.|[^`\\])*)`)/);
   if (descMatch) {
-    description = oneLine(decodeEntities(unescapeJs(descMatch[1] ?? descMatch[2] ?? descMatch[3] ?? '')));
+    description = plainText(unescapeJs(descMatch[1] ?? descMatch[2] ?? descMatch[3] ?? ''));
   }
   if (!description) {
     const pMatch = raw.match(/<p[^>]*>([\s\S]*?)<\/p>/);
-    if (pMatch) description = oneLine(decodeEntities(pMatch[1]));
+    if (pMatch) description = plainText(pMatch[1]);
   }
   description = truncate(description, 200);
 

--- a/website/test/ssr/docs-llms.test.ts
+++ b/website/test/ssr/docs-llms.test.ts
@@ -20,7 +20,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
-import { bodyToMarkdown, getDocPage, getDocPages } from '#lib/docs-llms.server.ts';
+import { bodyToMarkdown, getDocPage, getDocPages, plainText } from '#lib/docs-llms.server.ts';
 
 const fenceCount = (md: string) => (md.match(/^```/gm) ?? []).length / 2;
 
@@ -55,53 +55,20 @@ test('a fenced sample keeps the interpolation holes and indentation the prose pi
   assert.match(layout, /\n {2,}\S/, 'indentation survives inside the fence');
 });
 
-/**
- * The one page whose samples do NOT all reach the corpus, pinned at its exact
- * counts rather than merely named. A bare name would exempt the page from
- * every check, which is the failure this set exists to avoid: skipped by name
- * is still skipped, and the page could then lose its remaining samples
- * unnoticed. The counts are asserted below in both directions, so further loss
- * fails and so does a repair, the latter forcing this entry to be removed
- * instead of quietly outliving the bug.
- *
- * Cause, verified rather than assumed: `oneLine()` decodes `&lt;` to a bare
- * `<` while rewriting a `<p>`, and the generic tag strip that runs afterwards
- * (`lib/docs-llms.server.ts`, `.replace(/<[^>]+>/g, ' ')`) then matches from
- * that stray `<` to the next `>`, swallowing whatever lies between. On this
- * page that is 5 of its 9 code-block sentinels plus the paragraphs among
- * them. Removing the angle-bracket decode from `oneLine()` restores all 9,
- * which is how the cause was pinned down; that is not the fix, because the
- * decode is what makes prose about markup readable in the corpus, and the
- * real repair reorders the pipeline for all 43 pages. Pre-existing: the
- * generated corpus is byte-identical on main, so this PR neither causes it
- * nor fixes it.
- */
-const KNOWN_TRUNCATED = new Map([['/docs/metadata-routes', { authored: 9, fenced: 4 }]]);
-
-test('the truncation exemption still describes reality', async () => {
-  // An exemption nobody rechecks is a blind spot. This is what keeps the
-  // entry above honest: it fails if the page loses more samples, and it fails
-  // if the pipeline is repaired, which is the signal to delete the entry.
-  for (const [path, expected] of KNOWN_TRUNCATED) {
-    const page = (await getDocPages()).find((p) => p.path === path);
-    assert.ok(page, `${path} is exempted but no longer exists, so remove the entry`);
-    const src = await readFile(new URL(`../../app${path}/page.ts`, import.meta.url), 'utf8');
-    assert.equal((src.match(/<code-block(?=[\s>])/g) ?? []).length, expected.authored, `${path} authors a different number of samples now`);
-    assert.equal(fenceCount(page.markdown), expected.fenced, `${path} reaches the corpus with a different number of samples now: if it is ${expected.authored}, the pipeline was repaired, so delete its KNOWN_TRUNCATED entry`);
-  }
-});
-
 test('every sample a page authors reaches the corpus', async () => {
   // Stronger than the fence test above, which only asks for one fence per
   // page: this asks for ALL of them. A regression that drops or merges blocks
-  // changes this count, and the named exemption is what stops such a
-  // regression from being waved through as "already known".
+  // changes this count. There is no exemption: /docs/metadata-routes used to
+  // carry one, pinned at 9 authored and 4 fenced, because a decoded `<` in its
+  // prose let the generic tag strip eat 5 of its sentinels. The extractor now
+  // decodes exactly once, at the end, so every page reaches parity and an
+  // exemption would only hide the next such loss.
   const off: string[] = [];
   let checked = 0;
   for (const page of await getDocPages()) {
     const src = await readFile(new URL(`../../app${page.path}/page.ts`, import.meta.url), 'utf8');
     const authored = (src.match(/<code-block(?=[\s>])/g) ?? []).length;
-    if (!authored || KNOWN_TRUNCATED.has(page.path)) continue;
+    if (!authored) continue;
     checked++;
     const fenced = fenceCount(page.markdown);
     if (fenced !== authored) off.push(`${page.path}: ${authored} authored, ${fenced} fenced`);
@@ -172,6 +139,43 @@ test('a sample teaching escaped markup keeps it', () => {
   // decoded tags out of a sample whose whole point was showing them.
   const md = bodyToMarkdown('html`<code-block>use &lt;code&gt;x&lt;/code&gt; inline</code-block>`');
   assert.match(md, /```\nuse <code>x<\/code> inline\n```/);
+});
+
+test('a paragraph teaching a lone escaped angle bracket does not eat the rest of the page', () => {
+  // The exact shape of /docs/metadata-routes: a lone `&lt;` in one paragraph,
+  // a sample, then a later paragraph whose own escaped tag supplies the `>`
+  // that closed the runaway match. A PAIRED `&lt;code&gt;` does not reproduce
+  // it, because that decodes into a complete tag the strip removes locally.
+  const md = bodyToMarkdown(
+    'html`<p>a value with <code>&lt;</code> cannot break the document</p>' +
+      '<code-block>const x = 1;</code-block>' +
+      '<p>injects <code>&lt;title&gt;</code> tags</p>`'
+  );
+  assert.match(md, /a value with < cannot break the document/);
+  assert.match(md, /```\nconst x = 1;\n```/);
+  assert.match(md, /injects <title> tags/);
+});
+
+test('an escaped tag in prose survives to the corpus', () => {
+  // oneLine used to decode &lt;code&gt; to a real <code> tag mid-pipeline and
+  // the generic strip deleted it, so the sentence lost the very thing it was
+  // written to show. This is the site-wide half of the same bug.
+  const md = bodyToMarkdown('html`<p>a value with &lt;code&gt; here</p>`');
+  assert.equal(md, 'a value with <code> here');
+});
+
+test('plainText strips tags before it decodes entities', () => {
+  assert.equal(plainText('a value with &lt;code&gt; here'), 'a value with <code> here');
+  assert.match(plainText('intercepts same-origin &lt;a&gt; clicks'), /same-origin <a> clicks/);
+});
+
+test('a page description keeps the escaped tags it teaches', async () => {
+  // extractPage used to run oneLine(decodeEntities(...)), decoding first and
+  // stripping second, so a description teaching a tag lost it. This is the
+  // counterfactual for the plainText fixture above, which passes on its own.
+  const page = await getDocPage('client-router');
+  assert.ok(page, 'the client-router page is in the corpus');
+  assert.match(page.description, /same-origin <a> clicks and <form> submissions/);
 });
 
 test('a sample is fenced whether it is authored as code-block or pre', () => {

--- a/website/test/ssr/docs-llms.test.ts
+++ b/website/test/ssr/docs-llms.test.ts
@@ -164,14 +164,30 @@ test('an escaped tag in prose survives to the corpus', () => {
   assert.equal(md, 'a value with <code> here');
 });
 
-test('a nested template hole leaves no debris behind', () => {
-  // The hole strip used to be `\$\{[^}]*\}`, which stops at the FIRST `}`, so
-  // the nested hole /docs/architecture authors left `"}` in the prose. It was
-  // invisible while the runaway strip above deleted the whole fragment, and
-  // reader-visible once the decode ordering was fixed, which is why the two
-  // ship together.
+test('a hole whose value is a string literal keeps the value', () => {
+  // /docs/architecture authors this shape. The outer hole interpolates a
+  // string literal, so a reader of the rendered page sees the inner text, and
+  // the corpus has to show the same thing. Dropping it printed
+  // `<form action=>`, a form-binding sentence with the binding deleted, in
+  // the one surface whose reader is an LLM.
   const md = bodyToMarkdown('html`<p>a <code>&lt;form action=${"${createPost}"}&gt;</code> posts</p>`');
-  assert.equal(md, 'a <form action=> posts');
+  assert.equal(md, 'a <form action=${createPost}> posts');
+});
+
+test('an escaped hole is literal text, not an interpolation to drop', () => {
+  // `\${x}` in the source is NOT a hole: the escape means the page renders the
+  // literal `${x}`. Dropping it as if it were dynamic deleted the binding and
+  // stranded the escape backslash, which is what put `@submit=\` and
+  // `<form action=\>` in the corpus.
+  const md = bodyToMarkdown('html`<p>handlers (<code>@submit=\\${e =&gt; { e.preventDefault(); }}</code>) are untouched</p>`');
+  assert.equal(md, 'handlers ( @submit=${e => { e.preventDefault(); }} ) are untouched');
+});
+
+test('a genuinely dynamic hole is still dropped', () => {
+  // The counterpart to the two above: a hole referencing a variable renders
+  // something known only at render time, so there is nothing to put in the
+  // corpus and it must still go.
+  assert.equal(bodyToMarkdown('html`<p>text ${children} here</p>`'), 'text here');
 });
 
 test('plainText strips tags before it decodes entities', () => {

--- a/website/test/ssr/docs-llms.test.ts
+++ b/website/test/ssr/docs-llms.test.ts
@@ -164,6 +164,16 @@ test('an escaped tag in prose survives to the corpus', () => {
   assert.equal(md, 'a value with <code> here');
 });
 
+test('a nested template hole leaves no debris behind', () => {
+  // The hole strip used to be `\$\{[^}]*\}`, which stops at the FIRST `}`, so
+  // the nested hole /docs/architecture authors left `"}` in the prose. It was
+  // invisible while the runaway strip above deleted the whole fragment, and
+  // reader-visible once the decode ordering was fixed, which is why the two
+  // ship together.
+  const md = bodyToMarkdown('html`<p>a <code>&lt;form action=${"${createPost}"}&gt;</code> posts</p>`');
+  assert.equal(md, 'a <form action=> posts');
+});
+
 test('plainText strips tags before it decodes entities', () => {
   assert.equal(plainText('a value with &lt;code&gt; here'), 'a value with <code> here');
   assert.match(plainText('intercepts same-origin &lt;a&gt; clicks'), /same-origin <a> clicks/);

--- a/website/test/ssr/docs-llms.test.ts
+++ b/website/test/ssr/docs-llms.test.ts
@@ -190,6 +190,33 @@ test('a genuinely dynamic hole is still dropped', () => {
   assert.equal(bodyToMarkdown('html`<p>text ${children} here</p>`'), 'text here');
 });
 
+test('a dynamic hole containing braces is dropped whole', () => {
+  // This is what makes the dynamic strip brace-aware. A naive `[^}]*` stops at
+  // the FIRST `}`, so the nested object literal leaves `)}` behind as debris.
+  // The kept-hole shapes above no longer reach this strip, so without this
+  // fixture nothing pins its brace-awareness at all.
+  assert.equal(bodyToMarkdown('html`<p>text ${fn({a: 1})} here</p>`'), 'text here');
+});
+
+test('a kept hole is unescaped, since the source is a template literal', () => {
+  // The hole text is copied out of page SOURCE, where a backtick has to be
+  // written `\\``. Keeping it verbatim moved the escape debris from in front
+  // of the hole to inside it: /docs/components rendered `.fallback=${html\`…\`}`
+  // where the page shows `.fallback=${html`…`}`.
+  const md = bodyToMarkdown('html`<p>x <code>.fallback=\\${html\\`hi\\`}</code> y</p>`');
+  assert.equal(md, 'x .fallback=${html`hi`} y');
+});
+
+test('a kept hole nested inside another leaves no sentinel in the output', () => {
+  // The two keep passes run in sequence, so a string-literal hole can park
+  // text that already contains an escaped hole's sentinel. Restoring once
+  // emitted the inner sentinel verbatim, shipping a private-use codepoint into
+  // a text/plain response and the search index.
+  const md = bodyToMarkdown('html`<p>a ${"\\${x}"} b</p>`');
+  assert.equal(md, 'a ${x} b');
+  assert.ok(!/[\uE000-\uF8FF]/.test(md), 'no private-use sentinel survives into the output');
+});
+
 test('plainText strips tags before it decodes entities', () => {
   assert.equal(plainText('a value with &lt;code&gt; here'), 'a value with <code> here');
   assert.match(plainText('intercepts same-origin &lt;a&gt; clicks'), /same-origin <a> clicks/);

--- a/website/test/ssr/docs-llms.test.ts
+++ b/website/test/ssr/docs-llms.test.ts
@@ -191,11 +191,16 @@ test('a genuinely dynamic hole is still dropped', () => {
 });
 
 test('a dynamic hole containing braces is dropped whole', () => {
-  // This is what makes the dynamic strip brace-aware. A naive `[^}]*` stops at
-  // the FIRST `}`, so the nested object literal leaves `)}` behind as debris.
-  // The kept-hole shapes above no longer reach this strip, so without this
-  // fixture nothing pins its brace-awareness at all.
+  // A naive `[^}]*` stops at the FIRST `}`, so the nested object literal
+  // leaves `)}` behind as debris. The kept-hole shapes above no longer reach
+  // this strip, so without this fixture nothing pins it at all.
+  //
+  // ONE level of nesting is all the regex handles, which is what the docs
+  // actually author: `${fn({a:{b:1}})}` still leaves `)}`, and no page writes
+  // that (checked across all 44). Arbitrary depth is not a regex's job, so the
+  // limit is stated rather than papered over.
   assert.equal(bodyToMarkdown('html`<p>text ${fn({a: 1})} here</p>`'), 'text here');
+  assert.equal(bodyToMarkdown('html`<p>a ${fn({a:{b:1}})} b</p>`'), 'a )} b');
 });
 
 test('a kept hole is unescaped, since the source is a template literal', () => {
@@ -205,6 +210,11 @@ test('a kept hole is unescaped, since the source is a template literal', () => {
   // where the page shows `.fallback=${html`…`}`.
   const md = bodyToMarkdown('html`<p>x <code>.fallback=\\${html\\`hi\\`}</code> y</p>`');
   assert.equal(md, 'x .fallback=${html`hi`} y');
+
+  // The string-literal pass copies from source too, so it needs the same fold.
+  // No docs page carries an escape inside one today, so only a fixture can
+  // hold that half of the rule.
+  assert.equal(bodyToMarkdown('html`<p>x ${"a\\`b"} y</p>`'), 'x a`b y');
 });
 
 test('a kept hole nested inside another leaves no sentinel in the output', () => {


### PR DESCRIPTION
Closes #1261

## Summary

The llms corpus builder decoded HTML entities inside `oneLine()` and then ran a generic tag strip over the decoded text. A `&lt;` that a docs page authored as prose became a bare `<`, and the later strip matched from it to the next `>` anywhere in the document, deleting everything between the two. On `/docs/metadata-routes` that was a single 935-character match that swallowed 5 of the page's 9 code samples plus the paragraphs among them. Site-wide it deleted an escaped tag out of 253 prose lines, and where the match crossed a newline it merged separate list items into one run-on line.

Tags are now stripped at every stage and entities decoded exactly once, at the end, so no stage ever sees text an earlier stage decoded. The pipeline becomes correct by removal rather than by reordering.

## What changed

`website/lib/docs-llms.server.ts`:

- `oneLine()` no longer decodes entities. It is a tag strip plus a whitespace collapse and a trim. The single `decodeEntities(body)` already sits after the generic strip, so it does all prose decoding.
- New exported `plainText()` applies the safe order (strip, then decode). Both `extractPage` description sites called `oneLine(decodeEntities(...))`, which is the same inversion spelled the other way round, and both now route through it.
- Prose template holes now keep what a reader actually sees. A hole has three shapes and only one is dynamic: `\${x}` is ESCAPED, so the page renders the literal `${x}` and there is no interpolation at all; `${"lit"}` interpolates a string literal the reader sees; only a bare `${x}` is resolved at render time and has nothing to contribute. The first two are preserved (parked behind a sentinel so the dynamic strip cannot eat them), the third is still dropped.

  This was not in the original plan and is the one place the PR grew. Fixing the decode ordering RESTORES fragments main had deleted outright, and those fragments are mostly sentences about form bindings, so the corpus went from **zero** `<form action=\>` lines to **12**. The corpus is the surface whose only reader is an LLM, and root `AGENTS.md` invariant 12 is precisely about which shapes a bound form may take, so shipping that would have traded one defect for another. It now renders **24 correct** `<form action=${importedAction}>` bindings and zero broken ones.
- The stale comment block describing this loss as live is replaced by the invariant the file now holds.

`website/test/ssr/docs-llms.test.ts`: the `KNOWN_TRUNCATED` pin, its explanatory comment, and the `the truncation exemption still describes reality` test are deleted, and the walk `every sample a page authors reaches the corpus` now covers all 44 pages with no exemption. The pin asserted the broken counts in both directions precisely so a correct fix would red it. Ten tests added: one per behaviour the decode fix restores, and one per hole shape plus the two failure modes preserving them introduced.

`website/AGENTS.md`: records both invariants the module now holds, the strip-then-decode ordering and the three hole shapes.

## Measured, before and after

The issue's absolute figures were taken when the corpus had 43 pages; it now has 44, so the numbers below are re-measured on this branch against current `main`. Every relative shape the issue predicted holds exactly.

| | before | after |
|---|---|---|
| pages | 44 | 44 |
| fenced samples reaching the corpus | 480 | 485 |
| pages where authored `<code-block>` count differs from fenced count | 1 | **0** |
| `/docs/metadata-routes` | 9 authored, **4 fenced** | 9 authored, **9 fenced**, 8838 chars |
| `/llms-full.txt` | 964128 bytes, 15838 lines | 972347 bytes, 15921 lines |
| prose `<form action=${...}>` bindings | clause deleted entirely | **restored, 9 more than main** |
| broken bindings (`<form action=\>` etc.) | 0 | **0** (would be 12 with the decode fix alone) |

The diff accounts for itself completely: **278 evenly-paired changed lines, every one of them longer and none shorter**, plus four structural hunks (2 lines to 7, 1 to 76, 1 to 3, 2 to 3) for a net **+83 lines**, which are the merged list items un-merging on `/docs/no-build`, `/docs/metadata-routes`, `/docs/editor-setup`, and `/docs/deployment`. No corpus line loses a character. `Diagnostics :` is its own bullet again and `<script type="importmap">` is back in the no-build list. The `/docs/client-router` index description now reads `intercepts same-origin <a> clicks and <form> submissions`.

Checks on the output, all clean: no private-use sentinel leak (U+E000 or U+E001), no residual entity (`&lt;` `&gt;` `&amp;` `&quot;` all absent, so prose about markup reads as `<div>`), no `action="}` debris, no broken binding (`<form action=\>`, `<form action=>`, `<button formaction=\>` and `@submit=\` are each 0),. The backslash-backtick count is identical to main (371), so the escape debris that remains is all inside fenced samples, on the code-block path this PR does not touch.

## Test plan

- **Unit**: `cd website && node --test test/ssr/docs-llms.test.ts`, 18 pass.
- **Counterfactuals**, proven at [`cf0933c4`](https://github.com/webjsdev/webjs/commit/cf0933c4) by toggling each source change independently and re-running. Every one of the three hunks has one:
  - Reverting the `oneLine` decode chain reds three tests: both `bodyToMarkdown` fixtures and the now-unexempted corpus walk, which reports `/docs/metadata-routes: 9 authored, 4 fenced`.
  - Reverting only the two `extractPage` description sites reds `a page description keeps the escaped tags it teaches`.
  - Reverting only the hole handling reds `a hole whose value is a string literal keeps the value` and `an escaped hole is literal text, not an interpolation to drop`, while `a genuinely dynamic hole is still dropped` holds the other side of that line so the two kept shapes cannot be over-generalised into keeping everything.

  Reverting the whole file at once proves nothing, so do not use it as the counterfactual: the import of `plainText` then fails and the suite never loads.
- **App suite + typecheck**: `npm test` and `npm run typecheck` in `website`, the two the CI `apps` job runs.
- **Route-level integration**: `node --test test/docs/llms.test.mjs`.
- **Conventions**: `npx webjs check` and `npx webjs doctor` over `website`.

Layers that do not apply: **browser** (nothing hydrates, this is a `.server.ts` module serving `text/plain`), **e2e** (the routes are already covered by the integration test through `createRequestHandler`, and no navigation or streaming behaviour changes), **Bun parity** (a pure string transform in an app's own `lib/`, no runtime-specific API, no `packages/*/src` touched, so the parity hook does not fire), **smoke** (covers the example apps, not the marketing site).

## Docs surfaces

- **Updated**: `website/AGENTS.md`.
- **N/A**: the module is website-internal server code exporting no public API, no CLI flag, no `webjs` config key, no `html` hole prefix, no lifecycle hook. So the root `AGENTS.md`, the skill at `.agents/skills/webjs/`, the docs site pages, the marketing copy, the scaffold templates, `README.md`, the MCP server, `CONVENTIONS.md`, and the changelogs all stay untouched. No docs page's prose changes either: `website/app/docs/metadata-routes/page.ts:52` is correct documentation and rewriting it to dodge the bug would only defer it to the next page teaching escaping.

## Out of scope

`#1262` (the docs search fence tracking) owns `website/app/api/search/route.ts` and rebases on this. For its measurements: the phantom heading count stays at 53, unchanged by this fix, because the restored `metadata-routes` samples open no line with `# `. The totals move, so #1262 refreshes its own expectations as the later merge.


## A note on the one deferral

The fenced-sample capture copies from page source without folding JS escapes, so a sample still reaches the corpus as `${html\`...\`}` where the page shows `` ${html`...`} ``. It is the same question this PR answers for prose, but on a code path the PR does not touch, and it is **unchanged in both directions against main** (5 fenced form bindings before and after, backslash-backtick count identical at 371). Fixing it moves roughly 775 more corpus positions and needs a rethink of `a sample that reaches the corpus reaches it whole`, which compares raw source text, so it is separate work rather than a tail on this one. Recorded on the review thread, awaiting a call on filing.

One environmental note for whoever runs the suites: `test/bun/listener.test.mjs` fails in a linked worktree (`clientIp` reads `_anon_`) and passes in a full checkout at the same commit. It is not affected by this branch: reverting all three changed files makes the tree byte-identical to `main` and it still fails.
