### PR TITLE
fix: teach cn() the Tailwind v4 parenthesis hint spelling

### DIFF
--- a/examples/blog/lib/utils/cn.ts
+++ b/examples/blog/lib/utils/cn.ts
@@ -155,9 +155,11 @@ const GROUPS: Array<[RegExp, string]> = [
  * Classification, after an optional side / axis segment: a bare or numeric
  * value is a width (`border`, `border-2`, `border-t-4`), an arbitrary value
  * that opens with a digit, a dot, or `length:` is a width (`border-[3px]`,
- * `border-[length:var(--w)]`), and everything else is a colour
+ * `border-[length:var(--w)]`, and the v4 paren spelling
+ * `border-(length:--w)`), and everything else is a colour
  * (`border-primary`, `border-red-500/50`, `border-[#fff]`). An ambiguous
- * `border-[var(--x)]` falls to colour, which is the far more common intent.
+ * `border-[var(--x)]`, or its paren spelling `border-(--x)`, falls to colour,
+ * which is the far more common intent.
  *
  * Each side is its own group so a per-side utility only overrides its own side,
  * and the shorthand / axis subsumption is declared in CONFLICTS below, exactly
@@ -167,7 +169,7 @@ const GROUPS: Array<[RegExp, string]> = [
  * the writing direction, so an axis override there would be a guess.
  */
 function borderGroups(): Array<[RegExp, string]> {
-  const width = '(\\d+(\\.\\d+)?|\\[(length:|\\d|\\.)[^\\]]*\\])';
+  const width = '(\\d+(\\.\\d+)?|\\[(length:|\\d|\\.)[^\\]]*\\]|\\(length:[^)]*\\))';
   const out: Array<[RegExp, string]> = [];
   // Sides before the bare form: `border-t-primary` must match the `t` colour
   // group, not be swallowed by the side-less `^border-` colour pattern.
@@ -185,7 +187,8 @@ function borderGroups(): Array<[RegExp, string]> {
 
 /**
  * An arbitrary value may carry a Tailwind TYPE HINT: `bg-[image:var(--g)]`,
- * `text-[length:14px]`, `shadow-[color:red]`. The hint exists precisely because
+ * `text-[length:14px]`, `shadow-[color:red]`, and in the v4 paren shorthand
+ * `bg-(image:--g)`, `shadow-(color:--x)`. The hint exists precisely because
  * the utility prefix is ambiguous, so the PREFIX cannot decide the group and
  * the hint must. Letting a hinted value fall into the prefix's default group
  * evicts a class that sets an entirely different property (`shadow-[color:red]`
@@ -204,7 +207,13 @@ function borderGroups(): Array<[RegExp, string]> {
  * while `bg-` and `text-` were correct.
  *
  * These reach the matcher at all only because `variantPrefix` splits on the
- * last colon OUTSIDE brackets; see the comment there.
+ * last colon OUTSIDE brackets AND parentheses; see the comment there.
+ *
+ * Both spellings of one hint produce the identical `<prefix>:<hint>` key, so
+ * the map needs no paren-specific entries. The closing delimiter is
+ * deliberately not validated: the hint names the CSS property, and how the
+ * value terminates cannot change which property that is (the bracket branch
+ * has never validated its own close either).
  */
 const HINTED_GROUPS: Record<string, string> = {
   'bg:color': '',
@@ -227,7 +236,7 @@ const HINTED_GROUPS: Record<string, string> = {
  * should decide it, `undefined` when the token carries no hint at all.
  */
 function hintedGroup(bare: string): string | null | undefined {
-  const m = /^([a-z][a-z-]*)-\[([a-z][a-z-]*):/.exec(bare);
+  const m = /^([a-z][a-z-]*)-[\[(]([a-z][a-z-]*):/.exec(bare);
   if (!m) return undefined;
   const prefix = m[1];
   const hint = m[2];
@@ -300,19 +309,30 @@ function dedupeUtilities(input: string): string {
 
 function variantPrefix(token: string): string {
   // Capture leading variants like `hover:`, `dark:`, `md:`: overrides only
-  // conflict within the same variant set. The split is the last colon OUTSIDE
-  // square brackets, because an arbitrary value can contain one of its own
-  // (`border-[length:2px]`, `bg-[url(https://x/y.png)]`, `text-[color:var(--c)]`).
+  // conflict within the same variant set. The split is the last colon at top
+  // level, meaning outside BOTH square brackets and parentheses, because an
+  // arbitrary value can contain a colon of its own in either delimiter
+  // (`border-[length:2px]`, `bg-[url(https://x/y.png)]`, `text-[color:var(--c)]`,
+  // and the v4 paren spelling `shadow-(color:--x)`, `bg-(image:--g)`).
   // Splitting on the last colon anywhere hands the group matcher a fragment
-  // like `2px]`, which matches nothing, so the utility silently stops
-  // deduping against its own property.
-  let depth = 0;
+  // like `2px]` or `--x)`, which matches nothing, so the utility silently
+  // stops deduping against its own property.
+  //
+  // TWO counters, both required to be zero, rather than one shared counter.
+  // Tailwind's own top-level splitter is a MATCHED-PAIR stack, so a stray
+  // closer never cancels a live opener of the other kind. A single shared
+  // counter would let `)` cancel `[` and read `x-[y)-z:w` as having a
+  // top-level colon, which is the fragment bug above wearing a different hat.
+  let bracketDepth = 0;
+  let parenDepth = 0;
   let i = -1;
   for (let n = 0; n < token.length; n += 1) {
     const c = token[n];
-    if (c === '[') depth += 1;
-    else if (c === ']') depth -= 1;
-    else if (c === ':' && depth === 0) i = n;
+    if (c === '[') bracketDepth += 1;
+    else if (c === ']') bracketDepth -= 1;
+    else if (c === '(') parenDepth += 1;
+    else if (c === ')') parenDepth -= 1;
+    else if (c === ':' && bracketDepth === 0 && parenDepth === 0) i = n;
   }
   return i === -1 ? '' : token.slice(0, i + 1);
 }

--- a/examples/blog/lib/utils/cn.ts
+++ b/examples/blog/lib/utils/cn.ts
@@ -319,7 +319,9 @@ function variantPrefix(token: string): string {
   // stops deduping against its own property.
   //
   // TWO counters, both required to be zero, rather than one shared counter.
-  // Tailwind's own top-level splitter is a MATCHED-PAIR stack, so a stray
+  // Tailwind's own top-level splitter (`segment()`, in the upstream
+  // tailwindlabs/tailwindcss repo at packages/tailwindcss/src/utils/segment.ts,
+  // NOT a path in this repo) is a MATCHED-PAIR stack, so a stray
   // closer never cancels a live opener of the other kind. A single shared
   // counter would let `)` cancel `[` and read `x-[y)-z:w` as having a
   // top-level colon, which is the fragment bug above wearing a different hat.

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -478,11 +478,16 @@ names mechanically:
   cover. Which sources a given generator reads, and when it goes to the
   network, is the registry-resolution question, answered by the LOCAL-FIRST
   section above, so do not restate it here.
-- A variant prefix is split on the last colon OUTSIDE square brackets, because
-  an arbitrary value carries colons of its own (`border-[length:2px]`,
-  `bg-[url(https://x/y.png)]`). Splitting on the last colon anywhere hands the
-  group matcher a fragment like `2px]`, so the utility silently stops deduping.
-- Once a bracketed value reaches the matcher, its TYPE HINT names the property
+- A variant prefix is split on the last colon at TOP LEVEL, meaning outside
+  both square brackets and parentheses, because an arbitrary value carries
+  colons of its own in either delimiter (`border-[length:2px]`,
+  `bg-[url(https://x/y.png)]`, `shadow-(color:--x)`). Splitting on the last
+  colon anywhere hands the group matcher a fragment like `2px]` or `--x)`, so
+  the utility silently stops deduping. The two delimiters get SEPARATE
+  counters; see the paren-spelling bullet below for why one shared counter is
+  wrong.
+- Once an arbitrary value reaches the matcher, in either spelling, its TYPE
+  HINT names the property
   and picks the group, since the prefix alone cannot: `text-[length:14px]` is a
   font size and `bg-[url(...)]` is an image, so routing either by prefix would
   collapse it against a colour. That lives in `hintedGroup()` and the

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -515,12 +515,23 @@ names mechanically:
   prefix's values actually look like in real code rather than by analogy with
   another prefix: `border-[var(--x)]` is usually a colour, `shadow-[var(--x)]`
   is usually a shadow, so the same shape resolves opposite ways.
-- A PAREN-hinted arbitrary value (`shadow-(color:--x)`, `bg-(image:--g)`)
-  reaches neither `hintedGroup()` nor GROUPS: `variantPrefix` tracks only
-  `[` / `]` depth, so the colon inside the parentheses reads as a variant
-  separator and the matcher gets a fragment that matches nothing. The token
-  stays ungrouped, so it never evicts, but two of them do not collapse against
-  each other either. Fixing it means teaching `variantPrefix` paren depth.
+- A PAREN-hinted arbitrary value (`shadow-(color:--x)`, `bg-(image:--g)`, the
+  Tailwind v4 shorthand for the bracket form) classifies exactly like its
+  bracket sibling (#1338), because both spellings produce the identical
+  `<prefix>:<hint>` key that `HINTED_GROUPS` is keyed on, so the map carries
+  no paren-specific entries. Three pieces make that work, and all three are
+  load-bearing. `variantPrefix` counts brackets and parens in SEPARATE
+  counters and splits only where both are zero, never one shared counter: a
+  shared one lets a stray `)` cancel a live `[` and reads `x-[y)-z:w` as
+  having a top-level colon, which is the fragment bug it exists to prevent.
+  `hintedGroup()`'s regex accepts `-(` alongside `-[`. And `borderGroups()`'s
+  width fragment reads the length hint in both spellings. Teaching
+  `variantPrefix` paren depth ALONE is actively harmful rather than a partial
+  win: it hands an intact `bg-(image:--g)` to a matcher that cannot read the
+  hint, which falls through to the `^bg-` catch-all and evicts a real
+  background colour, the #1065 defect class. The closing delimiter is not
+  validated, in either spelling, because the hint names the property and how
+  the value terminates cannot change which property that is.
 
 ## Layout + typography helpers (the design system)
 

--- a/packages/ui/packages/registry/lib/utils.ts
+++ b/packages/ui/packages/registry/lib/utils.ts
@@ -155,9 +155,11 @@ const GROUPS: Array<[RegExp, string]> = [
  * Classification, after an optional side / axis segment: a bare or numeric
  * value is a width (`border`, `border-2`, `border-t-4`), an arbitrary value
  * that opens with a digit, a dot, or `length:` is a width (`border-[3px]`,
- * `border-[length:var(--w)]`), and everything else is a colour
+ * `border-[length:var(--w)]`, and the v4 paren spelling
+ * `border-(length:--w)`), and everything else is a colour
  * (`border-primary`, `border-red-500/50`, `border-[#fff]`). An ambiguous
- * `border-[var(--x)]` falls to colour, which is the far more common intent.
+ * `border-[var(--x)]`, or its paren spelling `border-(--x)`, falls to colour,
+ * which is the far more common intent.
  *
  * Each side is its own group so a per-side utility only overrides its own side,
  * and the shorthand / axis subsumption is declared in CONFLICTS below, exactly
@@ -167,7 +169,7 @@ const GROUPS: Array<[RegExp, string]> = [
  * the writing direction, so an axis override there would be a guess.
  */
 function borderGroups(): Array<[RegExp, string]> {
-  const width = '(\\d+(\\.\\d+)?|\\[(length:|\\d|\\.)[^\\]]*\\])';
+  const width = '(\\d+(\\.\\d+)?|\\[(length:|\\d|\\.)[^\\]]*\\]|\\(length:[^)]*\\))';
   const out: Array<[RegExp, string]> = [];
   // Sides before the bare form: `border-t-primary` must match the `t` colour
   // group, not be swallowed by the side-less `^border-` colour pattern.
@@ -185,7 +187,8 @@ function borderGroups(): Array<[RegExp, string]> {
 
 /**
  * An arbitrary value may carry a Tailwind TYPE HINT: `bg-[image:var(--g)]`,
- * `text-[length:14px]`, `shadow-[color:red]`. The hint exists precisely because
+ * `text-[length:14px]`, `shadow-[color:red]`, and in the v4 paren shorthand
+ * `bg-(image:--g)`, `shadow-(color:--x)`. The hint exists precisely because
  * the utility prefix is ambiguous, so the PREFIX cannot decide the group and
  * the hint must. Letting a hinted value fall into the prefix's default group
  * evicts a class that sets an entirely different property (`shadow-[color:red]`
@@ -204,7 +207,13 @@ function borderGroups(): Array<[RegExp, string]> {
  * while `bg-` and `text-` were correct.
  *
  * These reach the matcher at all only because `variantPrefix` splits on the
- * last colon OUTSIDE brackets; see the comment there.
+ * last colon OUTSIDE brackets AND parentheses; see the comment there.
+ *
+ * Both spellings of one hint produce the identical `<prefix>:<hint>` key, so
+ * the map needs no paren-specific entries. The closing delimiter is
+ * deliberately not validated: the hint names the CSS property, and how the
+ * value terminates cannot change which property that is (the bracket branch
+ * has never validated its own close either).
  */
 const HINTED_GROUPS: Record<string, string> = {
   'bg:color': '',
@@ -227,7 +236,7 @@ const HINTED_GROUPS: Record<string, string> = {
  * should decide it, `undefined` when the token carries no hint at all.
  */
 function hintedGroup(bare: string): string | null | undefined {
-  const m = /^([a-z][a-z-]*)-\[([a-z][a-z-]*):/.exec(bare);
+  const m = /^([a-z][a-z-]*)-[\[(]([a-z][a-z-]*):/.exec(bare);
   if (!m) return undefined;
   const prefix = m[1];
   const hint = m[2];
@@ -303,19 +312,31 @@ function dedupeUtilities(input: string): string {
 
 function variantPrefix(token: string): string {
   // Capture leading variants like `hover:`, `dark:`, `md:`: overrides only
-  // conflict within the same variant set. The split is the last colon OUTSIDE
-  // square brackets, because an arbitrary value can contain one of its own
-  // (`border-[length:2px]`, `bg-[url(https://x/y.png)]`, `text-[color:var(--c)]`).
+  // conflict within the same variant set. The split is the last colon at top
+  // level, meaning outside BOTH square brackets and parentheses, because an
+  // arbitrary value can contain a colon of its own in either delimiter
+  // (`border-[length:2px]`, `bg-[url(https://x/y.png)]`, `text-[color:var(--c)]`,
+  // and the v4 paren spelling `shadow-(color:--x)`, `bg-(image:--g)`).
   // Splitting on the last colon anywhere hands the group matcher a fragment
-  // like `2px]`, which matches nothing, so the utility silently stops
-  // deduping against its own property.
-  let depth = 0;
+  // like `2px]` or `--x)`, which matches nothing, so the utility silently
+  // stops deduping against its own property.
+  //
+  // TWO counters, both required to be zero, rather than one shared counter.
+  // Tailwind's own top-level splitter (`segment()` in
+  // packages/tailwindcss/src/utils/segment.ts) is a MATCHED-PAIR stack, so a
+  // stray closer never cancels a live opener of the other kind. A single
+  // shared counter would let `)` cancel `[` and read `x-[y)-z:w` as having a
+  // top-level colon, which is the fragment bug above wearing a different hat.
+  let bracketDepth = 0;
+  let parenDepth = 0;
   let i = -1;
   for (let n = 0; n < token.length; n += 1) {
     const c = token[n];
-    if (c === '[') depth += 1;
-    else if (c === ']') depth -= 1;
-    else if (c === ':' && depth === 0) i = n;
+    if (c === '[') bracketDepth += 1;
+    else if (c === ']') bracketDepth -= 1;
+    else if (c === '(') parenDepth += 1;
+    else if (c === ')') parenDepth -= 1;
+    else if (c === ':' && bracketDepth === 0 && parenDepth === 0) i = n;
   }
   return i === -1 ? '' : token.slice(0, i + 1);
 }

--- a/packages/ui/packages/registry/lib/utils.ts
+++ b/packages/ui/packages/registry/lib/utils.ts
@@ -322,8 +322,9 @@ function variantPrefix(token: string): string {
   // stops deduping against its own property.
   //
   // TWO counters, both required to be zero, rather than one shared counter.
-  // Tailwind's own top-level splitter (`segment()` in
-  // packages/tailwindcss/src/utils/segment.ts) is a MATCHED-PAIR stack, so a
+  // Tailwind's own top-level splitter (`segment()`, in the upstream
+  // tailwindlabs/tailwindcss repo at packages/tailwindcss/src/utils/segment.ts,
+  // NOT a path in this repo) is a MATCHED-PAIR stack, so a
   // stray closer never cancels a live opener of the other kind. A single
   // shared counter would let `)` cancel `[` and read `x-[y)-z:w` as having a
   // top-level colon, which is the fragment bug above wearing a different hat.

--- a/packages/ui/test/cn-helper.test.js
+++ b/packages/ui/test/cn-helper.test.js
@@ -343,17 +343,12 @@ test('cn: box-shadow size and box-shadow colour are SEPARATE groups (#1265)', ()
   // reads only the `-[hint:` form, so GROUPS is what classifies it.
   assert.equal(cn('shadow-lg', 'shadow-(--shadow-glow)'), 'shadow-(--shadow-glow)');
   assert.equal(cn('shadow-(--shadow-glow)', 'shadow-red-500'), 'shadow-(--shadow-glow) shadow-red-500');
-  // Its HINTED sibling `shadow-(color:--x)` is a different matter, and nothing
-  // here classifies it: `variantPrefix` tracks only `[` / `]` depth, so the
-  // colon inside the parentheses reads as a variant separator and the matcher
-  // is handed the fragment `--x)`, which matches no pattern. So the token stays
-  // ungrouped and never evicts, which is the safe direction, but two of them
-  // also fail to collapse against each other. That blindness is older than the
-  // shadow split and covers every paren-hinted spelling (`bg-(image:--g)` the
-  // same way); fixing it means changing `variantPrefix`, which is out of scope
-  // here. Asserted so the current behaviour is pinned rather than assumed.
-  assert.equal(cn('shadow-red-500', 'shadow-(color:--x)'), 'shadow-red-500 shadow-(color:--x)');
-  assert.equal(cn('shadow-(color:--x)', 'shadow-(color:--y)'), 'shadow-(color:--x) shadow-(color:--y)');
+  // Its HINTED sibling `shadow-(color:--x)` classifies identically now that
+  // `variantPrefix` counts parens as well as brackets and `hintedGroup()`
+  // reads both spellings, so the v4 paren hint joins the same group its
+  // bracket form has always landed in.
+  assert.equal(cn('shadow-red-500', 'shadow-(color:--x)'), 'shadow-(color:--x)');
+  assert.equal(cn('shadow-(color:--x)', 'shadow-(color:--y)'), 'shadow-(color:--y)');
   // Conflicts stay scoped to their variant.
   assert.equal(cn('hover:shadow-lg', 'hover:shadow-red-500'), 'hover:shadow-lg hover:shadow-red-500');
 });
@@ -411,6 +406,60 @@ test('cn: the neighbouring shadow and ring prefixes stay ungrouped (#1265)', () 
   assert.equal(cn('drop-shadow-lg', 'drop-shadow-red-500'), 'drop-shadow-lg drop-shadow-red-500');
   assert.equal(cn('ring-2', 'ring-red-500'), 'ring-2 ring-red-500');
   assert.equal(cn('inset-ring-2', 'inset-ring-red-500'), 'inset-ring-2 inset-ring-red-500');
+});
+
+test('cn: the v4 paren type hint classifies like its bracket sibling (#1338)', () => {
+  // Same hint under the same prefix collapses.
+  assert.equal(cn('bg-(image:--g)', 'bg-(image:--h)'), 'bg-(image:--h)');
+  assert.equal(cn('text-(length:--a)', 'text-(length:--b)'), 'text-(length:--b)');
+  assert.equal(cn('text-shadow-(color:--x)', 'text-shadow-(color:--y)'), 'text-shadow-(color:--y)');
+  // The two spellings share one group, in both orders.
+  assert.equal(cn('bg-[image:var(--g)]', 'bg-(image:--h)'), 'bg-(image:--h)');
+  assert.equal(cn('bg-(image:--g)', 'bg-[image:var(--h)]'), 'bg-[image:var(--h)]');
+  assert.equal(cn('shadow-[color:red]', 'shadow-(color:--x)'), 'shadow-(color:--x)');
+  // The hint keeps it OUT of the prefix's default group, which is what a
+  // variantPrefix-only fix got wrong (#1065 class: it dropped these).
+  assert.equal(cn('bg-(image:--g)', 'bg-primary'), 'bg-(image:--g) bg-primary');
+  assert.equal(cn('bg-primary', 'bg-(image:--g)'), 'bg-primary bg-(image:--g)');
+  assert.equal(cn('text-(length:--s)', 'text-primary'), 'text-(length:--s) text-primary');
+  assert.equal(cn('text-primary', 'text-(length:--s)'), 'text-primary text-(length:--s)');
+  assert.equal(cn('shadow-(color:--x)', 'shadow-lg'), 'shadow-(color:--x) shadow-lg');
+  assert.equal(cn('shadow-lg', 'shadow-(color:--x)'), 'shadow-lg shadow-(color:--x)');
+  // A hint naming the prefix's OWN default property falls through to GROUPS
+  // and collapses against a plain value, exactly as the bracket form does.
+  assert.equal(cn('bg-primary', 'bg-(color:--c)'), 'bg-(color:--c)');
+  assert.equal(cn('text-primary', 'text-(color:--c)'), 'text-(color:--c)');
+  assert.equal(cn('bg-cover', 'bg-(size:--s)'), 'bg-(size:--s)');
+  // Border delegates to borderGroups()'s value parser, which reads the length
+  // hint in both spellings. Without the width-fragment half, the first two
+  // lines DROP the width.
+  assert.equal(cn('border-(length:--w)', 'border-primary'), 'border-(length:--w) border-primary');
+  assert.equal(cn('border-t-(length:--w)', 'border-t-primary'), 'border-t-(length:--w) border-t-primary');
+  assert.equal(cn('border-(length:--w)', 'border-2'), 'border-2');
+  assert.equal(cn('border-2', 'border-(length:--w)'), 'border-(length:--w)');
+  assert.equal(cn('border-(color:--c)', 'border-2'), 'border-(color:--c) border-2');
+  assert.equal(cn('border-primary', 'border-(color:--c)'), 'border-(color:--c)');
+  // A bare paren variable carries no hint, so it stays ambiguous and resolves
+  // the way the prefix's convention says (colour for border, size for shadow).
+  assert.equal(cn('border-(--x)', 'border-primary'), 'border-primary');
+  assert.equal(cn('shadow-(--shadow-glow)', 'shadow-lg'), 'shadow-lg');
+  // A real variant still splits, and a paren inside a variant is untouched.
+  assert.equal(cn('hover:shadow-(color:--x)', 'shadow-(color:--y)'),
+    'hover:shadow-(color:--x) shadow-(color:--y)');
+  assert.equal(cn('hover:bg-primary', 'hover:bg-accent'), 'hover:bg-accent');
+  assert.equal(cn('supports-(--foo):flex', 'supports-(--foo):grid'), 'supports-(--foo):grid');
+  // The URL token stays protected: its parens are nested inside brackets, so
+  // both depths are non-zero at the `://` colon.
+  assert.equal(cn('bg-[url(https://x/y.png)]', 'bg-primary'),
+    'bg-[url(https://x/y.png)] bg-primary');
+  assert.equal(cn('bg-[url(https://x/y.png)]', 'bg-[linear-gradient(red,blue)]'),
+    'bg-[linear-gradient(red,blue)]');
+  // A paren that is not a hint must not be read as one.
+  assert.equal(cn('grid-cols-[repeat(2,minmax(0,1fr))]', 'grid-cols-3'), 'grid-cols-3');
+  assert.equal(cn('w-[calc(100%-1rem)]', 'w-8'), 'w-8');
+  // An unlisted <prefix>:<hint> pair still gets its own bucket, so it can only
+  // ever collide with itself. Safe direction, unchanged by this issue.
+  assert.equal(cn('mask-(image:--m)', 'mask-none'), 'mask-(image:--m) mask-none');
 });
 
 // The old `Base` / `defineElement` HTMLElement-era helpers were removed in #819

--- a/packages/ui/test/cn-helper.test.js
+++ b/packages/ui/test/cn-helper.test.js
@@ -120,9 +120,10 @@ test('cn: every display keyword shares one group, so a repeated one collapses', 
 });
 
 test('cn: an arbitrary value may contain a colon without losing its group', () => {
-  // variantPrefix() splits on the last colon OUTSIDE brackets. Splitting on the
-  // last colon anywhere hands the matcher a fragment like `2px]`, which matches
-  // nothing, so the utility silently stops deduping against its own property.
+  // variantPrefix() splits on the last colon OUTSIDE brackets AND parentheses.
+  // Splitting on the last colon anywhere hands the matcher a fragment like
+  // `2px]`, which matches nothing, so the utility silently stops deduping
+  // against its own property. The paren half is covered by the #1338 test.
   assert.equal(cn('border-[length:2px]', 'border-4'), 'border-4');
   assert.equal(cn('border-2', 'border-[length:var(--w)]'), 'border-[length:var(--w)]');
   assert.equal(cn('border-[length:2px]', 'border-primary'), 'border-[length:2px] border-primary');
@@ -138,7 +139,8 @@ test('cn: an arbitrary value may contain a colon without losing its group', () =
 });
 
 test('cn: an arbitrary value type hint names the property, so it picks the group', () => {
-  // Once a bracketed value reaches the matcher, the prefix alone is not enough
+  // Once an arbitrary value reaches the matcher, in either the bracket or the
+  // v4 paren spelling, the prefix alone is not enough
   // to say which property it sets: `text-[length:14px]` is a font SIZE, not a
   // colour, and `bg-[url(...)]` is an image, not a background colour. Routing
   // by prefix would collapse a size against a colour, which is the exact

--- a/test/ui/cn-copies-in-sync.test.mjs
+++ b/test/ui/cn-copies-in-sync.test.mjs
@@ -79,6 +79,10 @@ const TOKENS = [
   'shadow', 'shadow-none', 'shadow-inner', 'shadow-lg/25', 'shadow-red-500',
   'shadow-red-500/50', 'shadow-inherit', 'shadow-[#fff]',
   'shadow-[var(--shadow-glow)]', 'shadow-(--shadow-glow)', 'text-shadow-[var(--x)]',
+  'shadow-(color:--x)', 'bg-(image:--g)', 'bg-(color:--c)', 'bg-(size:--s)',
+  'text-(length:--s)', 'text-(color:--c)', 'text-shadow-(color:--x)',
+  'border-(length:--w)', 'border-(color:--c)', 'border-t-(length:--w)',
+  'border-(--x)', 'hover:shadow-(color:--x)', 'supports-(--foo):flex',
   'text-shadow-lg', 'text-shadow-none', 'text-shadow-red-500',
 ];
 
@@ -100,7 +104,7 @@ test('cn: the registry and blog copies merge every pair identically', () => {
   );
 });
 
-test('cn: the blog copy carries the conflict-group fixes (#1065, #1072, #1265)', () => {
+test('cn: the blog copy carries the conflict-group fixes (#1065, #1072, #1265, #1338)', () => {
   // A drift guard alone would stay green if BOTH copies regressed together, so
   // assert the headline behaviour directly on the blog copy too.
   assert.equal(blogCn('flex', 'flex-1'), 'flex flex-1');
@@ -119,4 +123,8 @@ test('cn: the blog copy carries the conflict-group fixes (#1065, #1072, #1265)',
   assert.equal(blogCn('text-shadow-sm', 'text-primary'), 'text-shadow-sm text-primary');
   assert.equal(blogCn('text-left', 'text-center'), 'text-center');
   assert.equal(blogCn('text-ellipsis', 'text-clip'), 'text-clip');
+  assert.equal(blogCn('bg-(image:--g)', 'bg-primary'), 'bg-(image:--g) bg-primary');
+  assert.equal(blogCn('bg-(image:--g)', 'bg-(image:--h)'), 'bg-(image:--h)');
+  assert.equal(blogCn('shadow-(color:--x)', 'shadow-lg'), 'shadow-(color:--x) shadow-lg');
+  assert.equal(blogCn('border-(length:--w)', 'border-primary'), 'border-(length:--w) border-primary');
 });


### PR DESCRIPTION
Closes #1338

Tailwind v4 added a second spelling for a type-hinted arbitrary value that uses parentheses instead of brackets, and `cn()` could not read it. `variantPrefix` counted only bracket depth, so the colon inside `shadow-(color:--x)` read as a variant separator and the group matcher was handed the fragment `--x)`, which matches nothing. The utility ended up ungrouped. That failed in the safe direction, since nothing was dropped, but it gave up the other half of the guarantee: two utilities setting the identical property did not collapse, so the winner fell to compiled stylesheet order.

## What changed

Three edits, in each of the two hand-synced copies (`packages/ui/packages/registry/lib/utils.ts` and `examples/blog/lib/utils/cn.ts`):

1. `variantPrefix()` counts parens in a SECOND counter and splits only where both depths are zero.
2. `hintedGroup()`'s regex accepts `-(` alongside `-[`, one character class.
3. `borderGroups()`'s `width` fragment gains one alternation branch for `(length:...)`.

No new `HINTED_GROUPS` entries. Both spellings produce the identical `<prefix>:<hint>` key the map is already keyed on, which is why the fix is this small.

## Two counters, not one

A single shared counter lets a stray `)` cancel a live `[`, so `x-[y)-z:w` reads as having a top-level colon and the matcher gets the fragment `w`. That is precisely the bug this PR removes, wearing a different hat. Tailwind's own top-level splitter is a matched-pair stack, and two counters agree with it on every well-formed class and every unbalanced-delimiter case in the issue's corpus. Porting the full stack was considered and rejected: the only input it decides differently is a string Tailwind cannot compile, and `cn()` is deliberately small and auditable (package invariant 2).

## Why all three edits land together

A `variantPrefix`-only fix is worse than the bug. It hands an intact `bg-(image:--g)` to a matcher that cannot read the hint, the token falls through to the `^bg-` catch-all as `bg-color`, and it evicts a real background colour. Same for `text-`, and same for `border-` if the `borderGroups()` fragment is left out. That is the #1065 defect class, so the halves are one change.

## Test plan

- **Unit** `packages/ui/test/cn-helper.test.js`: 21/21. The two #1332 pinning assertions are inverted with their comment rewritten, and a new `#1338` test covers 30 assertions across the prefixes a partial fix damages. The other 201 pre-existing assertions pass unchanged.
- **Unit + cross-runtime** `test/ui/cn-copies-in-sync.test.mjs`: 2/2 on Node and under Bun. Thirteen paren tokens joined the shared `TOKENS` battery, so every ordered pair merges through both copies and is compared.
- **Counterfactual**, each of the three logic edits reverted individually against the committed fix, all three individually load-bearing:
  - `variantPrefix`'s paren counter reverted: 2 test failures (the new `#1338` test and the box-shadow test carrying the two inverted pins).
  - `hintedGroup()`'s regex reverted: 1 test failure. The shadow pins survive here, because `shadow-(color:--x)` still reaches the `^shadow-` catch-all through GROUPS once `variantPrefix` stops mangling it.
  - `borderGroups()`'s width fragment reverted: 1 test failure, and it is a DROP rather than a non-collapse. `cn('border-(length:--w)', 'border-primary')` returns `border-primary`, losing the width. That is the defect the third edit exists to prevent.
- **Repo-root `npm test`**: 4150 tests, 4142 pass, 7 fail, and all 7 are pre-existing. Five are the known linked-worktree baseline (the listener pair and three elision assertions, which pass in a primary checkout and in CI). The other two are `test/scaffolds/gallery-coverage.test.js`, which I reproduced on an untouched primary checkout at `79fc28fc` with none of this change present.
- **`npm test --workspace=@webjsdev/ui`**: 210/210.
- **`webjs check`** from `examples/blog`: all checks pass.
- **Layers N/A**: browser, e2e and smoke. `cn()` is a pure string function with no DOM, no network and no app-boot behaviour, and the N by N sweep in the issue shows zero changed pairs where neither token contains a parenthesis.
- **New `test/bun/<feature>.mjs` N/A**: the Bun parity hook gates on `^packages/([^/]+/src|editors/[^/]+/src|cli/lib)/`, which neither touched source path matches. Cross-runtime coverage is real regardless, through the drift file above.

## Docs

- **Updated** `packages/ui/AGENTS.md`: the paren-gap bullet described the gap as live behaviour and is rewritten rather than deleted, since the `hintedGroup()` centrality lesson still applies.
- **Updated** the `variantPrefix`, `HINTED_GROUPS` and `borderGroups()` header comments in both copies.
- **N/A** `.agents/skills/webjs/references/styling.md`: its coarseness caveat names two other gaps and never named this one, so nothing there became false.
- **N/A** the docs site and marketing website: neither mentions `cn()`'s hint handling. `website/lib/utils/cn.ts` is generated from the registry and inherits the fix.
- **N/A** scaffold templates: a scaffolded app's `lib/utils/cn.ts` is copied verbatim from the registry at create time.

## Merge dependency

#1320 edits the same `utils.ts` in a different region (it memoises the `GROUPS` table at L53 to L145 and its read site at L286). This diff stays strictly inside `variantPrefix()`, `hintedGroup()` and one string literal in `borderGroups()`, so the two land on separate hunks. #1320 merges first; this branch rebases onto main and re-runs before merging.
