### PR TITLE
docs: correct the CI route named in seven bun test wrappers

### DIFF
--- a/test/bun/action-error.test.mjs
+++ b/test/bun/action-error.test.mjs
@@ -1,10 +1,12 @@
 /**
  * Run the cross-runtime server-action error-sanitization proof (#749) under
  * WHICHEVER runtime executes the suite. Picked up by the root `node --test`
- * runner (so `npm test` exercises the Node path); CI also runs
- * `bun test/bun/action-error.mjs` for the Bun path. The proof is a plain assert
- * script (`action-error.mjs`, not `*.test.mjs`, so the runner does not
- * double-run it); importing it runs it and throws on any failure.
+ * runner (so `npm test` exercises the Node path); CI reaches the Bun path
+ * through `node scripts/run-bun-tests.js`, which auto-discovers
+ * `test/bun/*.test.mjs` and re-runs them under `bun`, rather than through a
+ * per-file step. The proof is a plain assert script (`action-error.mjs`, not
+ * `*.test.mjs`, so the runner does not double-run it); importing it runs it
+ * and throws on any failure.
  */
 import { test } from 'node:test';
 

--- a/test/bun/dev-regenerate.test.mjs
+++ b/test/bun/dev-regenerate.test.mjs
@@ -1,10 +1,11 @@
 /**
  * Run the cross-runtime on-request-regeneration proof (#967) under WHICHEVER
  * runtime executes the suite. Picked up by the root `node --test` runner (so
- * `npm test` exercises the Node path); CI also runs `bun test/bun/dev-regenerate.mjs`
- * for the Bun path. The proof is a plain assert script (`dev-regenerate.mjs`,
- * not `*.test.mjs`, so the runner does not double-run it); importing it runs it
- * and throws on any failure.
+ * `npm test` exercises the Node path); CI reaches the Bun path through `node
+ * scripts/run-bun-tests.js`, which auto-discovers `test/bun/*.test.mjs` and
+ * re-runs them under `bun`, rather than through a per-file step. The proof is
+ * a plain assert script (`dev-regenerate.mjs`, not `*.test.mjs`, so the runner
+ * does not double-run it); importing it runs it and throws on any failure.
  */
 import { test } from 'node:test';
 

--- a/test/bun/dynamic-import-graph.test.mjs
+++ b/test/bun/dynamic-import-graph.test.mjs
@@ -1,10 +1,12 @@
 /**
  * Run the cross-runtime dynamic-import-graph proof (#751) under WHICHEVER
  * runtime executes the suite. Picked up by the root `node --test` runner (so
- * `npm test` exercises the Node path); CI also runs
- * `bun test/bun/dynamic-import-graph.mjs` for the Bun path. The proof is a plain
- * assert script (`dynamic-import-graph.mjs`, not `*.test.mjs`, so the runner
- * does not double-run it); importing it runs it and throws on any failure.
+ * `npm test` exercises the Node path); CI reaches the Bun path through `node
+ * scripts/run-bun-tests.js`, which auto-discovers `test/bun/*.test.mjs` and
+ * re-runs them under `bun`, rather than through a per-file step. The proof is
+ * a plain assert script (`dynamic-import-graph.mjs`, not `*.test.mjs`, so the
+ * runner does not double-run it); importing it runs it and throws on any
+ * failure.
  */
 import { test } from 'node:test';
 

--- a/test/bun/host-display-default.test.mjs
+++ b/test/bun/host-display-default.test.mjs
@@ -1,10 +1,12 @@
 /**
  * Run the cross-runtime host-display-default proof under WHICHEVER runtime
- * executes the suite. Picked up by the root `node --test` runner (so `npm test`
- * exercises the Node path); CI also runs `bun test/bun/host-display-default.mjs`
- * for the Bun path. The proof is a plain assert script (`host-display-default.mjs`,
- * not `*.test.mjs`, so the runner does not double-run it); importing it runs it
- * and throws on any failure.
+ * executes the suite. Picked up by the root `node --test` runner (so `npm
+ * test` exercises the Node path); CI reaches the Bun path through `node
+ * scripts/run-bun-tests.js`, which auto-discovers `test/bun/*.test.mjs` and
+ * re-runs them under `bun`, rather than through a per-file step. The proof is
+ * a plain assert script (`host-display-default.mjs`, not `*.test.mjs`, so the
+ * runner does not double-run it); importing it runs it and throws on any
+ * failure.
  */
 import { test } from 'node:test';
 

