### PR TITLE
feat: stamp the bundled MCP docs corpus at prepack

### DIFF
--- a/packages/mcp/AGENTS.md
+++ b/packages/mcp/AGENTS.md
@@ -90,8 +90,13 @@ scripts/
                          Also emits resources/corpus.json, the build stamp naming
                          the package, version, commit SHA, and copy time the
                          bundle froze (#1319). Exports bundleDocs(...) (whose
-                         `stamp` is optional) + readGitSha(...), which returns
-                         null rather than throwing outside a git checkout.
+                         `stamp` is optional) + readGitSha(...), which answers
+                         only for a checkout ROOT (rev-parse walks up, so a tree
+                         nested in an unrelated repo would otherwise stamp that
+                         repo's HEAD) and returns null rather than throwing.
+                         Every stamp field is null when unknown, never a
+                         plausible default, so no answer stays distinguishable
+                         from a real one.
   clean-mcp-resources.js postpack: remove the transient resources/ bundle so dev
                          always reads the live repo-root docs. Exports
                          cleanBundle(...).

--- a/packages/mcp/AGENTS.md
+++ b/packages/mcp/AGENTS.md
@@ -87,7 +87,11 @@ src/
 scripts/
   copy-mcp-resources.js  prepack: bundle the repo-root skill (references + SKILL.md) + AGENTS.md
                          into resources/ (in `files`) so npx is self-contained.
-                         Exports the reusable bundleDocs(...).
+                         Also emits resources/corpus.json, the build stamp naming
+                         the package, version, commit SHA, and copy time the
+                         bundle froze (#1319). Exports bundleDocs(...) (whose
+                         `stamp` is optional) + readGitSha(...), which returns
+                         null rather than throwing outside a git checkout.
   clean-mcp-resources.js postpack: remove the transient resources/ bundle so dev
                          always reads the live repo-root docs. Exports
                          cleanBundle(...).
@@ -102,9 +106,14 @@ scripts/
    function (or reads source/docs) and mutates nothing. No app module is loaded
    (export names are extracted lexically) so there are no DB-init side effects.
 3. **The docs bundle is transient.** `resources/` exists only inside the
-   published tarball (prepack writes it, postpack removes it). In the monorepo
-   it is absent and `resolveDocsLocation` falls back to the live repo-root docs,
-   so source stays single.
+   published tarball (prepack writes it, postpack removes it). That covers the
+   whole tree, `corpus.json` build stamp included; postpack removes the
+   directory recursively, so nothing added to the bundle needs its own cleanup.
+   In the monorepo the tree is absent and `resolveDocsLocation` falls back to
+   the live repo-root docs, so source stays single. The stamp is build metadata,
+   not a doc, which is why it sits beside `AGENTS.md` rather than inside
+   `references/`: `catalogue()` lists only `*.md` under the references dir, so a
+   stamp there would surface to agents as readable guidance.
 
 ## Tests
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -47,4 +47,22 @@ subcommand) delegates to this same server, so both routes run identical code.
 The docs corpus is bundled into the package at `prepack`, so `npx @webjsdev/mcp`
 is self-contained; in the monorepo it falls back to the live repo-root docs.
 
