### PR TITLE
chore: release cli 0.10.53 and ui 0.3.12

### DIFF
--- a/changelog/cli/0.10.53.md
+++ b/changelog/cli/0.10.53.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.53
+date: 2026-08-08T14:04:19.046Z
+commit_count: 1
+---
+## Fixes
+
+- **lowercase the postgres database name derived from the app name** ([#1330](https://github.com/webjsdev/webjs/pull/1330)) [`a9f88caa`](https://github.com/webjsdev/webjs/commit/a9f88caa)
+  * fix(cli): lowercase the postgres database name in the scaffold
+  
+  `webjs create MyApp --db postgres` wrote the app name into the emitted
+  DATABASE_URL with a case-preserving replace, so the URL named `MyApp`.

--- a/changelog/ui/0.3.12.md
+++ b/changelog/ui/0.3.12.md
@@ -1,0 +1,12 @@
+---
+package: "@webjsdev/ui"
+version: 0.3.12
+date: 2026-08-08T14:04:19.176Z
+commit_count: 1
+---
+## Fixes
+
+- **split the coarse bg, shadow and text-shadow cn() groups by property** ([#1332](https://github.com/webjsdev/webjs/pull/1332)) [`4e952b9b`](https://github.com/webjsdev/webjs/commit/4e952b9b)
+  Closes #1265
+  
+  A `cn()` conflict group is one CSS property, never one class prefix. Three groups were still keyed by prefix, so a utility was evicted by an unrelated one that merely shared its prefix and the dropped class was silently gone. `bg-clip-*`, `bg-origin-*` and `bg-blend-*` all sat in `bg-color`, so the gradient-text idiom `bg-linear-to-r bg-clip-text text-transparent` lost its clip the moment any later `bg-*` colour landed on the same element. A box-shadow size shared one group with its colour, in both directions. And `text-shadow-*` fell into `text-color`, so a shadow ate a text colour.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6934,7 +6934,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.52",
+      "version": "0.10.53",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -7035,7 +7035,7 @@
     },
     "packages/ui": {
       "name": "@webjsdev/ui",
-      "version": "0.3.11",
+      "version": "0.3.12",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.52",
+  "version": "0.10.53",
   "type": "module",
   "description": "The CLI for WebJs, a full-stack JavaScript framework built on web components with server-side rendering and no build step. Runs the dev and production servers, scaffolds apps, validates conventions, and drives the database. Node 24+ or Bun.",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/ui",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "type": "module",
   "description": "The AI-first component library for WebJs, a full-stack JavaScript framework built on web components with server-side rendering and no build step. Class-helper functions for visuals, custom elements only where state matters, source-copied into your repo so you own it.",
   "bin": {


### PR DESCRIPTION
## Summary

Releases the two published packages carrying unreleased user-facing fixes since `718dd188`.

| Package | Version | What ships |
|---|---|---|
| `@webjsdev/cli` | 0.10.52 to **0.10.53** | `webjs create <Name> --db postgres` wrote the app name into `DATABASE_URL` case-preserving, so the URL named `MyApp` ([#1330](https://github.com/webjsdev/webjs/pull/1330)) |
| `@webjsdev/ui` | 0.3.11 to **0.3.12** | `cn()` conflict groups keyed by class prefix rather than CSS property, so `bg-clip-text` was evicted by any later `bg-*` colour ([#1332](https://github.com/webjsdev/webjs/pull/1332)) |

Both are patch bumps, so every dependent caret (`^0.10.0` in blog, website and the two wrappers; `^0.3.1` in cli and `^0.3.9` in mcp) still resolves and no range needed widening. `package-lock.json` is regenerated and its diff is exactly the two version lines.

## Not bumped, and why

**`server` stays at 0.8.60.** It is the third package with a commit in its tree since the last release, but that commit ([`c0917df3`](https://github.com/webjsdev/webjs/commit/c0917df3)) only removed a dash from two JSDoc lines in `actions.js` and `check.js` to satisfy the prose-punctuation hook. No shipped behaviour changed, so it does not earn a release.

That same commit is why both changelogs were hand-trimmed. The backfill generator attributes by commit tree and the commit is titled `fix:`, so it landed in the cli and ui entries as a user-facing fix, which it is not for either package. Removed from both, with `commit_count` corrected to 1. Its real content is a hook change plus a `ui-registry` description string.

`core`, `mcp` and `intellisense` have no qualifying commits since the last release.

## What merging does

Adding `changelog/**.md` to `main` triggers `release.yml` to `npm publish` and cut the GitHub Releases (idempotent).

## Test plan

- [x] `npm install --package-lock-only`, lock diff limited to the two versions
- [x] Changelogs reviewed against the actual diffs of `a9f88caa` and `4e952b9b`
- [x] Dependent ranges verified to still satisfy both bumps
- [ ] CI green before merge
