### PR TITLE
docs(website): rebuild the landing page as one argument

### DIFF
--- a/website/app/layout.ts
+++ b/website/app/layout.ts
@@ -340,6 +340,11 @@ export default function RootLayout({ children }: LayoutProps) {
          brackets on purpose: a literal element tag inside this style
          block is rendered as a real component by the SSR pass. */
       copy-cmd { display: block; flex: 1; min-width: 0; max-width: 100%; }
+      /* The in-a-sentence variant. The block host above would break the
+         sentence around the command; this puts it back in the text flow.
+         copy-cmd[inline] is one specificity point above the bare tag, so it
+         wins without !important and without reordering. */
+      copy-cmd[inline] { display: inline; flex: none; max-width: none; }
       /* Template-card commands hide the horizontal scrollbar entirely (no
          track, no gutter, even on hover), so all three sit flush at the same
          bottom baseline with no reserved strip. The command stays scrollable

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -367,13 +367,37 @@ export default function LandingPage() {
              is the sentence a stranger reads before deciding to scroll. Both
              wrap to two lines at 1440, so the extra word is free.
 
-             The break after the bold sentence is deliberate and costs nothing:
-             two lines either way at the same 64px, but 674 and 600 rather than
-             784 and 489, and the break lands on the sentence boundary instead
-             of mid-clause. The definition owns one line, the promise owns the
-             other. On a phone it is two lines each, breaking where the sentence
-             breaks rather than four lines running together. -->
-        <p class="text-lede leading-[1.55] text-fg-muted max-w-[62ch] mx-auto mb-9 text-pretty">
+             The break after the bold sentence, the 53rem box and the 1.6rem
+             cap are ONE decision solved against three constraints that pull
+             against each other. Change any of them and re-solve all three.
+
+               1. Each sentence gets its own line on a laptop. So the box must
+                  be at least as wide as the definition sets solid, or that
+                  sentence wraps and orphans its last word.
+               2. The subtitle must read narrower than the title. The title's
+                  longest line is 925px at 1280, so the definition has to come
+                  in under that with room to spare, not at 916px like it did.
+               3. On a phone the definition needs two lines, not three, which
+                  it only does at 18.4px or smaller.
+
+             1 and 2 together fix the type size, because the definition's width
+             scales with it: at 27.8px it sets at 916px (99% of the title, the
+             complaint), at 25.6px it sets at 842px (91%, which is as large as
+             it goes while still reading narrower). So 1.6rem is a ceiling
+             derived from the headline, not a taste call, and it is AT that
+             ceiling: the next step up starts reading level with the title
+             again. The box is then 53rem, the first round number above 842.
+
+             3 fixes the curve's low end. The clamp MIN is not the operative
+             term on a phone: at 390px the preferred term runs, so an earlier
+             attempt to fix this by raising the min alone changed nothing at
+             all. The slope carries it instead.
+
+             Measured 18.5 / 21.5 / 25.6 / 25.6px at 390 / 768 / 1280 / 1440, with
+             the definition on 2 / 1 / 1 / 1 lines and the install bar above
+             the fold on a 390x844 phone at 547 of 844.
+-->
+        <p class="text-lede leading-[1.55] text-fg-muted max-w-[53rem] mx-auto mb-9 text-pretty">
           <span class="text-fg font-medium">WebJs is a full-stack web components framework with no build step.</span><br>
           Your agent starts working on your feature, not the scaffolding.
         </p>

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -81,8 +81,8 @@ export const metadata = {
 //
 //   hero              what this is, and what your agent does with it
 //   first paint       the trade every framework made, and the other side of it
-//   nothing           a first paint is only honest if what you wrote is what
-//   compiled away     shipped, so here are two files served as they sit on disk
+//   nothing           the editor file and the network-tab file are one file,
+//   compiled away     so here are two of them served as they sit on disk
 //   browser is the    everything here falls out of that one decision
 //   framework
 //   the app has a     the demos teach, the clear removes them, the shape
@@ -118,15 +118,26 @@ export const metadata = {
 // when missing it costs them the wrong idea.
 //
 // A sequential reader loses nothing, because a self-contained opening still
-// echoes the section above it. "A first paint is only honest..." reads as a
-// hand-off if you came from "The first paint is the whole page" and as a plain
-// claim if you did not. Get both, do not trade one for the other.
+// echoes the section above it. "The file in your editor and the file in the
+// network tab are the same file" reads as the next step if you came from "The
+// first paint is the whole page" and as a plain claim if you did not. Get both,
+// do not trade one for the other.
+//
+// But a hand-off must not be BOUGHT with a false claim, which is how that lede
+// read for a long time: "A first paint is only honest if what you wrote is what
+// shipped." It chains beautifully off the section above and it is not true.
+// Whether the first paint is complete and whether the shipped bytes match your
+// source are unrelated properties, and a Rails or PHP app with a bundled
+// frontend has a perfectly honest first paint. A reader who thinks about the
+// sentence for one second catches it, which is the worst possible place to lose
+// them: the section directly below is the one asking to be trusted. State the
+// section's own claim plainly and let the sequence be a bonus.
 //
 // A lede may hand BACK to the section above, but it must NAME what it is
 // handing back to. A bare pronoun cannot survive the trip, because a large
 // heading sits between the pronoun and its referent and steals the antecedent.
-// "That first paint is only honest..." works, since it names the thing. Three
-// ledes once did not and all three read as broken:
+// "That first paint arrives..." works, since it names the thing. Three ledes
+// once did not and all three read as broken:
 //
 //   "Everything below falls out of that one decision"  which decision?
 //   "All of that only helps if the agent finds it"     all of what?
@@ -410,7 +421,7 @@ export default function LandingPage() {
       <div class="max-w-6xl mx-auto px-6">
         <div class="max-w-3xl mx-auto mb-12 text-center">
           <h2 class="font-display font-bold text-h2 leading-[1.12] tracking-[-0.03em] my-3 text-balance">Nothing is compiled away</h2>
-          <p class="text-fg-muted text-base leading-[1.6] m-0">A first paint is only honest if what you wrote is what shipped. Here is a server action and the page that calls it, both served to the browser exactly as they sit on disk. Rails has shipped its default frontend without a bundler since Rails 7 in 2021, so the approach has production miles behind it. The types cross with the import, so the page reads the action's real return type, the action reads the row type off your database schema, and nothing is generated in between.</p>
+          <p class="text-fg-muted text-base leading-[1.6] m-0">The file in your editor and the file in the network tab are the same file. Here is a server action and the page that calls it, both served to the browser exactly as they sit on disk. Rails has shipped its default frontend without a bundler since Rails 7 in 2021, so the approach has production miles behind it. The types cross with the import, so the page reads the action's real return type, the action reads the row type off your database schema, and nothing is generated in between.</p>
         </div>
         <div class="grid gap-6 grid-cols-1 md:grid-cols-2 max-w-5xl mx-auto">
           <div class="flex flex-col min-w-0">

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -635,7 +635,7 @@ export default function LandingPage() {
           <div class="${CARD}">
             <div class="mb-6">
               <h3 class="font-display font-bold text-base leading-[1.3] tracking-[-0.02em] mt-0 mb-2">Auth is not a side quest</h3>
-              <p class="m-0 text-sm leading-[1.6] text-fg-muted">Login, a signed session, and a protected route ship in the scaffold, on a real database with a schema and migrations from the first command. Caching, page caching, and rate limits share one store. It runs in memory by default, and one line moves all three to Redis.</p>
+              <p class="m-0 text-sm leading-[1.6] text-fg-muted">Login, a signed session, and a protected route ship in the scaffold, on a real database with a schema and migrations from the first command.</p>
             </div>
             <div class="bg-[var(--editor-sidebar-bg)] border border-[var(--editor-border)] rounded-xl p-2.5 flex flex-col gap-1.5 font-mono text-xs text-[var(--editor-fg)] select-none">
               <div class="flex justify-between items-center px-2 py-1 bg-[var(--editor-bg)] border border-[var(--editor-border)] rounded"><span>Login &amp; sessions</span> <span class="text-[var(--accent-text)]">&check;</span></div>
@@ -646,7 +646,7 @@ export default function LandingPage() {
           <div class="${CARD}">
             <div class="mb-6">
               <h3 class="font-display font-bold text-base leading-[1.3] tracking-[-0.02em] mt-0 mb-2">The unglamorous half, included</h3>
-              <p class="m-0 text-sm leading-[1.6] text-fg-muted">Caching, rate limiting, file storage, and WebSockets, sharing one pluggable store. The parts nobody demos and every production app needs.</p>
+              <p class="m-0 text-sm leading-[1.6] text-fg-muted">Caching, rate limiting, file storage, and WebSockets, sharing one pluggable store. Memory by default, Redis in one line. The parts nobody demos and every production app needs.</p>
             </div>
             <div class="bg-[var(--editor-sidebar-bg)] border border-[var(--editor-border)] rounded-xl p-3.5 flex flex-wrap gap-1.5 justify-center select-none text-[var(--editor-fg)]">
               <span class="px-2 py-1 bg-[var(--editor-bg)] border border-[var(--editor-border)] text-fg-subtle text-xs font-mono rounded">Caching</span>

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -670,7 +670,12 @@ middleware.ts</pre>
           </div>
         </div>
         <p class="mt-8 mx-auto max-w-3xl text-center text-base leading-[1.6] text-fg-muted">Light DOM components, Tailwind, Drizzle, a modules layout, and design tokens are wired before you write a line. Every one of them is a default, not a lock-in. Swap what does not suit you.</p>
-        <p class="mt-6 mx-auto max-w-3xl text-center text-fg-subtle text-sm leading-[1.55]">Prefer Bun instead of Node.js? Run <code class="font-mono">bun create webjs@latest my-app</code> to flavor the scaffold for Bun automatically.</p>
+        <!-- max-w-4xl, not the max-w-3xl every other lede uses. The line is 782px
+             set solid and a 3xl box is 768px, so it wrapped by 14px, which put one
+             trailing clause on a second line under a centred first. 4xl gives 114px
+             of slack, enough that a font substitution cannot re-wrap it, and it
+             still folds to two lines below ~830px where two lines are correct. -->
+        <p class="mt-6 mx-auto max-w-4xl text-center text-fg-subtle text-sm leading-[1.55]">Prefer Bun instead of Node.js? Flavor the whole scaffold for Bun by running <copy-cmd inline>bun create webjs@latest my-app</copy-cmd></p>
       </div>
     </section>
 

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -1,7 +1,7 @@
 import { html } from '@webjsdev/core';
 import '#components/copy-cmd.ts';
 import '#components/like-button.ts';
-import { COMPONENT_SAMPLE, TOGGLE_SAMPLE, ACTION_SAMPLE, PAGE_SAMPLE, USAGE_SAMPLE } from '#lib/samples.ts';
+import { COMPONENT_SAMPLE, TOGGLE_SAMPLE, ACTION_SAMPLE, PAGE_SAMPLE, USAGE_SAMPLE, CORE_SOURCE_SAMPLE, SERVER_SOURCE_SAMPLE } from '#lib/samples.ts';
 import { DOCS_START_PATH, GALLERY_URL, GH_URL, NEW_TAB, SAME_AS } from '#lib/links.ts';
 // highlight() runs only at SSR (codeWindow renders its output into the served
 // HTML), but it does ship to the client as a small dead module: the page loads
@@ -88,6 +88,8 @@ export const metadata = {
 //   framework
 //   the app has a     the demos teach, the clear removes them, the shape
 //   shape             stays. pays off the hero's first half
+//   framework         and when the demos and the skill run out, the framework
+//   source            itself is readable, in this app's own node_modules
 //   works without     the backend template is the option nobody expects, and
 //   a UI too          it is what converts a reader who thinks this is UI-only.
 //                     NOT "Start where you are": that collided with the CTA
@@ -225,6 +227,21 @@ function codeWindow(title: string, sample: string) {
     <figure class=${WIN}>
       <figcaption class=${WINBAR}>${DOTS}<span class=${WINNAME}>${title}</span></figcaption>
       <pre class="scroll-thin m-0 p-4 overflow-x-auto font-mono text-sm leading-[1.7] [tab-size:2] flex-1" role="region" tabindex="0" aria-label=${title + ' code sample'}><code>${highlight(sample)}</code></pre>
+    </figure>
+  `;
+}
+
+/**
+ * codeWindow's smaller sibling, for the two framework-source windows.
+ * Identical chrome, 12px instead of 14px: see the note at the call site for
+ * why verbatim source needs the smaller type where a hand-written sample
+ * does not.
+ */
+function sourceWindow(title: string, sample: string) {
+  return html`
+    <figure class=${WIN}>
+      <figcaption class=${WINBAR}>${DOTS}<span class=${WINNAME}>${title}</span></figcaption>
+      <pre class="scroll-thin m-0 p-4 overflow-x-auto font-mono text-xs leading-[1.75] [tab-size:2] flex-1" role="region" tabindex="0" aria-label=${title + ' source'}><code>${highlight(sample)}</code></pre>
     </figure>
   `;
 }
@@ -679,8 +696,7 @@ export default function LandingPage() {
             ships, so your agent reads working code instead of guessing at an
             API. One command clears the demos and leaves the wiring, and the
             architecture stays decided either way, carried in a skill your agent
-            reads on demand. When even that runs out, the framework's own source
-            sits uncompiled in node_modules.
+            reads on demand.
           </p>
         </div>
         <!-- THREE artifacts telling one arc: what arrives, what clearing leaves,
@@ -786,6 +802,95 @@ db/schema.server.ts
             </figure>
           </div>
                 </div>
+      </div>
+    </section>
+
+    <!-- Sits HERE, after the scaffold section, because its first sentence picks
+         up that section's demos and skill. It was drafted for the slot after
+         "Nothing is compiled away", where it chains off the no-build decision
+         instead, and that reads well until you notice the lede would be naming
+         a ladder (demos, then skill, then source) the reader has not climbed
+         yet. The trigger decides the slot.
+
+         This is the readable half of the deleted "Light enough for AI" section,
+         which sold two things: that the framework is small and that it is
+         readable. The size half was the STATS grid whose numbers turned out to
+         be wrong (a 29 KB bundle that measured 43, a 16k line count that
+         measured 23,465 in core alone), so it stayed deleted. The readability
+         half survived as one trailing clause in the scaffold lede, which is
+         where it sat until now.
+
+         The claim is about LOCATION, not availability. Every framework's source
+         is on GitHub; this one's is in the working directory your agent is
+         already in, at the version actually installed. Do not write "no other
+         framework ships its source", which is false, or "no bundle stands
+         between the agent and the code", which is false here too: core ships
+         dist/webjs-core-browser.js and the export map resolves there by
+         default. The section stays silent about that rather than asserting
+         its opposite, which is the difference between an omission and a false
+         claim. If a future edit does mention it, note that CORE is the only
+         package with a dist: server, mcp and ui publish src alone, and cli
+         publishes bin plus lib. Verified from each package.json files
+         array. -->
+    <section class="py-16">
+      <div class="max-w-6xl mx-auto px-6">
+        <div class="max-w-3xl mx-auto mb-12 text-center">
+          <h2 class="font-display font-bold text-h2 leading-[1.12] tracking-[-0.03em] my-3 text-balance">The framework source is in your own project</h2>
+          <p class="text-fg-muted text-base leading-[1.6] m-0">
+            A scaffolded app answers most questions with its demos and its agent
+            skill. When those run out, your agent opens the framework itself. It
+            reads the router or the renderer it is actually calling straight from
+            node_modules, not a version recalled from training data. The files
+            you write ship as written, and so do the framework's, so what it
+            reads is what is running.
+          </p>
+        </div>
+        <!-- TWO windows, one per package, because the claim is about the
+             framework rather than about core. They also fix a real gap: one
+             window at 1024px held 596px of code and 400px of air.
+
+             12px, not the 14px every other window on this page uses, and the
+             grid is the full max-w-6xl rather than the 1024px the other code
+             grids share. Both are forced by the content. These excerpts are
+             VERBATIM framework source, so they cannot be rewrapped the way a
+             hand-written sample can, and this codebase runs to 78 columns at
+             p90. A 1024px two-up holds 56 columns at 14px and 66 at 12px;
+             1152px holds 74 at 12px. That is the first combination that fits
+             real source with slack, and the excerpts were then picked at 69
+             columns or under. Change any one of the three (grid width, font
+             size, excerpt) and re-measure the other two. -->
+        <div class="grid gap-4 grid-cols-1 wide:grid-cols-2 items-stretch">
+          <div class="flex flex-col min-w-0">
+            <p class="text-sm font-medium leading-[1.4] text-fg-subtle mb-2.5 ml-1">The renderer, client side</p>
+            ${sourceWindow('node_modules/@webjsdev/core/src/component.js', CORE_SOURCE_SAMPLE)}
+          </div>
+          <div class="flex flex-col min-w-0">
+            <p class="text-sm font-medium leading-[1.4] text-fg-subtle mb-2.5 ml-1">The server that renders it</p>
+            ${sourceWindow('node_modules/@webjsdev/server/src/dev.js', SERVER_SOURCE_SAMPLE)}
+          </div>
+        </div>
+        <!-- One line, replacing a caption plus a closer. The caption read "Core
+             keeps a dist, for the browser. The source sits next to it", and
+             the whole of its second half existed to handle that one exception.
+             Dropping it is an omission, not a false claim: nothing in this
+             section says a build output does not exist, and the windows show
+             src paths rather than asserting anything about dist.
+
+             It points at @webjsdev rather than @webjsdev/core/src because the
+             two windows above are core AND server, and because the readable
+             folder is src in most packages but lib in the CLI, so the scope
+             above them is the one address that is right everywhere.
+
+             What went with the merge is the second half of the dare, "then open
+             the same folder for whatever you shipped last". That was doing real
+             work, in the register the JavaScript-off P.S. established: a claim
+             the reader confirms beats one they accept. If it comes back, it
+             needs to name the folder and the action ("then try to read the
+             framework in your last project's node_modules"), because "the same
+             folder" pointed at a path that exists in no other app. -->
+        <p class="text-sm leading-[1.6] text-fg-subtle max-w-[68ch] mx-auto mt-6 mb-0 text-center text-pretty">
+          Open <code class="font-mono text-sm bg-fg/8 px-1.5 py-0.5 rounded">node_modules/@webjsdev</code> in your app and read any of it.
+        </p>
       </div>
     </section>
 

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -409,9 +409,22 @@ export default function LandingPage() {
                is why the sentence lists what works rather than claiming
                everything does. Keep it that way: the whole point of an
                invitation to go and check is that checking confirms it. -->
-          <p class="text-sm leading-[1.6] text-fg-subtle max-w-[62ch] mx-auto mt-5 mb-0 text-pretty">
-            P.S. Turn JavaScript off and reload. It still reads, navigates, and
-            respects your system theme. Then try that on the <em>next</em>
+          <!-- 68ch, not the 62ch a measure-based default would pick. At 62ch the
+               greedy fill left "mind" and the wink alone on a third line: the
+               text sets solid at about 1078px, so two lines want 539px each and
+               a 62ch box is 548px, close enough that the last words could not
+               fit but not close enough to absorb them. Two lines start at 64ch
+               (564px of a 566px box, flush against the edge), so 68ch is the
+               first width with enough slack that a font substitution cannot push
+               it back to three. Measures 601px wide with lines of 567 and 562 on
+               a laptop. Re-measure if the sentence changes length: three lines
+               here are not a wrapping bug, they are the last two words orphaned,
+               which is the one paragraph on the page where a ragged tail
+               undercuts the tone. Below about 650px of viewport it wraps further
+               and that is correct. -->
+          <p class="text-sm leading-[1.6] text-fg-subtle max-w-[68ch] mx-auto mt-5 mb-0 text-pretty">
+            P.S. Turn JavaScript off and reload. The page still reads, navigates,
+            and respects your system theme. Then try that on the <em>next</em>
             framework's website that comes to mind. 😉
           </p>
         </div>

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -80,7 +80,8 @@ export const metadata = {
 // previous section closed on:
 //
 //   hero              what this is, and what your agent does with it
-//   first paint       the trade every framework made, and the other side of it
+//   first paint       the server sends a finished page, and only the
+//                     interactive parts load after it
 //   nothing           the editor file and the network-tab file are one file,
 //   compiled away     so here are two of them served as they sit on disk
 //   browser is the    everything here falls out of that one decision
@@ -352,16 +353,32 @@ export default function LandingPage() {
       <div class="max-w-6xl mx-auto px-6">
         <div class="max-w-3xl mx-auto mb-12 text-center">
           <h2 class="font-display font-bold text-h2 leading-[1.12] tracking-[-0.03em] my-3 text-balance">The first paint is the whole page</h2>
+          <!-- 31 words, down from 106, and the shortening was a FACT-CHECK rather
+               than an edit. The old version made three claims about frameworks in
+               general and not one of them survived being checked against the Next
+               source sitting on this machine.
+                 "The runtime has to load, parse, and hydrate before the page can
+               be read at all" is false: Next server-renders client components too
+               (use-flight-response.tsx feeds the Flight stream through
+               createFromReadableStream with an ssrModuleMapping, and next/dynamic
+               defaults to ssr: true), so its HTML reads immediately.
+                 "Every page pays for the runtime" is true of the App Router, whose
+               getRequiredScripts throws an invariant on an empty script list, and
+               false of the Pages Router, which has unstable_runtimeJS: false.
+                 "A page with nothing interactive ships none at all" is true of
+               this framework (ssr.js emits no <script> when moduleUrls is empty)
+               and describes a case almost no app reaches, since one interactive
+               component in the root layout puts every page under it back on the
+               runtime. This website is the proof: all five routes ship core,
+               because the layout renders theme-toggle and site-nav-menu.
+                 So the rule for this lede: claim nothing about another framework
+               and nothing that needs a footnote about which configuration you are
+               in. The chips below enumerate, the P.S. below runs the comparison
+               in the reader's own browser, and the prose only has to be true. -->
           <p class="text-fg-muted text-base leading-[1.6] m-0">
-            Frameworks got good at hiding the platform, and for years that paid
-            for itself. What changed is when the bill arrives. The runtime has to
-            load, parse, and hydrate before the page can be read at all. WebJs
-            takes the other side of that trade. Pages and components render to
-            real HTML on the server, so the page reads, links navigate, and forms
-            submit before a single script loads. Nothing hydrates that does not
-            have to. Pages and layouts never hydrate at all, an interactive
-            component hydrates on its own when the browser upgrades its tag, and
-            a display-only one is statically elided rather than shipped.
+            The server sends a finished page. It reads, its links navigate, and
+            its forms submit before a single script runs. What loads afterwards
+            is only the components that are actually interactive.
           </p>
           <!-- The dare belongs to THIS section, whose chips below enumerate the
                very things it invites you to check. It stays a dare by naming

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -333,25 +333,38 @@ export default function LandingPage() {
              so every phone rendered the identical 46.4px and the size stopped
              responding exactly where it mattered: 58 characters at 46.4px in a
              342px box is 5 ragged lines and a 237px-tall headline. The floor is
-             now 1.75rem, reached only below 314px, so the size is genuinely fluid
+             now 1.5rem, reached only below 282px, so the size is genuinely fluid
              across every real device.
 
-             The slope was then steepened a second time, to land on 32px at
-             390px rather than 34px. That is a 2px change with a whole line in
-             it: at 34px the headline takes FOUR lines on a phone, ending on a
-             75px orphan ("own."), and at 32px it takes three (333/289/180).
-             The curve is solved backwards from that wrap point and the 66px
-             cap, so it still reaches the cap at ~1044px and desktop is
-             untouched.
+             The headline carries a HARD break between its two sentences, and
+             the slope is solved backwards from what that break costs. A break
+             is free at 768 and above, where each sentence fits its own line
+             anyway. On a phone it is not free: at 34px the two sentences take
+             four lines with two orphans ("follows." at 103px, "own." at 70px).
+             At 30px they take three (232/183/337), the same count the inline
+             version needed, with the sentence boundary respected instead of
+             straddling line two. So 30px at 390px is the constraint the whole
+             curve is fitted to, and it still reaches the 66px cap at ~1044px.
 
-             Below about 360px it goes back to four lines, which is correct: a
-             320px phone cannot hold this headline in three without type too
-             small to lead a page.
+             text-balance is safe on the H1 ONLY because of that break. Without
+             it, balance rearranged both sentences together and at 768 shortened
+             the H1 to 547/475/295, which made the subtitle measure 119% of the
+             title, wider than the thing it sits under. With the break, balance
+             can only even the lines WITHIN a sentence, which is what turns
+             312/103/337 into 232/183/337 on a phone and changes nothing above
+             it. Do not remove the break and keep the balance.
 
-             Re-measure line counts at 390 / 768 / 1440 before touching any of the
-             three numbers; they are chosen against the wrap points, not picked. -->
-        <h1 class="font-display font-extrabold text-[clamp(1.75rem,0.73rem+5.2vw,4.125rem)] leading-[0.98] tracking-[-0.038em] mx-auto mt-2 mb-6 max-w-[64rem]">
-          Conventions your agent follows. Architecture you still own.
+             Below about 360px it goes to four lines, which is correct: a 320px
+             phone cannot hold this headline in three without type too small to
+             lead a page.
+
+             Measured 26.1 / 29.9 / 50.7 / 66px at 320 / 390 / 768 / 1280, with
+             the H1 at 4 / 3 / 2 / 2 lines and the subtitle at 91-92% of the
+             title's longest line from 768 up. Re-measure all of them before
+             touching any of the three numbers; they are chosen against the wrap
+             points, not picked. -->
+        <h1 class="font-display font-extrabold text-[clamp(1.5rem,0.53rem+5.5vw,4.125rem)] leading-[0.98] tracking-[-0.038em] mx-auto mt-2 mb-6 max-w-[64rem] text-balance">
+          Conventions your agent follows.<br>Architecture you still own.
         </h1>
         <!-- Two sentences. The second one is the PAGE'S THESIS, and it took a
              long time to find because it is not any single section's claim.

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -83,7 +83,7 @@ export const metadata = {
 //   first paint       the server sends a finished page, and only the
 //                     interactive parts load after it
 //   nothing           the editor file and the network-tab file are one file,
-//   compiled away     so here are two of them served as they sit on disk
+//   compiled away     and the action beside it never ships at all
 //   browser is the    everything here falls out of that one decision
 //   framework
 //   the app has a     the demos teach, the clear removes them, the shape
@@ -438,7 +438,17 @@ export default function LandingPage() {
       <div class="max-w-6xl mx-auto px-6">
         <div class="max-w-3xl mx-auto mb-12 text-center">
           <h2 class="font-display font-bold text-h2 leading-[1.12] tracking-[-0.03em] my-3 text-balance">Nothing is compiled away</h2>
-          <p class="text-fg-muted text-base leading-[1.6] m-0">The file in your editor and the file in the network tab are the same file. Here is a server action and the page that calls it, both served to the browser exactly as they sit on disk. Rails has shipped its default frontend without a bundler since Rails 7 in 2021, so the approach has production miles behind it. The types cross with the import, so the page reads the action's real return type, the action reads the row type off your database schema, and nothing is generated in between.</p>
+          <!-- The two windows below are NOT the same kind of file, and the lede
+               must not say they are. It read "both served to the browser exactly
+               as they sit on disk", which denies invariant 1: the action is a
+               'use server' .server.ts, so it NEVER reaches the browser, and its
+               import is rewritten to an RPC stub. The page does ship, with its
+               types blanked to whitespace, so it is identical line for line and
+               column for column rather than byte for byte. Saying so is also the
+               better story, since the boundary is more interesting than the
+               sameness. Check both windows against this sentence before editing
+               either: the sample files decide what the sentence may claim. -->
+          <p class="text-fg-muted text-base leading-[1.6] m-0">The file in your editor and the file in the network tab are the same file. Here is a server action and the page that calls it. The page ships as you see it. The action never ships at all, and its import becomes a typed RPC call. Rails has shipped its default frontend without a bundler since Rails 7 in 2021, so the approach has production miles behind it. The types cross with the import, so the page reads the action's real return type, the action reads the row type off your database schema, and nothing is generated in between.</p>
         </div>
         <div class="grid gap-6 grid-cols-1 md:grid-cols-2 max-w-5xl mx-auto">
           <div class="flex flex-col min-w-0">

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -402,12 +402,21 @@ export default function LandingPage() {
                for, next to the brand name. That naming is also why this lede
                says WebJs at all: nothing else in the section does, and someone
                arriving here from a search result needs to know whose page this
-               is. "Here it is the default" said nothing to them. -->
+               is. "Here it is the default" said nothing to them.
+
+               The third sentence leads with JavaScript on purpose. It read
+               "What loads afterwards is only the components that are actually
+               interactive", which says the MARKUP arrives late, the opposite of
+               this section's claim: every component is server-rendered into the
+               first paint, and what follows is the module for the interactive
+               ones. Naming JavaScript first makes the sentence unreadable as a
+               statement about markup. -->
 
           <p class="text-fg-muted text-base leading-[1.6] m-0">
             The server sends a finished page. It reads, its links navigate, and
             its forms submit before a single script runs. What loads afterwards
-            is only the components that are actually interactive. That is
+            is JavaScript, and only for the components that are actually
+            interactive. That is
             progressive enhancement, and with WebJs it is the default rather
             than an effort.
           </p>

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -333,13 +333,24 @@ export default function LandingPage() {
              so every phone rendered the identical 46.4px and the size stopped
              responding exactly where it mattered: 58 characters at 46.4px in a
              342px box is 5 ragged lines and a 237px-tall headline. The floor is
-             now 1.75rem, reached only below 264px, so the size is genuinely fluid
-             across every real device. The slope was steepened to match, and the
-             cap trimmed to 4.125rem (66px), which still lands at ~1044px so the
-             desktop crossover point has not moved.
+             now 1.75rem, reached only below 314px, so the size is genuinely fluid
+             across every real device.
+
+             The slope was then steepened a second time, to land on 32px at
+             390px rather than 34px. That is a 2px change with a whole line in
+             it: at 34px the headline takes FOUR lines on a phone, ending on a
+             75px orphan ("own."), and at 32px it takes three (333/289/180).
+             The curve is solved backwards from that wrap point and the 66px
+             cap, so it still reaches the cap at ~1044px and desktop is
+             untouched.
+
+             Below about 360px it goes back to four lines, which is correct: a
+             320px phone cannot hold this headline in three without type too
+             small to lead a page.
+
              Re-measure line counts at 390 / 768 / 1440 before touching any of the
              three numbers; they are chosen against the wrap points, not picked. -->
-        <h1 class="font-display font-extrabold text-[clamp(1.75rem,0.93rem+4.9vw,4.125rem)] leading-[0.98] tracking-[-0.038em] mx-auto mt-2 mb-6 max-w-[64rem]">
+        <h1 class="font-display font-extrabold text-[clamp(1.75rem,0.73rem+5.2vw,4.125rem)] leading-[0.98] tracking-[-0.038em] mx-auto mt-2 mb-6 max-w-[64rem]">
           Conventions your agent follows. Architecture you still own.
         </h1>
         <!-- Two sentences. The second one is the PAGE'S THESIS, and it took a

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -410,9 +410,9 @@ export default function LandingPage() {
                everything does. Keep it that way: the whole point of an
                invitation to go and check is that checking confirms it. -->
           <p class="text-sm leading-[1.6] text-fg-subtle max-w-[62ch] mx-auto mt-5 mb-0 text-pretty">
-            P.S. Turn JavaScript off and reload. The page still reads, the links
-            still work, and it still respects your system theme. Then try that on
-            the <em>next</em> framework's website that comes to your mind. 😉
+            P.S. Turn JavaScript off and reload. It still reads, navigates, and
+            respects your system theme. Then try that on the <em>next</em>
+            framework's website that comes to mind. 😉
           </p>
         </div>
 

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -999,16 +999,24 @@ middleware.ts</pre>
       // three with "are already in there" alone on the last one.
       //
       // What went: "coding" from "coding agent" (the page says "your agent"
-      // everywhere else, so this is the house term rather than a loss), the
-      // articles before demos and framework source, and "already". What stayed
-      // is "framework source": shortening it to "source" also fits, and makes
-      // it read as the app's own source, which is the opposite of the point.
+      // everywhere else, so this is the house term rather than a loss) and the
+      // articles before demos and framework source. What stayed is "framework
+      // source": shortening it to "source" also fits, and makes it read as the
+      // app's own source, which is the opposite of the point.
       //
-      // Measures 521 and 442 with 87px of total slack. Variants existed at 26px
-      // and 56px and were rejected: on a two-line fill, one substituted glyph
-      // pushes a word down, and the second line has to absorb it or the
-      // paragraph goes back to three.
-      lede: 'Run the command below, then start your agent in the new app folder. The conventions, demos, and framework source are there.',
+      // Measures 521 and 503, which is only 26px of total slack, the tightest
+      // two-line fit on the page. It is deliberate: "already" is load-bearing
+      // (nothing has to be fetched) and worth the margin. Two ways to buy room
+      // if this ever re-wraps, measured live in the element rather than a
+      // clone: dropping "The" before conventions gives 57px, dropping
+      // "already" as well gives 87px.
+      //
+      // On a two-line fill, one substituted glyph pushes a word down and the
+      // second line has to absorb it, which is how this paragraph reached three
+      // lines in the first place. So measure the ELEMENT, not a copy of it: an
+      // earlier pass measured a clone whose class list had been rewritten and
+      // read 57px here, 31px off.
+      lede: 'Run the command below, then start your agent in the new app folder. The conventions, demos, and framework source are already there.',
       primary: { href: DOCS_START_PATH, label: 'Get started' },
       // NOT a second docs link. This slot used to point at DOCS_PATH while the
       // primary pointed at DOCS_START_PATH, and /docs is a 308 to

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -675,7 +675,17 @@ middleware.ts</pre>
     </section>
 
     ${ctaPanel({
-      title: 'Start building with AI',
+      // "One command, then a prompt", not "Start building with AI". The old
+      // title was the seventh agent mention on the page and the only one
+      // carrying no information, and it landed right after the page's most
+      // concrete section. This one describes the two steps the lede then
+      // explains, so the install bar below reads as step one.
+      //
+      // It also avoids a dangling pronoun. "then tell it what to build" was
+      // the first draft, and the only noun near that "it" is "one command",
+      // so it briefly reads as instructing the command. The lede can use "it"
+      // safely because it names the agent in the same sentence.
+      title: 'One command, then a prompt',
       lede: 'Run the command below in your terminal, launch your AI coding agent from the app folder, and tell it what you would like to build.',
       primary: { href: DOCS_START_PATH, label: 'Get started' },
       // NOT a second docs link. This slot used to point at DOCS_PATH while the

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -994,7 +994,21 @@ middleware.ts</pre>
       // A hand-back to the page is allowed here and nowhere else. The
       // stand-alone rule protects readers arriving mid-page from a search
       // result, and nobody arrives at a closing CTA cold.
-      lede: 'Run the command below, then start your coding agent inside the new app folder. The conventions, the demos, and the framework source are already in there.',
+      // Two lines in the CTA panel, which is a 52ch box (525px) shared with
+      // /why-webjs, so the text was cut rather than the box widened. It ran to
+      // three with "are already in there" alone on the last one.
+      //
+      // What went: "coding" from "coding agent" (the page says "your agent"
+      // everywhere else, so this is the house term rather than a loss), the
+      // articles before demos and framework source, and "already". What stayed
+      // is "framework source": shortening it to "source" also fits, and makes
+      // it read as the app's own source, which is the opposite of the point.
+      //
+      // Measures 521 and 442 with 87px of total slack. Variants existed at 26px
+      // and 56px and were rejected: on a two-line fill, one substituted glyph
+      // pushes a word down, and the second line has to absorb it or the
+      // paragraph goes back to three.
+      lede: 'Run the command below, then start your agent in the new app folder. The conventions, demos, and framework source are there.',
       primary: { href: DOCS_START_PATH, label: 'Get started' },
       // NOT a second docs link. This slot used to point at DOCS_PATH while the
       // primary pointed at DOCS_START_PATH, and /docs is a 308 to

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -84,7 +84,7 @@ export const metadata = {
 //                     interactive parts load after it
 //   nothing           the editor file and the network-tab file are one file,
 //   compiled away     and the action beside it never ships at all
-//   browser is the    everything here falls out of that one decision
+//   browser is the    the standard is kept and the ergonomics are kept too
 //   framework
 //   the app has a     the demos teach, the clear removes them, the shape
 //   shape             stays. pays off the hero's first half
@@ -514,7 +514,18 @@ export default function LandingPage() {
       <div class="max-w-6xl mx-auto px-6">
         <div class="max-w-3xl mx-auto mb-12 text-center">
           <h2 class="font-display font-bold text-h2 leading-[1.12] tracking-[-0.03em] my-3 text-balance">The browser is the framework. The rest is here.</h2>
-          <p class="text-fg-muted text-base leading-[1.6] m-0">Everything below falls out of the decision to skip the build step. Staying close to the platform is usually where a framework starts asking you to give things up, so each card is a place WebJs takes the standard and keeps the ergonomics anyway. Everything you need to ship, none of the build toolchain you don't.</p>
+          <!-- The lede opened with "Everything below falls out of the decision to
+               skip the build step" and that was false of five of the six cards.
+               File routing, server actions, streaming, auth, and the caching /
+               rate-limit / storage / WebSocket set all exist in frameworks that
+               DO build; only elision has even a weak link, being per-module
+               because there is no bundler to tree-shake instead. It also fought
+               the header, which promises the cards are what the BROWSER does not
+               give you, so a reader hunting the build-step connection in "Auth is
+               not a side quest" found nothing. The organising principle is the
+               header's, not the build step's. Do not reintroduce a causal frame
+               here: check any new opener against all six cards first. -->
+          <p class="text-fg-muted text-base leading-[1.6] m-0">Staying close to the platform is usually where a framework starts asking you to give things up, so each card is a place WebJs takes the standard and keeps the ergonomics anyway. Everything you need to ship, none of the build toolchain you don't.</p>
         </div>
         <div class="grid gap-px overflow-hidden rounded-2xl border border-border bg-border grid-cols-1 xs:grid-cols-2 wide:grid-cols-3 shadow-[var(--shadow-sm)]">
 

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -476,6 +476,16 @@ export default function LandingPage() {
                sameness. Check both windows against this sentence before editing
                either: the sample files decide what the sentence may claim.
 
+               "Because there is no build step" is the section NAMING what it has
+               spent four sentences demonstrating, the same demonstrate-then-name
+               move the first-paint lede makes with progressive enhancement. It
+               was missing: the phrase appeared twice on the whole page, both
+               times in the hero, and the section that proves it said only
+               "without a bundler", attributed to Rails. So a reader landing here
+               cold got the evidence and never the name. It also rescues the Rails
+               sentence, which reads as a non sequitur unless the paragraph has
+               already made a build claim for "without a bundler" to echo.
+
                The lede does NOT make the type-safety point, on purpose. The
                "Call the server like a function" card two sections down already
                says the call site keeps the function's real argument and return
@@ -495,7 +505,7 @@ export default function LandingPage() {
                means typed at author time, which is right for a reference doc
                and misleading in a sentence whose subject is what ships. -->
 
-          <p class="text-fg-muted text-base leading-[1.6] m-0">The file in your editor and the file in the browser network tab are the same file. Here is a server action and the page that calls it. The page ships as you see it. The action never ships at all, and its import becomes an RPC call. Rails has shipped its default frontend without a bundler since Rails 7 in 2021, so the approach has production miles behind it.</p>
+          <p class="text-fg-muted text-base leading-[1.6] m-0">The file in your editor and the file in the browser network tab are the same file. Here is a server action and the page that calls it. The page ships as you see it, because there is no build step. The action never ships at all, and its import becomes an RPC call. Rails has shipped its default frontend without a bundler since Rails 7 in 2021, so the approach has production miles behind it.</p>
         </div>
         <div class="grid gap-6 grid-cols-1 md:grid-cols-2 max-w-5xl mx-auto">
           <div class="flex flex-col min-w-0">

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -342,30 +342,53 @@ export default function LandingPage() {
         <h1 class="font-display font-extrabold text-[clamp(1.75rem,0.93rem+4.9vw,4.125rem)] leading-[1.02] tracking-[-0.038em] mx-auto mt-2 mb-6 max-w-[64rem]">
           Conventions your agent follows. Architecture you still own.
         </h1>
-        <!-- Two sentences, 18 words, cut from 45. What went and why, because
-             each cut looks like a loss until you see what pays for it below.
+        <!-- Two sentences. The second one is the PAGE'S THESIS, and it took a
+             long time to find because it is not any single section's claim.
+
+             Read the six sections as one argument and five of them are the
+             same claim about a different layer: the browser is not kept
+             waiting (first paint), a build does not stand between your file
+             and the wire (nothing compiled away), the scaffold is readable
+             rather than magic (the app has a shape), the framework itself is
+             openable (source in your project), and the same holds with no
+             frontend at all (works without a UI). The through line is that
+             nothing is concealed, at any layer. That is what the subtitle now
+             says, so every section below is evidence for it rather than a new
+             topic.
+
+             It ends on "you" deliberately. The H1's second half is about
+             ownership, and the comma before "or from you" echoes it without
+             restating it.
+
+             What came out, and why each looked like a loss until it was not:
 
              "What your agent writes reaches the browser line for line, so it
-             debugs real code and you read exactly what runs" is the claim
-             "Nothing is compiled away" makes two sections down, with two code
-             windows and a server-action boundary as evidence. A demonstrated
-             claim beats a stated one, and stating it here spends the reveal.
+             debugs real code and you read exactly what runs" is what "Nothing
+             is compiled away" proves two sections down with two code windows.
+             A demonstrated claim beats a stated one; stating it here spends
+             the reveal.
 
              "Conventions guide the first prompt to production-ready code, so
-             fewer tokens go to plumbing" said the mechanism rather than the
-             outcome, and token economy is the page's only mention of tokens.
+             fewer tokens go to plumbing" gave the mechanism rather than the
+             outcome, and token economy was the page's only mention of tokens.
              Rails leads with token efficiency and can afford to, because its
-             subtitle never has to say what Rails is. Half of this one does.
+             subtitle never has to say what Rails is. Half of this one does,
+             which is the tax an unrecognised name pays.
 
              An ownership clause was drafted twice ("everything it writes stays
-             yours to read and change") and cut twice: the H1's second half
-             already says it, and sections 4 and 5 both pay it off.
+             yours to read and change") and cut twice: the H1 says it already.
 
-             What is left is the definition, which an unknown framework cannot
-             skip, and one checkable outcome. "Starts WORKING on your feature"
-             rather than "starts on": the idiom can read as "begin at", and this
-             is the sentence a stranger reads before deciding to scroll. Both
-             wrap to two lines at 1440, so the extra word is free.
+             "Built for agents from the ground up while providing excellent DX
+             for humans" was proposed and declined: it restates the H1, "DX"
+             cannot be checked, and it sets at 923px in an 848px box.
+
+             "Your agent starts working on your feature, not the scaffolding"
+             was the last version before this one. Accurate, checkable, and
+             narrower than the page: it described the scaffold section only.
+
+             Do not elaborate this. A third sentence has been tried four times
+             and every one turned out to be some section's claim said weaker.
+             The six sections ARE the elaboration.
 
              The break after the bold sentence, the 53rem box and the 1.6rem
              cap are ONE decision solved against three constraints that pull
@@ -399,7 +422,7 @@ export default function LandingPage() {
 -->
         <p class="text-lede leading-[1.55] text-fg-muted max-w-[53rem] mx-auto mb-9 text-pretty">
           <span class="text-fg font-medium">WebJs is a full-stack web components framework with no build step.</span><br>
-          Your agent starts working on your feature, not the scaffolding.
+          Nothing is hidden from your agent, or from you.
         </p>
         <div class="flex gap-3 justify-center flex-wrap items-center">
           <a class=${BTN_PRIMARY} href=${DOCS_START_PATH}>

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -2,7 +2,7 @@ import { html } from '@webjsdev/core';
 import '#components/copy-cmd.ts';
 import '#components/like-button.ts';
 import { COMPONENT_SAMPLE, TOGGLE_SAMPLE, ACTION_SAMPLE, PAGE_SAMPLE, USAGE_SAMPLE } from '#lib/samples.ts';
-import { DOCS_PATH, DOCS_START_PATH, GH_URL, NEW_TAB, SAME_AS } from '#lib/links.ts';
+import { DOCS_START_PATH, GALLERY_URL, GH_URL, NEW_TAB, SAME_AS } from '#lib/links.ts';
 // highlight() runs only at SSR (codeWindow renders its output into the served
 // HTML), but it does ship to the client as a small dead module: the page loads
 // in the browser to register copy-cmd, and that pulls in its
@@ -79,18 +79,71 @@ export const metadata = {
 // section ledes are what carry it. Each one opens by picking up the idea the
 // previous section closed on:
 //
-//   hero              what this is
-//   arrives finished  the trade every framework made, and the other side of it
+//   hero              what this is, and what your agent does with it
+//   first paint       the trade every framework made, and the other side of it
 //   nothing           a first paint is only honest if what you wrote is what
 //   compiled away     shipped, so here are two files served as they sit on disk
-//   give up nothing   everything here falls out of that one decision
-//   light for AI      a framework that compiles nothing is one you can read
-//   start where       so all of it arrives in one command
+//   browser is the    everything here falls out of that one decision
+//   framework
+//   the app has a     the demos teach, the clear removes them, the shape
+//   shape             stays. pays off the hero's first half
+//   works without     the backend template is the option nobody expects, and
+//   a UI too          it is what converts a reader who thinks this is UI-only.
+//                     NOT "Start where you are": that collided with the CTA
+//                     heading "Start building with AI" directly below it.
 //
 // Rewriting a lede in isolation is what breaks this: the hand-off is in the
 // FIRST sentence of each, so a lede that opens on its own section's topic
 // leaves the page reading as a spec sheet again. Move a section and the two
 // ledes on either side of the seam have to move with it.
+//
+// EVERY SECTION MUST STAND ALONE. This outranks the hand-off above whenever the
+// two conflict. Readers arrive mid-page from a search result or a shared link,
+// so a header and its opening sentence have to resolve with nothing above them.
+// Test it by reading the header plus the first sentence with everything above
+// covered. Four failed that test at once and every failure was a backward
+// reference: "That first paint" (which paint?), "By the time the demos go"
+// (what demos?), "All of it arrives" (all of what?), and the header "Your agent
+// reaches before it writes" (reaches where?).
+//
+// PROTECTIVE repetition is allowed. The anti-repetition rule below is about
+// re-making an ARGUMENT, which is waste, and that is why two bento cards were
+// deleted for restating whole sections. It does NOT cover a line that stops a
+// fast scroller forming a wrong impression from the section they landed on.
+// "It works without a UI too" therefore repeats two things on purpose: that the app
+// arrives with demos AND that one command clears them, and that the defaults
+// are swappable. Someone who lands there cold and reads only "you get a working
+// app full of demos" bounces, and the fix for that is not upstream prose they
+// did not read. Cut an echo when missing it costs the reader nothing. Keep it
+// when missing it costs them the wrong idea.
+//
+// A sequential reader loses nothing, because a self-contained opening still
+// echoes the section above it. "A first paint is only honest..." reads as a
+// hand-off if you came from "The first paint is the whole page" and as a plain
+// claim if you did not. Get both, do not trade one for the other.
+//
+// A lede may hand BACK to the section above, but it must NAME what it is
+// handing back to. A bare pronoun cannot survive the trip, because a large
+// heading sits between the pronoun and its referent and steals the antecedent.
+// "That first paint is only honest..." works, since it names the thing. Three
+// ledes once did not and all three read as broken:
+//
+//   "Everything below falls out of that one decision"  which decision?
+//   "All of that only helps if the agent finds it"     all of what?
+//   "That is true of your code"                        read as referring to the
+//                                                      header directly above it,
+//                                                      which INVERTED the meaning
+//
+// Name it, or open on something self-contained. Do not write "as the previous
+// section showed" either: that is documentation voice and it makes the reader
+// do bookkeeping.
+//
+// The trap is easy to fall into WHILE FIXING one of these. The replacement for
+// the third was "When it needs to go deeper than that, it can", which is the
+// same defect wearing different words. If your fix still contains a bare
+// "that", "this", "the above", or a comparative with no stated baseline, it is
+// not fixed. Read the first sentence with the heading covering everything above
+// it: if it still resolves, it is done.
 //
 // The HEADERS carry their own rule, learned by getting it wrong twice. Each is
 // a self-contained CLAIM, never a label for the contents and never a pointer at
@@ -100,26 +153,20 @@ export const metadata = {
 // header alone. The consequence link belongs in the lede's first sentence,
 // where there is room to name what it refers back to.
 
-// Framework-weight stats. Every number here is MEASURED, and anyone reading
-// the page can re-measure it in seconds, so a stale one is a public error
-// rather than a rounding quibble. Two of them were, which is why the exact
-// command sits beside each. Re-run these before editing a figure:
+// The one surviving measured number, rendered under the bento. It was a
+// four-stat grid in its own section; three of those stats restated sections
+// above them and the section resisted every header it was given, so it went.
+// This one stays because it answers the objection the bento raises, which is
+// that a framework with everything in it must be heavy.
 //
-//   wire size   curl -H 'Accept-Encoding: gzip' -o /dev/null -w '%{size_download}' \
-//                 https://webjs.dev/__webjs/core/dist/webjs-core-browser.js
-//               (the importmap points @webjsdev/core at that exact file, so it
-//                is what a visitor actually pays. It INCLUDES the client
-//                router, which index-browser.js side-effect-imports.)
-//   source      find packages/core/src -name '*.js' | xargs wc -l
-//
-// The ~99 KB Next baseline is the full one (react + react-dom + the Next
-// runtime + the app-router client); react + react-dom alone is ~44 KB.
-const STATS = [
-  { big: '~43 KB', label: 'Client runtime, gzipped', sub: 'A minimal Next.js client bundle is ~99 KB gzipped including React. WebJs is self-sufficient at ~43 KB, 2.3x lighter on the wire, and that already includes the client router.' },
-  { big: '0 build', label: 'Instant agent loops', sub: 'No compilation, no bundler. Agents edit, run tests, and verify in the browser in milliseconds.' },
-  { big: '100%', label: 'Web standards', sub: 'Standard-aligned Web Component lifecycles, so models write components reliably.' },
-  { big: '~23k', label: 'Lines an agent can open', sub: 'The whole of @webjsdev/core is plain JavaScript with JSDoc in node_modules. An agent greps the renderer or the router it is calling and reads the real implementation.' },
-];
+// MEASURE BEFORE EDITING. It has been stale once, at ~29 KB, which made the
+// derived multiplier wrong too:
+//   curl -H 'Accept-Encoding: gzip' -o /dev/null -w '%{size_download}' \
+//     https://webjs.dev/__webjs/core/dist/webjs-core-browser.js
+// The importmap points @webjsdev/core at that exact file, so it is what a
+// visitor pays, and it INCLUDES the client router that index-browser.js
+// side-effect-imports. The ~99 KB Next baseline is the full one (react +
+// react-dom + the Next runtime + the app-router client).
 
 // The interactive component / server action / page samples live in
 // #lib/samples.ts and render through codeWindow() in "Show, don't tell".
@@ -231,14 +278,35 @@ export default function LandingPage() {
     <main id="main" tabindex="-1" class="focus:outline-none">
     <section class="px-6 pt-12 md:pt-20 lg:pt-28 pb-10 md:pb-14 lg:pb-18">
       <div class="text-center">
-        <h1 class="font-display font-extrabold text-display leading-[0.98] tracking-[-0.042em] mx-auto mt-2 mb-6 max-w-[16ch] text-balance">
-          The web framework for AI agents
+        <!-- Same clamp curve as --text-display but with the ceiling lowered from
+             5.5rem to 4.5rem, and a max-width in REM rather than ch. Both are
+             deliberate. This headline is 59 characters where the token was tuned
+             for 31, and at 5.5rem its first sentence alone ran 1222px inside a
+             1464px container, so the line broke mid-second-sentence and the
+             headline sprawled edge to edge. 4.5rem with 62rem breaks it exactly
+             at the full stop, one claim per line. 64rem is 1024px against a measured
+             1008.66px first sentence, so the margin is 15px. Measure an UNWRAPPED
+             clone: summing a Range getClientRects() over already-wrapped text
+             sums the line fragments and gives the wrong number.
+
+             The max-width MUST NOT be in ch. A previous attempt used max-w-[32ch]
+             which computes to 1918px at this font size, wider than the container,
+             so it constrained nothing at all. ch scales with the font, which is
+             the whole trap.
+
+             NO text-balance here either, for the same reason. Balancing splits
+             the headline into evenly weighted lines, which produced three lines
+             breaking mid-word ("Conventions your agent f") even though the first
+             sentence fits its line with 13px to spare. The max-width IS the line
+             break, so greedy filling is what we want. -->
+        <h1 class="font-display font-extrabold text-[clamp(2.9rem,1.55rem+4.5vw,4.5rem)] leading-[1.02] tracking-[-0.038em] mx-auto mt-2 mb-6 max-w-[64rem]">
+          Conventions your agent follows. Architecture you still own.
         </h1>
         <p class="text-lede leading-[1.55] text-fg-muted max-w-[62ch] mx-auto mb-9 text-pretty">
-          WebJs is a full-stack framework that leans on <span class="text-fg font-medium">web standards</span>:
-          native web components, SSR, and progressive enhancement, with
-          <span class="text-fg font-medium">zero build step</span>.
-          Lean enough for an agent to read end to end. Runs on Node 24+ or Bun.
+          <span class="text-fg font-medium">WebJs is a full-stack web components framework with no build step.</span>
+          Conventions guide the first prompt to production-ready code, so fewer
+          tokens go to plumbing. What your agent writes reaches the browser line
+          for line, so it debugs real code and you read exactly what runs.
         </p>
         <div class="flex gap-3 justify-center flex-wrap items-center">
           <a class=${BTN_PRIMARY} href=${DOCS_START_PATH}>
@@ -261,7 +329,7 @@ export default function LandingPage() {
     <section class="py-16">
       <div class="max-w-6xl mx-auto px-6">
         <div class="max-w-3xl mx-auto mb-12 text-center">
-          <h2 class="font-display font-bold text-h2 leading-[1.12] tracking-[-0.03em] my-3 text-balance">The page arrives finished</h2>
+          <h2 class="font-display font-bold text-h2 leading-[1.12] tracking-[-0.03em] my-3 text-balance">The first paint is the whole page</h2>
           <p class="text-fg-muted text-base leading-[1.6] m-0">
             Frameworks got good at hiding the platform, and for years that paid
             for itself. What changed is when the bill arrives. The runtime has to
@@ -272,6 +340,26 @@ export default function LandingPage() {
             have to. Pages and layouts never hydrate at all, an interactive
             component hydrates on its own when the browser upgrades its tag, and
             a display-only one is statically elided rather than shipped.
+          </p>
+          <!-- The dare belongs to THIS section, whose chips below enumerate the
+               very things it invites you to check. It stays a dare by naming
+               nobody: it asserts nothing about any other site, so it cannot go
+               stale when somebody else redeploys, and it links nowhere, so it
+               does not hand the page's highest-intent readers to a competitor.
+               The pun carries the target.
+
+               Everything it DOES claim about this page is true with JS off: the
+               content reads, an <a> navigates, and the palette follows the OS
+               because it is light-dark() in CSS rather than a class an inline
+               script applies. What does NOT survive is an explicitly toggled
+               theme, whose bootstrap script cannot run, and the live demos. That
+               is why the sentence lists what works rather than claiming
+               everything does. Keep it that way: the whole point of an
+               invitation to go and check is that checking confirms it. -->
+          <p class="text-sm leading-[1.6] text-fg-subtle max-w-[62ch] mx-auto mt-5 mb-0 text-pretty">
+            P.S. Turn JavaScript off and reload. The page still reads, the links
+            still work, and it still respects your system theme. Then try that on
+            the <em>next</em> framework's website that comes to your mind. 😉
           </p>
         </div>
 
@@ -311,7 +399,7 @@ export default function LandingPage() {
       <div class="max-w-5xl mx-auto px-6">
         <div class="max-w-3xl mx-auto mb-12 text-center">
           <h2 class="font-display font-bold text-h2 leading-[1.12] tracking-[-0.03em] my-3 text-balance">Nothing is compiled away</h2>
-          <p class="text-fg-muted text-base leading-[1.6] m-0">That first paint is only honest if what you wrote is what shipped. Here is a server action and the page that calls it, both served to the browser exactly as they sit on disk. The types cross with the import, so the page reads the action's real return type, the action reads the row type off your database schema, and nothing is generated in between.</p>
+          <p class="text-fg-muted text-base leading-[1.6] m-0">A first paint is only honest if what you wrote is what shipped. Here is a server action and the page that calls it, both served to the browser exactly as they sit on disk. <a class="text-fg font-medium underline underline-offset-4 decoration-border-strong hover:decoration-accent hover:text-accent transition-colors" href="https://rubyonrails.org" target="_blank" rel="noopener noreferrer">Rails${NEW_TAB}</a> has shipped its default frontend without a bundler since Rails 7 in 2021, so the approach has production miles behind it. The types cross with the import, so the page reads the action's real return type, the action reads the row type off your database schema, and nothing is generated in between.</p>
         </div>
         <div class="grid gap-6 grid-cols-1 md:grid-cols-2">
           <div class="flex flex-col min-w-0">
@@ -329,48 +417,42 @@ export default function LandingPage() {
     <section class="py-16">
       <div class="max-w-6xl mx-auto px-6">
         <div class="max-w-3xl mx-auto mb-12 text-center">
-          <h2 class="font-display font-bold text-h2 leading-[1.12] tracking-[-0.03em] my-3 text-balance">You give up nothing to stay on the platform</h2>
-          <p class="text-fg-muted text-base leading-[1.6] m-0">Everything below falls out of that one decision. Staying close to the platform is usually where a framework starts asking you to give things up, so each card is a place WebJs takes the standard and keeps the ergonomics anyway. Everything you need to ship, none of the build toolchain you don't.</p>
+          <h2 class="font-display font-bold text-h2 leading-[1.12] tracking-[-0.03em] my-3 text-balance">The browser is the framework. The rest is here.</h2>
+          <p class="text-fg-muted text-base leading-[1.6] m-0">Everything below falls out of the decision to skip the build step. Staying close to the platform is usually where a framework starts asking you to give things up, so each card is a place WebJs takes the standard and keeps the ergonomics anyway. Everything you need to ship, none of the build toolchain you don't.</p>
         </div>
         <div class="grid gap-px overflow-hidden rounded-2xl border border-border bg-border grid-cols-1 xs:grid-cols-2 wide:grid-cols-3 shadow-[var(--shadow-sm)]">
 
+          <!-- CARD RULE, same as the section headers: the h3 is a self-contained
+               CLAIM that makes a scroller stop, the body is the payoff, and the
+               inset carries the concrete noun so the grid still SKIMS. A reader
+               who never reads a body should still be able to tell from the six
+               insets that routing, data, auth, and the rest are covered, because
+               "is this framework complete?" is the objection this grid exists to
+               answer and no other section on the page answers it.
+
+               Two cards were deleted rather than reworded when this grid was
+               rewritten, and they should not come back: "Zero build step" and
+               "Progressive enhancement" each restated a whole section the reader
+               had just finished ("Nothing is compiled away" and "The first paint
+               is the whole page"). They also contradicted this section's header,
+               which promises the cards are what the BROWSER does not give you. -->
           <div class="${CARD}">
             <div class="mb-6">
-              <h3 class="font-display font-bold text-base leading-[1.3] tracking-[-0.02em] mt-0 mb-2">Zero build step</h3>
-              <p class="m-0 text-sm leading-[1.6] text-fg-muted">Source files run as-is, so what you write is exactly what the browser serves. An AI agent debugs against the real served code, never a bundled or minified artifact. Not an untested bet either. Rails has shipped its default frontend without a bundler since Rails 7 in 2021.</p>
+              <h3 class="font-display font-bold text-base leading-[1.3] tracking-[-0.02em] mt-0 mb-2">Your folders are the routes</h3>
+              <p class="m-0 text-sm leading-[1.6] text-fg-muted">A <code class="font-mono text-[0.9em]">page.ts</code> is a route, a <code class="font-mono text-[0.9em]">layout.ts</code> wraps everything under it, and a <code class="font-mono text-[0.9em]">route.ts</code> is an HTTP handler. Dynamic segments, groups, catch-alls, and error boundaries all follow the folder tree, so the URL map is the directory listing.</p>
             </div>
-            <div class="bg-[var(--editor-sidebar-bg)] border border-[var(--editor-border)] rounded-xl p-3.5 font-mono text-xs leading-[1.6] text-[var(--editor-fg)]">
-              <div class="flex items-center gap-1.5 text-fg-subtle mb-2 border-b border-[var(--editor-border)] pb-1.5 select-none">
-                <span class="w-2 h-2 rounded-full bg-[#28c840]"></span><span>bun dev</span>
-              </div>
-              <div><span class="text-fg-subtle">$</span> bun run dev<br><span class="text-fg-subtle">Ready on http://localhost:5001</span><br><span class="text-fg-muted">page.ts reloaded in 3ms</span></div>
+            <div class="bg-[var(--editor-sidebar-bg)] border border-[var(--editor-border)] rounded-xl p-3.5 font-mono text-xs leading-[1.7] text-[var(--editor-fg)] select-none">
+              <div class="text-fg-subtle">app/</div>
+              <div>&nbsp;&nbsp;page.ts<span class="text-fg-subtle"> → /</span></div>
+              <div>&nbsp;&nbsp;posts/[id]/page.ts<span class="text-fg-subtle"> → /posts/7</span></div>
+              <div>&nbsp;&nbsp;api/hooks/route.ts<span class="text-fg-subtle"> → POST</span></div>
             </div>
           </div>
 
           <div class="${CARD}">
             <div class="mb-6">
-              <h3 class="font-display font-bold text-base leading-[1.3] tracking-[-0.02em] mt-0 mb-2">Light DOM web components</h3>
-              <p class="m-0 text-sm leading-[1.6] text-fg-muted">Components render to light DOM by default, so Tailwind and global CSS just work, no shadow plumbing. Scoped styles are one line away when you want them.</p>
-            </div>
-            <!-- Two rows rather than a markup snippet: the point of this card
-                 is which mode is the DEFAULT and how you leave it, and a tag
-                 with Tailwind classes on it shows neither. Same row idiom as
-                 the Built-in essentials card, with the accent border marking
-                 the default and the opt-in stating the real one-line API. -->
-            <div class="bg-[var(--editor-sidebar-bg)] border border-[var(--editor-border)] rounded-xl p-2.5 flex flex-col gap-1.5 font-mono text-xs text-[var(--editor-fg)] select-none">
-              <div class="flex justify-between items-center gap-2 px-2 py-1 bg-[var(--editor-bg)] border border-[var(--accent-border)] rounded">
-                <span>Light DOM</span> <span class="text-[var(--accent-text)] whitespace-nowrap">default</span>
-              </div>
-              <div class="flex justify-between items-center gap-2 px-2 py-1 bg-[var(--editor-bg)] border border-[var(--editor-border)] rounded text-fg-subtle">
-                <span>Shadow DOM</span> <span class="whitespace-nowrap">static shadow = true</span>
-              </div>
-            </div>
-          </div>
-
-          <div class="${CARD}">
-            <div class="mb-6">
-              <h3 class="font-display font-bold text-base leading-[1.3] tracking-[-0.02em] mt-0 mb-2">Server actions, fully typed</h3>
-              <p class="m-0 text-sm leading-[1.6] text-fg-muted">Mark a file <code class="font-mono text-[0.9em]">'use server'</code> and import it. The call site keeps the function's real argument and return types, with no code generation in between, and Date, Map, Set, BigInt, and Blob all round-trip across the wire with real http verbs (GET, POST, PUT, PATCH, DELETE).</p>
+              <h3 class="font-display font-bold text-base leading-[1.3] tracking-[-0.02em] mt-0 mb-2">Call the server like a function</h3>
+              <p class="m-0 text-sm leading-[1.6] text-fg-muted">Mark a file <code class="font-mono text-[0.9em]">'use server'</code> and import it. The call site keeps the function's real argument and return types with no code generation in between, and Date, Map, Set, BigInt, and Blob round-trip across the wire. You never hand-write a fetch.</p>
             </div>
             <div class="bg-[var(--editor-sidebar-bg)] border border-[var(--editor-border)] rounded-xl p-3.5 flex items-center justify-between text-xs font-mono select-none text-[var(--editor-fg)]">
               <div class="text-fg-subtle px-2 py-1 bg-[var(--editor-bg)] rounded border border-[var(--editor-border)]">Client</div>
@@ -381,8 +463,23 @@ export default function LandingPage() {
 
           <div class="${CARD}">
             <div class="mb-6">
-              <h3 class="font-display font-bold text-base leading-[1.3] tracking-[-0.02em] mt-0 mb-2">Streaming Suspense</h3>
-              <p class="m-0 text-sm leading-[1.6] text-fg-muted">Stream slow regions progressively. The shell paints instantly, fallbacks render, and async data fills in as it resolves.</p>
+              <h3 class="font-display font-bold text-base leading-[1.3] tracking-[-0.02em] mt-0 mb-2">Some components ship no JavaScript</h3>
+              <p class="m-0 text-sm leading-[1.6] text-fg-muted">Components render on the server. An interactive one hydrates on its own when the browser upgrades its tag, and a display-only one is stripped from the browser entirely, module and vendor imports included.</p>
+            </div>
+            <div class="bg-[var(--editor-sidebar-bg)] border border-[var(--editor-border)] rounded-xl p-2.5 flex flex-col gap-1.5 font-mono text-xs text-[var(--editor-fg)] select-none">
+              <div class="flex justify-between items-center gap-2 px-2 py-1 bg-[var(--editor-bg)] border border-[var(--accent-border)] rounded">
+                <span>&lt;price-tag&gt;</span> <span class="text-[var(--accent-text)] whitespace-nowrap">0 KB</span>
+              </div>
+              <div class="flex justify-between items-center gap-2 px-2 py-1 bg-[var(--editor-bg)] border border-[var(--editor-border)] rounded text-fg-subtle">
+                <span>&lt;add-to-cart&gt;</span> <span class="whitespace-nowrap">hydrates</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="${CARD}">
+            <div class="mb-6">
+              <h3 class="font-display font-bold text-base leading-[1.3] tracking-[-0.02em] mt-0 mb-2">Slow data never blocks the first byte</h3>
+              <p class="m-0 text-sm leading-[1.6] text-fg-muted">Wrap a slow region and the shell paints immediately while the data streams in behind it. Navigation is client-side already, with nothing to import and nothing to configure.</p>
             </div>
             <div class="bg-[var(--editor-sidebar-bg)] border border-[var(--editor-border)] rounded-xl p-3.5 flex flex-col gap-2 text-[var(--editor-fg)]">
               <div class="h-3 w-1/3 bg-[var(--editor-border)] rounded"></div>
@@ -394,60 +491,161 @@ export default function LandingPage() {
 
           <div class="${CARD}">
             <div class="mb-6">
-              <h3 class="font-display font-bold text-base leading-[1.3] tracking-[-0.02em] mt-0 mb-2">Progressive enhancement</h3>
-              <p class="m-0 text-sm leading-[1.6] text-fg-muted">Real HTML first. Links navigate, forms submit, and pages read before JavaScript loads, so the page is usable well before anything hydrates.</p>
+              <h3 class="font-display font-bold text-base leading-[1.3] tracking-[-0.02em] mt-0 mb-2">Auth is not a side quest</h3>
+              <p class="m-0 text-sm leading-[1.6] text-fg-muted">Login, a signed session, and a protected route ship in the scaffold, on a real database with a schema and migrations from the first command. Memory store in dev, Redis when you configure one.</p>
             </div>
-            <div class="bg-[var(--editor-sidebar-bg)] border border-[var(--editor-border)] rounded-xl p-3.5 flex flex-wrap gap-1.5 justify-center select-none text-[var(--editor-fg)]">
-              <span class="px-2 py-1 bg-bg-subtle border border-border text-fg-muted text-xs font-mono rounded">Usable before hydration</span>
-              <span class="px-2 py-1 bg-[var(--editor-bg)] border border-[var(--editor-border)] text-fg-subtle text-xs font-mono rounded">Static elision</span>
+            <div class="bg-[var(--editor-sidebar-bg)] border border-[var(--editor-border)] rounded-xl p-2.5 flex flex-col gap-1.5 font-mono text-xs text-[var(--editor-fg)] select-none">
+              <div class="flex justify-between items-center px-2 py-1 bg-[var(--editor-bg)] border border-[var(--editor-border)] rounded"><span>Login &amp; sessions</span> <span class="text-[var(--accent-text)]">&check;</span></div>
+              <div class="flex justify-between items-center px-2 py-1 bg-[var(--editor-bg)] border border-[var(--editor-border)] rounded"><span>Database &amp; migrations</span> <span class="text-[var(--accent-text)]">&check;</span></div>
             </div>
           </div>
 
           <div class="${CARD}">
             <div class="mb-6">
-              <h3 class="font-display font-bold text-base leading-[1.3] tracking-[-0.02em] mt-0 mb-2">Built-in essentials</h3>
-              <p class="m-0 text-sm leading-[1.6] text-fg-muted">Auth, sessions, cache, rate limits, and websockets are built right in. Pluggable adapters, zero glue.</p>
+              <h3 class="font-display font-bold text-base leading-[1.3] tracking-[-0.02em] mt-0 mb-2">The unglamorous half, included</h3>
+              <p class="m-0 text-sm leading-[1.6] text-fg-muted">Caching, rate limiting, file storage, and WebSockets, sharing one pluggable store. The parts nobody demos and every production app needs.</p>
             </div>
-            <div class="bg-[var(--editor-sidebar-bg)] border border-[var(--editor-border)] rounded-xl p-2.5 flex flex-col gap-1.5 font-mono text-xs text-[var(--editor-fg)] select-none">
-              <div class="flex justify-between items-center px-2 py-1 bg-[var(--editor-bg)] border border-[var(--editor-border)] rounded"><span>Auth &amp; sessions</span> <span class="text-[var(--accent-text)]">&check;</span></div>
-              <div class="flex justify-between items-center px-2 py-1 bg-[var(--editor-bg)] border border-[var(--editor-border)] rounded"><span>Rate limiting</span> <span class="text-[var(--accent-text)]">&check;</span></div>
+            <div class="bg-[var(--editor-sidebar-bg)] border border-[var(--editor-border)] rounded-xl p-3.5 flex flex-wrap gap-1.5 justify-center select-none text-[var(--editor-fg)]">
+              <span class="px-2 py-1 bg-[var(--editor-bg)] border border-[var(--editor-border)] text-fg-subtle text-xs font-mono rounded">Caching</span>
+              <span class="px-2 py-1 bg-[var(--editor-bg)] border border-[var(--editor-border)] text-fg-subtle text-xs font-mono rounded">Rate limits</span>
+              <span class="px-2 py-1 bg-[var(--editor-bg)] border border-[var(--editor-border)] text-fg-subtle text-xs font-mono rounded">File storage</span>
+              <span class="px-2 py-1 bg-[var(--editor-bg)] border border-[var(--editor-border)] text-fg-subtle text-xs font-mono rounded">WebSockets</span>
             </div>
           </div>
 
         </div>
+        <p class="mt-8 mx-auto max-w-3xl text-center text-base leading-[1.6] text-fg-muted">
+          All of it in <span class="text-fg font-medium">43 KB gzipped</span>, client router
+          included, with zero runtime dependencies. A minimal Next.js client bundle is
+          around 99 KB.
+        </p>
+        <!-- The familiarity argument, rescued from the deleted stats section,
+             where it read "Familiar from day one. WebJs uses Next.js-style
+             file-based routing and lit-style web components". It is an adoption
+             lever (your existing knowledge transfers, so trying this costs
+             less) and nothing else on the page makes it.
+
+             Stated as restraint rather than as a disclaimer. "WebJs is not
+             trying to be unique" says the same thing and reads as an apology;
+             "invents as little as possible" is the same restraint offered as a
+             deliberate choice. Both halves are accurate: routing is the Next.js
+             app/ tree, and the component API matches lit with reactive
+             properties as the one documented divergence, which is why this says
+             "as little as possible" rather than "nothing". -->
+        <p class="mt-4 mx-auto max-w-3xl text-center text-base leading-[1.6] text-fg-muted">
+          WebJs invents as little as possible. Routing follows the Next.js file
+          conventions, components follow lit's, and everything under them is the
+          platform, so what you already know transfers, and so does what your
+          agent was trained on.
+        </p>
       </div>
     </section>
 
     <section class="py-16">
       <div class="max-w-6xl mx-auto px-6">
         <div class="max-w-3xl mx-auto mb-12 text-center">
-          <h2 class="font-display font-bold text-h2 leading-[1.12] tracking-[-0.03em] my-3 text-balance">Light enough for AI</h2>
-          <p class="text-fg-muted text-base leading-[1.6] m-0">A framework that compiles nothing away is a framework you can read, and that turns out to matter most to the newest reader on your team. An AI agent reads and reasons about the entire WebJs source end to end, straight from node_modules, because there is no bundle standing between it and the code.</p>
+          <h2 class="font-display font-bold text-h2 leading-[1.12] tracking-[-0.03em] my-3 text-balance">The app has a shape before your agent starts</h2>
+          <p class="text-fg-muted text-base leading-[1.6] m-0">
+            A scaffolded app arrives with a live demo of every feature WebJs
+            ships, so your agent reads working code instead of guessing at an
+            API. One command clears the demos and leaves the wiring. The
+            architecture stays decided either way, carried in a skill your agent
+            reads on demand, so where a feature's code goes, how the palette is
+            declared, and how a component arrives are all settled. It starts on
+            your feature instead of on the scaffolding. When even that runs out,
+            WebJs ships its own uncompiled source into the app's node_modules,
+            so the router or the renderer it is calling is a file it can open and
+            grep without leaving the working directory.
+          </p>
         </div>
-        <div class="grid gap-px bg-border grid-cols-1 xs:grid-cols-2 wide:grid-cols-4 rounded-2xl border border-border overflow-hidden shadow-[var(--shadow-sm)]">
-          ${STATS.map(s => html`
-            <div class="p-8 text-center bg-bg-elev hover:bg-[color-mix(in_oklch,var(--bg-elev)_92%,var(--fg))] transition-colors">
-              <div class="font-display font-extrabold leading-none tracking-[-0.03em] text-doc-h1 text-fg">${s.big}</div>
-              <div class="mt-3 font-semibold text-sm">${s.label}</div>
-              <p class="mt-1.5 m-0 text-sm leading-[1.55] text-fg-muted">${s.sub}</p>
-            </div>
-          `)}
-        </div>
-        <p class="mt-8 mx-auto max-w-3xl text-center text-base leading-[1.6] text-fg-muted">Familiar from day one. WebJs uses Next.js-style file-based routing and lit-style web components, conventions both people and agents already know.</p>
-        <p class="mt-6 mx-auto max-w-3xl text-center text-fg-subtle text-xs leading-[1.5]">Gzipped production sizes, measured over the wire. A Next.js app ships a client bundle around ~99 KB gzipped (react, react-dom, and the Next runtime); <code class="font-mono">@webjsdev/core</code> is self-sufficient at ~43 KB gzipped, client router included, with zero runtime dependencies and no build step.</p>
+        <!-- THREE artifacts telling one arc: what arrives, what clearing leaves,
+             and the shape that survives both. This section used to be two (a
+             "Read the demos. Then delete them." section sat above it) and they
+             were merged, which is why the lede is longer than the others: it is
+             now the only place the gallery, the clear, the conventions, and the
+             framework-source fallback are described. Two windows did not survive
+             the merge, the webjs ui add terminal and the design tokens; their
+             content lives in the lede's third sentence.
+
+             Every one of these is COPIED FROM A REAL SCAFFOLDED APP, not
+             composed for the page. Verified by running webjs create then
+             npm run gallery:clear: 26 routes under app/features before,
+             "Gallery cleared (44 paths removed)" as the actual stdout, and the
+             module paths from the generated tree. Re-generate and re-run before
+             editing any of them. The 26 and the 44 go stale quietly, and a
+             plausible-looking invented path is exactly what a reader tries once.
+
+             (No backticks in here, per invariant 9: a backtick inside an html
+             template body closes the literal at JS-parse time, comment or not.
+             This comment had two and took the page down until tsc caught it.) -->
+        <div class="grid grid-cols-1 mid:grid-cols-2 gap-px overflow-hidden rounded-2xl border border-border bg-border shadow-[var(--shadow-sm)]">
+          <div class="p-6 bg-bg-elev hover:bg-[color-mix(in_oklch,var(--bg-elev)_92%,var(--fg))] transition-colors duration-200 flex flex-col h-full">
+            <h3 class="font-display font-bold text-base leading-[1.3] tracking-[-0.02em] mt-0 mb-4 pl-1">What arrives</h3>
+            <pre class="scroll-thin m-0 px-5 py-4 overflow-x-auto rounded-xl border border-[var(--editor-border)] bg-[var(--editor-sidebar-bg)] font-mono text-xs leading-[1.7] [tab-size:2] flex-1" role="region" tabindex="0" aria-label="The feature gallery a scaffolded app ships with"><code><span class="text-accent">$</span> npm create webjs@latest my-app
+<span class="text-accent">$</span> ls my-app/app/features
+async-render    auth             boundaries    broadcast
+caching         client-router    components    directives
+env             file-storage     forms         frames
+<span class="text-fg-subtle">... 26 in all</span>
+<span class="text-fg-subtle"># a working demo of every feature WebJs ships,</span>
+<span class="text-fg-subtle"># in the repo your agent already has open.</span></code></pre>
+          </div>
+          <div class="p-6 bg-bg-elev hover:bg-[color-mix(in_oklch,var(--bg-elev)_92%,var(--fg))] transition-colors duration-200 flex flex-col h-full">
+            <h3 class="font-display font-bold text-base leading-[1.3] tracking-[-0.02em] mt-0 mb-4 pl-1">What is left</h3>
+            <pre class="scroll-thin m-0 px-5 py-4 overflow-x-auto rounded-xl border border-[var(--editor-border)] bg-[var(--editor-sidebar-bg)] font-mono text-xs leading-[1.7] [tab-size:2] flex-1" role="region" tabindex="0" aria-label="Clearing the gallery with npm run gallery clear"><code><span class="text-accent">$</span> npm run gallery:clear
+Gallery cleared (44 paths removed).
+The agent skill and your database wiring are kept.
+<span class="text-fg-subtle"># app/ is layout.ts and page.ts now. the demos</span>
+<span class="text-fg-subtle"># are gone. what your agent learned from them</span>
+<span class="text-fg-subtle"># is not.</span></code></pre>
+          </div>
+          <div class="p-6 bg-bg-elev hover:bg-[color-mix(in_oklch,var(--bg-elev)_92%,var(--fg))] transition-colors duration-200 flex flex-col h-full">
+            <h3 class="font-display font-bold text-base leading-[1.3] tracking-[-0.02em] mt-0 mb-4 pl-1">Where the code goes</h3>
+            <pre class="scroll-thin m-0 px-5 py-4 overflow-x-auto rounded-xl border border-[var(--editor-border)] bg-[var(--editor-sidebar-bg)] font-mono text-xs leading-[1.7] [tab-size:2] flex-1" role="region" tabindex="0" aria-label="The modules architecture a scaffolded app ships with"><code>modules/auth/
+  actions/signup.server.ts
+  queries/current-user.server.ts
+  types.ts
+db/schema.server.ts
+<span class="text-fg-subtle"># one feature, one folder. writes live in</span>
+<span class="text-fg-subtle"># actions, reads in queries, one function per</span>
+<span class="text-fg-subtle"># file.</span></code></pre>
+          </div>
+          <div class="p-6 bg-bg-elev hover:bg-[color-mix(in_oklch,var(--bg-elev)_92%,var(--fg))] transition-colors duration-200 flex flex-col h-full">
+            <h3 class="font-display font-bold text-base leading-[1.3] tracking-[-0.02em] mt-0 mb-4 pl-1">How the UI is built</h3>
+            <pre class="scroll-thin m-0 px-5 py-4 overflow-x-auto rounded-xl border border-[var(--editor-border)] bg-[var(--editor-sidebar-bg)] font-mono text-xs leading-[1.7] [tab-size:2] flex-1" role="region" tabindex="0" aria-label="Installing a kit component and the design tokens that theme it"><code><span class="text-accent">$</span> webjs ui add button
+<span class="text-accent">✔</span> Wrote components/ui/button.ts
+
+--background  --card    --primary   --border
+--foreground  --muted   --accent    --input
+<span class="text-accent">class="bg-background text-foreground"</span>
+<span class="text-fg-subtle"># the component is a file you own. the palette</span>
+<span class="text-fg-subtle"># is tokens, so restyling means editing them.</span></code></pre>
+          </div>
+                </div>
       </div>
     </section>
+
 
     <section id="templates" class="scroll-mt-24 py-16">
       <div class="max-w-6xl mx-auto px-6">
         <div class="max-w-3xl mx-auto mb-12 text-center">
-          <h2 class="font-display font-bold text-h2 leading-[1.12] tracking-[-0.03em] my-3 text-balance">Start where you are</h2>
-          <p class="text-fg-muted text-base leading-[1.6] m-0">All of it arrives in one command. Every decision above is already made in the scaffold, so the first thing you run is a working app rather than an empty directory.</p>
+          <h2 class="font-display font-bold text-h2 leading-[1.12] tracking-[-0.03em] my-3 text-balance">It works without a UI too</h2>
+          <p class="text-fg-muted text-base leading-[1.6] m-0">Two starting points, one command each. One is full-stack, the other is routes and modules with no UI at all. Either gives you a working app with live feature demos rather than an empty directory, and one command takes the demos out whenever you want to start clean.</p>
         </div>
         <div class="grid gap-4 grid-cols-1 max-w-2xl mx-auto wide:grid-cols-2 wide:max-w-3xl">
           <div class="flex flex-col gap-3 p-6 min-w-0 rounded-2xl border border-border bg-bg-elev">
-            <h3 class="font-display font-bold text-lg leading-[1.25] m-0">Full Stack</h3>
-            <p class="m-0 text-sm leading-[1.6] text-fg-muted">SSR pages, web components, server actions, Drizzle, streaming, and a browsable feature gallery. Auth (login, sessions, a protected route) ships as a gallery card. The default.</p>
+            <!-- "Default" is a MARKER beside the heading, not the words "The
+                 default." trailing the paragraph, because someone comparing two
+                 options reads the headings and may never reach the last line of
+                 the body. The card also says "a database" rather than "Drizzle":
+                 the vendor is named once, in the defaults paragraph below, which
+                 is where "default, not a lock-in" lands. Naming it here too split
+                 one idea across two places. -->
+            <div class="flex items-center gap-2.5">
+              <h3 class="font-display font-bold text-lg leading-[1.25] m-0">Full Stack</h3>
+              <span class="font-mono text-[0.65rem] leading-none tracking-widest uppercase text-[var(--accent-text)] border border-[var(--accent-border)] rounded-full px-2 py-1">Default</span>
+            </div>
+            <p class="m-0 text-sm leading-[1.6] text-fg-muted">SSR pages, web components, server actions, a database, streaming, and a browsable feature gallery. Auth (login, sessions, a protected route) ships as a gallery card.</p>
             <pre class="scroll-thin m-0 px-3.5 py-3 overflow-x-auto rounded-lg border border-border bg-bg-subtle font-mono text-xs leading-[1.6] text-fg-muted" role="region" tabindex="0" aria-label="Example files in a full-stack app">app/page.ts
 components/counter.ts
 actions/posts.server.ts</pre>
@@ -462,8 +660,8 @@ middleware.ts</pre>
             <div class="cmd-foot pt-2 mt-auto font-mono text-xs leading-[1.6] text-fg-muted max-w-full min-w-0"><copy-cmd>npm create webjs@latest my-api -- --template api</copy-cmd></div>
           </div>
         </div>
-        <p class="mt-8 mx-auto max-w-3xl text-center text-base leading-[1.6] text-fg-muted">Both scaffolds arrive with the calls already made. Light DOM components, Tailwind, Drizzle, a modules layout, and design tokens are wired before you write a line, and an agent skill ships alongside them so a coding agent reads how this app is meant to be built rather than guessing from what it saw elsewhere. Every one of those is a default, not a lock-in. Swap what does not suit you.</p>
-        <p class="mt-6 mx-auto max-w-3xl text-center text-fg-subtle text-sm leading-[1.55]">Prefer Bun? Add <code class="font-mono">--runtime bun</code> to either template, or run <code class="font-mono">bun create webjs my-app</code> to flavor the scaffold for Bun automatically.</p>
+        <p class="mt-8 mx-auto max-w-3xl text-center text-base leading-[1.6] text-fg-muted">Light DOM components, Tailwind, Drizzle, a modules layout, and design tokens are wired before you write a line. Every one of them is a default, not a lock-in. Swap what does not suit you.</p>
+        <p class="mt-6 mx-auto max-w-3xl text-center text-fg-subtle text-sm leading-[1.55]">Prefer Bun instead of Node.js? Run <code class="font-mono">bun create webjs@latest my-app</code> to flavor the scaffold for Bun automatically.</p>
       </div>
     </section>
 
@@ -471,7 +669,12 @@ middleware.ts</pre>
       title: 'Start building with AI',
       lede: 'Run the command below in your terminal, launch your AI coding agent from the app folder, and tell it what you would like to build.',
       primary: { href: DOCS_START_PATH, label: 'Get started' },
-      secondary: { href: DOCS_PATH, label: 'Read the docs' },
+      // NOT a second docs link. This slot used to point at DOCS_PATH while the
+      // primary pointed at DOCS_START_PATH, and /docs is a 308 to
+      // /docs/getting-started, so both buttons resolved to the identical URL and
+      // the secondary was dead weight. The pair now offers two different
+      // actions, read it or watch it work, which is what a secondary is for.
+      secondary: { href: GALLERY_URL, label: 'See it running', ext: true },
     })}
 
     </main>

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -198,7 +198,7 @@ const HERO_SAMPLE = `class LikeButton extends WebComponent({ count: Number }) {
 LikeButton.register('like-button');
 
 // No build step. No bundler. No virtual DOM.
-// The panel to the right is this file, server-rendered
+// The live button is this file, server-rendered
 // and upgraded in place. Click it.`;
 
 const WIN = 'flex flex-col flex-1 m-0 min-w-0 max-w-full rounded-2xl overflow-hidden border border-border bg-bg-subtle shadow-[var(--shadow)]';
@@ -407,12 +407,12 @@ export default function LandingPage() {
     </section>
 
     <section class="py-16">
-      <div class="max-w-5xl mx-auto px-6">
+      <div class="max-w-6xl mx-auto px-6">
         <div class="max-w-3xl mx-auto mb-12 text-center">
           <h2 class="font-display font-bold text-h2 leading-[1.12] tracking-[-0.03em] my-3 text-balance">Nothing is compiled away</h2>
-          <p class="text-fg-muted text-base leading-[1.6] m-0">A first paint is only honest if what you wrote is what shipped. Here is a server action and the page that calls it, both served to the browser exactly as they sit on disk. <a class="text-fg font-medium underline underline-offset-4 decoration-border-strong hover:decoration-accent hover:text-accent transition-colors" href="https://rubyonrails.org" target="_blank" rel="noopener noreferrer">Rails${NEW_TAB}</a> has shipped its default frontend without a bundler since Rails 7 in 2021, so the approach has production miles behind it. The types cross with the import, so the page reads the action's real return type, the action reads the row type off your database schema, and nothing is generated in between.</p>
+          <p class="text-fg-muted text-base leading-[1.6] m-0">A first paint is only honest if what you wrote is what shipped. Here is a server action and the page that calls it, both served to the browser exactly as they sit on disk. Rails has shipped its default frontend without a bundler since Rails 7 in 2021, so the approach has production miles behind it. The types cross with the import, so the page reads the action's real return type, the action reads the row type off your database schema, and nothing is generated in between.</p>
         </div>
-        <div class="grid gap-6 grid-cols-1 md:grid-cols-2">
+        <div class="grid gap-6 grid-cols-1 md:grid-cols-2 max-w-5xl mx-auto">
           <div class="flex flex-col min-w-0">
             <p class="text-sm font-medium leading-[1.4] text-fg-subtle mb-2.5 ml-1">Server action (RPC)</p>
             ${codeWindow('actions/get-post.server.ts', ACTION_SAMPLE)}
@@ -602,9 +602,8 @@ caching        client-router
 <span class="text-fg-subtle">... 26 in all</span>
 
 <span class="text-accent">$</span> npm run gallery:clear
-Gallery cleared (44 paths
-removed). The skill and your
-database wiring are kept.</code></pre>
+Gallery cleared (44 paths removed).
+The skill and db wiring are kept.</code></pre>
             </figure>
           </div>
                     <div class="flex flex-col min-w-0">
@@ -614,14 +613,13 @@ database wiring are kept.</code></pre>
               <pre class="scroll-thin m-0 p-4 overflow-x-auto font-mono text-sm leading-[1.7] [tab-size:2] flex-1" role="region" tabindex="0" aria-label="The modules architecture a scaffolded app ships with"><code>modules/auth/
   actions/signup.server.ts
   queries/current-user.server.ts
-  auth.server.ts
   types.ts
 modules/forms/
   actions/send-message.server.ts
 db/schema.server.ts
-<span class="text-fg-subtle"># one feature, one folder.</span>
-<span class="text-fg-subtle"># writes in actions, reads in</span>
-<span class="text-fg-subtle"># queries, one per file.</span></code></pre>
+<span class="text-fg-subtle"># one feature, one folder. reads in</span>
+<span class="text-fg-subtle"># queries, writes in actions, one</span>
+<span class="text-fg-subtle"># function per file.</span></code></pre>
             </figure>
           </div>
           <div class="flex flex-col min-w-0">
@@ -635,10 +633,9 @@ db/schema.server.ts
 --foreground   --border
 --card         --muted
 <span class="text-accent">class="bg-background ..."</span>
-<span class="text-fg-subtle"># the component is a file</span>
-<span class="text-fg-subtle"># you own. the palette is</span>
-<span class="text-fg-subtle"># tokens, so restyling is</span>
-<span class="text-fg-subtle"># editing them.</span></code></pre>
+<span class="text-fg-subtle"># the component is a file you own.</span>
+<span class="text-fg-subtle"># the palette is tokens, so</span>
+<span class="text-fg-subtle"># restyling is editing them.</span></code></pre>
             </figure>
           </div>
                 </div>
@@ -701,7 +698,14 @@ middleware.ts</pre>
       // the first draft, and the only noun near that "it" is "one command",
       // so it briefly reads as instructing the command. The lede can use "it"
       // safely because it names the agent in the same sentence.
-      title: 'One command, then a prompt',
+      // The two spaces inside "then a prompt" are NBSPs (U+00A0), which is the
+      // whole mobile line-break fix. The title is a plain string in a text
+      // hole, so there is no markup to hang a <br> or a responsive class off,
+      // and at 390px the greedy fill broke it "One command, then a" / "prompt".
+      // Gluing the second clause makes it one unwrappable unit, so the break
+      // lands at the comma where the sense already breaks. Width-adaptive by
+      // construction: nothing wraps at all above ~430px.
+      title: 'One command, then a prompt',
       lede: 'Run the command below in your terminal, launch your AI coding agent from the app folder, and tell it what you would like to build.',
       primary: { href: DOCS_START_PATH, label: 'Get started' },
       // NOT a second docs link. This slot used to point at DOCS_PATH while the

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -447,8 +447,28 @@ export default function LandingPage() {
                column for column rather than byte for byte. Saying so is also the
                better story, since the boundary is more interesting than the
                sameness. Check both windows against this sentence before editing
-               either: the sample files decide what the sentence may claim. -->
-          <p class="text-fg-muted text-base leading-[1.6] m-0">The file in your editor and the file in the network tab are the same file. Here is a server action and the page that calls it. The page ships as you see it. The action never ships at all, and its import becomes a typed RPC call. Rails has shipped its default frontend without a bundler since Rails 7 in 2021, so the approach has production miles behind it. The types cross with the import, so the page reads the action's real return type, the action reads the row type off your database schema, and nothing is generated in between.</p>
+               either: the sample files decide what the sentence may claim.
+
+               The lede does NOT make the type-safety point, on purpose. The
+               "Call the server like a function" card two sections down already
+               says the call site keeps the function's real argument and return
+               types, and it has a client-to-server diagram beside it. A lede
+               sentence here would be the same argument made twice, weaker, and
+               without the picture. The sentence that used to sit here ("the
+               types cross with the import...") was also carrying a claim that
+               does not survive checking: codegen-free typing across the
+               client / server boundary is what Next server actions and tRPC
+               both already do, so "nothing is generated in between" describes
+               the field rather than distinguishing this framework from it.
+
+               "Typed RPC call" was likewise cut from the sentence above. Every
+               clause around it is about what reaches the BROWSER, where the
+               types are already whitespace, so "typed" there reads as if type
+               information rides the wire. AGENTS.md says "typed RPC stub" and
+               means typed at author time, which is right for a reference doc
+               and misleading in a sentence whose subject is what ships. -->
+
+          <p class="text-fg-muted text-base leading-[1.6] m-0">The file in your editor and the file in the browser network tab are the same file. Here is a server action and the page that calls it. The page ships as you see it. The action never ships at all, and its import becomes an RPC call. Rails has shipped its default frontend without a bundler since Rails 7 in 2021, so the approach has production miles behind it.</p>
         </div>
         <div class="grid gap-6 grid-cols-1 md:grid-cols-2 max-w-5xl mx-auto">
           <div class="flex flex-col min-w-0">

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -635,7 +635,7 @@ export default function LandingPage() {
           <div class="${CARD}">
             <div class="mb-6">
               <h3 class="font-display font-bold text-base leading-[1.3] tracking-[-0.02em] mt-0 mb-2">Auth is not a side quest</h3>
-              <p class="m-0 text-sm leading-[1.6] text-fg-muted">Login, a signed session, and a protected route ship in the scaffold, on a real database with a schema and migrations from the first command. Memory store in dev, Redis when you configure one.</p>
+              <p class="m-0 text-sm leading-[1.6] text-fg-muted">Login, a signed session, and a protected route ship in the scaffold, on a real database with a schema and migrations from the first command. Caching, page caching, and rate limits share one store. It runs in memory by default, and one line moves all three to Redis.</p>
             </div>
             <div class="bg-[var(--editor-sidebar-bg)] border border-[var(--editor-border)] rounded-xl p-2.5 flex flex-col gap-1.5 font-mono text-xs text-[var(--editor-fg)] select-none">
               <div class="flex justify-between items-center px-2 py-1 bg-[var(--editor-bg)] border border-[var(--editor-border)] rounded"><span>Login &amp; sessions</span> <span class="text-[var(--accent-text)]">&check;</span></div>
@@ -657,11 +657,6 @@ export default function LandingPage() {
           </div>
 
         </div>
-        <p class="mt-8 mx-auto max-w-3xl text-center text-base leading-[1.6] text-fg-muted">
-          All of it in <span class="text-fg font-medium">43 KB gzipped</span>, client router
-          included, with zero runtime dependencies. A minimal Next.js client bundle is
-          around 99 KB.
-        </p>
         <!-- The familiarity argument, rescued from the deleted stats section,
              where it read "Familiar from day one. WebJs uses Next.js-style
              file-based routing and lit-style web components". It is an adoption
@@ -686,12 +681,29 @@ export default function LandingPage() {
              751 and 729 with 39px of tail slack. A tighter phrasing was
              available at 751/749 and rejected, since 19px is one font
              substitution away from wrapping again. Re-measure before changing a
-             word here. -->
+             word here: the size sentence below was appended after that tuning
+             and re-wrapped the paragraph, so the two-line figure applies to the
+             first two sentences only.
+
+             The size fact used to be its own paragraph above this one ("All of
+             it in 43 KB gzipped, client router included, with zero runtime
+             dependencies. A minimal Next.js client bundle is around 99 KB"),
+             which read as a stat sitting next to an unrelated claim. It is one
+             paragraph now, but NOT one argument: an earlier merge tried "that
+             is why it fits in 43 KB", and inventing little does not cause a
+             bundle size any more than it causes transferability. Two facts, two
+             sentences, no causal frame between them.
+
+             The 99 KB comparison stays because 43 KB means nothing without it.
+             "Zero runtime dependencies" was dropped for length and is the thing
+             to restore first if this ever gets more room. -->
 
         <p class="mt-4 mx-auto max-w-3xl text-center text-base leading-[1.6] text-fg-muted">
           WebJs invents as little as possible. Routing follows Next.js file
           conventions, components follow lit's, and the rest is the platform, so
-          what you know and what your agent was trained on both transfer.
+          what you know and what your agent was trained on both transfer. All of
+          it is <span class="text-fg font-medium">43 KB gzipped</span>, client
+          router included, against about 99 KB for a minimal Next.js bundle.
         </p>
       </div>
     </section>

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -578,48 +578,57 @@ export default function LandingPage() {
              (No backticks in here, per invariant 9: a backtick inside an html
              template body closes the literal at JS-parse time, comment or not.
              This comment had two and took the page down until tsc caught it.) -->
-        <div class="grid grid-cols-1 mid:grid-cols-2 gap-px overflow-hidden rounded-2xl border border-border bg-border shadow-[var(--shadow-sm)]">
-          <div class="p-6 bg-bg-elev hover:bg-[color-mix(in_oklch,var(--bg-elev)_92%,var(--fg))] transition-colors duration-200 flex flex-col h-full">
-            <h3 class="font-display font-bold text-base leading-[1.3] tracking-[-0.02em] mt-0 mb-4 pl-1">What arrives</h3>
-            <pre class="scroll-thin m-0 px-5 py-4 overflow-x-auto rounded-xl border border-[var(--editor-border)] bg-[var(--editor-sidebar-bg)] font-mono text-xs leading-[1.7] [tab-size:2] flex-1" role="region" tabindex="0" aria-label="The feature gallery a scaffolded app ships with"><code><span class="text-accent">$</span> npm create webjs@latest my-app
+        <div class="grid gap-4 grid-cols-1 wide:grid-cols-3 items-stretch">
+          <div class="flex flex-col min-w-0">
+            <p class="text-sm font-medium leading-[1.4] text-fg-subtle mb-2.5 ml-1">What arrives, and what leaves</p>
+            <figure class=${WIN}>
+              <figcaption class=${WINBAR}>${DOTS}<span class=${WINNAME}>terminal</span></figcaption>
+              <pre class="scroll-thin m-0 p-4 overflow-x-auto font-mono text-sm leading-[1.7] [tab-size:2] flex-1" role="region" tabindex="0" aria-label="The feature gallery a scaffolded app ships with"><code><span class="text-accent">$</span> npm create webjs@latest my-app
 <span class="text-accent">$</span> ls my-app/app/features
-async-render    auth             boundaries    broadcast
-caching         client-router    components    directives
-env             file-storage     forms         frames
+async-render   boundaries
+auth           broadcast
+caching        client-router
 <span class="text-fg-subtle">... 26 in all</span>
-<span class="text-fg-subtle"># a working demo of every feature WebJs ships,</span>
-<span class="text-fg-subtle"># in the repo your agent already has open.</span></code></pre>
+
+<span class="text-accent">$</span> npm run gallery:clear
+Gallery cleared (44 paths
+removed). The skill and your
+database wiring are kept.</code></pre>
+            </figure>
           </div>
-          <div class="p-6 bg-bg-elev hover:bg-[color-mix(in_oklch,var(--bg-elev)_92%,var(--fg))] transition-colors duration-200 flex flex-col h-full">
-            <h3 class="font-display font-bold text-base leading-[1.3] tracking-[-0.02em] mt-0 mb-4 pl-1">What is left</h3>
-            <pre class="scroll-thin m-0 px-5 py-4 overflow-x-auto rounded-xl border border-[var(--editor-border)] bg-[var(--editor-sidebar-bg)] font-mono text-xs leading-[1.7] [tab-size:2] flex-1" role="region" tabindex="0" aria-label="Clearing the gallery with npm run gallery clear"><code><span class="text-accent">$</span> npm run gallery:clear
-Gallery cleared (44 paths removed).
-The agent skill and your database wiring are kept.
-<span class="text-fg-subtle"># app/ is layout.ts and page.ts now. the demos</span>
-<span class="text-fg-subtle"># are gone. what your agent learned from them</span>
-<span class="text-fg-subtle"># is not.</span></code></pre>
-          </div>
-          <div class="p-6 bg-bg-elev hover:bg-[color-mix(in_oklch,var(--bg-elev)_92%,var(--fg))] transition-colors duration-200 flex flex-col h-full">
-            <h3 class="font-display font-bold text-base leading-[1.3] tracking-[-0.02em] mt-0 mb-4 pl-1">Where the code goes</h3>
-            <pre class="scroll-thin m-0 px-5 py-4 overflow-x-auto rounded-xl border border-[var(--editor-border)] bg-[var(--editor-sidebar-bg)] font-mono text-xs leading-[1.7] [tab-size:2] flex-1" role="region" tabindex="0" aria-label="The modules architecture a scaffolded app ships with"><code>modules/auth/
+                    <div class="flex flex-col min-w-0">
+            <p class="text-sm font-medium leading-[1.4] text-fg-subtle mb-2.5 ml-1">Where the code goes</p>
+            <figure class=${WIN}>
+              <figcaption class=${WINBAR}>${DOTS}<span class=${WINNAME}>modules/</span></figcaption>
+              <pre class="scroll-thin m-0 p-4 overflow-x-auto font-mono text-sm leading-[1.7] [tab-size:2] flex-1" role="region" tabindex="0" aria-label="The modules architecture a scaffolded app ships with"><code>modules/auth/
   actions/signup.server.ts
   queries/current-user.server.ts
+  auth.server.ts
   types.ts
+modules/forms/
+  actions/send-message.server.ts
 db/schema.server.ts
-<span class="text-fg-subtle"># one feature, one folder. writes live in</span>
-<span class="text-fg-subtle"># actions, reads in queries, one function per</span>
-<span class="text-fg-subtle"># file.</span></code></pre>
+<span class="text-fg-subtle"># one feature, one folder.</span>
+<span class="text-fg-subtle"># writes in actions, reads in</span>
+<span class="text-fg-subtle"># queries, one per file.</span></code></pre>
+            </figure>
           </div>
-          <div class="p-6 bg-bg-elev hover:bg-[color-mix(in_oklch,var(--bg-elev)_92%,var(--fg))] transition-colors duration-200 flex flex-col h-full">
-            <h3 class="font-display font-bold text-base leading-[1.3] tracking-[-0.02em] mt-0 mb-4 pl-1">How the UI is built</h3>
-            <pre class="scroll-thin m-0 px-5 py-4 overflow-x-auto rounded-xl border border-[var(--editor-border)] bg-[var(--editor-sidebar-bg)] font-mono text-xs leading-[1.7] [tab-size:2] flex-1" role="region" tabindex="0" aria-label="Installing a kit component and the design tokens that theme it"><code><span class="text-accent">$</span> webjs ui add button
+          <div class="flex flex-col min-w-0">
+            <p class="text-sm font-medium leading-[1.4] text-fg-subtle mb-2.5 ml-1">How the UI is built</p>
+            <figure class=${WIN}>
+              <figcaption class=${WINBAR}>${DOTS}<span class=${WINNAME}>design system</span></figcaption>
+              <pre class="scroll-thin m-0 p-4 overflow-x-auto font-mono text-sm leading-[1.7] [tab-size:2] flex-1" role="region" tabindex="0" aria-label="Installing a kit component and the design tokens that theme it"><code><span class="text-accent">$</span> webjs ui add button
 <span class="text-accent">✔</span> Wrote components/ui/button.ts
 
---background  --card    --primary   --border
---foreground  --muted   --accent    --input
-<span class="text-accent">class="bg-background text-foreground"</span>
-<span class="text-fg-subtle"># the component is a file you own. the palette</span>
-<span class="text-fg-subtle"># is tokens, so restyling means editing them.</span></code></pre>
+--background   --primary
+--foreground   --border
+--card         --muted
+<span class="text-accent">class="bg-background ..."</span>
+<span class="text-fg-subtle"># the component is a file</span>
+<span class="text-fg-subtle"># you own. the palette is</span>
+<span class="text-fg-subtle"># tokens, so restyling is</span>
+<span class="text-fg-subtle"># editing them.</span></code></pre>
+            </figure>
           </div>
                 </div>
       </div>

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -339,7 +339,7 @@ export default function LandingPage() {
              desktop crossover point has not moved.
              Re-measure line counts at 390 / 768 / 1440 before touching any of the
              three numbers; they are chosen against the wrap points, not picked. -->
-        <h1 class="font-display font-extrabold text-[clamp(1.75rem,0.93rem+4.9vw,4.125rem)] leading-[1.02] tracking-[-0.038em] mx-auto mt-2 mb-6 max-w-[64rem]">
+        <h1 class="font-display font-extrabold text-[clamp(1.75rem,0.93rem+4.9vw,4.125rem)] leading-[0.98] tracking-[-0.038em] mx-auto mt-2 mb-6 max-w-[64rem]">
           Conventions your agent follows. Architecture you still own.
         </h1>
         <!-- Two sentences. The second one is the PAGE'S THESIS, and it took a
@@ -390,38 +390,42 @@ export default function LandingPage() {
              and every one turned out to be some section's claim said weaker.
              The six sections ARE the elaboration.
 
-             The break after the bold sentence, the 53rem box and the 1.6rem
-             cap are ONE decision solved against three constraints that pull
-             against each other. Change any of them and re-solve all three.
+             Line breaking is the BROWSER'S job here, not ours. text-balance on
+             the subtitle, no hand-placed break, and the same 64rem box the H1
+             uses. This is the rubyonrails.org model, read off their live CSS:
+             text-wrap: balance on the hero copy, no br anywhere, and no
+             max-width of its own.
 
-               1. Each sentence gets its own line on a laptop. So the box must
-                  be at least as wide as the definition sets solid, or that
-                  sentence wraps and orphans its last word.
-               2. The subtitle must read narrower than the title. The title's
-                  longest line is 925px at 1280, so the definition has to come
-                  in under that with room to spare, not at 916px like it did.
-               3. On a phone the definition needs two lines, not three, which
-                  it only does at 18.4px or smaller.
+             It replaced a hand-tuned system (a br, a 53rem box solved against
+             the title's longest line, and a type cap derived from it) that took
+             six rounds to converge and broke whenever a word changed. What
+             balance buys, measured:
 
-             1 and 2 together fix the type size, because the definition's width
-             scales with it: at 27.8px it sets at 916px (99% of the title, the
-             complaint), at 25.6px it sets at 842px (91%, which is as large as
-             it goes while still reading narrower). So 1.6rem is a ceiling
-             derived from the headline, not a taste call, and it is AT that
-             ceiling: the next step up starts reading level with the title
-             again. The box is then 53rem, the first round number above 842.
+               390px   4 ragged lines (341/262/326/83, an 83px orphan)
+                       becomes 3 even ones (342/336/341)
+               1280px  842/575 becomes 841/842
 
-             3 fixes the curve's low end. The clamp MIN is not the operative
-             term on a phone: at 390px the preferred term runs, so an earlier
-             attempt to fix this by raising the min alone changed nothing at
-             all. The slope carries it instead.
+             The subtitle reads narrower than the title WITHOUT a narrower box,
+             which is the part worth understanding: it has more text, so balance
+             spreads it into even lines while the H1 fills its measure. 91% of
+             the title's longest line at 1280.
 
-             Measured 18.5 / 21.5 / 25.6 / 25.6px at 390 / 768 / 1280 / 1440, with
-             the definition on 2 / 1 / 1 / 1 lines and the install bar above
-             the fold on a 390x844 phone at 547 of 844.
+             The H1 does NOT get text-balance, and that is deliberate. Adding it
+             shortened the H1's lines at 768 (547/475/295 instead of
+             547/655/115) and the subtitle then measured 119% of the title, wider
+             than the thing it sits under. Balance is right for the element with
+             more text and wrong for the one with less.
+
+             Sizes are two tokens now, --text-hero-lede and --text-lede, because
+             a hero subtitle wants to be half the headline and a page lede wants
+             to be readable at six lines. They were fighting over one number.
+
+             Measured 18.5 / 23.6 / 30.4px at 390 / 768 / 1280, install bar above
+             the fold at 499 of 844 on a phone (was 547, the tighter H1 leading
+             bought that back).
 -->
-        <p class="text-lede leading-[1.55] text-fg-muted max-w-[53rem] mx-auto mb-9 text-pretty">
-          <span class="text-fg font-medium">WebJs is a full-stack web components framework with no build step.</span><br>
+        <p class="text-hero-lede leading-[1.3] text-fg-muted max-w-[64rem] mx-auto mb-9 text-balance">
+          <span class="text-fg font-medium">WebJs is a full-stack web components framework with no build step.</span>
           Nothing is hidden from your agent, or from you.
         </p>
         <div class="flex gap-3 justify-center flex-wrap items-center">

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -617,24 +617,43 @@ export default function LandingPage() {
           <p class="text-fg-muted text-base leading-[1.6] m-0">
             A scaffolded app arrives with a live demo of every feature WebJs
             ships, so your agent reads working code instead of guessing at an
-            API. One command clears the demos and leaves the wiring. The
+            API. One command clears the demos and leaves the wiring, and the
             architecture stays decided either way, carried in a skill your agent
-            reads on demand, so where a feature's code goes, how the palette is
-            declared, and how a component arrives are all settled. It starts on
-            your feature instead of on the scaffolding. When even that runs out,
-            WebJs ships its own uncompiled source into the app's node_modules,
-            so the router or the renderer it is calling is a file it can open and
-            grep without leaving the working directory.
+            reads on demand. When even that runs out, the framework's own source
+            sits uncompiled in node_modules.
           </p>
         </div>
         <!-- THREE artifacts telling one arc: what arrives, what clearing leaves,
              and the shape that survives both. This section used to be two (a
              "Read the demos. Then delete them." section sat above it) and they
-             were merged, which is why the lede is longer than the others: it is
-             now the only place the gallery, the clear, the conventions, and the
-             framework-source fallback are described. Two windows did not survive
-             the merge, the webjs ui add terminal and the design tokens; their
-             content lives in the lede's third sentence.
+             were merged.
+
+             The lede was 115 words, the longest on the page, and the merge is
+             why: two windows did not survive it (the webjs ui add terminal and
+             the design tokens) so their content was moved into the prose. The
+             cards have since been rebuilt and both are back, in "How the UI is
+             built". The sentence outlived its reason, and by then it was reading
+             out the card headings: "where a feature's code goes" IS the second
+             card, "how the palette is declared, and how a component arrives" IS
+             the third. It is gone. Before adding prose here, check whether a
+             card already shows it, because a window beats a clause every time.
+
+             The payoff sentence went the same way, for the same reason one level
+             up: "It starts on your feature instead of on the scaffolding" is what
+             the H2 above already says, three inches away, and a scroller reads
+             the heading rather than the fourth clause of a paragraph. Check the
+             HEADER too, not just the cards.
+
+             63 words now, from 115. That is close to the floor: what is left is
+             four facts carried once each (the demos exist, one command removes
+             them, the architecture is decided and lives in a skill, the source is
+             readable). Cutting further costs content rather than duplication.
+
+             What the lede must keep carrying is the LAST sentence, the framework
+             source readable in node_modules. That is the one claim in this
+             section no card illustrates, and grepping the page shows this is its
+             only mention anywhere. -->
+
 
              Every one of these is COPIED FROM A REAL SCAFFOLDED APP, not
              composed for the page. Verified by running webjs create then

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -979,7 +979,22 @@ middleware.ts</pre>
       // lands at the comma where the sense already breaks. Width-adaptive by
       // construction: nothing wraps at all above ~430px.
       title: 'One command, then a prompt',
-      lede: 'Run the command below in your terminal, launch your AI coding agent from the app folder, and tell it what you would like to build.',
+      // The lede used to be the header in longhand: "Run the command below in
+      // your terminal, launch your AI coding agent from the app folder, and
+      // tell it what you would like to build" is command-then-prompt said
+      // twice, once in the H2 and once at three times the length.
+      //
+      // The one phrase carrying weight was "from the app folder", buried as an
+      // aside. It is what the two sections above just earned: the conventions
+      // live in a skill inside the app, and the framework source lives in its
+      // node_modules, so launching the agent THERE is what puts either in
+      // reach. That is now the second sentence rather than a detail about
+      // which directory you happen to be in.
+      //
+      // A hand-back to the page is allowed here and nowhere else. The
+      // stand-alone rule protects readers arriving mid-page from a search
+      // result, and nobody arrives at a closing CTA cold.
+      lede: 'Run the command below, then start your coding agent inside the new app folder. The conventions, the demos, and the framework source are already in there.',
       primary: { href: DOCS_START_PATH, label: 'Get started' },
       // NOT a second docs link. This slot used to point at DOCS_PATH while the
       // primary pointed at DOCS_START_PATH, and /docs is a 308 to

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -299,7 +299,18 @@ export default function LandingPage() {
              breaking mid-word ("Conventions your agent f") even though the first
              sentence fits its line with 13px to spare. The max-width IS the line
              break, so greedy filling is what we want. -->
-        <h1 class="font-display font-extrabold text-[clamp(2.9rem,1.55rem+4.5vw,4.5rem)] leading-[1.02] tracking-[-0.038em] mx-auto mt-2 mb-6 max-w-[64rem]">
+        <!-- The clamp FLOOR is the thing to be careful with, not the max. It was
+             2.9rem (46.4px), which the preferred term reaches at a 476px viewport,
+             so every phone rendered the identical 46.4px and the size stopped
+             responding exactly where it mattered: 58 characters at 46.4px in a
+             342px box is 5 ragged lines and a 237px-tall headline. The floor is
+             now 1.75rem, reached only below 264px, so the size is genuinely fluid
+             across every real device. The slope was steepened to match, and the
+             cap trimmed to 4.125rem (66px), which still lands at ~1044px so the
+             desktop crossover point has not moved.
+             Re-measure line counts at 390 / 768 / 1440 before touching any of the
+             three numbers; they are chosen against the wrap points, not picked. -->
+        <h1 class="font-display font-extrabold text-[clamp(1.75rem,0.93rem+4.9vw,4.125rem)] leading-[1.02] tracking-[-0.038em] mx-auto mt-2 mb-6 max-w-[64rem]">
           Conventions your agent follows. Architecture you still own.
         </h1>
         <p class="text-lede leading-[1.55] text-fg-muted max-w-[62ch] mx-auto mb-9 text-pretty">

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -698,7 +698,7 @@ export default function LandingPage() {
              "Zero runtime dependencies" was dropped for length and is the thing
              to restore first if this ever gets more room. -->
 
-        <p class="mt-4 mx-auto max-w-3xl text-center text-base leading-[1.6] text-fg-muted">
+        <p class="mt-8 mx-auto max-w-3xl text-center text-base leading-[1.6] text-fg-muted">
           WebJs invents as little as possible. Routing follows Next.js file
           conventions, components follow lit's, and the rest is the platform, so
           what you know and what your agent was trained on both transfer. All of
@@ -909,7 +909,7 @@ db/schema.server.ts
              needs to name the folder and the action ("then try to read the
              framework in your last project's node_modules"), because "the same
              folder" pointed at a path that exists in no other app. -->
-        <p class="text-sm leading-[1.6] text-fg-subtle max-w-[68ch] mx-auto mt-6 mb-0 text-center text-pretty">
+        <p class="text-sm leading-[1.6] text-fg-subtle max-w-[68ch] mx-auto mt-8 mb-0 text-center text-pretty">
           Open <code class="font-mono text-sm bg-fg/8 px-1.5 py-0.5 rounded">node_modules/@webjsdev</code> in your app and read any of it.
         </p>
       </div>

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -342,11 +342,40 @@ export default function LandingPage() {
         <h1 class="font-display font-extrabold text-[clamp(1.75rem,0.93rem+4.9vw,4.125rem)] leading-[1.02] tracking-[-0.038em] mx-auto mt-2 mb-6 max-w-[64rem]">
           Conventions your agent follows. Architecture you still own.
         </h1>
+        <!-- Two sentences, 18 words, cut from 45. What went and why, because
+             each cut looks like a loss until you see what pays for it below.
+
+             "What your agent writes reaches the browser line for line, so it
+             debugs real code and you read exactly what runs" is the claim
+             "Nothing is compiled away" makes two sections down, with two code
+             windows and a server-action boundary as evidence. A demonstrated
+             claim beats a stated one, and stating it here spends the reveal.
+
+             "Conventions guide the first prompt to production-ready code, so
+             fewer tokens go to plumbing" said the mechanism rather than the
+             outcome, and token economy is the page's only mention of tokens.
+             Rails leads with token efficiency and can afford to, because its
+             subtitle never has to say what Rails is. Half of this one does.
+
+             An ownership clause was drafted twice ("everything it writes stays
+             yours to read and change") and cut twice: the H1's second half
+             already says it, and sections 4 and 5 both pay it off.
+
+             What is left is the definition, which an unknown framework cannot
+             skip, and one checkable outcome. "Starts WORKING on your feature"
+             rather than "starts on": the idiom can read as "begin at", and this
+             is the sentence a stranger reads before deciding to scroll. Both
+             wrap to two lines at 1440, so the extra word is free.
+
+             The break after the bold sentence is deliberate and costs nothing:
+             two lines either way at the same 64px, but 674 and 600 rather than
+             784 and 489, and the break lands on the sentence boundary instead
+             of mid-clause. The definition owns one line, the promise owns the
+             other. On a phone it is two lines each, breaking where the sentence
+             breaks rather than four lines running together. -->
         <p class="text-lede leading-[1.55] text-fg-muted max-w-[62ch] mx-auto mb-9 text-pretty">
-          <span class="text-fg font-medium">WebJs is a full-stack web components framework with no build step.</span>
-          Conventions guide the first prompt to production-ready code, so fewer
-          tokens go to plumbing. What your agent writes reaches the browser line
-          for line, so it debugs real code and you read exactly what runs.
+          <span class="text-fg font-medium">WebJs is a full-stack web components framework with no build step.</span><br>
+          Your agent starts working on your feature, not the scaffolding.
         </p>
         <div class="flex gap-3 justify-center flex-wrap items-center">
           <a class=${BTN_PRIMARY} href=${DOCS_START_PATH}>

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -938,7 +938,7 @@ middleware.ts</pre>
             <div class="cmd-foot pt-2 mt-auto font-mono text-xs leading-[1.6] text-fg-muted max-w-full min-w-0"><copy-cmd>npm create webjs@latest my-api -- --template api</copy-cmd></div>
           </div>
         </div>
-        <p class="mt-8 mx-auto max-w-3xl text-center text-base leading-[1.6] text-fg-muted">Light DOM components, Tailwind, Drizzle, a modules layout, and design tokens are wired before you write a line. Every one of them is a default, not a lock-in. Swap what does not suit you.</p>
+        <p class="mt-8 mx-auto max-w-3xl text-center text-base leading-[1.6] text-fg-muted">Light DOM components, Tailwind CSS, Drizzle ORM, a modules layout, and design tokens are wired before you write a line. Every one of them is a default, not a lock-in. Swap what does not suit you.</p>
         <!-- max-w-4xl, not the max-w-3xl every other lede uses. The line is 782px
              set solid and a 3xl box is 768px, so it wrapped by 14px, which put one
              trailing clause on a second line under a centred first. 4xl gives 114px

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -638,12 +638,24 @@ export default function LandingPage() {
              deliberate choice. Both halves are accurate: routing is the Next.js
              app/ tree, and the component API matches lit with reactive
              properties as the one documented divergence, which is why this says
-             "as little as possible" rather than "nothing". -->
+             "as little as possible" rather than "nothing".
+
+             Kept to TWO lines at max-w-3xl on a laptop, which is what the length
+             is tuned to. It was three, with "what your agent was trained on"
+             orphaned on the last one. The text sets solid at 1728px against a
+             768px box, so two lines want 864px each and roughly 30 characters
+             had to go: "the Next.js file conventions" lost its article,
+             "everything under them is the platform" became "the rest is the
+             platform", and the two transfer clauses merged into one. Measures
+             751 and 729 with 39px of tail slack. A tighter phrasing was
+             available at 751/749 and rejected, since 19px is one font
+             substitution away from wrapping again. Re-measure before changing a
+             word here. -->
+
         <p class="mt-4 mx-auto max-w-3xl text-center text-base leading-[1.6] text-fg-muted">
-          WebJs invents as little as possible. Routing follows the Next.js file
-          conventions, components follow lit's, and everything under them is the
-          platform, so what you already know transfers, and so does what your
-          agent was trained on.
+          WebJs invents as little as possible. Routing follows Next.js file
+          conventions, components follow lit's, and the rest is the platform, so
+          what you know and what your agent was trained on both transfer.
         </p>
       </div>
     </section>

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -374,11 +374,25 @@ export default function LandingPage() {
                  So the rule for this lede: claim nothing about another framework
                and nothing that needs a footnote about which configuration you are
                in. The chips below enumerate, the P.S. below runs the comparison
-               in the reader's own browser, and the prose only has to be true. -->
+               in the reader's own browser, and the prose only has to be true.
+
+               The term "progressive enhancement" comes LAST, after the three
+               concrete behaviours, and it is the one label allowed in here. Put
+               it first and a reader pattern-matches it to no-JS purism and skips
+               the section, which is a constraint they think they know rather
+               than a capability they can check. After the demonstration it is a
+               handle for what they just read, plus the phrase they would search
+               for, next to the brand name. That naming is also why this lede
+               says WebJs at all: nothing else in the section does, and someone
+               arriving here from a search result needs to know whose page this
+               is. "Here it is the default" said nothing to them. -->
+
           <p class="text-fg-muted text-base leading-[1.6] m-0">
             The server sends a finished page. It reads, its links navigate, and
             its forms submit before a single script runs. What loads afterwards
-            is only the components that are actually interactive.
+            is only the components that are actually interactive. That is
+            progressive enhancement, and with WebJs it is the default rather
+            than an effort.
           </p>
           <!-- The dare belongs to THIS section, whose chips below enumerate the
                very things it invites you to check. It stays a dare by naming

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -652,8 +652,7 @@ export default function LandingPage() {
              What the lede must keep carrying is the LAST sentence, the framework
              source readable in node_modules. That is the one claim in this
              section no card illustrates, and grepping the page shows this is its
-             only mention anywhere. -->
-
+             only mention anywhere.
 
              Every one of these is COPIED FROM A REAL SCAFFOLDED APP, not
              composed for the page. Verified by running webjs create then
@@ -665,7 +664,18 @@ export default function LandingPage() {
 
              (No backticks in here, per invariant 9: a backtick inside an html
              template body closes the literal at JS-parse time, comment or not.
-             This comment had two and took the page down until tsc caught it.) -->
+             This comment had two and took the page down until tsc caught it.
+
+             And exactly ONE closing marker, at the very end. Appending a
+             paragraph to a comment this long, it is easy to close it where your
+             new text stops, which ends the comment mid-block and renders
+             everything after it as visible page text. That shipped once. Note
+             the closing marker cannot be written out even here, since typing it
+             inside a comment is the very thing being warned about, so count the
+             markers instead: openers and closers must be equal in this file.
+             Neither tsc nor webjs check can see the mistake, because a
+             prematurely closed comment is still valid TS and valid HTML. The
+             only detector is looking at the page.) -->
         <div class="grid gap-4 grid-cols-1 wide:grid-cols-3 items-stretch">
           <div class="flex flex-col min-w-0">
             <p class="text-sm font-medium leading-[1.4] text-fg-subtle mb-2.5 ml-1">What arrives, and what leaves</p>

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -471,10 +471,30 @@ export default function LandingPage() {
                 <span class="hidden group-has-[:checked]/stage:inline">Show rendered</span>
               </label>
             </div>
-            <div class="flex-1 grid place-items-center px-6 py-10 group-has-[:checked]/stage:hidden">
-              <like-button count="3"></like-button>
+            <!-- Both states occupy the SAME grid cell (col-start-1 row-start-1),
+                 so the row is as tall as the taller of them and toggling cannot
+                 change the stage's height. They used to be flex siblings
+                 swapped with the hidden utility, which took the usage pane out
+                 of flow: on a phone, where the stage is stacked rather than
+                 side by side, pressing "Show usage" shrank the stage by 60px
+                 and pulled the whole page up under the reader's thumb.
+
+                 The invisible utility rather than hidden is what keeps the
+                 reserved height. It is also the accessible half:
+                 visibility:hidden drops the inactive pane out of the tab order
+                 and the accessibility tree, which an opacity-0 swap would not,
+                 and this pre carries tabindex 0 for its scroll region.
+
+                 (No backticks in here, invariant 9. Writing this comment with
+                 utility names in backticks is what broke the build a minute
+                 ago: a backtick inside an html template body closes the
+                 literal at parse time, comment or not.) -->
+            <div class="flex-1 grid min-w-0">
+              <div class="col-start-1 row-start-1 grid place-items-center px-6 py-10 group-has-[:checked]/stage:invisible">
+                <like-button count="3"></like-button>
+              </div>
+              <pre class="col-start-1 row-start-1 min-w-0 invisible group-has-[:checked]/stage:visible m-0 p-5 overflow-x-auto font-mono text-xs leading-[1.72] text-left" role="region" tabindex="0" aria-label="like-button usage"><code>${highlight(USAGE_SAMPLE)}</code></pre>
             </div>
-            <pre class="hidden group-has-[:checked]/stage:block flex-1 m-0 p-5 overflow-x-auto font-mono text-xs leading-[1.72] text-left" role="region" tabindex="0" aria-label="like-button usage"><code>${highlight(USAGE_SAMPLE)}</code></pre>
             <div class="px-4 py-3 border-t border-border text-center font-mono text-xs leading-[1.5] text-fg-subtle">
               Server-rendered first, then upgraded. Click it.
             </div>

--- a/website/components/copy-cmd.ts
+++ b/website/components/copy-cmd.ts
@@ -1,4 +1,4 @@
-import { WebComponent, html, signal, createRef, ref } from '@webjsdev/core';
+import { WebComponent, html, prop, signal, createRef, ref } from '@webjsdev/core';
 
 /**
  * gtag is installed by the root layout's Google tag snippet. Declaring it
@@ -33,6 +33,17 @@ declare global {
  * Usage:
  *   <copy-cmd>npm create webjs@latest my-app</copy-cmd>
  *
+ * The `inline` variant is for a command sitting INSIDE a sentence rather
+ * than in its own command bar:
+ *   Run <copy-cmd inline>bun create webjs@latest my-app</copy-cmd> to ...
+ *
+ * It renders a `<code>` chip carrying the site's inline-code styling with a
+ * small trailing icon, instead of the bar's absolutely-positioned button. The
+ * bar reserves `pr-9` for that button and the host is `display: block`
+ * (app/layout.ts), both of which would push the chip onto its own line and
+ * put a 28px bordered button in the middle of a 22px line of prose. The whole
+ * chip is the click target here, so the affordance is the chip itself.
+ *
  * On click (or Enter / Space), writes the trimmed text content to the
  * clipboard via navigator.clipboard.writeText and flips the icon to a
  * checkmark for ~1.5s.
@@ -42,7 +53,14 @@ declare global {
  * addEventListener in lifecycle hooks. Cleanup of the auto-reset
  * timer happens in disconnectedCallback.
  */
-export class CopyCmd extends WebComponent {
+export class CopyCmd extends WebComponent({
+  /**
+   * Renders the in-a-sentence chip instead of the command bar. A plain
+   * attribute (`<copy-cmd inline>`), so SSR emits it and the host CSS in
+   * app/layout.ts can select it to undo the block display.
+   */
+  inline: prop(Boolean),
+}) {
   copied = signal(false);
   // Increments on every successful copy. The live-region text is keyed off its
   // parity so a repeat copy within the reset window still changes the text node
@@ -100,6 +118,25 @@ export class CopyCmd extends WebComponent {
     // repeat copy (forcing a re-announce). trim() still yields "Copied", so a
     // screen reader reads the same word and assertions stay simple.
     const announce = isCopied ? (this._copies.get() % 2 ? 'Copied ' : 'Copied') : '';
+    if (this.inline) {
+      // The icon sits INSIDE the [data-copy-text] target, which is safe because
+      // an svg contributes no text nodes: _copy reads textContent and still gets
+      // exactly the command. Keeping it inside is what lets the chip be one
+      // unbreakable inline unit (whitespace-nowrap), so the background box can
+      // never split across two lines mid-command.
+      return html`
+        <code
+          class="font-mono text-sm bg-fg/8 px-1.5 py-0.5 rounded whitespace-nowrap cursor-copy outline-none focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2"
+          data-copy-text
+          ${ref(this._textRef)}
+          role="button"
+          tabindex="0"
+          title="Copy command to clipboard"
+          @click=${this._copy}
+          @keydown=${this._onKey}
+        ><slot></slot><span class="inline-block ml-1.5 align-[-0.15em] transition-colors duration-[140ms] ${isCopied ? 'text-[oklch(0.66_0.16_150)]' : 'text-fg-subtle'}" aria-hidden="true">${isCopied ? CHECK_ICON : COPY_ICON}</span></code><span class="sr-only" role="status" aria-live="polite">${announce}</span>
+      `;
+    }
     return html`
       <span class="group relative flex items-center min-w-0">
         <span

--- a/website/lib/design/recipes.ts
+++ b/website/lib/design/recipes.ts
@@ -86,6 +86,29 @@ export const READING = 'max-w-210 mx-auto px-6';
 export const SECTION = 'py-16';
 
 /**
+ * The marketing section's vertical rhythm, in one place because it is four
+ * numbers that have to agree across every section on a page and there is no
+ * single element that owns them.
+ *
+ *   section padding      py-16   64px, the SECTION recipe above
+ *   heading to lede      my-3    12px, from the H2 recipe's own margin
+ *   header to artifact   mb-12   48px, on the centered header block
+ *   artifact to closer   mt-8    32px, the FIRST trailing paragraph
+ *   closer to closer     mt-6    24px, every one after that
+ *
+ * The last two are the ones that drift, because a closing sentence is added
+ * one section at a time and each author picks a margin by eye. The landing
+ * page had 16, 24, 32 and 24 across four closers before this was written down.
+ * If a section needs a different value, it needs a reason in a comment.
+ *
+ * Deliberate exception: a closing line that sits INSIDE the header block,
+ * above the artifact rather than below it, is not this pattern. The landing
+ * page's JavaScript-off P.S. is the only one, at mt-5.
+ */
+export const CLOSER = 'mt-8';
+export const CLOSER_NEXT = 'mt-6';
+
+/**
  * A small uppercase label: window chrome, card kickers, sidebar section names.
  *
  * Built from Tailwind's own steps rather than a custom size. A token one pixel

--- a/website/lib/samples.ts
+++ b/website/lib/samples.ts
@@ -69,3 +69,47 @@ export const SSR_OUTPUT = `<!-- what the browser receives, before any JS -->
      an interaction actually needs it. -->`;
 
 export const USAGE_SAMPLE = `<like-button count="3"></like-button>`;
+
+/**
+ * The two framework-source windows, VERBATIM from the packages that ship to
+ * every app's node_modules. Contiguous, unedited, de-indented only. That
+ * fidelity is the argument the section makes, so a reworded excerpt would be
+ * a claim ABOUT readable source rather than a sample of it. Re-derive them
+ * from the files rather than hand-editing here.
+ *
+ * Both were chosen against three constraints:
+ *   1. The comment explains WHY, not what. That is the half a build step
+ *      destroys and the half an agent needs.
+ *   2. No backtick anywhere, per invariant 9, which rules out most of the
+ *      codebase's JSDoc.
+ *   3. Code-dominant. The first core pick was 5 comment lines to 4 of code
+ *      and read as documentation rather than as the source that runs, which
+ *      is the opposite of the point. Aim for 3 comment to 7 code or better.
+ *      That pick also STARTED MID-SENTENCE, because its comment opened two
+ *      lines earlier on a line containing backticks. Check that an excerpt
+ *      begins where its comment does.
+ *   4. At most 69 columns. Real source runs to 78 at p90, and a two-up card
+ *      at the 1152px grid holds 74 at 12px, so most of the codebase simply
+ *      does not fit beside itself. Check the width before swapping either.
+ */
+export const CORE_SOURCE_SAMPLE = `// Dispose the signal watcher so dependency edges drop. Without
+// this the element holds references to module-scope signals
+// (and vice versa) forever.
+if (this.__signalWatcher) {
+  this.__signalWatcher.dispose();
+  this.__signalWatcher = undefined;
+}
+for (const c of this.__controllers) {
+  if (c.hostDisconnected) c.hostDisconnected();
+}`;
+
+export const SERVER_SOURCE_SAMPLE = `// 103 Early Hints: before running SSR, send preload hints for the
+// page's module URLs so the browser can begin fetching them while
+// the server is still computing the body. Skipped in dev (file churn
+// would send stale URLs after rebuilds) and for non-GET/HEAD.
+if (
+  !dev &&
+  (req.method === 'GET' || req.method === 'HEAD') &&
+  typeof res.writeEarlyHints === 'function'
+) {
+  const match = app.routeFor(url.pathname);`;

--- a/website/lib/samples.ts
+++ b/website/lib/samples.ts
@@ -26,9 +26,9 @@ import { eq } from 'drizzle-orm';
 import { db } from '#db/connection.server.ts';
 import { posts } from '#db/schema.server.ts';
 
-// Import this from a page or component. WebJs
-// rewrites the import into a typed RPC stub (the
-// real call at SSR). No fetch by hand.
+// Import this from a page or component. In the
+// browser the import becomes an RPC call. On the
+// server it is just this function. No fetch by hand.
 export async function getPost(id) {
   const [post] = await db.select()
     .from(posts)

--- a/website/lib/samples.ts
+++ b/website/lib/samples.ts
@@ -26,11 +26,13 @@ import { eq } from 'drizzle-orm';
 import { db } from '#db/connection.server.ts';
 import { posts } from '#db/schema.server.ts';
 
-// Import this from a page or component. WebJs rewrites
-// the import into a typed RPC stub (the real call at SSR). No
-// fetch by hand.
+// Import this from a page or component. WebJs
+// rewrites the import into a typed RPC stub (the
+// real call at SSR). No fetch by hand.
 export async function getPost(id) {
-  const [post] = await db.select().from(posts).where(eq(posts.id, id));
+  const [post] = await db.select()
+    .from(posts)
+    .where(eq(posts.id, id));
   return post;
 }`;
 

--- a/website/public/input.css
+++ b/website/public/input.css
@@ -79,7 +79,14 @@
 
   --text-display: clamp(2.9rem, 1.55rem + 4.5vw, 5.5rem);
   --text-h2:      clamp(1.7rem, 1.2rem + 1.4vw, 2.5rem);
-  --text-lede:    clamp(1.08rem, 0.98rem + 0.4vw, 1.28rem);
+  /* The lede step. Raised from a 1.28rem cap: at 20.5px against a 66px h1 the
+     hero subtitle sat at 0.31 of the headline and read as body copy rather
+     than as the second voice. 1.4rem puts it at 0.34.
+
+     The line count does not move with it, because every lede on the site is
+     measured in ch (max-w-[62ch] on the landing hero), so the box grows with
+     the type. Verified 2 lines at 1.28 through 1.5rem before picking. */
+  --text-lede:    clamp(1.08rem, 0.98rem + 0.5vw, 1.4rem);
 
   /* Documentation-page type scale. The docs run a tighter heading rhythm than
      the marketing pages (a reference page wants a calm h1, not a hero), so

--- a/website/public/input.css
+++ b/website/public/input.css
@@ -79,14 +79,26 @@
 
   --text-display: clamp(2.9rem, 1.55rem + 4.5vw, 5.5rem);
   --text-h2:      clamp(1.7rem, 1.2rem + 1.4vw, 2.5rem);
-  /* The lede step. Raised from a 1.28rem cap: at 20.5px against a 66px h1 the
-     hero subtitle sat at 0.31 of the headline and read as body copy rather
-     than as the second voice. 1.4rem puts it at 0.34.
+  /* The lede step, raised from an original 1.28rem cap. At 20.5px against a
+     66px h1 the hero subtitle sat at 0.31 of the headline and read as body
+     copy rather than as the second voice. It is 0.42 now.
 
-     The line count does not move with it, because every lede on the site is
-     measured in ch (max-w-[62ch] on the landing hero), so the box grows with
-     the type. Verified 2 lines at 1.28 through 1.5rem before picking. */
-  --text-lede:    clamp(1.08rem, 0.98rem + 0.5vw, 1.4rem);
+     Measured at all three sizes rather than at the one being reviewed:
+     390px 20.8px / 5 lines, 768px 23.7px / 3, 1280px 27.8px / 2, 1440px
+     28.8px. The install bar stays above the fold on a 390x844 phone, at
+     593px of 844.
+
+     The min matters as much as the max here, and for opposite reasons. The
+     landing hero measures in ch (max-w-[62ch]), so on a desktop the box grows
+     WITH the type and the line count never moves however far the max goes. On
+     a phone the viewport caps the box first, so the min is the only term that
+     changes anything, and raising it from 1.08 to 1.3rem is what took the
+     subtitle from four lines to five. That was accepted, not missed.
+
+     Shared with /what-is-webjs, /why-webjs and /brand, whose ledes are longer
+     and therefore feel a raise more: /why-webjs runs to 7 lines at 768px.
+     Check those three, not just the landing page, after any change here. */
+  --text-lede:    clamp(1.3rem, 1.1rem + 0.8vw, 1.8rem);
 
   /* Documentation-page type scale. The docs run a tighter heading rhythm than
      the marketing pages (a reference page wants a calm h1, not a hero), so

--- a/website/public/input.css
+++ b/website/public/input.css
@@ -98,7 +98,7 @@
      Shared with /what-is-webjs, /why-webjs and /brand, whose ledes are longer
      and therefore feel a raise more: /why-webjs runs to 7 lines at 768px.
      Check those three, not just the landing page, after any change here. */
-  --text-lede:    clamp(1.3rem, 1.1rem + 0.8vw, 1.8rem);
+  --text-lede:    clamp(1.1rem, 0.96rem + 0.8vw, 1.6rem);
 
   /* Documentation-page type scale. The docs run a tighter heading rhythm than
      the marketing pages (a reference page wants a calm h1, not a hero), so

--- a/website/public/input.css
+++ b/website/public/input.css
@@ -79,26 +79,18 @@
 
   --text-display: clamp(2.9rem, 1.55rem + 4.5vw, 5.5rem);
   --text-h2:      clamp(1.7rem, 1.2rem + 1.4vw, 2.5rem);
-  /* The lede step, raised from an original 1.28rem cap. At 20.5px against a
-     66px h1 the hero subtitle sat at 0.31 of the headline and read as body
-     copy rather than as the second voice. It is 0.42 now.
+  /* Two lede steps, because the landing hero and a page lede are not the same
+     role and were fighting over one number. The hero wants to be half the
+     headline; a page lede wants to be readable at 6 lines.
 
-     Measured at all three sizes rather than at the one being reviewed:
-     390px 20.8px / 5 lines, 768px 23.7px / 3, 1280px 27.8px / 2, 1440px
-     28.8px. The install bar stays above the fold on a 390x844 phone, at
-     593px of 844.
+     --text-hero-lede is sized against the H1 rather than by eye. Its ceiling
+     is the point where the subtitle's balanced lines stop reading narrower
+     than the title's longest line, which is what "it feels wider" meant.
 
-     The min matters as much as the max here, and for opposite reasons. The
-     landing hero measures in ch (max-w-[62ch]), so on a desktop the box grows
-     WITH the type and the line count never moves however far the max goes. On
-     a phone the viewport caps the box first, so the min is the only term that
-     changes anything, and raising it from 1.08 to 1.3rem is what took the
-     subtitle from four lines to five. That was accepted, not missed.
-
-     Shared with /what-is-webjs, /why-webjs and /brand, whose ledes are longer
-     and therefore feel a raise more: /why-webjs runs to 7 lines at 768px.
-     Check those three, not just the landing page, after any change here. */
-  --text-lede:    clamp(1.1rem, 0.96rem + 0.8vw, 1.6rem);
+     Both are fluid: the MIN term is not the operative one on a phone (at 390px
+     the preferred term runs), so tune the slope, not the min. */
+  --text-hero-lede: clamp(1.1rem, 0.83rem + 1.34vw, 1.9rem);
+  --text-lede:    clamp(1.15rem, 1rem + 0.6vw, 1.5rem);
 
   /* Documentation-page type scale. The docs run a tighter heading rhythm than
      the marketing pages (a reference page wants a calm h1, not a hero), so

--- a/website/test/components/browser/copy-cmd.test.js
+++ b/website/test/components/browser/copy-cmd.test.js
@@ -266,6 +266,73 @@ suite('copy-cmd', () => {
     }
   });
 
+  suite('inline variant', () => {
+    const mountInline = async (text) => {
+      const el = document.createElement('copy-cmd');
+      el.setAttribute('inline', '');
+      el.textContent = text;
+      document.body.appendChild(el);
+      await el.updateComplete;
+      return el;
+    };
+
+    test('renders a code chip and NOT the bar button', async () => {
+      const el = await mountInline('bun create webjs@latest my-app');
+      const target = el.querySelector('[data-copy-text]');
+      assert.ok(target, 'a [data-copy-text] click target is rendered');
+      assert.equal(target.tagName, 'CODE', 'the inline chip is a <code>, keeping the command semantic');
+      // The counterfactual for the whole variant: the bar renders an absolutely
+      // positioned <button> and reserves pr-9 for it, and BOTH would wreck a
+      // line of prose. If the inline branch is deleted, this fails.
+      assert.equal(el.querySelector('button'), null, 'no absolutely positioned bar button inline');
+      assert.ok(!target.className.includes('pr-9'), 'no pr-9 button reservation inline');
+      assert.ok(target.className.includes('whitespace-nowrap'), 'the chip is one unbreakable unit');
+      assert.ok(
+        target.textContent.includes('bun create webjs@latest my-app'),
+        'the slotted command is projected into the chip',
+      );
+      el.remove();
+    });
+
+    test('clicking the chip copies the command', async () => {
+      const el = await mountInline('   bun create webjs@latest my-app   ');
+      el.querySelector('[data-copy-text]').click();
+      await tick(10);
+      await el.updateComplete;
+      // The icon lives INSIDE the copy target here, so this also proves the svg
+      // contributes no text: an untrimmed or icon-polluted read would not equal
+      // the command exactly.
+      assert.equal(written, 'bun create webjs@latest my-app', 'the exact command was written to the clipboard');
+      assert.ok(el.querySelector('polyline'), 'the inline icon flipped to the checkmark');
+      assert.equal(el.querySelector('rect'), null, 'the copy icon is gone after copy');
+      assert.equal(
+        el.querySelector('[role="status"]').textContent.trim(),
+        'Copied',
+        'the live region announces to assistive tech inline too',
+      );
+      el.remove();
+    });
+
+    test('keyboard activation copies inline too', async () => {
+      const el = await mountInline('bun create webjs@latest my-app');
+      const target = el.querySelector('[data-copy-text]');
+      assert.equal(target.getAttribute('role'), 'button', 'the chip is exposed as a button');
+      assert.equal(target.getAttribute('tabindex'), '0', 'the chip is reachable by keyboard');
+      target.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      await tick(10);
+      await el.updateComplete;
+      assert.equal(written, 'bun create webjs@latest my-app', 'Enter triggers a copy inline');
+      el.remove();
+    });
+
+    test('renders no generated ids inline either (ETag guard)', async () => {
+      const a = await mountInline('bun create webjs@latest my-app');
+      const b = await mountInline('bun create webjs@latest my-app');
+      assert.equal(a.innerHTML, b.innerHTML, 'two inline renders of the same command emit identical markup');
+      a.remove(); b.remove();
+    });
+  });
+
   test('the checkmark resets back to the copy icon', async () => {
     const el = await mount('npm create webjs@latest my-app');
     el.querySelector('[data-copy-text]').click();


### PR DESCRIPTION
Rebuilds the landing page as one argument rather than a list of features, and fixes what fact-checking turned up along the way.

## The argument

Six sections, each proving the same claim about a different layer: the browser is not kept waiting, a build does not stand between your file and the wire, the scaffold is readable rather than magic, the framework itself is openable, and the same holds with no frontend at all. The hero now states that thesis, so every section below is evidence for it:

> **Conventions your agent follows. Architecture you still own.**
> **WebJs is a full-stack web components framework with no build step.**
> Nothing is hidden from your agent, or from you.

45 words to 21.

## Four claims that were false

Each was checked against the source rather than reasoned about, and each had survived because it *sounded* like the argument.

1. **"A first paint is only honest if what you wrote is what shipped."** Whether the first paint is complete and whether the shipped bytes match your source are unrelated properties. A Rails or PHP app with a bundled frontend has a perfectly honest first paint.
2. **"Everything below falls out of the decision to skip the build step."** False of five of the six cards under it. File routing, server actions, streaming, auth and the caching set all exist in frameworks that do build.
3. **"Here is a server action and the page that calls it, both served to the browser exactly as they sit on disk."** The action is a `'use server'` `.server.ts`. It never reaches the browser at all, and its import is rewritten to an RPC stub. That is invariant 1, denied by the framework's own landing page.
4. **"The runtime has to load, parse, and hydrate before the page can be read at all."** Next server-renders client components too (`use-flight-response.tsx` feeds the Flight stream through `createFromReadableStream` with an `ssrModuleMapping`), so its HTML reads immediately.

Also corrected: "Memory store in dev, Redis when you configure one" implied production picks something else on its own. With no `setStore()` call, production runs the memory store too.

## New section

**The framework source is in your own project.** It had been one trailing clause at the end of another lede. Two windows, `@webjsdev/core` and `@webjsdev/server`, showing contiguous unedited source, chosen by script against three filters: the comment explains *why* rather than what, no backtick anywhere (invariant 9), and under 69 columns.

## Layout and type

- The hero stage no longer resizes when "Show usage" is toggled. Both panes share a grid cell, so the page cannot jump under a reader's thumb on a phone.
- Section closers had run 16 / 24 / 32 / 24px with no rule. The rhythm is now written into `recipes.ts` with all four numbers together.
- Hero typography follows the rubyonrails.org model, read off their live CSS: `text-wrap: balance` doing the breaking rather than hand-placed markup. That replaced a hand-tuned system that took six rounds to converge and would have broken on the next word change.
- The headline breaks at its sentence at every width, and the type curve is fitted to what that break costs on a phone.

## Verification

`npm run typecheck` clean, `webjs check` clean, 471/471 server tests, browser suite green. Every layout claim in the commit messages was measured in a real browser at 320 / 390 / 768 / 1280 / 1440 rather than reasoned about.
