### PR TITLE
feat(website): link the feature gallery from the header and footer

### DIFF
--- a/website/app/layout.ts
+++ b/website/app/layout.ts
@@ -2,7 +2,7 @@ import { html, cspNonce, asset } from '@webjsdev/core';
 import type { LayoutProps } from '@webjsdev/core';
 import '#components/theme-toggle.ts';
 import '#components/site-nav-menu.ts';
-import { DOCS_START_PATH, UI_PATH, GH_URL, NEW_TAB } from '#lib/links.ts';
+import { DOCS_START_PATH, UI_PATH, GALLERY_URL, GH_URL, NEW_TAB } from '#lib/links.ts';
 import { THEME_STORAGE_KEY, FORCED_THEMES } from '#lib/theme.ts';
 import { siteFooter } from '#lib/ui/site-footer.ts';
 import { brandLockup } from '#lib/design/brand.ts';
@@ -30,6 +30,7 @@ const NAV = [
   { label: 'Blog', href: '/blog', ext: false },
   { label: 'Compare', href: '/compare', ext: false },
   { label: 'Changelog', href: '/changelog', ext: false },
+  { label: 'Gallery', href: GALLERY_URL, ext: true },
   { label: 'GitHub', href: GH_URL, ext: true },
 ];
 

--- a/website/lib/links.ts
+++ b/website/lib/links.ts
@@ -31,6 +31,16 @@ export const DOCS_START_PATH = '/docs/getting-started';
  * because already-published CLI versions fetch from them.
  */
 export const UI_PATH = '/ui';
+
+/**
+ * The feature gallery is its own deployed WebJs app (a scaffolded app running
+ * the framework's own demos), so unlike the docs and the component library it
+ * is a real cross-origin URL rather than a path this app serves. It opens in a
+ * new tab for that reason: the client router only handles same-origin links,
+ * and sending a reader off-site mid-visit is the case the new-tab cue exists
+ * for.
+ */
+export const GALLERY_URL = 'https://gallery.webjs.dev';
 export const GH_URL = 'https://github.com/webjsdev/webjs';
 export const DISCORD_URL = 'https://discord.gg/qZScjWWNA8';
 export const X_URL = 'https://x.com/webjsdev';

--- a/website/lib/ui/site-footer.ts
+++ b/website/lib/ui/site-footer.ts
@@ -1,5 +1,5 @@
 import { html } from '@webjsdev/core';
-import { DOCS_START_PATH, UI_PATH, GH_URL, DISCORD_URL, X_URL, BLUESKY_URL, NEW_TAB } from '#lib/links.ts';
+import { DOCS_START_PATH, UI_PATH, GALLERY_URL, GH_URL, DISCORD_URL, X_URL, BLUESKY_URL, NEW_TAB } from '#lib/links.ts';
 import { brandLockup } from '#lib/design/brand.ts';
 
 /**
@@ -27,6 +27,7 @@ export function siteFooter() {
           <div class="flex flex-col gap-3">
             <h4 class="text-xs font-bold uppercase tracking-wider text-fg">Product</h4>
             <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href=${DOCS_START_PATH}>Docs</a>
+            <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href=${GALLERY_URL} target="_blank" rel="noopener noreferrer">Gallery${NEW_TAB}</a>
             <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href=${UI_PATH}>UI components</a>
             <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href="/#templates">Templates</a>
           </div>

--- a/website/test/ssr/nav-and-routes.test.ts
+++ b/website/test/ssr/nav-and-routes.test.ts
@@ -69,6 +69,28 @@ test('the header still carries the rest of the nav', async () => {
   }
 });
 
+test('both header and footer link the gallery, safely, in a new tab', async () => {
+  // The gallery is a separate deployment, so it is the one chrome entry that
+  // has to carry the full cross-origin treatment: the noopener/noreferrer pair
+  // (a target="_blank" link without it hands the opened page a window.opener
+  // handle back into this one) and the screen-reader cue that every other
+  // external link in the chrome already carries. Both surfaces are asserted
+  // because they are edited in different files and adding one alone is the
+  // easy half-done change.
+  const header = (await renderLayout()).split('<footer')[0];
+  for (const [surface, out] of [['header', header], ['footer', await renderToString(siteFooter())]] as const) {
+    const at = out.indexOf('href="https://gallery.webjs.dev"');
+    assert.ok(at >= 0, `${surface} links the gallery`);
+    const anchor = out.slice(at);
+    assert.ok(
+      anchor.startsWith('href="https://gallery.webjs.dev" target="_blank" rel="noopener noreferrer"'),
+      `${surface} gallery link opens safely in a new tab`,
+    );
+    assert.ok(anchor.slice(0, 400).includes('opens in a new tab'), `${surface} announces the new-tab context`);
+    assert.ok(anchor.slice(0, 400).includes('>Gallery'), `${surface} gallery link is labelled`);
+  }
+});
+
 test('the sitemap lists /why-webjs and not the old /why', async () => {
   const xml = String(await Sitemap());
   assert.ok(xml.includes('<loc>https://webjs.dev/why-webjs</loc>'), 'lists the new path');


### PR DESCRIPTION
Adds a **Gallery** entry to the marketing site chrome, pointing at the deployed gallery app at https://gallery.webjs.dev.

- Header nav: after Changelog, before GitHub.
- Footer Product column: after Docs, before UI components.

The gallery is a separate deployment rather than a path this app serves, so unlike Docs and UI it is a real cross-origin link: both entries open in a new tab with `rel="noopener noreferrer"` and the visually-hidden new-tab cue the chrome's other external links already carry. The URL is declared once as `GALLERY_URL` in `website/lib/links.ts` so the two surfaces cannot drift.

## Verification

- `website/test/ssr/nav-and-routes.test.ts` gains a case asserting BOTH surfaces render the link with the full external-link treatment (a change that adds only one of the two fails it). Full file: 9/9 pass.
- `npx webjs check` in `website/`: clean.
- `https://gallery.webjs.dev` probed: 200.