### PR TITLE
fix(website): fold JS escapes out of the llms corpus

### DIFF
--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -136,26 +136,37 @@ website/
                        `${x}` is render-time and gets dropped. Treating all
                        three alike printed `<form action=\>` on 12 corpus
                        lines, teaching an LLM the one shape invariant 12
-                       exists to rule out. EVERYTHING it emits is copied out
-                       of page SOURCE, which is a JS template literal, so
-                       every path folds its backslash escapes BEFORE that
-                       single entity decode: a fenced sample at capture, a
-                       kept hole as it parks, and ordinary prose in one pass
-                       once the hole passes have run. That order is the
-                       browser's own, since JS cooks the literal first and the
-                       HTML parser only ever sees cooked text. The prose fold
-                       runs AFTER the hole passes because those are what tell
-                       `\${x}` (literal text) from `${x}` (render-time, and
-                       dropped), so folding first would drop the literal.
-                       Only the hole half existed, which is why the corpus
-                       printed `<form action=\${createPost}>` on 5 lines and
-                       ``html\`...\` `` on 50 more, where the rendered page
+                       exists to rule out. Everything it takes from a docs
+                       page is copied out of page SOURCE, which is a JS
+                       template literal, so all four paths fold their
+                       backslash escapes BEFORE that single entity decode: a
+                       fenced sample at capture, a kept hole as it parks,
+                       ordinary prose in one pass once the hole passes have
+                       run, and a title or description in `extractPage`
+                       (where the fold sits inside `plainText`, since only 8
+                       of 44 pages declare `metadata.description` and the
+                       other 36 fall back to their first `<p>`). That order
+                       is the browser's own, since JS cooks the literal first
+                       and the HTML parser only ever sees cooked text. The
+                       prose fold runs AFTER the hole passes because those
+                       are what tell `\${x}` (literal text) from `${x}`
+                       (render-time, and dropped), so folding first would
+                       drop the literal. Fold exactly once per path: a second
+                       fold eats an authored `\\`. Only the hole half
+                       existed, which is why the corpus printed
+                       `<form action=\${createPost}>` on 5 lines and
+                       ``html\`...\` `` on 23 more, where the rendered page
                        shows `<form action=${createPost}>` and a plain
-                       backtick. A backslash surviving into the corpus is now
-                       one an author WROTE as `\\`, so a page that escapes a
+                       backtick. A backslash now surviving out of a DOCS PAGE
+                       is one an author WROTE as `\\`, so a page escaping a
                        letter (`/\s+/g`, which cooks to `/s+/g` and rendered
                        that way live on two pages) is a page bug, guarded by
-                       a test rather than by convention.
+                       a test rather than by convention. That says nothing
+                       about the rest of /llms-full.txt: `renderLlmsFull`
+                       appends the repo-root skill markdown verbatim, never
+                       through `bodyToMarkdown`, and those `.md` files are
+                       not template literals, so their single `\` is correct
+                       at source and reaches the corpus unfolded.
   modules/
     ui/components/     GITIGNORED mirror of the @webjsdev/ui registry sources,
                        written by scripts/copy-registry.mjs. NEVER hand-write

--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -139,21 +139,28 @@ website/
                        exists to rule out. Everything it takes from a docs
                        page is copied out of page SOURCE, which is a JS
                        template literal, so all four paths fold their
-                       backslash escapes BEFORE that single entity decode: a
-                       fenced sample at capture, a kept hole as it parks,
-                       ordinary prose in one pass once the hole passes have
-                       run, and a title or description in `extractPage`
-                       (where the fold sits inside `plainText`, since only 8
-                       of 44 pages declare `metadata.description` and the
-                       other 36 fall back to their first `<p>`). That order
-                       is the browser's own, since JS cooks the literal first
-                       and the HTML parser only ever sees cooked text. The
-                       prose fold runs AFTER the hole passes because those
-                       are what tell `\${x}` (literal text) from `${x}`
-                       (render-time, and dropped), so folding first would
-                       drop the literal. Fold exactly once per path: a second
-                       fold eats an authored `\\`. Only the hole half
-                       existed, which is why the corpus printed
+                       backslash escapes: a fenced sample at capture, a kept
+                       hole as it parks, ordinary prose in one pass once the
+                       hole passes have run, and a description inside
+                       `plainText` (which is where it belongs rather than at
+                       a call site, because only 8 of 44 pages declare
+                       `metadata.description` and the other 36 fall back to
+                       their first `<p>`, so both sites need it). Those three
+                       all fold BEFORE their single entity decode, which is
+                       the browser's own order, since JS cooks the literal
+                       first and the HTML parser only ever sees cooked text.
+                       A title is the exception that proves it: it folds at
+                       its call site because it never passes through
+                       `plainText`, and it decodes nothing at all, since it
+                       is read from a quoted metadata string rather than out
+                       of markup. The prose fold runs AFTER the hole passes
+                       because those are what tell `\${x}` (literal text)
+                       from `${x}` (render-time, and dropped), so folding
+                       first would drop the literal. Fold exactly once per
+                       path: a second fold eats an authored `\\`, which is
+                       why no `plainText` call site folds and a test reads
+                       the call sites to keep it that way. Only the hole
+                       half existed, which is why the corpus printed
                        `<form action=\${createPost}>` on 5 lines and
                        ``html\`...\` `` on 23 more, where the rendered page
                        shows `<form action=${createPost}>` and a plain

--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -136,15 +136,26 @@ website/
                        `${x}` is render-time and gets dropped. Treating all
                        three alike printed `<form action=\>` on 12 corpus
                        lines, teaching an LLM the one shape invariant 12
-                       exists to rule out. A fenced sample and a kept prose
-                       hole are both copied out of page SOURCE, which is a JS
-                       template literal, so both fold their backslash escapes
-                       BEFORE that single entity decode. That order is the
-                       browser's own: JS cooks the literal first and the HTML
-                       parser only ever sees cooked text. The fenced half was
-                       missing, which is why the corpus printed
-                       `<form action=\${createPost}>` on 5 lines while the
-                       rendered page showed `<form action=${createPost}>`.
+                       exists to rule out. EVERYTHING it emits is copied out
+                       of page SOURCE, which is a JS template literal, so
+                       every path folds its backslash escapes BEFORE that
+                       single entity decode: a fenced sample at capture, a
+                       kept hole as it parks, and ordinary prose in one pass
+                       once the hole passes have run. That order is the
+                       browser's own, since JS cooks the literal first and the
+                       HTML parser only ever sees cooked text. The prose fold
+                       runs AFTER the hole passes because those are what tell
+                       `\${x}` (literal text) from `${x}` (render-time, and
+                       dropped), so folding first would drop the literal.
+                       Only the hole half existed, which is why the corpus
+                       printed `<form action=\${createPost}>` on 5 lines and
+                       ``html\`...\` `` on 50 more, where the rendered page
+                       shows `<form action=${createPost}>` and a plain
+                       backtick. A backslash surviving into the corpus is now
+                       one an author WROTE as `\\`, so a page that escapes a
+                       letter (`/\s+/g`, which cooks to `/s+/g` and rendered
+                       that way live on two pages) is a page bug, guarded by
+                       a test rather than by convention.
   modules/
     ui/components/     GITIGNORED mirror of the @webjsdev/ui registry sources,
                        written by scripts/copy-registry.mjs. NEVER hand-write

--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -136,7 +136,15 @@ website/
                        `${x}` is render-time and gets dropped. Treating all
                        three alike printed `<form action=\>` on 12 corpus
                        lines, teaching an LLM the one shape invariant 12
-                       exists to rule out.
+                       exists to rule out. A fenced sample and a kept prose
+                       hole are both copied out of page SOURCE, which is a JS
+                       template literal, so both fold their backslash escapes
+                       BEFORE that single entity decode. That order is the
+                       browser's own: JS cooks the literal first and the HTML
+                       parser only ever sees cooked text. The fenced half was
+                       missing, which is why the corpus printed
+                       `<form action=\${createPost}>` on 5 lines while the
+                       rendered page showed `<form action=${createPost}>`.
   modules/
     ui/components/     GITIGNORED mirror of the @webjsdev/ui registry sources,
                        written by scripts/copy-registry.mjs. NEVER hand-write

--- a/website/app/docs/backend-only/page.ts
+++ b/website/app/docs/backend-only/page.ts
@@ -333,7 +333,7 @@ export async function GET() {
 export async function POST(req: Request) {
   const { title, body, authorId } = await req.json();
   const [post] = await db.insert(posts).values({
-    title, body, slug: title.toLowerCase().replace(/\s+/g, '-'), authorId,
+    title, body, slug: title.toLowerCase().replace(/\\s+/g, '-'), authorId,
   }).returning();
   return json(post, { status: 201 });
 }</code-block>

--- a/website/app/docs/websockets/page.ts
+++ b/website/app/docs/websockets/page.ts
@@ -77,7 +77,7 @@ export function WS(ws: WebSocket, req: Request) {
 
 function parseCookies(header: string): Record&lt;string, string&gt; {
   const out: Record&lt;string, string&gt; = {};
-  for (const part of header.split(/;\s*/)) {
+  for (const part of header.split(/;\\s*/)) {
     const eq = part.indexOf('=');
     if (eq &gt; 0) out[part.slice(0, eq)] = decodeURIComponent(part.slice(eq + 1));
   }

--- a/website/lib/docs-llms.server.ts
+++ b/website/lib/docs-llms.server.ts
@@ -283,6 +283,20 @@ export function bodyToMarkdown(raw: string): string {
     // behind a nested hole.
     .replace(/\$\{(?:[^{}]|\{[^}]*\})*\}/g, '');
 
+  // Prose is copied out of the same JS template literal as a hole or a
+  // sample, so it folds its escapes too. Without this the corpus taught
+  // ``export a function returning html\`...\` `` on 50 lines across 8 pages,
+  // where the rendered page shows a plain backtick, which is the same
+  // disagreement the two hole passes above and the sample capture were
+  // written to remove.
+  //
+  // AFTER those hole passes, never before: the escaped-hole pass is what
+  // tells `\${x}` (literal text a reader sees) apart from `${x}` (render-time
+  // and dropped), so folding first would erase the distinction and drop the
+  // literal. BEFORE the restore below, so the text those passes already
+  // folded cannot fold a second time. The single decode still comes last.
+  body = unescapeJs(body);
+
   // Restore kept holes. A kept hole can itself contain a parked sentinel (an
   // escaped hole nested inside a string-literal one), so this repeats until
   // none is left. Replacing once emitted the inner sentinel verbatim, which

--- a/website/lib/docs-llms.server.ts
+++ b/website/lib/docs-llms.server.ts
@@ -217,7 +217,21 @@ export function bodyToMarkdown(raw: string): string {
   // a bare `<` in front of a strip that then eats to the next `>`.
   const codeBlocks: string[] = [];
   body = body.replace(/<(?:pre|code-block)(?=[\s>])[^>]*>([\s\S]*?)<\/(?:pre|code-block)>/g, (_m, code) => {
-    codeBlocks.push(decodeEntities(String(code)).replace(/\n+$/, ''));
+    // A sample is copied out of page SOURCE, which is a JS template literal,
+    // so a backtick in it is written `\`` and a literal hole `\${`. Without
+    // this fold the corpus taught `<form action=\${createPost}>` where the
+    // rendered page shows `<form action=${createPost}>`, on the exact shape
+    // invariant 12 governs, in the one surface whose reader is an LLM.
+    //
+    // Escapes fold BEFORE entities decode, which is the order the browser
+    // applies them: JS cooks the literal first, and the HTML parser sees only
+    // the cooked text. The two orders agree on every sample in the repo and
+    // differ on one shape, an escape splitting an entity, where `&am\p;`
+    // cooks to `&amp;` and the parser then shows `&`. The reverse order can
+    // never help, because the entity table below yields no backslash, so
+    // decoding cannot manufacture an escape for this fold to eat. Same order
+    // the prose keep-passes use below.
+    codeBlocks.push(decodeEntities(unescapeJs(String(code))).replace(/\n+$/, ''));
     return `\uE000CODE${codeBlocks.length - 1}\uE000`;
   });
 

