### PR TITLE
docs: sell the standards, type-safety and defaults case, and give the landing page a narrative spine

### DIFF
--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -192,8 +192,9 @@ export default function LandingPage() {
           The web framework for AI agents
         </h1>
         <p class="text-lede leading-[1.55] text-fg-muted max-w-[62ch] mx-auto mb-9 text-pretty">
-          WebJs is a full-stack framework built on <span class="text-fg font-medium">web components</span>, SSR, and
-          progressive enhancement with <span class="text-fg font-medium">zero build step</span>.
+          WebJs is a full-stack framework that leans on <span class="text-fg font-medium">web standards</span>:
+          native web components, SSR, and progressive enhancement, with
+          <span class="text-fg font-medium">zero build step</span>.
           Lean enough for an agent to read end to end. Runs on Node 24+ or Bun.
         </p>
         <div class="flex gap-3 justify-center flex-wrap items-center">
@@ -262,7 +263,7 @@ export default function LandingPage() {
       <div class="max-w-5xl mx-auto px-6">
         <div class="max-w-3xl mx-auto mb-12 text-center">
           <h2 class="font-display font-bold text-h2 leading-[1.12] tracking-[-0.03em] my-3 text-balance">Server action & SSR page</h2>
-          <p class="text-fg-muted text-base leading-[1.6] m-0">A server action and a page. No build, no boilerplate, all web standards.</p>
+          <p class="text-fg-muted text-base leading-[1.6] m-0">A server action and a page. No build, no boilerplate, all web standards. The types cross with the import, so the page reads the action's real return type, the action reads the row type off your database schema, and nothing is generated in between.</p>
         </div>
         <div class="grid gap-6 grid-cols-1 md:grid-cols-2">
           <div class="flex flex-col min-w-0">
@@ -281,14 +282,14 @@ export default function LandingPage() {
       <div class="max-w-6xl mx-auto px-6">
         <div class="max-w-3xl mx-auto mb-12 text-center">
           <h2 class="font-display font-bold text-h2 leading-[1.12] tracking-[-0.03em] my-3 text-balance">Modern full-stack, on web standards</h2>
-          <p class="text-fg-muted text-base leading-[1.6] m-0">Everything you need to ship, none of the build toolchain you don't.</p>
+          <p class="text-fg-muted text-base leading-[1.6] m-0">Everything you need to ship, none of the build toolchain you don't. Staying close to the platform is usually where a framework starts asking you to give things up. Every card below is a place WebJs takes the standard and keeps the ergonomics anyway.</p>
         </div>
         <div class="grid gap-px overflow-hidden rounded-2xl border border-border bg-border grid-cols-1 xs:grid-cols-2 wide:grid-cols-3 shadow-[var(--shadow-sm)]">
 
           <div class="${CARD}">
             <div class="mb-6">
               <h3 class="font-display font-bold text-base leading-[1.3] tracking-[-0.02em] mt-0 mb-2">Zero build step</h3>
-              <p class="m-0 text-sm leading-[1.6] text-fg-muted">Source files run as-is, so what you write is exactly what the browser serves. An AI agent debugs against the real served code, never a bundled or minified artifact.</p>
+              <p class="m-0 text-sm leading-[1.6] text-fg-muted">Source files run as-is, so what you write is exactly what the browser serves. An AI agent debugs against the real served code, never a bundled or minified artifact. Not an untested bet either. Rails has shipped its default frontend without a bundler since Rails 7 in 2021.</p>
             </div>
             <div class="bg-[var(--editor-sidebar-bg)] border border-[var(--editor-border)] rounded-xl p-3.5 font-mono text-xs leading-[1.6] text-[var(--editor-fg)]">
               <div class="flex items-center gap-1.5 text-fg-subtle mb-2 border-b border-[var(--editor-border)] pb-1.5 select-none">
@@ -320,8 +321,8 @@ export default function LandingPage() {
 
           <div class="${CARD}">
             <div class="mb-6">
-              <h3 class="font-display font-bold text-base leading-[1.3] tracking-[-0.02em] mt-0 mb-2">Server actions (RPC)</h3>
-              <p class="m-0 text-sm leading-[1.6] text-fg-muted">Mark a file <code class="font-mono text-[0.9em]">'use server'</code> and import it. Date, Map, Set, BigInt, and Blob all round-trip across the wire with real http verbs (GET, POST, PUT, PATCH, DELETE).</p>
+              <h3 class="font-display font-bold text-base leading-[1.3] tracking-[-0.02em] mt-0 mb-2">Server actions, fully typed</h3>
+              <p class="m-0 text-sm leading-[1.6] text-fg-muted">Mark a file <code class="font-mono text-[0.9em]">'use server'</code> and import it. The call site keeps the function's real argument and return types, with no code generation in between, and Date, Map, Set, BigInt, and Blob all round-trip across the wire with real http verbs (GET, POST, PUT, PATCH, DELETE).</p>
             </div>
             <div class="bg-[var(--editor-sidebar-bg)] border border-[var(--editor-border)] rounded-xl p-3.5 flex items-center justify-between text-xs font-mono select-none text-[var(--editor-fg)]">
               <div class="text-fg-subtle px-2 py-1 bg-[var(--editor-bg)] rounded border border-[var(--editor-border)]">Client</div>
@@ -412,7 +413,8 @@ middleware.ts</pre>
             <div class="cmd-foot pt-2 mt-auto font-mono text-xs leading-[1.6] text-fg-muted max-w-full min-w-0"><copy-cmd>npm create webjs@latest my-api -- --template api</copy-cmd></div>
           </div>
         </div>
-        <p class="mt-8 mx-auto max-w-3xl text-center text-fg-subtle text-sm leading-[1.55]">Prefer Bun? Add <code class="font-mono">--runtime bun</code> to either template, or run <code class="font-mono">bun create webjs my-app</code> to flavor the scaffold for Bun automatically.</p>
+        <p class="mt-8 mx-auto max-w-3xl text-center text-base leading-[1.6] text-fg-muted">Both scaffolds arrive with the calls already made. Light DOM components, Tailwind, Drizzle, a modules layout, and design tokens are wired before you write a line, and an agent skill ships alongside them so a coding agent reads how this app is meant to be built rather than guessing from what it saw elsewhere. Every one of those is a default, not a lock-in. Swap what does not suit you.</p>
+        <p class="mt-6 mx-auto max-w-3xl text-center text-fg-subtle text-sm leading-[1.55]">Prefer Bun? Add <code class="font-mono">--runtime bun</code> to either template, or run <code class="font-mono">bun create webjs my-app</code> to flavor the scaffold for Bun automatically.</p>
       </div>
     </section>
 

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -75,6 +75,23 @@ export const metadata = {
   ],
 };
 
+// The page is written as ONE argument, not as a list of features, and the
+// section ledes are what carry it. Each one opens by picking up the idea the
+// previous section closed on:
+//
+//   hero            what this is
+//   real HTML       the trade every framework made, and the other side of it
+//   nothing         a first paint is only honest if what you wrote is what
+//   compiled away   shipped, so here are two files served as they sit on disk
+//   the bento       everything here falls out of that one decision
+//   light for AI    a framework that compiles nothing is one you can read
+//   start where     so all of it arrives in one command
+//
+// Rewriting a lede in isolation is what breaks this: the hand-off is in the
+// FIRST sentence of each, so a lede that opens on its own section's topic
+// leaves the page reading as a spec sheet again. Move a section and the two
+// ledes on either side of the seam have to move with it.
+
 // Framework-weight stats. Measured: gzipped production browser bundle,
 // npm package metadata, and framework source line counts. Kept honest
 // and comparative against a Next.js app's first-load JS (react + react-dom
@@ -220,10 +237,13 @@ export default function LandingPage() {
         <div class="max-w-3xl mx-auto mb-12 text-center">
           <h2 class="font-display font-bold text-h2 leading-[1.12] tracking-[-0.03em] my-3 text-balance">Real HTML first. JavaScript only when it earns it.</h2>
           <p class="text-fg-muted text-base leading-[1.6] m-0">
-            Pages and components render to real HTML on the server, so the page
-            reads, links navigate, and forms submit before a single script loads.
-            There is no hydration runtime to pay for, and dead JavaScript is
-            statically elided, never shipped.
+            Frameworks got good at hiding the platform, and for years that paid
+            for itself. What changed is when the bill arrives. The runtime has to
+            load, parse, and hydrate before the page can be read at all. WebJs
+            takes the other side of that trade. Pages and components render to
+            real HTML on the server, so the page reads, links navigate, and forms
+            submit before a single script loads. No hydration runtime to pay for,
+            and dead JavaScript is statically elided rather than shipped.
           </p>
         </div>
 
@@ -262,8 +282,8 @@ export default function LandingPage() {
     <section class="py-16">
       <div class="max-w-5xl mx-auto px-6">
         <div class="max-w-3xl mx-auto mb-12 text-center">
-          <h2 class="font-display font-bold text-h2 leading-[1.12] tracking-[-0.03em] my-3 text-balance">Server action & SSR page</h2>
-          <p class="text-fg-muted text-base leading-[1.6] m-0">A server action and a page. No build, no boilerplate, all web standards. The types cross with the import, so the page reads the action's real return type, the action reads the row type off your database schema, and nothing is generated in between.</p>
+          <h2 class="font-display font-bold text-h2 leading-[1.12] tracking-[-0.03em] my-3 text-balance">Nothing is compiled away</h2>
+          <p class="text-fg-muted text-base leading-[1.6] m-0">That first paint is only honest if what you wrote is what shipped. Here is a server action and the page that calls it, both served to the browser exactly as they sit on disk. The types cross with the import, so the page reads the action's real return type, the action reads the row type off your database schema, and nothing is generated in between.</p>
         </div>
         <div class="grid gap-6 grid-cols-1 md:grid-cols-2">
           <div class="flex flex-col min-w-0">
@@ -282,7 +302,7 @@ export default function LandingPage() {
       <div class="max-w-6xl mx-auto px-6">
         <div class="max-w-3xl mx-auto mb-12 text-center">
           <h2 class="font-display font-bold text-h2 leading-[1.12] tracking-[-0.03em] my-3 text-balance">Modern full-stack, on web standards</h2>
-          <p class="text-fg-muted text-base leading-[1.6] m-0">Everything you need to ship, none of the build toolchain you don't. Staying close to the platform is usually where a framework starts asking you to give things up. Every card below is a place WebJs takes the standard and keeps the ergonomics anyway.</p>
+          <p class="text-fg-muted text-base leading-[1.6] m-0">Everything below falls out of that one decision. Staying close to the platform is usually where a framework starts asking you to give things up, so each card is a place WebJs takes the standard and keeps the ergonomics anyway. Everything you need to ship, none of the build toolchain you don't.</p>
         </div>
         <div class="grid gap-px overflow-hidden rounded-2xl border border-border bg-border grid-cols-1 xs:grid-cols-2 wide:grid-cols-3 shadow-[var(--shadow-sm)]">
 
@@ -374,7 +394,7 @@ export default function LandingPage() {
       <div class="max-w-6xl mx-auto px-6">
         <div class="max-w-3xl mx-auto mb-12 text-center">
           <h2 class="font-display font-bold text-h2 leading-[1.12] tracking-[-0.03em] my-3 text-balance">Light enough for AI</h2>
-          <p class="text-fg-muted text-base leading-[1.6] m-0">A zero build step means the source you read is what runs. Because the framework ships without compilation layers, an AI agent can read and reason about the entire WebJs source end to end, straight from node_modules.</p>
+          <p class="text-fg-muted text-base leading-[1.6] m-0">A framework that compiles nothing away is a framework you can read, and that turns out to matter most to the newest reader on your team. An AI agent reads and reasons about the entire WebJs source end to end, straight from node_modules, because there is no bundle standing between it and the code.</p>
         </div>
         <div class="grid gap-px bg-border grid-cols-1 xs:grid-cols-2 wide:grid-cols-4 rounded-2xl border border-border overflow-hidden shadow-[var(--shadow-sm)]">
           ${STATS.map(s => html`
@@ -394,6 +414,7 @@ export default function LandingPage() {
       <div class="max-w-6xl mx-auto px-6">
         <div class="max-w-3xl mx-auto mb-12 text-center">
           <h2 class="font-display font-bold text-h2 leading-[1.12] tracking-[-0.03em] my-3 text-balance">Start where you are</h2>
+          <p class="text-fg-muted text-base leading-[1.6] m-0">All of it arrives in one command. Every decision above is already made in the scaffold, so the first thing you run is a working app rather than an empty directory.</p>
         </div>
         <div class="grid gap-4 grid-cols-1 max-w-2xl mx-auto wide:grid-cols-2 wide:max-w-3xl">
           <div class="flex flex-col gap-3 p-6 min-w-0 rounded-2xl border border-border bg-bg-elev">

--- a/website/app/what-is-webjs/page.ts
+++ b/website/app/what-is-webjs/page.ts
@@ -91,6 +91,16 @@ const FAQ = [
       'Full-stack web applications with server-rendered pages, file-based routing, server actions, sessions, authentication, caching, rate limiting, WebSockets, and a database layer. It also runs backend-only as an HTTP and JSON API framework if you skip pages entirely.',
   },
   {
+    question: 'Is WebJs tied to Tailwind and Drizzle?',
+    answer:
+      'No. A scaffolded app arrives wired to Tailwind for styling, Drizzle with SQLite for data, light DOM components, and design tokens, because an agent building your app should not have to stop and ask. Those are defaults rather than requirements. Bring a different ORM, a different database, or a different way of styling and the framework does not object, since none of the routing, rendering, or server-action machinery depends on any of them.',
+  },
+  {
+    question: 'Does WebJs give you full-stack type safety?',
+    answer:
+      'Yes, and without a code generation step. A component imports a server action through an ordinary import, so the call site keeps that function\'s real argument and return types, and a database row carries its schema type from Drizzle through the action into the markup that renders it. Because types are stripped at request time rather than compiled, the types you read in the editor describe the code that actually runs.',
+  },
+  {
     question: 'How do you install WebJs?',
     answer:
       'Run npm create webjs@latest my-app to scaffold a full-stack application, then npm run dev to start it. The scaffold includes routing, a database layer, and a styled layout, so the app is production-shaped from the first command.',
@@ -181,7 +191,7 @@ const CAPABILITIES = [
   },
   {
     title: 'Server actions with real types',
-    body: 'Export an async function from a .server.ts file and import it straight into a component. The import becomes a typed RPC call, and the wire preserves Date, Map, Set, BigInt, Blob, File, FormData, and reference cycles. The server source never reaches the browser.',
+    body: 'Export an async function from a .server.ts file and import it straight into a component. The import becomes a typed RPC call, so the argument and return types cross the boundary with it and a database row keeps its schema type the whole way into the markup, with nothing generated in between. The wire preserves Date, Map, Set, BigInt, Blob, File, FormData, and reference cycles, and the server source never reaches the browser.',
   },
   {
     title: 'Batteries included',

--- a/website/app/why-webjs/page.ts
+++ b/website/app/why-webjs/page.ts
@@ -72,10 +72,12 @@ const REASONS = [
   },
 ];
 
-// What comes back from the one-sentence prompt. These are the four things the
+// What comes back from the one-sentence prompt. These are the things the
 // prompt would otherwise have had to specify, so each must stay a genuine
 // DEFAULT of the framework or of what `webjs create` scaffolds. If one ever
 // becomes something the prompt has to request, the section's claim is gone.
+// Keep the count EVEN: the grid is two columns at xs and up, so an odd entry
+// leaves an empty cell painted in the grid's border colour.
 const ARRIVES = [
   {
     title: 'Architecture',
@@ -83,7 +85,11 @@ const ARRIVES = [
   },
   {
     title: 'Code',
-    body: 'Server-rendered pages that work before any script loads, and no build step in between. Types run the whole way through, so a server function keeps its argument and return types at the call site and an agent has no reason to reach for any. Running webjs check catches what is outright wrong before it ships.',
+    body: 'Server-rendered pages that work before any script loads, and no build step in between. Running webjs check catches what is outright wrong before it ships, so a mistake surfaces as a failing command rather than as a bug a reader has to find.',
+  },
+  {
+    title: 'Type safety, end to end',
+    body: 'Types run the whole way through. A component importing a server function keeps that function\'s argument and return types at the call site, and a database row carries its schema type into the markup that renders it, with no code generation anywhere in between. An agent has no reason to reach for any.',
   },
   {
     title: 'Database',
@@ -92,6 +98,10 @@ const ARRIVES = [
   {
     title: 'Design system',
     body: 'A palette and a type scale ship as design tokens rather than values scattered through components, so every screen the app grows shares them and restyling the whole thing means editing the tokens, not hunting through the markup.',
+  },
+  {
+    title: 'Agent skills',
+    body: 'A scaffolded app ships a skill its coding agent reads on demand, covering the design system, the modules architecture, and the rest of the conventions. One source, understood by Claude Code, Cursor, Copilot, and opencode alike, so the agent looks up how this app is meant to be built instead of importing habits from another framework.',
   },
 ];
 
@@ -240,6 +250,17 @@ Counter.register('counter');
               <p class="m-0 text-sm leading-[1.65] text-fg-muted">${a.body}</p>
             </div>
           `)}
+        </div>
+        <div class="max-w-3xl mx-auto mt-8 text-center">
+          <p class="text-fg-muted text-base leading-[1.6] m-0">
+            Opinionated is the point, and none of it is a cage. Light DOM
+            components, Tailwind, and Drizzle on SQLite are what a scaffolded app
+            starts with, because something has to be chosen and leaving it open
+            is what pushed the decision into your prompt. Reach for a different
+            ORM, a different database, or a different way of styling and the
+            framework does not object. What you are opting out of is a default,
+            never a dependency the rest of it is built on.
+          </p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
Closes #1392

Two commits on `website/` only. No framework source touched.

## 1. The claims the site was not making

Several things that are true of WebJs and that a reader decides on were stated nowhere on a marketing page.

- **Web standards as a stance.** The home hero listed the pieces (web components, SSR, progressive enhancement) without saying what they add up to. It now leads with leaning on web standards.
- **No build, with a precedent.** The `Zero build step` card asserted the bet and cited nothing. It now notes Rails has shipped its default frontend without a bundler since Rails 7 in 2021. Kept to one clause on purpose: `articles/no-build-javascript-framework.md` owns that keyword, and `website/AGENTS.md` forbids two pages chasing the same one.
- **Full-stack type safety.** Present on `/docs/typescript` and in a blog post, absent from all three marketing pages. Now on the home bento (the RPC card became `Server actions, fully typed`), in the code-windows lede, as a card on `/why-webjs`, and as a FAQ entry on `/what-is-webjs`.
- **Defaults, not lock-in.** `/why-webjs` listed what a scaffolded app arrives with and never said any of it was replaceable, which is exactly the objection that grid raises. A paragraph under the grid now says so, and the home templates section names the stack (light DOM, Tailwind, Drizzle, modules layout, tokens, the agent skill).
- **The agent skill.** Documented on `/docs/ai-first`, never sold on the pitch page. Now a card in `ARRIVES`.

## 2. A narrative spine for the landing page

The page listed seven true things and none of them set up the next, so nothing on it earned a scroll. Sections and order are unchanged; each lede now opens by picking up what the previous section closed on.

| Section | The hand-off |
|---|---|
| Real HTML first | Frameworks got good at hiding the platform, and for years that paid for itself. What changed is when the bill arrives. |
| **Nothing is compiled away** (was `Server action & SSR page`) | That first paint is only honest if what you wrote is what shipped. |
| Modern full-stack, on web standards | Everything below falls out of that one decision. |
| Light enough for AI | A framework that compiles nothing away is a framework you can read. |
| Start where you are | All of it arrives in one command. (This section had no lede at all before.) |

The opening beat credits the trade rather than mocking it, matching the register `/why-webjs` already uses for the same move.

## Two things a future editor needs

**Grid parity.** Three grids here paint an empty cell in the grid's own border colour when the entry count goes odd (`gap-px` over `bg-border`). That is why type safety folded into the existing bento card instead of becoming a seventh, and why `ARRIVES` went 4 to 6 rather than to 5. A comment above `ARRIVES` records it.

**The spine is fragile in a way no test catches.** The hand-off lives in the first sentence of each lede, so rewriting one in isolation silently reverts the page to a spec sheet. A comment above `STATS` in `page.ts` records the chain and says so.

## Verification

`webjs typecheck` clean, `webjs check` clean, `webjs test --server` 471/471. Booted locally and read end to end.