--- a/test/bun/keyed-boundaries.test.mjs
+++ b/test/bun/keyed-boundaries.test.mjs
@@ -1,10 +1,12 @@
 /**
  * Run the cross-runtime keyed-boundary emission proof (#1015) under WHICHEVER
  * runtime executes the suite. Picked up by the root `node --test` runner (so
- * `npm test` exercises the Node path); CI also runs
- * `bun test/bun/keyed-boundaries.mjs` for the Bun path. The proof is a plain
- * assert script (`keyed-boundaries.mjs`, not `*.test.mjs`, so the runner does
- * not double-run it); importing it runs it and throws on any failure.
+ * `npm test` exercises the Node path); CI reaches the Bun path through `node
+ * scripts/run-bun-tests.js`, which auto-discovers `test/bun/*.test.mjs` and
+ * re-runs them under `bun`, rather than through a per-file step. The proof is
+ * a plain assert script (`keyed-boundaries.mjs`, not `*.test.mjs`, so the
+ * runner does not double-run it); importing it runs it and throws on any
+ * failure.
  */
 import { test } from 'node:test';
 

--- a/test/bun/reflect-function-guard.test.mjs
+++ b/test/bun/reflect-function-guard.test.mjs
@@ -1,10 +1,12 @@
 /**
  * Run the cross-runtime reflect-function-guard proof under WHICHEVER runtime
- * executes the suite. Picked up by the root `node --test` runner (so `npm test`
- * exercises the Node path); CI also runs `bun test/bun/reflect-function-guard.mjs`
- * for the Bun path. The proof is a plain assert script
- * (`reflect-function-guard.mjs`, not `*.test.mjs`, so the runner does not
- * double-run it); importing it runs it and throws on any failure.
+ * executes the suite. Picked up by the root `node --test` runner (so `npm
+ * test` exercises the Node path); CI reaches the Bun path through `node
+ * scripts/run-bun-tests.js`, which auto-discovers `test/bun/*.test.mjs` and
+ * re-runs them under `bun`, rather than through a per-file step. The proof is
+ * a plain assert script (`reflect-function-guard.mjs`, not `*.test.mjs`, so
+ * the runner does not double-run it); importing it runs it and throws on any
+ * failure.
  */
 import { test } from 'node:test';
 

--- a/test/bun/run-tasks.test.mjs
+++ b/test/bun/run-tasks.test.mjs
@@ -1,10 +1,12 @@
 /**
  * Run the cross-runtime dev/start task-orchestration proof (#550) under
  * WHICHEVER runtime executes the suite. Picked up by the root `node --test`
- * runner (so `npm test` exercises the Node path); CI also runs
- * `bun test/bun/run-tasks.mjs` for the Bun path. The proof is a plain assert
- * script (`run-tasks.mjs`, not `*.test.mjs`, so the runner does not double-run
- * it); importing it runs it and throws on any failure.
+ * runner (so `npm test` exercises the Node path); CI reaches the Bun path
+ * through `node scripts/run-bun-tests.js`, which auto-discovers
+ * `test/bun/*.test.mjs` and re-runs them under `bun`, rather than through a
+ * per-file step. The proof is a plain assert script (`run-tasks.mjs`, not
+ * `*.test.mjs`, so the runner does not double-run it); importing it runs it
+ * and throws on any failure.
  */
 import { test } from 'node:test';
 


### PR DESCRIPTION
Seven of the twelve `test/bun/*.test.mjs` wrappers claimed CI runs them as an explicit `bun test/bun/<name>.mjs` step. No such step exists for those seven; they are reached by `node scripts/run-bun-tests.js`, which auto-discovers `test/bun/*.test.mjs` and re-runs them under bun. The coverage was always real, only the stated route was wrong.

The other five do have explicit steps in `ci.yml`, so their sentence is accurate and untouched.

Comment-only, verified: the diff contains no non-comment lines, and the wrappers still run.

Found while fixing the same copied sentence in the wrapper added by #1335.