--- a/website/lib/docs-llms.server.ts
+++ b/website/lib/docs-llms.server.ts
@@ -136,15 +136,24 @@ function oneLine(s: string): string {
 }
 
 /**
- * `oneLine` plus the decode, in the one order that is safe: strip, THEN
- * decode. Exported for the same reason `bodyToMarkdown` is, so a unit test
- * can drive it on a fixture instead of planting scaffolding in a real docs
- * page. The whitespace collapse is re-run after decoding because `&nbsp;`
- * decodes to a literal space, so a run of them is only collapsible once the
- * decode has happened.
+ * `oneLine` plus the fold and the decode, in the one order that is safe:
+ * strip, fold, THEN decode. Exported for the same reason `bodyToMarkdown` is,
+ * so a unit test can drive it on a fixture instead of planting scaffolding in
+ * a real docs page. The whitespace collapse is re-run after decoding because
+ * `&nbsp;` decodes to a literal space, so a run of them is only collapsible
+ * once the decode has happened.
+ *
+ * The fold lives HERE rather than at the two call sites because both of them
+ * copy out of page source and so both need it, and one of them is the
+ * majority path: only 8 of 44 pages declare `metadata.description`, and the
+ * other 36 fall back to their first `<p>`. That fallback did not fold, so a
+ * paragraph reached /llms-full.txt cooked and the same paragraph reached
+ * /llms.txt and the search index with its escape debris intact. Folding once
+ * here is what makes "every path that copies source folds" true rather than
+ * nearly true.
  */
 export function plainText(s: string): string {
-  return decodeEntities(oneLine(s)).replace(/\s+/g, ' ').trim();
+  return decodeEntities(unescapeJs(oneLine(s))).replace(/\s+/g, ' ').trim();
 }
 
 /** Truncate at a word boundary, appending an ellipsis when cut. */
