### PR TITLE
chore: release core 0.7.49, server 0.8.61, cli 0.10.53 and two more

### DIFF
--- a/changelog/cli/0.10.53.md
+++ b/changelog/cli/0.10.53.md
@@ -1,0 +1,49 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.53
+date: 2026-08-08T19:38:45.616Z
+commit_count: 4
+---
+## Fixes
+
+- **`webjs doctor` no longer reports every `@webjsdev` dep as not installed** ([#1351](https://github.com/webjsdev/webjs/pull/1351)) [`d4226eb1`](https://github.com/webjsdev/webjs/commit/d4226eb1)
+  The `WEBJS_VERSIONS` check read `<appDir>/node_modules/<dep>/package.json`
+  directly. Under npm workspaces the `@webjsdev/*` deps hoist to the root
+  `node_modules`, so an app subdirectory has no local copy and a perfectly
+  healthy install warned on every declared dep, while `FRAMEWORK_RESOLVE` in the
+  same output said the framework resolves fine. The check asks Node's resolver
+  instead, anchored at the app dir, which is the question it was always asking
+  and picks up symlinked workspace links and nested trees for free. Both halves
+  of the resolve are load-bearing, since `@webjsdev/cli` is bin-only and has no
+  main entry while `@webjsdev/server` locks `./package.json` out of its exports
+  map. The check becomes gatable now that it no longer warns on a healthy
+  install.
+
+- **lowercase the postgres database name derived from the app name** ([#1330](https://github.com/webjsdev/webjs/pull/1330)) [`a9f88caa`](https://github.com/webjsdev/webjs/commit/a9f88caa)
+  `webjs create MyApp --db postgres` wrote the app name into the emitted
+  `DATABASE_URL` case-preserving, so the URL named `MyApp`. PostgreSQL folds an
+  unquoted identifier, so `CREATE DATABASE MyApp;` creates `myapp` and the
+  emitted URL then fails to connect, while `createdb MyApp` quotes and creates
+  `MyApp` literally. The emitted name is now derived once and is
+  quoting-invariant: folded with `toLowerCase`, every remaining
+  non-`[a-z0-9_]` character mapped to `_`, a leading digit prefixed with `_`,
+  then capped at 63 bytes. The app name itself is untouched everywhere else,
+  and the post-scaffold guidance names the database so you know what to create.
+
+- **a generated app type-checks its own tests** ([#1349](https://github.com/webjsdev/webjs/pull/1349)) [`6ccacf43`](https://github.com/webjsdev/webjs/commit/6ccacf43)
+  Every app `webjs create` emits left `test/` outside the tsconfig include, so
+  an author following the scaffold's own testing guidance got no type checking
+  on the tests they wrote, including the three starter tests the scaffold
+  itself writes. The generated `tsconfig.json` now covers them, and the starter
+  e2e test is annotated to pass under it.
+
+- **the scaffold's punctuation hook scans JSON and front-matter prose** ([#1334](https://github.com/webjsdev/webjs/pull/1334)) [`c0917df3`](https://github.com/webjsdev/webjs/commit/c0917df3)
+  The hook a scaffolded app ships gated its pause-hyphen and pause-semicolon
+  rules on four line shapes, so a JSON string value matched none of them and
+  passed straight through. A `description` / `title` / `displayName` value is
+  scanned now, in JSON and in column-0 YAML front matter, scoped by the KEY
+  rather than the file so semver ranges, script commands, urls, paths and globs
+  stay out of it. The same commit fixes a silent stop on a large payload: `grep
+  -q` exits on its first match, closing the pipe under `printf`, and under
+  `pipefail` the resulting SIGPIPE became the pipeline status, so the rule
+  skipped. Measured 0 of 8 blocks caught at 200 KB before, 8 of 8 after.

--- a/changelog/core/0.7.49.md
+++ b/changelog/core/0.7.49.md
@@ -1,0 +1,55 @@
+---
+package: "@webjsdev/core"
+version: 0.7.49
+date: 2026-08-08T19:38:45.486Z
+commit_count: 4
+---
+## Fixes
+
+- **a cyclic value on a JSON-typed reflect:true prop no longer throws** ([#1335](https://github.com/webjsdev/webjs/pull/1335)) [`549462da`](https://github.com/webjsdev/webjs/commit/549462da)
+  Reflection serialized an `Object` / `Array` property with a bare
+  `JSON.stringify`, so a value that cannot pass through it threw out of
+  reflection with nothing catching it. Three shapes hit this in practice: a
+  cycle, a `BigInt`, and an author `toJSON()` that throws. At SSR the
+  per-component error isolation swallowed the throw, so production returned 200
+  with the component rendered EMPTY and the cause only in the server log; on the
+  client the same throw came out of the author's property assignment, so a
+  component whose constructor set such a value never rendered at all.
+
+  The attribute is now REMOVED and a warning fires, matching what the
+  neighbouring function branch already did: an HTML attribute is a string, and a
+  value with no string form has no attribute representation. A JSON-typed value
+  merely CARRYING a function still reflects whole. The read side closes the round
+  trip on both renderers: an unparseable attribute reads back as `null` rather
+  than the raw string, matching an absent attribute and lit's
+  `defaultConverter.fromAttribute`, so SSR and the client cannot disagree.
+
+- **`loadFrame` is undefined from `@webjsdev/core/client-router` in prod** ([#1346](https://github.com/webjsdev/webjs/pull/1346)) [`d0ea7d50`](https://github.com/webjsdev/webjs/commit/d0ea7d50)
+  The `client-router` subpath declared `loadFrame` in its `.d.ts` but never
+  exported it at runtime, so a type-checking import resolved in the editor and
+  came back undefined in the browser. It is exported from the barrel now and
+  classified internal, the same way `WebjsFrame` already is, since an app uses
+  the `<webjs-frame src>` tag and `loadFrame` is the seam that element calls.
+
+  Two redundant bare exports (`collectBoundaries`, `planBoundarySwap`) that were
+  never public are dropped, and the forward `.d.ts` coverage check now runs over
+  every published exports overlay instead of a hardcoded three, so a runtime
+  export with no matching declaration reds CI rather than silently dropping out
+  of editor intelligence.
+
+- **a submitter's empty `formmethod` / `formenctype` / `formtarget` wins, as native** ([#1352](https://github.com/webjsdev/webjs/pull/1352)) [`0206464f`](https://github.com/webjsdev/webjs/commit/0206464f)
+  The form-submission algorithm resolves a submitter's override on whether the
+  attribute is PRESENT, never on its value being truthy. Those three siblings
+  used a `||` chain, so a present-but-empty value was falsy and fell through to
+  the form's. Measured against Chromium, Firefox and WebKit at the request
+  level, a `<button type="submit" formmethod="" formenctype="">` inside a
+  `<form method="post" enctype="multipart/form-data" action="/submit">` submits
+  natively as `GET /submit?a=1` with no body, while the router resolved it as a
+  multipart POST. One template, two different requests with JS on and JS off,
+  which is the divergence the bound-submitter work exists to eliminate.
+
+- **JSDoc types on the WebSocket client's returned `send` / `close`** ([#1349](https://github.com/webjsdev/webjs/pull/1349)) [`6ccacf43`](https://github.com/webjsdev/webjs/commit/6ccacf43)
+  `connectWS` returned methods with no JSDoc annotation, which surfaced as
+  implicit-any errors in a consuming app that sets `checkJs: true`. The public
+  shape in `index.d.ts` already declared the intended types, so the two now
+  agree.

--- a/changelog/mcp/0.1.13.md
+++ b/changelog/mcp/0.1.13.md
@@ -1,0 +1,24 @@
+---
+package: "@webjsdev/mcp"
+version: 0.1.13
+date: 2026-08-08T19:38:45.782Z
+commit_count: 1
+---
+## Features
+
+- **the bundled docs corpus is stamped at prepack** ([#1348](https://github.com/webjsdev/webjs/pull/1348)) [`d6741291`](https://github.com/webjsdev/webjs/commit/d6741291)
+  A published tarball carries a snapshot of the docs frozen on the day it was
+  cut, and the knowledge layer served that snapshot with no provenance at all,
+  so a globally installed server kept teaching pre-fix guidance forever with
+  nothing an agent could read to notice. The cost was real: a stale bundle
+  taught a layout-level client-router import that had been dropped, and the
+  resulting dead import defeated elision on three layouts.
+
+  `prepack` now writes `resources/corpus.json` naming the package, version,
+  commit SHA, and copy time the bundle froze. The SHA is the full 40 characters,
+  since an abbreviated one is ambiguous by definition, and it is `null` rather
+  than a guess whenever it cannot be vouched for: outside a git checkout, or
+  when a source tree merely sits inside an unrelated checkout, which
+  `git rev-parse` would otherwise answer with the OUTER repo's HEAD. This slice
+  only writes the stamp; reading it back out in the `init` tool changes that
+  tool's output contract and lands separately.

--- a/changelog/server/0.8.61.md
+++ b/changelog/server/0.8.61.md
@@ -1,0 +1,15 @@
+---
+package: "@webjsdev/server"
+version: 0.8.61
+date: 2026-08-08T19:38:45.550Z
+commit_count: 1
+---
+## Fixes
+
+- **a component importing `loadFrame` is no longer wrongly elided** ([#1346](https://github.com/webjsdev/webjs/pull/1346)) [`d0ea7d50`](https://github.com/webjsdev/webjs/commit/d0ea7d50)
+  The elision analyser's list of client-only router APIs from the
+  `@webjsdev/core` barrel omitted `loadFrame`, so a component whose only client
+  signal was that import read as display-only and had its module dropped. The
+  list is exported now and guarded the way `REACTIVE_IMPORTS` already is, so a
+  router function the barrel re-exports but the list omits reds a test instead
+  of producing a dead component in the browser.

--- a/changelog/ui/0.3.12.md
+++ b/changelog/ui/0.3.12.md
@@ -1,0 +1,33 @@
+---
+package: "@webjsdev/ui"
+version: 0.3.12
+date: 2026-08-08T19:38:45.744Z
+commit_count: 1
+---
+## Fixes
+
+- **split the coarse bg, shadow and text-shadow `cn()` groups by property** ([#1332](https://github.com/webjsdev/webjs/pull/1332)) [`4e952b9b`](https://github.com/webjsdev/webjs/commit/4e952b9b)
+  A `cn()` conflict group is one CSS property, never one class prefix. Three
+  groups were still keyed by prefix, so a utility was evicted by an unrelated
+  one that merely shared its prefix and the dropped class was silently gone.
+  `bg-clip-*`, `bg-origin-*` and `bg-blend-*` all sat in `bg-color`, so the
+  gradient-text idiom `bg-linear-to-r bg-clip-text text-transparent` lost its
+  clip the moment any later `bg-*` colour landed on the same element. A
+  box-shadow size shared one group with its colour, in both directions. And
+  `text-shadow-*` fell into `text-color`, so a shadow ate a text colour.
+  Enumerating each family rather than only the reported pairs surfaced more of
+  the same shape: the compound position keywords (`bg-top-left`) and the v4
+  functional `bg-size-*` / `bg-position-*` spellings fell into the colour
+  catch-all too, and text alignment, wrapping and overflow had no group at all,
+  so `text-left text-center` emitted both and stylesheet order picked the
+  winner.
+
+  Group names are taken verbatim from `tailwind-merge` 3.5.0, so the table stays
+  auditable line by line against the reference. Two classification rules are
+  worth knowing. An unhinted arbitrary shadow value is a SIZE when it opens with
+  `inset`, a sign, a dot, a digit, or `var(`, and a colour otherwise, so
+  `cn('shadow-red-500', 'shadow-[var(--x)]')` now keeps both: those are two
+  different properties. And a `@theme`-extended bare shadow NAME (`shadow-card`)
+  still reads as a colour, because nothing in a static table can tell it from
+  `shadow-primary` without reading the project's theme. The arbitrary form
+  `shadow-[var(--shadow-card)]` classifies correctly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6934,7 +6934,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.52",
+      "version": "0.10.53",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -6950,7 +6950,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.48",
+      "version": "0.7.49",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.25.0"
@@ -6984,7 +6984,7 @@
     },
     "packages/mcp": {
       "name": "@webjsdev/mcp",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/server": "^0.8.0",
@@ -6999,10 +6999,10 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.60",
+      "version": "0.8.61",
       "license": "MIT",
       "dependencies": {
-        "@webjsdev/core": "^0.7.48",
+        "@webjsdev/core": "^0.7.49",
         "ws": "^8.20.0"
       },
       "engines": {
@@ -7035,7 +7035,7 @@
     },
     "packages/ui": {
       "name": "@webjsdev/ui",
-      "version": "0.3.11",
+      "version": "0.3.12",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.52",
+  "version": "0.10.53",
   "type": "module",
   "description": "The CLI for WebJs, a full-stack JavaScript framework built on web components with server-side rendering and no build step. Runs the dev and production servers, scaffolds apps, validates conventions, and drives the database. Node 24+ or Bun.",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.48",
+  "version": "0.7.49",
   "type": "module",
   "description": "The runtime for WebJs, a full-stack JavaScript framework built on web components with server-side rendering and no build step. Ships the html and css template tags, the WebComponent base class, signals, directives, and the isomorphic renderers.",
   "types": "./index.d.ts",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/mcp",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "type": "module",
   "description": "The Model Context Protocol server for WebJs, a full-stack JavaScript framework built on web components with server-side rendering and no build step. Gives AI coding agents live app introspection over routes, actions, components, and convention checks, plus a knowledge layer of docs, recipes, and framework source.",
   "bin": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.60",
+  "version": "0.8.61",
   "type": "module",
   "description": "The server for WebJs, a full-stack JavaScript framework built on web components with server-side rendering and no build step. Provides the file-based router, SSR, server actions, route handlers, middleware, and live reload on Node 24+ or Bun.",
   "main": "index.js",
@@ -28,7 +28,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@webjsdev/core": "^0.7.48",
+    "@webjsdev/core": "^0.7.49",
     "ws": "^8.20.0"
   },
   "publishConfig": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/ui",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "type": "module",
   "description": "The AI-first component library for WebJs, a full-stack JavaScript framework built on web components with server-side rendering and no build step. Class-helper functions for visuals, custom elements only where state matters, source-copied into your repo so you own it.",
   "bin": {


### PR DESCRIPTION
Clears every package carrying unreleased user-facing work since the last
release. intellisense and the two editor packages picked up nothing in the
range, so they stay where they are.

core takes three fixes and a type annotation. A cyclic value, a BigInt, or a
throwing toJSON on a JSON-typed reflect:true property threw out of reflection
with nothing catching it, which at SSR was swallowed by per-component error
isolation into a 200 with an EMPTY component. loadFrame was declared in the
client-router .d.ts but never exported at runtime, so a type-checking import
came back undefined in the browser. And a submitter's present-but-empty
formmethod / formenctype / formtarget now wins over the form's, as every
browser does it, which removes a case where one template produced two
different requests with JS on and with JS off.

server takes the other half of the loadFrame fix: the elision analyser did
not count that import as client work, so a component whose only signal was
using it had its module dropped.

cli fixes two things a scaffolded app hit. webjs doctor reported every
@webjsdev dep as not installed under npm workspaces, contradicting the
FRAMEWORK_RESOLVE check in its own output, and the postgres DATABASE_URL an
uppercase app name produced named a database that CREATE DATABASE would never
create. A generated app also type-checks its own tests now.

mcp stamps the bundled docs corpus at prepack, so a globally installed server
can say which snapshot it is serving instead of teaching pre-fix guidance
with no provenance.

ui splits three cn() conflict groups that were keyed by class prefix rather
than by CSS property, where an unrelated utility silently evicted a real one.

Raises packages/server's declared @webjsdev/core range from ^0.7.48 to
^0.7.49. No new core export is imported statically, but the loadFrame fix
spans the two packages over one contract (the barrel export core publishes
and the import list server's analyser matches against), and the release PR is
the only place that bump is legal.

The generated notes were curated before committing: each entry is rewritten
to the package's own slice rather than the shared commit subject, and the
prose-punctuation commit is dropped from server and ui, where its slice was a
comment and a package description rather than anything a user runs.