+That bundle is a snapshot frozen at publish time, so a published tarball keeps
+serving the docs as they read on the day it was cut. `prepack` stamps it with
+`resources/corpus.json` so the snapshot can say which docs it holds:
+
+```json
+{
+  "package": "@webjsdev/mcp",
+  "version": "0.1.12",
+  "sha": "e5806e2400000000000000000000000000000000",
+  "copiedAt": "2026-08-08T09:14:22.031Z"
+}
+```
+
+`sha` is the full commit the docs were copied from, so it resolves straight to a
+GitHub diff, and it is `null` when `prepack` runs outside a git checkout (a
+missing SHA never fails the publish). A dev checkout has no bundle and so no
+stamp.
+
 STDOUT is the JSON-RPC channel; every diagnostic goes to stderr.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -61,8 +61,15 @@ serving the docs as they read on the day it was cut. `prepack` stamps it with
 ```
 
 `sha` is the full commit the docs were copied from, so it resolves straight to a
-GitHub diff, and it is `null` when `prepack` runs outside a git checkout (a
-missing SHA never fails the publish). A dev checkout has no bundle and so no
-stamp.
+GitHub diff. Every field is `null` rather than a plausible-looking default when
+it cannot be established, so a consumer can always tell a real answer from no
+answer: `sha` when the source tree is not itself a git checkout root, and
+`package` / `version` when the manifest cannot be read. None of those fails the
+publish. A dev checkout has no bundle and so no stamp.
+
+The SHA is deliberately refused when the tree merely SITS inside some other
+checkout, because `git rev-parse` walks up to an ancestor and would otherwise
+report an unrelated repository's HEAD as the commit these docs came from. That
+answer is a well-formed SHA, so nothing downstream could catch it.
 
 STDOUT is the JSON-RPC channel; every diagnostic goes to stderr.

--- a/packages/mcp/scripts/clean-mcp-resources.js
+++ b/packages/mcp/scripts/clean-mcp-resources.js
@@ -24,6 +24,8 @@ import { fileURLToPath } from 'node:url';
  * @returns {void}
  */
 export function cleanBundle(destRoot) {
+  // Recursive, so the `corpus.json` build stamp (#1319) goes with the tree. No
+  // separate unlink is owed for it, or for anything else added to the bundle.
   rmSync(destRoot, { recursive: true, force: true });
 }
 

--- a/packages/mcp/scripts/copy-mcp-resources.js
+++ b/packages/mcp/scripts/copy-mcp-resources.js
@@ -22,45 +22,69 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { cpSync, mkdirSync, copyFileSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { cpSync, mkdirSync, copyFileSync, rmSync, writeFileSync, readFileSync, realpathSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+/** True when two paths name the same directory, symlinks resolved where possible. */
+function sameDir(a, b) {
+  if (!a || !b) return false;
+  const real = (p) => {
+    try {
+      return realpathSync(p);
+    } catch {
+      return resolve(p);
+    }
+  };
+  return real(a) === real(b);
+}
+
 /**
- * The commit the corpus was copied from, or `null` when it cannot be known.
+ * The commit `cwd` itself is checked out at, or `null` when that cannot be known.
  *
  * `prepack` can run outside a git checkout (a consumer running `npm pack` inside
  * an extracted tarball, a Docker build with no `.git`), and the `git` binary may
  * be absent entirely, so this never throws and never fails the publish. Copying
  * markdown is this script's job; a missing SHA costs a diagnostic, not a release.
  * `spawnSync` over `execSync` so an absent binary is a returned error object
- * rather than a throw. Anything that is not a 40-hex string is treated as absent,
- * which is a SEPARATE guard from the exit status: a git that exits 0 while
- * printing something else (a wrapper on PATH, a future porcelain change) must not
- * put that text into a published tarball as if it were a commit.
+ * rather than a throw.
  *
- * `spawn` is injectable so each of those guards is testable independently. The
- * real `git` in a temp dir exits non-zero, so it can only ever exercise the
- * status branch, which would leave the other two proven by nothing.
+ * Three independent things must hold before a SHA is returned, and each rejects a
+ * failure the others cannot see:
  *
- * @param {string} cwd  the directory to resolve HEAD from
+ * - the exit status, which is how an absent `.git` and a missing binary report;
+ * - the 40-hex shape, because a git that exits 0 while printing something else
+ *   (a wrapper on PATH, a future porcelain change) must not put that text into a
+ *   published tarball as if it were a commit;
+ * - `--show-toplevel` matching `cwd`, because `rev-parse` walks UP from `cwd` and
+ *   will happily answer from an ancestor. An extracted tarball sitting inside an
+ *   unrelated checkout would otherwise stamp the OUTER repo's HEAD as the commit
+ *   the docs came from, and that answer is a well-formed SHA, so nothing else
+ *   here could reject it. This is the one guard where a wrong answer is worse
+ *   than no answer, since it is confidently wrong rather than absent.
+ *
+ * `spawn` is injectable so each guard is testable independently: the real `git`
+ * in a temp dir exits non-zero, so on its own it can only ever reach the first.
+ *
+ * @param {string} cwd  the directory whose own checkout HEAD is wanted
  * @param {typeof spawnSync} [spawn]  seam for tests; defaults to the real spawnSync
  * @returns {string | null}
  */
 export function readGitSha(cwd, spawn = spawnSync) {
   try {
-    const out = spawn('git', ['rev-parse', 'HEAD'], { cwd, encoding: 'utf8' });
+    const out = spawn('git', ['rev-parse', '--show-toplevel', 'HEAD'], { cwd, encoding: 'utf8' });
     if (!out || out.status !== 0 || typeof out.stdout !== 'string') return null;
-    const sha = out.stdout.trim();
-    return /^[0-9a-f]{40}$/.test(sha) ? sha : null;
+    const [toplevel, sha] = out.stdout.trim().split('\n').map((line) => line.trim());
+    if (!/^[0-9a-f]{40}$/.test(sha || '')) return null;
+    return sameDir(toplevel, cwd) ? sha : null;
   } catch {
     return null;
   }
 }
 
 /**
- * Copy `srcDocs` (a dir of `*.md`) + `srcAgents` (a single file) into
- * `<destRoot>/references/` + `<destRoot>/SKILL.md` + `<destRoot>/AGENTS.md`. Cleans `destRoot` first so
+ * Copy `srcRefs` (a dir of `*.md`) + `srcAgents` + `srcSkill` (single files) into
+ * `<destRoot>/references/` + `<destRoot>/AGENTS.md` + `<destRoot>/SKILL.md`. Cleans `destRoot` first so
  * a removed/renamed doc never lingers in the bundle. PURE side effect on the
  * given paths, so it is testable against temp dirs without touching the package.
  *
@@ -70,7 +94,7 @@ export function readGitSha(cwd, spawn = spawnSync) {
  * under the references dir) can never surface build metadata as a readable doc.
  * `stamp` is optional so the function stays pure over its arguments.
  *
- * @param {{ srcDocs: string, srcAgents: string, destRoot: string, stamp?: object }} paths
+ * @param {{ srcRefs: string, srcAgents: string, srcSkill: string, destRoot: string, stamp?: object }} paths
  * @returns {void}
  */
 export function bundleDocs({ srcRefs, srcAgents, srcSkill, destRoot, stamp }) {
@@ -89,13 +113,20 @@ function main() {
   const pkgRoot = resolve(here, '..'); // packages/mcp/scripts -> packages/mcp
   const repoRoot = resolve(here, '..', '..', '..'); // -> monorepo root
   const skill = join(repoRoot, '.agents', 'skills', 'webjs');
-  let version = '0.0.0';
+  // Both identity fields come from the manifest that is about to be packed, so a
+  // rename cannot leave the stamp naming the wrong package. An unreadable
+  // manifest yields nulls, never a plausible-looking default: the whole point of
+  // a provenance stamp is that a consumer can tell a real answer from no answer,
+  // and a fabricated "0.0.0" is indistinguishable from a genuine version.
+  let pkg = {};
   try {
-    version = JSON.parse(readFileSync(join(pkgRoot, 'package.json'), 'utf8')).version || version;
-  } catch {}
+    pkg = JSON.parse(readFileSync(join(pkgRoot, 'package.json'), 'utf8'));
+  } catch (err) {
+    console.error(`[webjs] could not read the package manifest for the corpus stamp: ${err.message}`);
+  }
   const stamp = {
-    package: '@webjsdev/mcp',
-    version,
+    package: pkg.name || null,
+    version: pkg.version || null,
     // Full 40 chars, never abbreviated: a short SHA is ambiguous by definition
     // and a consumer can always shorten it for display.
     sha: readGitSha(repoRoot),
@@ -110,7 +141,9 @@ function main() {
   });
   // Diagnostics to stderr so they never pollute a tool parsing `npm pack --json` stdout.
   console.error('[webjs] bundled MCP knowledge into resources/ (references + SKILL.md + AGENTS.md)');
-  console.error(`[webjs] corpus stamp: ${stamp.package}@${stamp.version} sha=${stamp.sha || 'unknown'} copiedAt=${stamp.copiedAt}`);
+  console.error(
+    `[webjs] corpus stamp: ${stamp.package || 'unknown'}@${stamp.version || 'unknown'} sha=${stamp.sha || 'unknown'} copiedAt=${stamp.copiedAt}`,
+  );
 }
 
 // Only run the side effect when invoked directly (not when imported by a test).

--- a/packages/mcp/scripts/copy-mcp-resources.js
+++ b/packages/mcp/scripts/copy-mcp-resources.js
@@ -9,6 +9,11 @@
  * tarball, absent in dev (where `resolveDocsLocation` falls back to the live
  * repo-root docs, so source stays single).
  *
+ * It also writes `resources/corpus.json`, a build stamp naming the package,
+ * version, commit, and copy time the bundle froze (#1319). A published tarball
+ * carries a snapshot of the docs forever, so without the stamp a globally
+ * installed server has no way to say which docs it is holding.
+ *
  * The reusable `bundleDocs(...)` is exported + unit-tested; the script body just
  * runs it against the real repo paths. Mirrors `next-devtools-mcp`'s
  * `copy-resources`. Dependency-free.
@@ -16,9 +21,34 @@
  * @module copy-mcp-resources
  */
 
-import { cpSync, mkdirSync, copyFileSync, rmSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { cpSync, mkdirSync, copyFileSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+/**
+ * The commit the corpus was copied from, or `null` when it cannot be known.
+ *
+ * `prepack` can run outside a git checkout (a consumer running `npm pack` inside
+ * an extracted tarball, a Docker build with no `.git`), and the `git` binary may
+ * be absent entirely, so this never throws and never fails the publish. Copying
+ * markdown is this script's job; a missing SHA costs a diagnostic, not a release.
+ * `spawnSync` over `execSync` so an absent binary is a returned error object
+ * rather than a throw. Anything that is not a 40-hex string is treated as absent.
+ *
+ * @param {string} cwd  the directory to resolve HEAD from
+ * @returns {string | null}
+ */
+export function readGitSha(cwd) {
+  try {
+    const out = spawnSync('git', ['rev-parse', 'HEAD'], { cwd, encoding: 'utf8' });
+    if (out.status !== 0 || typeof out.stdout !== 'string') return null;
+    const sha = out.stdout.trim();
+    return /^[0-9a-f]{40}$/.test(sha) ? sha : null;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Copy `srcDocs` (a dir of `*.md`) + `srcAgents` (a single file) into
@@ -26,16 +56,23 @@ import { fileURLToPath } from 'node:url';
  * a removed/renamed doc never lingers in the bundle. PURE side effect on the
  * given paths, so it is testable against temp dirs without touching the package.
  *
- * @param {{ srcDocs: string, srcAgents: string, destRoot: string }} paths
+ * With a `stamp`, also writes `<destRoot>/corpus.json`, the build stamp that
+ * identifies WHICH docs this tarball froze (#1319). It sits beside `AGENTS.md`
+ * rather than inside `references/`, so `catalogue()` (which lists only `*.md`
+ * under the references dir) can never surface build metadata as a readable doc.
+ * `stamp` is optional so the function stays pure over its arguments.
+ *
+ * @param {{ srcDocs: string, srcAgents: string, destRoot: string, stamp?: object }} paths
  * @returns {void}
  */
-export function bundleDocs({ srcRefs, srcAgents, srcSkill, destRoot }) {
+export function bundleDocs({ srcRefs, srcAgents, srcSkill, destRoot, stamp }) {
   const destRefs = join(destRoot, 'references');
   rmSync(destRoot, { recursive: true, force: true });
   mkdirSync(destRefs, { recursive: true });
   cpSync(srcRefs, destRefs, { recursive: true });
   copyFileSync(srcAgents, join(destRoot, 'AGENTS.md'));
   copyFileSync(srcSkill, join(destRoot, 'SKILL.md'));
+  if (stamp) writeFileSync(join(destRoot, 'corpus.json'), JSON.stringify(stamp, null, 2) + '\n');
 }
 
 /** Run against the real repo paths when invoked as the prepack script. */
@@ -44,14 +81,28 @@ function main() {
   const pkgRoot = resolve(here, '..'); // packages/mcp/scripts -> packages/mcp
   const repoRoot = resolve(here, '..', '..', '..'); // -> monorepo root
   const skill = join(repoRoot, '.agents', 'skills', 'webjs');
+  let version = '0.0.0';
+  try {
+    version = JSON.parse(readFileSync(join(pkgRoot, 'package.json'), 'utf8')).version || version;
+  } catch {}
+  const stamp = {
+    package: '@webjsdev/mcp',
+    version,
+    // Full 40 chars, never abbreviated: a short SHA is ambiguous by definition
+    // and a consumer can always shorten it for display.
+    sha: readGitSha(repoRoot),
+    copiedAt: new Date().toISOString(),
+  };
   bundleDocs({
     srcRefs: join(skill, 'references'),
     srcAgents: join(repoRoot, 'AGENTS.md'),
     srcSkill: join(skill, 'SKILL.md'),
     destRoot: join(pkgRoot, 'resources'),
+    stamp,
   });
   // Diagnostics to stderr so they never pollute a tool parsing `npm pack --json` stdout.
   console.error('[webjs] bundled MCP knowledge into resources/ (references + SKILL.md + AGENTS.md)');
+  console.error(`[webjs] corpus stamp: ${stamp.package}@${stamp.version} sha=${stamp.sha || 'unknown'} copiedAt=${stamp.copiedAt}`);
 }
 
 // Only run the side effect when invoked directly (not when imported by a test).

--- a/packages/mcp/scripts/copy-mcp-resources.js
+++ b/packages/mcp/scripts/copy-mcp-resources.js
@@ -34,15 +34,23 @@ import { fileURLToPath } from 'node:url';
  * be absent entirely, so this never throws and never fails the publish. Copying
  * markdown is this script's job; a missing SHA costs a diagnostic, not a release.
  * `spawnSync` over `execSync` so an absent binary is a returned error object
- * rather than a throw. Anything that is not a 40-hex string is treated as absent.
+ * rather than a throw. Anything that is not a 40-hex string is treated as absent,
+ * which is a SEPARATE guard from the exit status: a git that exits 0 while
+ * printing something else (a wrapper on PATH, a future porcelain change) must not
+ * put that text into a published tarball as if it were a commit.
+ *
+ * `spawn` is injectable so each of those guards is testable independently. The
+ * real `git` in a temp dir exits non-zero, so it can only ever exercise the
+ * status branch, which would leave the other two proven by nothing.
  *
  * @param {string} cwd  the directory to resolve HEAD from
+ * @param {typeof spawnSync} [spawn]  seam for tests; defaults to the real spawnSync
  * @returns {string | null}
  */
-export function readGitSha(cwd) {
+export function readGitSha(cwd, spawn = spawnSync) {
   try {
-    const out = spawnSync('git', ['rev-parse', 'HEAD'], { cwd, encoding: 'utf8' });
-    if (out.status !== 0 || typeof out.stdout !== 'string') return null;
+    const out = spawn('git', ['rev-parse', 'HEAD'], { cwd, encoding: 'utf8' });
+    if (!out || out.status !== 0 || typeof out.stdout !== 'string') return null;
     const sha = out.stdout.trim();
     return /^[0-9a-f]{40}$/.test(sha) ? sha : null;
   } catch {

--- a/packages/mcp/test/mcp-docs.test.mjs
+++ b/packages/mcp/test/mcp-docs.test.mjs
@@ -243,37 +243,46 @@ test('cleanBundle: the stamp goes with the tree, no separate unlink owed', () =>
   assert.ok(!existsSync(paths.destRoot), 'bundle removed');
 });
 
-test('readGitSha: a real checkout yields 40 hex, a non-checkout yields null and never throws', () => {
-  // The repo itself is a checkout, so this proves the happy path against the real
-  // git binary, seam and all.
+test('readGitSha: answers for a checkout root only, against the real git binary', () => {
+  // The repo root IS its own git toplevel, which is the shape prepack runs in.
   const sha = readGitSha(REPO);
-  assert.match(sha, /^[0-9a-f]{40}$/, 'resolves HEAD in a checkout');
+  assert.match(sha, /^[0-9a-f]{40}$/, 'resolves HEAD at a checkout root');
 
   // A fresh temp dir is outside any checkout (git either errors, or on a machine
   // with no git at all spawnSync returns an error object). Either way: null.
   const outside = mkdtempSync(join(tmpdir(), 'mcp-nogit-'));
   _cleanup.push(outside);
   assert.equal(readGitSha(outside), null, 'no SHA outside a checkout, and no throw');
+
+  // The guard that a temp dir cannot prove: `rev-parse` walks UP, so a directory
+  // that merely SITS inside a checkout gets an answer from its ancestor. A
+  // subdirectory of this repo stands in for an extracted tarball unpacked inside
+  // an unrelated checkout, whose HEAD is not the commit these docs came from.
+  assert.equal(readGitSha(join(REPO, 'packages')), null, 'a nested dir does not borrow its ancestor HEAD');
 });
 
 test('readGitSha: each guard is exercised on its own, through the injected spawn', () => {
-  // The real binary in a temp dir exits non-zero, so it can only ever reach the
-  // status branch. These drive the other guards directly, so none of them is a
-  // line no test can red.
+  // The real binary reaches only some of these branches, so the rest would be
+  // lines no test can red. `--show-toplevel HEAD` prints the root then the SHA.
   const spawnOf = (result) => () => {
     if (result instanceof Error) throw result;
     return result;
   };
   const ok = 'b'.repeat(40);
+  const at = (top, sha) => ({ status: 0, stdout: `${top}\n${sha}\n` });
+  const root = mkdtempSync(join(tmpdir(), 'mcp-top-'));
+  _cleanup.push(root);
 
-  assert.equal(readGitSha('/x', spawnOf({ status: 0, stdout: ok + '\n' })), ok, 'trims a clean SHA');
-  assert.equal(readGitSha('/x', spawnOf({ status: 128, stdout: ok })), null, 'non-zero status wins over parseable output');
-  assert.equal(readGitSha('/x', spawnOf({ status: 0, stdout: 'fatal: not a git repository\n' })), null, 'exit 0 with prose is not a SHA');
-  assert.equal(readGitSha('/x', spawnOf({ status: 0, stdout: ok.slice(0, 7) })), null, 'an abbreviated SHA is rejected');
-  assert.equal(readGitSha('/x', spawnOf({ status: 0, stdout: 'B'.repeat(40) })), null, 'uppercase is not the git output shape');
-  assert.equal(readGitSha('/x', spawnOf({ status: 0, stdout: undefined })), null, 'no stdout, e.g. a spawn error object');
-  assert.equal(readGitSha('/x', spawnOf(null)), null, 'a spawn that returns nothing');
-  assert.equal(readGitSha('/x', spawnOf(new Error('spawn EACCES'))), null, 'a throwing spawn is swallowed');
+  assert.equal(readGitSha(root, spawnOf(at(root, ok))), ok, 'trims a clean SHA at a matching toplevel');
+  assert.equal(readGitSha(root, spawnOf({ status: 128, stdout: `${root}\n${ok}\n` })), null, 'non-zero status wins over parseable output');
+  assert.equal(readGitSha(root, spawnOf(at(root, 'fatal: not a git repository'))), null, 'exit 0 with prose is not a SHA');
+  assert.equal(readGitSha(root, spawnOf(at(root, ok.slice(0, 7)))), null, 'an abbreviated SHA is rejected');
+  assert.equal(readGitSha(root, spawnOf(at(root, 'B'.repeat(40)))), null, 'uppercase is not the git output shape');
+  assert.equal(readGitSha(root, spawnOf(at(join(root, '..'), ok))), null, 'an ancestor toplevel is rejected, SHA shape notwithstanding');
+  assert.equal(readGitSha(root, spawnOf({ status: 0, stdout: ok + '\n' })), null, 'a lone SHA with no toplevel line is rejected');
+  assert.equal(readGitSha(root, spawnOf({ status: 0, stdout: undefined })), null, 'no stdout, e.g. a spawn error object');
+  assert.equal(readGitSha(root, spawnOf(null)), null, 'a spawn that returns nothing');
+  assert.equal(readGitSha(root, spawnOf(new Error('spawn EACCES'))), null, 'a throwing spawn is swallowed');
 });
 
 test('the stamp lands inside the published files allowlist', () => {

--- a/packages/mcp/test/mcp-docs.test.mjs
+++ b/packages/mcp/test/mcp-docs.test.mjs
@@ -244,7 +244,8 @@ test('cleanBundle: the stamp goes with the tree, no separate unlink owed', () =>
 });
 
 test('readGitSha: a real checkout yields 40 hex, a non-checkout yields null and never throws', () => {
-  // The repo itself is a checkout, so this proves the happy path without mocking git.
+  // The repo itself is a checkout, so this proves the happy path against the real
+  // git binary, seam and all.
   const sha = readGitSha(REPO);
   assert.match(sha, /^[0-9a-f]{40}$/, 'resolves HEAD in a checkout');
 
@@ -253,6 +254,26 @@ test('readGitSha: a real checkout yields 40 hex, a non-checkout yields null and 
   const outside = mkdtempSync(join(tmpdir(), 'mcp-nogit-'));
   _cleanup.push(outside);
   assert.equal(readGitSha(outside), null, 'no SHA outside a checkout, and no throw');
+});
+
+test('readGitSha: each guard is exercised on its own, through the injected spawn', () => {
+  // The real binary in a temp dir exits non-zero, so it can only ever reach the
+  // status branch. These drive the other guards directly, so none of them is a
+  // line no test can red.
+  const spawnOf = (result) => () => {
+    if (result instanceof Error) throw result;
+    return result;
+  };
+  const ok = 'b'.repeat(40);
+
+  assert.equal(readGitSha('/x', spawnOf({ status: 0, stdout: ok + '\n' })), ok, 'trims a clean SHA');
+  assert.equal(readGitSha('/x', spawnOf({ status: 128, stdout: ok })), null, 'non-zero status wins over parseable output');
+  assert.equal(readGitSha('/x', spawnOf({ status: 0, stdout: 'fatal: not a git repository\n' })), null, 'exit 0 with prose is not a SHA');
+  assert.equal(readGitSha('/x', spawnOf({ status: 0, stdout: ok.slice(0, 7) })), null, 'an abbreviated SHA is rejected');
+  assert.equal(readGitSha('/x', spawnOf({ status: 0, stdout: 'B'.repeat(40) })), null, 'uppercase is not the git output shape');
+  assert.equal(readGitSha('/x', spawnOf({ status: 0, stdout: undefined })), null, 'no stdout, e.g. a spawn error object');
+  assert.equal(readGitSha('/x', spawnOf(null)), null, 'a spawn that returns nothing');
+  assert.equal(readGitSha('/x', spawnOf(new Error('spawn EACCES'))), null, 'a throwing spawn is swallowed');
 });
 
 test('the stamp lands inside the published files allowlist', () => {

--- a/packages/mcp/test/mcp-docs.test.mjs
+++ b/packages/mcp/test/mcp-docs.test.mjs
@@ -6,7 +6,7 @@
  */
 import { test, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readdirSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync, readdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve, dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -24,7 +24,7 @@ const {
   PROMPTS,
   resolveDocsLocation,
 } = await import(resolve(REPO, 'packages', 'mcp', 'src', 'mcp-docs.js'));
-const { bundleDocs } = await import(resolve(REPO, 'packages', 'mcp', 'scripts', 'copy-mcp-resources.js'));
+const { bundleDocs, readGitSha } = await import(resolve(REPO, 'packages', 'mcp', 'scripts', 'copy-mcp-resources.js'));
 const { cleanBundle } = await import(resolve(REPO, 'packages', 'mcp', 'scripts', 'clean-mcp-resources.js'));
 
 const _cleanup = [];
@@ -189,6 +189,88 @@ test('bundleDocs + cleanBundle: copy bundles references + SKILL + AGENTS, clean 
 
   cleanBundle(destRoot);
   assert.ok(!existsSync(destRoot), 'cleanBundle removed the transient bundle');
+});
+
+/** The throwaway source layout the stamp tests bundle from. Never the real package. */
+function bundleFixture() {
+  const root = mkdtempSync(join(tmpdir(), 'mcp-stamp-'));
+  _cleanup.push(root);
+  const srcRefs = join(root, 'src', 'references');
+  mkdirSync(srcRefs, { recursive: true });
+  writeFileSync(join(srcRefs, 'components.md'), '# Components\n');
+  const srcAgents = join(root, 'src', 'AGENTS.md');
+  const srcSkill = join(root, 'src', 'SKILL.md');
+  writeFileSync(srcAgents, '# AGENTS\n');
+  writeFileSync(srcSkill, '# SKILL\n');
+  return { srcRefs, srcAgents, srcSkill, destRoot: join(root, 'pkg', 'resources') };
+}
+
+test('bundleDocs: a stamp is written as parseable JSON beside AGENTS.md, and omitted when none is passed', () => {
+  const paths = bundleFixture();
+  const stamp = {
+    package: '@webjsdev/mcp',
+    version: '9.9.9',
+    sha: 'a'.repeat(40),
+    copiedAt: '2026-08-08T00:00:00.000Z',
+  };
+
+  bundleDocs({ ...paths, stamp });
+  const stampPath = join(paths.destRoot, 'corpus.json');
+  assert.ok(existsSync(stampPath), 'corpus.json written');
+  const parsed = JSON.parse(readFileSync(stampPath, 'utf8'));
+  assert.deepEqual(parsed, stamp, 'round-trips through JSON unchanged');
+  assert.equal(typeof parsed.package, 'string');
+  assert.equal(typeof parsed.version, 'string');
+  assert.equal(typeof parsed.sha, 'string');
+  assert.equal(typeof parsed.copiedAt, 'string');
+  // Build metadata, not a doc: it sits beside AGENTS.md so `catalogue()` (which
+  // lists only *.md under references/) can never surface it as a readable doc.
+  assert.ok(!existsSync(join(paths.destRoot, 'references', 'corpus.json')));
+
+  // Every pre-existing caller passes no stamp, so that branch must stay a no-op.
+  bundleDocs(paths);
+  assert.ok(!existsSync(stampPath), 'no stamp written when none is passed');
+});
+
+test('cleanBundle: the stamp goes with the tree, no separate unlink owed', () => {
+  const paths = bundleFixture();
+  bundleDocs({ ...paths, stamp: { package: '@webjsdev/mcp', version: '9.9.9', sha: null, copiedAt: 'x' } });
+  const stampPath = join(paths.destRoot, 'corpus.json');
+  assert.ok(existsSync(stampPath));
+
+  cleanBundle(paths.destRoot);
+  assert.ok(!existsSync(stampPath), 'stamp removed');
+  assert.ok(!existsSync(paths.destRoot), 'bundle removed');
+});
+
+test('readGitSha: a real checkout yields 40 hex, a non-checkout yields null and never throws', () => {
+  // The repo itself is a checkout, so this proves the happy path without mocking git.
+  const sha = readGitSha(REPO);
+  assert.match(sha, /^[0-9a-f]{40}$/, 'resolves HEAD in a checkout');
+
+  // A fresh temp dir is outside any checkout (git either errors, or on a machine
+  // with no git at all spawnSync returns an error object). Either way: null.
+  const outside = mkdtempSync(join(tmpdir(), 'mcp-nogit-'));
+  _cleanup.push(outside);
+  assert.equal(readGitSha(outside), null, 'no SHA outside a checkout, and no throw');
+});
+
+test('the stamp lands inside the published files allowlist', () => {
+  // Asserted by inspection rather than by packing: `npm pack` would run prepack
+  // against the REAL packages/mcp/resources in a repo several agents share, and
+  // postpack does not run when a pack fails, so a failed run leaves a stale
+  // bundle shadowing the live repo-root skill (clean-mcp-resources.js:4-8).
+  const pkg = JSON.parse(readFileSync(join(REPO, 'packages', 'mcp', 'package.json'), 'utf8'));
+  assert.ok(pkg.files.includes('resources'), 'resources/ is published');
+
+  // The other half: the stamp is written INTO that directory. `main()` sets
+  // destRoot to join(pkgRoot, 'resources'), and bundleDocs writes corpus.json at
+  // destRoot's top level, which the two assertions below pin together.
+  const paths = bundleFixture();
+  bundleDocs({ ...paths, stamp: { package: '@webjsdev/mcp', version: '9.9.9', sha: null, copiedAt: 'x' } });
+  assert.ok(existsSync(join(paths.destRoot, 'corpus.json')), 'written at the destRoot top level');
+  const script = readFileSync(join(REPO, 'packages', 'mcp', 'scripts', 'copy-mcp-resources.js'), 'utf8');
+  assert.match(script, /destRoot: join\(pkgRoot, 'resources'\)/, "main() bundles into the package's resources/");
 });
 
 test('getPrompt: every listed prompt resolves to a user message; unknown throws', () => {


### PR DESCRIPTION
PR 1 of 4 against #1319. The issue stays open until the staleness signal actually reaches the agent, at the end of PR 4, so there is no `Closes` here.

## Summary

A published `@webjsdev/mcp` tarball carries a snapshot of the docs frozen on the day it was cut, and the knowledge layer serves that snapshot with no provenance at all. A globally installed server therefore keeps teaching pre-fix guidance forever, with nothing an agent can read to notice. `prepack` now writes `resources/corpus.json` naming the package, version, commit SHA, and copy time the bundle froze, so the snapshot can say which docs it holds.

That cost was real rather than theoretical. A bun-global `@webjsdev/mcp@0.1.4` was still serving the pre-#628 sentence about enabling the client router from a layout import, which produced that import in three layouts of a real app, and `importsClientRouter()` treats it as a genuine client side effect, so all three layouts shipped whole instead of eliding.

## What changed

- `packages/mcp/scripts/copy-mcp-resources.js` gains `readGitSha(cwd)` and an optional `stamp` on `bundleDocs`. `main()` builds the stamp from the package's own `version`, `readGitSha(repoRoot)`, and `new Date().toISOString()`, and the stderr diagnostic now names what was stamped so a release log records it.
- `packages/mcp/scripts/clean-mcp-resources.js` gains one comment. `rmSync` is already recursive, so the stamp goes with the tree and no separate unlink is owed; the comment exists so a future reader does not add one.
- `packages/mcp/package.json` needed no change: its `files` array already carries `resources`, which covers every file inside the directory.

The stamp is the full 40-character SHA, since an abbreviated one is ambiguous by definition and a consumer can shorten it for display. Every field is `null` rather than a plausible-looking default when it cannot be established, so a consumer can always tell a real answer from no answer: `sha` when the tree is not itself a checkout root or `git` is absent, `package` and `version` when the manifest cannot be read. None of that fails the publish, because this script's job is copying markdown and failing a release over a missing diagnostic is the wrong trade. Fail-soft is already this module family's posture (`resolveDocsLocation` callers, `initText`'s swallowed read, `frameworkVersion()`).

`readGitSha` asks for `--show-toplevel` alongside `HEAD` and refuses anything whose toplevel is not the directory it was asked about. `rev-parse` walks UP, so a source tree that merely sits inside an unrelated checkout would otherwise stamp that repo's HEAD as the commit these docs came from, and since that answer is a well-formed SHA nothing downstream could reject it. It is the one failure mode here where being wrong is worse than being absent.

`corpus.json` sits beside `AGENTS.md`, never inside `references/`. `catalogue()` lists only `*.md` under the references dir, so a stamp there would surface to agents as a readable doc, and a build stamp is not guidance.

## Deliberately not here

Reading the stamp back out in `init` is PR 2. Surfacing it is not one line: it needs a `corpusPath` from `resolveDocsLocation`, threading through the `docsDeps` construction, a fallback line for the dev path that has no stamp, and updates to the docs that describe what `init` returns. That is a change to the tool's output contract, which is exactly what this slice was scoped to exclude. This PR changes no served byte.

`packages/server/src/component-elision.js` is untouched on purpose. An explicit `client-router` import IS a real client side effect and the root `AGENTS.md` documents it as one; the bug is upstream, in what the agent was told to write.

## Test plan

- `packages/mcp/test/mcp-docs.test.mjs`: five new cases covering the write branch, the no-stamp branch (which every pre-existing caller takes), the clean, the git-absent fallback, each `readGitSha` guard on its own, and the published-`files` coverage.
- Counterfactuals, proven at `f4040486` and re-checked after the fix commit: deleting the `writeFileSync` call reds three tests; deleting the `/^[0-9a-f]{40}$/` shape guard, the exit-status guard, the toplevel guard, or the swallowed throw each red the guard test.
- `readGitSha` takes an injectable `spawn`, which is why those last three are provable. Written against the real binary only, the outside-a-checkout case could reach nothing but the exit-status branch, since git exits non-zero in a temp dir and returns before the output is ever inspected, so removing the shape guard left the suite green. The shape guard is not redundant with the status one: a git that exits 0 while printing something else would otherwise put that text into a published tarball as if it were a commit.
- No `npm pack` anywhere in the suite. Packing runs `prepack`, which writes into the real `packages/mcp/resources/` in a repo several agents share, and `postpack` does not run when a pack fails, so a failed run leaves a stale bundle shadowing the live repo-root skill. The `files` coverage is asserted by inspection instead.
- Ran `prepack` then `postpack` by hand once in this worktree: the stamp wrote with a real SHA and `postpack` removed the tree.
- `node --test packages/mcp/test/*.mjs test/knowledge/*.js`: 76 pass, 0 fail.

## Layers

- Browser, e2e: N/A. This is a build script that runs under `npm publish` and serves nothing to a browser.
- Bun: N/A. `packages/mcp/package.json` invokes the script as `node scripts/copy-mcp-resources.js`, and the CI runner that publishes is `actions/setup-node` on Node 24, never Bun. None of the runtime-sensitive surfaces is touched.
- Dogfood boot check: N/A. Nothing in `core`, `server`, `cli`, the dist build, or the importmap changed, so what the two in-repo apps serve is byte-identical.

## Docs

- `packages/mcp/AGENTS.md`: the `scripts/` module map, and invariant 3 now states that the transient tree covers the stamp and why the stamp lives outside `references/`.
- `packages/mcp/README.md`: the bundling paragraph now shows the stamp and explains the null SHA.
- `framework-dev.md`: nothing owed. The `prepack` script keeps its name and invocation, so the release flow is unchanged.
- `.agents/skills/webjs/**`, `packages/cli/templates/**`, `website/`: nothing owed by this slice. No app-authoring API changed, and `init`'s output is untouched until PR 2.