@@ -285,7 +294,7 @@ export function bodyToMarkdown(raw: string): string {
 
   // Prose is copied out of the same JS template literal as a hole or a
   // sample, so it folds its escapes too. Without this the corpus taught
-  // ``export a function returning html\`...\` `` on 50 lines across 8 pages,
+  // ``export a function returning html\`...\` `` on 23 lines across 8 pages,
   // where the rendered page shows a plain backtick, which is the same
   // disagreement the two hole passes above and the sample capture were
   // written to remove.
@@ -361,7 +370,10 @@ async function extractPage(file: string): Promise<DocPage> {
   // description like 'SSR\'d to real HTML...' otherwise truncates at the
   // backslash, and that garbage fragment ships verbatim in /llms.txt and the
   // search index. `(?:\\.|[^'\\])*` consumes any escaped character as a
-  // unit; unescapeJs() then folds the backslashes back out of the capture.
+  // unit; the fold then takes the backslashes back out of the capture. The
+  // title folds here because it never passes through plainText; both
+  // descriptions fold inside plainText instead, so neither folds twice (a
+  // second fold is destructive, since it would eat an authored `\\`).
   const titleMatch = meta.match(/title:\s*(?:'((?:\\.|[^'\\])*)'|"((?:\\.|[^"\\])*)"|`((?:\\.|[^`\\])*)`)/);
   const rawTitle = unescapeJs(titleMatch?.[1] ?? titleMatch?.[2] ?? titleMatch?.[3] ?? '') || slug;
   const title = rawTitle.replace(/\s*\|\s*webjs\s*$/i, '').trim();
@@ -370,7 +382,7 @@ async function extractPage(file: string): Promise<DocPage> {
   let description = '';
   const descMatch = meta.match(/description:\s*(?:'((?:\\.|[^'\\])*)'|"((?:\\.|[^"\\])*)"|`((?:\\.|[^`\\])*)`)/);
   if (descMatch) {
-    description = plainText(unescapeJs(descMatch[1] ?? descMatch[2] ?? descMatch[3] ?? ''));
+    description = plainText(descMatch[1] ?? descMatch[2] ?? descMatch[3] ?? '');
   }
   if (!description) {
     const pMatch = raw.match(/<p[^>]*>([\s\S]*?)<\/p>/);

--- a/website/test/ssr/docs-llms.test.ts
+++ b/website/test/ssr/docs-llms.test.ts
@@ -102,13 +102,23 @@ test('a sample that reaches the corpus reaches it whole', async () => {
       // what it says is only known at render time.
       if (m[1].includes('${')) continue;
       compared++;
-      const text = decodeEntities(m[1]).replace(/\n+$/, '');
+      const text = decodeEntities(unescapeJs(m[1])).replace(/\n+$/, '');
       if (!page.markdown.includes(text)) mangled.push(`${page.path}: ${JSON.stringify(text.slice(0, 70))}`);
     }
   }
   assert.ok(compared > 300, `only ${compared} samples compared, so this proves little`);
   assert.deepEqual(mangled.slice(0, 5), [], `${mangled.length} samples arrived in the corpus with characters missing`);
 });
