### PR TITLE
docs: narrow the temp-id claim in the optimistic-UI payoff

### DIFF
--- a/blog/optimistic-ui-without-boilerplate.md
+++ b/blog/optimistic-ui-without-boilerplate.md
@@ -175,7 +175,7 @@ This is deliberate. The point of the API is to remove the bookkeeping, and bookk
 
 If you are building your first full-stack app, optimistic UI is one of those things that separates a prototype from a product. A prototype shows a spinner and waits. A product shows the result immediately and corrects itself if wrong. The difference in perceived speed is enormous, and it is the kind of polish that makes users trust an app.
 
-But the boilerplate cost is high enough that many developers skip it entirely, especially when they are learning. The old pattern required understanding temp IDs, state caching, try-catch reconciliation, and concurrent update handling. That is a lot of concepts to hold in your head when you are just trying to make a todo app work.
+But the boilerplate cost is high enough that many developers skip it entirely, especially when they are learning. The old pattern required understanding temp-id reconciliation, state caching, try-catch reverts, and concurrent update handling. That is a lot of concepts to hold in your head when you are just trying to make a todo app work.
 
 The new API reduces it to three steps: declare the reducer, call `.add()`, reconcile on success. The concepts are the same (optimistic update, server call, reconciliation), but the code is small enough that you can see the whole thing at once. That is the difference between "I understand this pattern" and "I copied this pattern and hope it works."
 


### PR DESCRIPTION
Closes #1336

The payoff paragraph listed temp IDs among the concepts the new API lifts, two sentences before "The new API reduces it to three steps". Three of the four items are lifted and one is not: the post's corrected example mints a temp id in the handler and spends four lines of comment explaining why it has to be minted there rather than in the reducer. So the one concept a reader has just been taught they still need was sitting in the list of things they were about to be told they no longer need.

The sentence was not false, since it describes the old pattern and that pattern did require all four. But literal accuracy is not the bar for a paragraph aimed at readers who are learning the pattern, and it should not imply a lift the post's own code disproves.

Two words change in one sentence. `temp IDs` becomes `temp-id reconciliation`, which is what the API actually removes and the exact phrasing the front-matter description and the closing paragraph already use. `try-catch reconciliation` becomes `try-catch reverts`, because the first change would otherwise put two `reconciliation` items adjacent in a four-item list, and `reverts` is the better word for what that catch block does anyway.

The neighbouring sentences, the three-steps sentence after it, and the other mentions of temp IDs at lines 12 and 57 are untouched. Those two describe the hand-rolled pattern on its own terms with no adjacent lift claim, so they are correct as written.

## Test plan

- Rendered `/blog/optimistic-ui-without-boilerplate` through the real page module with HTML tags stripped: the new sentence is present, the old one is gone.
- `cd website && npm test`.
- No new test. Nothing in the repo reads blog markdown, and a test that string-matches published prose would fail on every legitimate rewording while still missing a semantically wrong sentence written in different words.
- Counterfactual: none owed, for the same reason.

## Doc surfaces

This IS the doc change, and the sentence is prose unique to this post rather than a copy of anything in AGENTS.md, the skill references, the docs site, or the scaffold. Tests N/A per above. Scaffold, MCP, editor plugins, README, changelog, marketing copy, dogfood apps: N/A, no code or generated surface changes.
