### PR TITLE
fix(website): docs search no longer ranks shell comments as headings

### DIFF
--- a/website/app/api/search/route.ts
+++ b/website/app/api/search/route.ts
@@ -11,8 +11,18 @@
  * anchors its file reads to import.meta.url rather than process.cwd(), which
  * is what makes this work identically under `webjs start`, in the
  * createRequestHandler test harness, and in a deployed app.
+ *
+ * Fenced code samples stay in the `text` match corpus at the flat body
+ * weight, deliberately. Roughly three thousand tokens in this corpus appear
+ * only inside a sample and nowhere in their page's prose, and they are
+ * exactly what a reader searches for: a flag, an env var, a header name, an
+ * import specifier. Dropping them would trade a ranking bug for a
+ * zero-results bug, and would empty the snippet for a code-only match. What
+ * code must NOT do is reach the heading tier, which is why the heading scan
+ * tracks fences (lib/utils/doc-headings.ts).
  */
 import { getDocPages } from '#lib/docs-llms.server.ts';
+import { extractHeadings } from '#lib/utils/doc-headings.ts';
 
 type SearchEntry = {
   path: string;
@@ -33,10 +43,10 @@ async function buildIndex(): Promise<SearchEntry[]> {
     title: page.title,
     // The markdown rendering already turned headings into leading-hash
     // lines, so they are recoverable without a second parse of the source.
-    headings: page.markdown
-      .split('\n')
-      .filter((line) => line.startsWith('#'))
-      .map((line) => line.replace(/^#+\s*/, '').trim()),
+    // Lines inside a ``` fence are skipped: a sample's `# ` shell comment
+    // is not a section title, and scoring it as one put 53 phantom
+    // headings into this index across 9 pages.
+    headings: extractHeadings(page.markdown),
     text: (page.title + '\n' + page.description + '\n' + page.markdown).toLowerCase(),
   }));
   return index;

--- a/website/lib/docs-llms.server.ts
+++ b/website/lib/docs-llms.server.ts
@@ -193,10 +193,13 @@ export function bodyToMarkdown(raw: string): string {
   // and teaches code nobody can run. `(?=[\s>])` keeps <pre from matching
   // <preview-tabs.
   //
-  // Separately, and NOT something fencing fixes: the docs search index
-  // (app/api/search/route.ts) picks its headings with a plain
-  // `line.startsWith('#')` and does no fence tracking, so a line-leading
-  // "# " shell comment inside a sample is scored as a heading either way.
+  // The fencing done here is what the docs search index depends on to tell
+  // a sample apart from prose. It recovers its headings from this markdown
+  // through lib/utils/doc-headings.ts, which tracks fences with the SAME
+  // predicate the whitespace normalisation below uses, so a line-leading
+  // "# " shell comment inside a sample is not scored as a heading. Two
+  // passes over this output that disagreed about where a fence starts would
+  // drift silently, which is why they share the rule.
   //
   // Nothing strips a <code> wrapper out of the captured text any more. That
   // strip existed for the `<pre><code>` shape docs pages used to author, and

--- a/website/lib/docs-llms.server.ts
+++ b/website/lib/docs-llms.server.ts
@@ -197,9 +197,11 @@ export function bodyToMarkdown(raw: string): string {
   // a sample apart from prose. It recovers its headings from this markdown
   // through lib/utils/doc-headings.ts, which tracks fences with the SAME
   // predicate the whitespace normalisation below uses, so a line-leading
-  // "# " shell comment inside a sample is not scored as a heading. Two
-  // passes over this output that disagreed about where a fence starts would
-  // drift silently, which is why they share the rule.
+  // "# " shell comment inside a sample is not scored as a heading. That
+  // helper keeps its own copy of the predicate (it is import-free and this
+  // module is server-only), and two passes over this output that disagreed
+  // about where a fence starts would drift silently, so
+  // test/lib/doc-headings.test.ts pins the two copies equal.
   //
   // Nothing strips a <code> wrapper out of the captured text any more. That
   // strip existed for the `<pre><code>` shape docs pages used to author, and

--- a/website/lib/utils/doc-headings.ts
+++ b/website/lib/utils/doc-headings.ts
@@ -11,9 +11,12 @@
  * query for `localhost` once ranked /docs/backend-only at 16.
  *
  * The fence predicate is byte-identical to the one bodyToMarkdown runs in
- * its normalisation pass (lib/docs-llms.server.ts). Two passes over the
- * same corpus that disagree about where a fence starts would drift
- * silently, so they share the rule rather than each having their own.
+ * its normalisation pass (lib/docs-llms.server.ts). It is a hand-kept
+ * duplicate rather than a shared import, because this file stays a pure
+ * browser-safe helper with no imports and that module is server-only. Two
+ * passes over the same corpus that disagreed about where a fence starts
+ * would drift silently, so `test/lib/doc-headings.test.ts` pins the two
+ * copies equal: change one and it reds.
  */
 export function extractHeadings(markdown: string): string[] {
   const headings: string[] = [];

--- a/website/lib/utils/doc-headings.ts
+++ b/website/lib/utils/doc-headings.ts
@@ -1,0 +1,30 @@
+/**
+ * Heading extraction for the docs search index (app/api/search/route.ts).
+ *
+ * `lib/docs-llms.server.ts` renders each doc page to markdown, turning
+ * <h1> through <h4> into leading-hash lines and wrapping every code sample
+ * in a ``` fence. Recovering the headings is therefore a line scan, with
+ * one rule that is easy to miss: a docs sample routinely opens a line with
+ * `# ` (a shell comment) or `#field` (a JS private class field), and a scan
+ * with no fence tracking scores those as section titles. Fifty-three of
+ * them were indexed across nine pages before this existed, which is how a
+ * query for `localhost` once ranked /docs/backend-only at 16.
+ *
+ * The fence predicate is byte-identical to the one bodyToMarkdown runs in
+ * its normalisation pass (lib/docs-llms.server.ts). Two passes over the
+ * same corpus that disagree about where a fence starts would drift
+ * silently, so they share the rule rather than each having their own.
+ */
+export function extractHeadings(markdown: string): string[] {
+  const headings: string[] = [];
+  let inFence = false;
+  for (const line of markdown.split('\n')) {
+    if (line.trimStart().startsWith('```')) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    if (line.startsWith('#')) headings.push(line.replace(/^#+\s*/, '').trim());
+  }
+  return headings;
+}

--- a/website/test/lib/doc-headings.test.ts
+++ b/website/test/lib/doc-headings.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Unit tests for the docs search index's heading extraction
+ * (lib/utils/doc-headings.ts).
+ *
+ * The extractor exists because the docs corpus is full of code samples that
+ * open a line with `#`: a shell comment, or a JavaScript private class
+ * field. Scored as headings they earn +5 each in `app/api/search/route.ts`,
+ * accumulating per match, which is how a query for `localhost` ranked
+ * /docs/backend-only at 16 off three `# → http://localhost:8080` comments.
+ *
+ * Two levels of coverage here, on purpose. The fixture pins the rule in
+ * isolation, and the corpus test pins that the rule still holds against the
+ * real docs, where the samples that motivated it actually live.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { extractHeadings } from '#lib/utils/doc-headings.ts';
+import { getDocPages, type DocPage } from '#lib/docs-llms.server.ts';
+
+const FIXTURE = [
+  '# Getting Started',
+  '',
+  'Some prose.',
+  '',
+  '## Quick Start',
+  '',
+  '```',
+  '# not a heading',
+  'npm create webjs@latest my-app',
+  'class Themed {',
+  '  #field = 1;',
+  '}',
+  '```',
+  '',
+  '### Manual setup',
+  '',
+  '#### package.json',
+  '',
+  '  ```',
+  '  # indented fence, still a fence',
+  '  ```',
+  '',
+  '## Next Steps',
+].join('\n');
+
+test('a hash line inside a fence is not a heading, at any nesting', () => {
+  assert.deepEqual(extractHeadings(FIXTURE), [
+    'Getting Started',
+    'Quick Start',
+    'Manual setup',
+    'package.json',
+    'Next Steps',
+  ]);
+});
+
+test('the real corpus keeps its headings and drops the shell comments', async () => {
+  const pages = await getDocPages();
+  const page = pages.find((p: DocPage) => p.path === '/docs/getting-started');
+  assert.ok(page, 'expected /docs/getting-started in the corpus');
+  const headings = extractHeadings(page.markdown);
+
+  // A real heading survives at more than one level (## and ###).
+  assert.ok(headings.includes('Quick Start'), 'an h2 survives');
+  assert.ok(headings.includes('Using the scaffold'), 'an h3 survives');
+
+  // Authored as a `# ` shell comment in app/docs/getting-started/page.ts.
+  assert.ok(
+    !headings.includes('scaffold a new app (no global install needed)'),
+    'a shell comment inside a sample is not a heading',
+  );
+
+  // The floor is what stops an empty list passing the exclusion above, which
+  // is the trap an absence-only assertion falls into. 13 today.
+  assert.ok(headings.length >= 10, `expected the page's real headings, found ${headings.length}`);
+});

--- a/website/test/lib/doc-headings.test.ts
+++ b/website/test/lib/doc-headings.test.ts
@@ -14,6 +14,7 @@
  */
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import { extractHeadings } from '#lib/utils/doc-headings.ts';
 import { getDocPages, type DocPage } from '#lib/docs-llms.server.ts';
 
@@ -38,7 +39,9 @@ const FIXTURE = [
   '#### package.json',
   '',
   '  ```',
-  '  # indented fence, still a fence',
+  // Column 0 inside an INDENTED fence. Drop trimStart() from the predicate
+  // and the fence stops toggling, so this line becomes a heading.
+  '#not a heading either, the fence around it is indented',
   '  ```',
   '',
   '## Next Steps',
@@ -52,6 +55,19 @@ test('a hash line inside a fence is not a heading, at any nesting', () => {
     'package.json',
     'Next Steps',
   ]);
+});
+
+test('both fence scans use the same predicate, so they cannot drift apart', () => {
+  // This helper stays import-free: lib/utils is the browser-safe shelf and
+  // docs-llms.server.ts is server-only, so the predicate is a hand-kept
+  // duplicate rather than a shared export. That is only safe if something
+  // pins the two copies together, which is this test. Editing one scan's
+  // idea of where a fence starts and not the other's reds here.
+  const PREDICATE = "line.trimStart().startsWith('```')";
+  for (const rel of ['../../lib/utils/doc-headings.ts', '../../lib/docs-llms.server.ts']) {
+    const src = readFileSync(new URL(rel, import.meta.url), 'utf8');
+    assert.ok(src.includes(PREDICATE), `${rel} no longer uses the shared fence predicate`);
+  }
 });
 
 test('the real corpus keeps its headings and drops the shell comments', async () => {

--- a/website/test/lib/doc-headings.test.ts
+++ b/website/test/lib/doc-headings.test.ts
@@ -27,9 +27,10 @@ const FIXTURE = [
   '```',
   '# not a heading',
   'npm create webjs@latest my-app',
-  'class Themed {',
-  '  #field = 1;',
-  '}',
+  // Column 0, the shape the real corpus has: /docs/context and /docs/task
+  // both open a sample on a private field, dedented out of its class body.
+  '#theme = new ContextConsumer(this, {',
+  '## nor is this a heading',
   '```',
   '',
   '### Manual setup',

--- a/website/test/ssr/docs-llms.test.ts
+++ b/website/test/ssr/docs-llms.test.ts
@@ -11,11 +11,12 @@
  * is exactly the failure a test has to catch instead of a reader.
  *
  * The docs search index is built from this same markdown
- * (`app/api/search/route.ts`), so it inherits whatever this produces. Note
- * that its heading extraction is a plain `line.startsWith('#')` with no fence
- * tracking, so a line-leading `# ` shell comment inside a sample scores as a
- * heading whether or not the fence is there. That is a separate pre-existing
- * problem, not one these tests cover.
+ * (`app/api/search/route.ts`), so it inherits whatever this produces. Its
+ * heading extraction now tracks fences (`lib/utils/doc-headings.ts`), using
+ * the same fence predicate this module's normalisation pass uses, so a
+ * line-leading `# ` shell comment inside a sample is not scored as a
+ * heading. That behaviour is covered by `test/lib/doc-headings.test.ts` and
+ * `test/ssr/docs-search.test.ts`, not here.
  */
 import test from 'node:test';
 import assert from 'node:assert/strict';

--- a/website/test/ssr/docs-search.test.ts
+++ b/website/test/ssr/docs-search.test.ts
@@ -51,6 +51,24 @@ test('a title match outranks a passing mention in the body', async () => {
   assert.equal(hits[0].path, '/docs/middleware', 'the page ABOUT the term wins');
 });
 
+test('a term that only appears in shell comments scores at the body floor', async () => {
+  // `localhost` reaches this corpus only through `# → http://localhost:8080`
+  // sample comments. Before the heading scan tracked fences those counted as
+  // headings at +5 each, and they accumulate, so /docs/backend-only scored 16
+  // for the term and /docs/getting-started 11, both off comment lines alone.
+  //
+  // If a future doc page grows a REAL heading containing `localhost`, that
+  // page legitimately scores above 1 and this expectation should change with
+  // it rather than be worked around.
+  const hits = await search('localhost');
+  assert.ok(hits.length > 0, 'the term still matches, at body weight');
+  assert.deepEqual(
+    hits.filter((h: Hit) => h.score !== 1).map((h: Hit) => `${h.path}=${h.score}`),
+    [],
+    'no page is promoted above the body floor by a sample comment',
+  );
+});
+
 test('a query shorter than two characters returns nothing', async () => {
   assert.deepEqual(await search('r'), []);
   assert.deepEqual(await search(''), []);


### PR DESCRIPTION
Closes #1262

## Summary

The docs search index recovered each page's headings by filtering the generated markdown for lines starting with a hash, with no fence tracking. Docs samples routinely open a line with `# ` (a shell comment) or `#field` (a JS private class field), so 53 of those were indexed as headings across 9 pages. A heading match scores +5 and accumulates per match, so a query for `localhost` ranked `/docs/backend-only` at 16 off nothing but three `# → http://localhost:8080` comment lines.

The scan moved into `website/lib/utils/doc-headings.ts` as a pure `extractHeadings(markdown)`, where it is unit-testable directly rather than only over HTTP (the endpoint never exposes `headings`). It skips lines inside a fence using the same predicate `bodyToMarkdown` already runs in its whitespace pass, because two passes over the same corpus that disagreed about where a fence starts would drift silently and nothing would catch it.

Fenced code stays in the `text` match corpus at its existing weight. `route.ts` L40 and the scoring and snippet blocks are byte-unchanged. Roughly three thousand tokens in this corpus appear only inside a sample and nowhere in their page's prose, and those are exactly what a reader searches a docs site for: a flag, an env var, a header name, an import specifier. Dropping them would trade a ranking bug for a zero-results bug. The decision is recorded in the route's own module header.

## Measured, re-verified at `e7eb5dcb`

Every figure in the issue reproduces: 44 pages, 752 hash-leading lines, 699 outside a fence, so 53 phantom headings across the same 9 pages. All 970 fence lines are bare ` ``` ` at column 0, every page has an even count, and there are no `~~~` lines, so the toggle cannot desync on this corpus. 7 h4 headings sit outside a fence, which is why the strip regex stays `/^#+\s*/`.

| Query | Page | Before | After |
|---|---|---|---|
| `localhost` | `/docs/backend-only` | 16 | 1 |
| `localhost` | `/docs/getting-started` | 11 | 1 |
| `curl` | `/docs/backend-only` | 11 | 1 |
| `bun` | `/docs/runtime` | 21 | 21 |
| `bun` | `/docs/getting-started` | 16 | 6 |
| `bun` | `/docs/ai-first` | 6 | 1 |

`/docs/runtime` is unchanged because its points are a title match plus real headings. `/docs/getting-started` keeps 13 real headings, `Prerequisites` through `Next Steps`.

The one number I could not reproduce exactly is the code-only token count. It is tokenizer-dependent, as the issue says: a `[a-z0-9]+` tokenizer gives 3081, dropping single characters gives 2946, and a looser one that keeps `.` and `/` gives 4455. The route header says "roughly three thousand" rather than pinning a figure that depends on how you split.

## Counterfactual

Reverting `extractHeadings` to the bare `.filter((line) => line.startsWith('#'))` reds all three tests:

```
✖ a hash line inside a fence is not a heading, at any nesting
    actual: [ 'Getting Started', 'Quick Start', 'not a heading',
              'theme = new ContextConsumer(this, {', 'nor is this a heading',
              'Manual setup', 'package.json', 'Next Steps' ],
✖ the real corpus keeps its headings and drops the shell comments
    'a shell comment inside a sample is not a heading'
✖ a term that only appears in shell comments scores at the body floor
    actual: [ '/docs/backend-only=16', '/docs/getting-started=11' ],
ℹ tests 10  ℹ pass 7  ℹ fail 3
```

The first run of that counterfactual caught a hole in my own fixture, fixed in [`7769a527`](https://github.com/webjsdev/webjs/commit/7769a527). The private class field was written indented inside a class body, where `startsWith('#')` never saw it under either extractor, so that half of the fixture proved nothing. The real corpus opens those samples dedented (`/docs/context`, `/docs/task`), so the fixture now matches, and a nested `##` covers the third shape (`/docs/ai-first` embeds a markdown outline in a sample).

## Test plan

- `website/test/lib/doc-headings.test.ts`, new. A fixture pinning the rule in isolation, the same rule against the real corpus via `getDocPages()` with an at-least-10 length floor so an empty list cannot pass the exclusion assertion, and a drift guard asserting both fence scans still carry the same predicate literal.
- `website/test/ssr/docs-search.test.ts`, extended. Every `localhost` hit scores exactly 1 through the live endpoint.
- `npm test` from `website/`: 459 pass, 0 fail (Node), 84 pass, 0 fail (browser).
- `npm run typecheck`: clean. `npx webjs check`: all checks pass. `npx webjs doctor`: 10 passed, 3 warnings, 0 failed, exit 0. The three warnings (`ENV_DRIFT`, `WEBJS_VERSIONS`, `ELISION_CARRIERS`) are pre-existing and none is gated to `error`.
- Typechecked the whole `website/test/` tree under the app's `strict` config with the glob added, the way #1299 will add it: my files contribute **0** errors. The 17 that remain are the pre-existing ones #1299 exists to fix, in `docs-sitemap`, `layout-ssr`, `nav-and-routes`, `render-determinism`, and `seo-infra`.

## Review

One round over the whole diff, two findings, both fixed in [`5cb2546e`](https://github.com/webjsdev/webjs/commit/5cb2546e).

The indented-fence line in the fixture was itself indented, so `startsWith('#')` was false for it either way and dropping `trimStart()` from the predicate left the test green. It sits at column 0 now, where the fence failing to toggle promotes it.

The more interesting one: both comments said the two fence scans share a rule, when each carried its own copy with nothing holding them together. The comment was the only thing handling a drift risk it claimed was already handled. Sharing by import is not available, since `lib/utils` is the browser-safe shelf and `docs-llms.server.ts` is server-only, so a test now reads both files and asserts each still contains the predicate literal. Rewriting either reds it, and both comments say so.

Both fixes are proven by toggling `trimStart()` off, which reds the fixture assertion and the drift guard together.

## Layers that do not apply

- **Browser.** The response shape is unchanged, so `website/test/components/browser/doc-search.test.js` covers the component as before. It runs green.
- **e2e / smoke.** No navigation, streaming, or network-probe behaviour changes, and the smoke suites are scoped to scaffolded example apps.
- **Bun parity.** A pure string helper in an in-repo app, no runtime-sensitive surface, no framework source staged.
- **Docs.** No published-package export, CLI flag, config key, `html` hole, lifecycle hook, or convention changes. The three prose surfaces that did change (the route's module header, and the two in-repo comments that described this as an open defect) are part of the code commits.

## Findings, all fixed here

No follow-up issues filed. The fixture hole above is the only thing this work turned up beyond the issue's plan, and it is fixed in the same PR.