+
+/**
+ * Mirrors the extractor's own source-escape fold, which is module-private. A
+ * sample is copied out of page SOURCE, where it is a JS template literal, so
+ * the corpus carries it cooked and a comparison against the raw source has to
+ * cook it the same way.
+ */
+function unescapeJs(s: string): string {
+  return s.replace(/\\(.)/g, '$1');
+}
 
 /** Mirrors the extractor's own entity decoding, which is module-private. */
 function decodeEntities(s: string): string {
@@ -216,6 +226,23 @@ test('a kept hole is unescaped, since the source is a template literal', () => {
   // No docs page carries an escape inside one today, so only a fixture can
   // hold that half of the rule.
   assert.equal(bodyToMarkdown('html`<p>x ${"a\\`b"} y</p>`'), 'x a`b y');
+});
+
+test('a fenced sample is unescaped, since the source is a template literal', () => {
+  // The prose half of this rule is pinned above. The fenced half was left out,
+  // so the corpus taught `<form action=\${createPost}>` on 5 lines while the
+  // rendered docs page showed `<form action=${createPost}>`, disagreeing with
+  // itself about the one shape invariant 12 governs.
+  const md = bodyToMarkdown('html`<code-block>html\\`&lt;form action=\\${createPost}&gt;&lt;/form&gt;\\`</code-block>`');
+  assert.equal(md, '```\nhtml`<form action=${createPost}></form>`\n```');
+});
+
+test('a fenced sample folds its escapes before it decodes its entities', () => {
+  // Order matters on exactly one shape, and the browser settles it: JS cooks
+  // the template literal first, so `&am\p;` reaches the HTML parser as
+  // `&amp;`, which it decodes to `&`. Decoding first would ship `&amp;`.
+  // No docs page carries this shape, so only a fixture can hold the rule.
+  assert.equal(bodyToMarkdown('html`<code-block>a &am\\p; b</code-block>`'), '```\na & b\n```');
 });
 
 test('a kept hole nested inside another leaves no sentinel in the output', () => {

--- a/website/test/ssr/docs-llms.test.ts
+++ b/website/test/ssr/docs-llms.test.ts
@@ -245,6 +245,42 @@ test('a fenced sample folds its escapes before it decodes its entities', () => {
   assert.equal(bodyToMarkdown('html`<code-block>a &am\\p; b</code-block>`'), '```\na & b\n```');
 });
 
+test('prose is unescaped too, since it comes out of the same template literal', () => {
+  // A hole and a sample were folded before prose was, so the corpus still
+  // taught ``returning html\`...\` `` on 50 lines across 8 pages where the
+  // rendered page shows a plain backtick.
+  assert.equal(bodyToMarkdown('html`<p>returning <code>html\\`...\\`</code></p>`'), 'returning html`...`');
+
+  // The fold runs AFTER the hole passes, never before. Folding first would
+  // turn `\${x}` into `${x}`, which the dynamic-hole pass then drops, losing
+  // the literal text a reader actually sees.
+  assert.equal(bodyToMarkdown('html`<p>a \\${x} b ${y} c</p>`'), 'a ${x} b c');
+});
+
+test('no docs page escapes a letter, which the extractor would fold away', async () => {
+  // A page body is a JS template literal, so `\s` cooks to a bare `s`: the
+  // LIVE page rendered `replace(/s+/g, '-')` on /docs/backend-only and
+  // `/;s*/` on /docs/websockets until those two were corrected to `\\s`.
+  // The extractor is faithful, so it copies that damage into the corpus as a
+  // teaching sample, and the corpus's only reader is an LLM.
+  //
+  // Escaping a letter or a digit is never meaningful here. `\``, `\$` and
+  // `\\` are the escapes a template literal genuinely needs, and punctuation
+  // escapes are at worst redundant. So a letter or digit after a backslash
+  // is always the mistake above, and this is the only thing that would
+  // notice the next one.
+  const offenders: string[] = [];
+  for (const page of await getDocPages()) {
+    const src = await readFile(new URL(`../../app${page.path}/page.ts`, import.meta.url), 'utf8');
+    // Pair-consuming, so the `\\` in a correctly authored `\\s` is eaten as
+    // one escape and its `s` is never read as escaped.
+    for (const m of src.matchAll(/\\([\s\S])/g)) {
+      if (/[A-Za-z0-9]/.test(m[1])) offenders.push(`${page.path}: \\${m[1]} in ${JSON.stringify(src.slice(Math.max(0, m.index - 30), m.index + 30))}`);
+    }
+  }
+  assert.deepEqual(offenders.slice(0, 5), [], `${offenders.length} docs-page escapes fold to a bare letter`);
+});
+
 test('a kept hole nested inside another leaves no sentinel in the output', () => {
   // The two keep passes run in sequence, so a string-literal hole can park
   // text that already contains an escaped hole's sentinel. Restoring once

--- a/website/test/ssr/docs-llms.test.ts
+++ b/website/test/ssr/docs-llms.test.ts
@@ -305,10 +305,25 @@ test('a description folds its escapes, on the fallback path 36 pages take', () =
   // escape debris intact.
   assert.equal(plainText('a function returning html\\`...\\` today'), 'a function returning html`...` today');
 
-  // Folding once, not twice. The metadata path used to fold at its call site
-  // and now folds here instead; doing both would eat a backslash an author
-  // deliberately wrote as `\\`.
+  // plainText folds ONCE. This says nothing about a caller that folds too,
+  // which is a different shape and is asserted separately below.
   assert.equal(plainText('a literal \\\\n stays'), 'a literal \\n stays');
+});
+
+test('no plainText call site folds, since plainText already does', async () => {
+  // The metadata description used to fold at its call site and now folds
+  // inside plainText instead. Doing BOTH is destructive, because a second
+  // fold eats a backslash an author deliberately wrote as `\\`.
+  //
+  // Nothing else can see that. The fixture above drives plainText alone, so
+  // it cannot observe a fold that happens across two functions, and no docs
+  // page carries a backslash in its description, so the corpus walks have
+  // nothing to compare. `extractPage` is module-private and reads a real
+  // file, so there is no fixture to hand it either. That leaves the call
+  // sites themselves, which is what this reads.
+  const src = await readFile(new URL('../../lib/docs-llms.server.ts', import.meta.url), 'utf8');
+  const doubled = [...src.matchAll(/plainText\(\s*unescapeJs\(/g)].length;
+  assert.equal(doubled, 0, 'a plainText call site folds as well, so that value folds twice');
 });
 
 test('a page description keeps the escaped tags it teaches', async () => {

--- a/website/test/ssr/docs-llms.test.ts
+++ b/website/test/ssr/docs-llms.test.ts
@@ -247,7 +247,7 @@ test('a fenced sample folds its escapes before it decodes its entities', () => {
 
 test('prose is unescaped too, since it comes out of the same template literal', () => {
   // A hole and a sample were folded before prose was, so the corpus still
-  // taught ``returning html\`...\` `` on 50 lines across 8 pages where the
+  // taught ``returning html\`...\` `` on 23 lines across 8 pages where the
   // rendered page shows a plain backtick.
   assert.equal(bodyToMarkdown('html`<p>returning <code>html\\`...\\`</code></p>`'), 'returning html`...`');
 
@@ -294,6 +294,21 @@ test('a kept hole nested inside another leaves no sentinel in the output', () =>
 test('plainText strips tags before it decodes entities', () => {
   assert.equal(plainText('a value with &lt;code&gt; here'), 'a value with <code> here');
   assert.match(plainText('intercepts same-origin &lt;a&gt; clicks'), /same-origin <a> clicks/);
+});
+
+test('a description folds its escapes, on the fallback path 36 pages take', () => {
+  // The fourth path that copies out of page source. It matters more than its
+  // 8-page metadata sibling, not less: only 8 of 44 pages declare
+  // `metadata.description`, so the other 36 fall back to their first `<p>`,
+  // and that fallback did not fold. A paragraph reached /llms-full.txt cooked
+  // while the SAME paragraph reached /llms.txt and the search index with its
+  // escape debris intact.
+  assert.equal(plainText('a function returning html\\`...\\` today'), 'a function returning html`...` today');
+
+  // Folding once, not twice. The metadata path used to fold at its call site
+  // and now folds here instead; doing both would eat a backslash an author
+  // deliberately wrote as `\\`.
+  assert.equal(plainText('a literal \\\\n stays'), 'a literal \\n stays');
 });
 
 test('a page description keeps the escaped tags it teaches', async () => {


### PR DESCRIPTION
Closes #1344

The llms corpus builder copied text straight out of page source with only entity decoding applied. A docs page body is a JS template literal, so a backtick in it is written `` \` `` and a literal hole `\${`, and the corpus carried that debris: 853 backslashes across 29 of 44 pages, including 5 form bindings that taught `<form action=\${createPost}>` where the rendered page shows `<form action=${createPost}>`. The corpus is the surface whose only reader is an LLM, and invariant 12 governs exactly that shape.

`#1331` had already taught the two prose HOLE passes to fold, so this finishes the job on the other two paths: fenced samples, which is what #1344 asks for, and ordinary prose, which review turned up as the same defect from the same cause and which is fixed here rather than documented as a limit.

## What changed

1. `website/lib/docs-llms.server.ts`, the fenced-capture site: run the module's existing `unescapeJs` before `decodeEntities`.
2. `website/lib/docs-llms.server.ts`, prose: one fold pass over the body. It runs AFTER the two hole passes because those are what tell a literal `\${x}` from a render-time `${x}`, so folding first would erase the distinction and the dynamic-hole pass would drop the literal. It runs BEFORE the hole restore, so text those passes already folded cannot fold twice. The single entity decode still comes last, so the module's "strip at every stage, decode exactly once, at the end" rule holds verbatim.
3. `website/lib/docs-llms.server.ts`, page title and description: the fold moves inside `plainText`, which both description sites already go through, and comes off the metadata call site so neither folds twice. A second fold is destructive, since it eats a backslash an author deliberately wrote as `\\`. This is the path review caught: only 8 of 44 pages declare `metadata.description`, so 36 fall back to their first `<p>`, and that fallback never folded, which meant a paragraph could reach `/llms-full.txt` cooked while the same paragraph reached `/llms.txt` and the search index raw. No live page trips it, so the corpus is byte-identical and a fixture is what holds the rule.
4. `website/app/docs/backend-only/page.ts` and `website/app/docs/websockets/page.ts` authored a regex with a single backslash, so the LIVE page already rendered `replace(/s+/g, '-')` and `/;s*/`. The fold is faithful, so without this it would ship those broken samples to the corpus verbatim. `website/app/docs/api-routes/page.ts:296` was already correct and is the precedent. Both live pages were re-rendered through `renderToString` and now show `\s`.
5. `website/test/ssr/docs-llms.test.ts`: the corpus walk's mirror of the extractor gains the same fold, plus four fixtures and an authoring guard.
6. `website/AGENTS.md`: the `docs-llms.server.ts` inventory entry records the fold, its ordering, and where a backslash may still legitimately appear.

### Why escapes fold before entities decode

That is the order the browser applies them: JS cooks the template literal first, and the HTML parser only ever sees cooked text. `packages/core/src/html.js` stores the `strings` array as handed to it and never touches `.raw`, exactly as lit-html does, so the cooked array is what the renderer sees.

Both orders were prototyped over the whole real corpus and produce byte-identical output, so the corpus cannot settle it. They differ on exactly one shape, an escape splitting an entity: `` `&am\p;` `` cooks to `&amp;`, which the parser then shows as `&`, while decoding first would ship `&amp;`. No docs page carries that shape, which is why a fixture holds the rule. The reverse order can never help either, because nothing in the entity table yields a backslash, so decoding cannot manufacture an escape for the fold to eat.

## Accounted before-and-after

`renderLlmsFull()` at `main` versus at this branch's head.

| | value |
|---|---|
| line count | 16,083 both, so no line added or removed |
| changed lines | 480: 457 from the fenced fold, 23 from the prose fold |
| bytes | 998,990 -> 998,157 |
| backslashes in the corpus | 853 -> 20 |
| lines whose change is not purely backslash removal | 0 |
| lines that gained a backslash | 0 |
| `grep -cF 'form action=\${'` | 5 -> 0 |
| `grep -cF 'form action=${'` | 24 -> 29 |
| fence markers, balanced | 1,234 both, balanced both |
| triple-backtick inside a fence | 0 both |
| sentinel leakage (U+E000 / U+E001) | 0 both |

Every one of the 20 surviving backslashes is one an author wrote as `\\` and meant: two `curl` line continuations, three regexes (the two fixed here plus `api-routes`), a `'\n'` in a string, a `<\/p>` in a regex, and 13 in the repo-root skill markdown that `renderLlmsFull` folds in verbatim without passing it through `bodyToMarkdown`, which is out of this change's reach by construction. Nothing in the docs-page half of the corpus carries escape debris any more.

The 833 removed backslashes account to the escape table (512 `` \` ``, 265 `\$`, 5 `\\`, 2 `\s` and 1 `\}` inside fences, plus 50 in prose), minus the 2 the regex fixes put back. Those two regex lines read identically before and after, which is why they do not appear in the changed set: `\s+` in the old source and `\\s+` in the new one both reach the corpus as `\s+`, the difference being that only the new one also renders correctly on the live page.

## Test plan

- `website/test/ssr/docs-llms.test.ts`: 24 pass. The corpus walk still compares 348 samples with 0 mangled, mirror extended rather than assertion weakened, so it stays well above its `> 300` gate.
- Counterfactuals, all three run at [`723073cb`](https://github.com/webjsdev/webjs/commit/723073cb) with the change committed first and reverted through git, never by editing a sentinel into the source:
  - revert the fenced-capture fold: 2 fixtures red AND the corpus walk reds with exactly 27 mangled samples. That second one is worth noting, since extending the mirror does not merely keep the test passing, it turns the corpus walk itself into a counterfactual. 27 of the 348 compared samples contain a backslash, which is exactly the set that reds if mirror and extractor disagree in either direction.
  - revert the prose fold: the prose fixture reds.
  - revert either page's regex fix: the authoring guard reds with 1 offender. Checked on both pages.
  - revert the `plainText` fold: the description fixture reds.
  - restore the fold at the metadata description call site, so that value folds twice: the call-site guard reds. This is the one the fixtures could not see, because a double fold happens across two functions while a fixture drives `plainText` alone.
- `cd website && npm test`: 469 node tests pass, 84 browser tests pass across 8 files.
- `cd website && npm run typecheck`: clean.
- `npx webjs check`: all checks pass. `npx webjs doctor`: 11 passed, 2 warnings, 0 failed (both warnings pre-existing).
- `node --test test/docs/llms.test.mjs`: 11 pass, unchanged, it asserts nothing about escaping.
- `website/test/lib/doc-headings.test.ts` and `website/test/ssr/docs-search.test.ts`: 11 pass with no edit. They consume this markdown and pin the fence predicate, and fence parity is unchanged.

Repo-root `npm test`: 4,143 pass, 5 fail. Those 5 are the documented linked-worktree failures (the two `test/bun/listener*` tests and three elision assertions), not this change. Proven rather than asserted: a detached worktree at `origin/main`, linked the same way, fails the identical 5 by name. They pass in the primary checkout and in CI.

Layers that do not apply: browser and e2e, because this is a `.server.ts` module whose output is served as `text/plain`, so nothing hydrates and the unit layer holds the exact bytes. Bun parity does not apply, checked against the hook rather than asserted: `.claude/hooks/require-bun-parity-with-runtime-src.sh` scopes its runtime-sensitive match to `^packages/([^/]+/src|editors/[^/]+/src|cli/lib)/`, which nothing under `website/` can match, and on the merits this is a pure string-to-string transform with no listener, serializer, crypto or stream surface. Smoke covers the example apps, not the marketing site. Dogfood: the website IS the app under change, and its own suite plus `webjs check` and `webjs doctor` are reported above; `examples/blog` is untouched by a `website/lib` change.

## Docs surfaces

- `website/AGENTS.md` updated, as above. That is the doc surface for this change.
- Everything else N/A: this is website-internal server code exporting no public API, so no `@webjsdev/*` export, CLI flag, `webjs` config key, `html` hole prefix, lifecycle hook or app-author convention moved. Root `AGENTS.md`, the skill at `.agents/skills/webjs/`, `README.md`, `CONVENTIONS.md` and the scaffold templates all stay untouched. The two docs-page edits are content corrections rather than doc-surface sync.

## Deliberately not in this change

One thing #1344 scoped out and I left alone, worth your call rather than mine: the fenced path copies a `${'...'}` string-literal hole verbatim, so `website/app/docs/data-fetching/page.ts:36` reaches the corpus as `` .fallback=${'${html`<p>Loading section...</p>`}'} `` where the rendered page shows `` .fallback=${html`<p>Loading section...</p>`} ``. About 40 fence lines carry that shape. It is a real and separate defect, it is not an escape problem, and fixing it would collide with `a fenced sample keeps the interpolation holes and indentation the prose pipeline would eat`, which depends on a genuine `${children}` surviving a fence verbatim.
