### PR TITLE
docs(website): retitle for the category, and cut a claim that was false

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ components.** It server-renders every page and component to real HTML,
 needs no build step or bundler, and runs on Node 24+ or Bun.
 
 Nothing is hidden from your agent. The framework ships in `node_modules` as
-plain JavaScript it can read end to end, and your app code is served to the
-browser exactly as written. Any model reasons about the whole stack and debugs it,
-with no training data required and no single blessed model, on the web
-components and standard HTML every model already knows.
+plain JavaScript, so an agent opens the router or the renderer it is calling
+instead of recalling an API from training data, and your app code is served to
+the browser exactly as written. Any model debugs the running app against the
+real source, with no single blessed model, on the web components and standard
+HTML every model already knows.
 
 **AI-first is a design constraint here, not a marketing tag.** File
 conventions are predictable, each server function lives in its own file, and

--- a/website/app/layout.ts
+++ b/website/app/layout.ts
@@ -21,8 +21,29 @@ import { brandLockup } from '#lib/design/brand.ts';
  * lib/links.ts, imported here and by app/page.ts.
  */
 
-const TITLE = 'WebJs - The Web Framework for AI Agents';
-const DESCRIPTION = 'An AI-first full-stack web framework built on web components, SSR, and progressive enhancement, with zero build step. Lean enough for AI agents to read end to end. File-based routing, server actions, and streaming SSR on web standards. Runs on Node 24+ or Bun.';
+// The title carries the CATEGORY, because that is what people type. The old
+// one named neither "web components" nor "build step", so the phrase this
+// whole site is built around matched nothing in the strongest on-page signal
+// there is. The H1 stays the positioning claim: it is a minor ranking signal
+// and the only line that differentiates us, and the definition sentence sits
+// in bold directly beneath it either way. 56 characters, inside the SERP
+// truncation limit, brand first. The separator is a colon rather than the
+// spaced hyphen the old title used, per invariant 11.
+const TITLE = 'WebJs: Full-stack web components framework, no build step';
+// 155 characters, against 256 before. Google renders about 160, so a third of
+// the old one was never shown to anyone.
+//
+// It also carried a false claim: "Lean enough for AI agents to read end to
+// end". packages/core/src alone is 23,465 lines and core plus server is
+// 50,511, so nothing reads it end to end and none of it "fits in context".
+// That sentence outlived the "Light enough for AI" section it was written for,
+// because a section gets reviewed and metadata does not, and it was live in
+// every search result.
+//
+// The true version of that idea is about LOCATION, not volume: the source sits
+// in the app's own node_modules at the installed version, so an agent opens
+// the file it needs instead of recalling an API from training data.
+const DESCRIPTION = 'A full-stack web components framework with no build step, built for AI agents. Server-rendered pages, server actions, and file-based routing. Node 24+ or Bun.';
 
 const NAV = [
   { label: 'Docs', href: DOCS_START_PATH, ext: false },

--- a/website/app/llms.txt/route.ts
+++ b/website/app/llms.txt/route.ts
@@ -56,7 +56,7 @@ export async function GET(): Promise<Response> {
     '',
     '> An AI-first, web-components-first full-stack web framework with no build step. Pages are server-rendered and progressively enhanced; components are native custom elements that hydrate as islands. Server actions give typed client-to-server RPC. Runs on Node 24+ or Bun.',
     '',
-    'WebJs is inspired by Next.js, Lit, and Rails, but ships its own no-build runtime: TypeScript is stripped at load, ES modules are served directly, and the view layer is web components rather than React. It is designed to be read end to end by AI coding agents: because it is no-build and self-contained, its own readable source is the context a model needs, with no training data required. It works with any assistant through one cross-agent contract, and scaffolds a production-shaped app from the first command.',
+    'WebJs is inspired by Next.js, Lit, and Rails, but ships its own no-build runtime: TypeScript is stripped at load, ES modules are served directly, and the view layer is web components rather than React. Its own source ships uncompiled in node_modules, so a coding agent opens the file it is calling at the version installed, rather than recalling an API from training data. It works with any assistant through one cross-agent contract, and scaffolds a production-shaped app from the first command.',
     '',
     'Key facts:',
     "- Agent-agnostic: a single cross-agent `AGENTS.md` contract drives Claude, Cursor, Copilot, Gemini, and others, not one vendor's assistant.",

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -655,7 +655,7 @@ export default function LandingPage() {
                means typed at author time, which is right for a reference doc
                and misleading in a sentence whose subject is what ships. -->
 
-          <p class="text-fg-muted text-base leading-[1.6] m-0">The file in your editor and the file in the browser network tab are the same file. Here is a server action and the page that calls it. The page ships as you see it, because there is no build step. The action never ships at all, and its import becomes an RPC call. Rails has shipped its default frontend without a bundler since Rails 7 in 2021, so the approach has production miles behind it.</p>
+          <p class="text-fg-muted text-base leading-[1.6] m-0">The file in your editor and the file in the browser network tab are the same file. Here is a server action and the page that calls it. The page ships as you see it, because there is no build step. TypeScript is stripped to whitespace rather than compiled, so a stack trace points at the line you wrote. The action becomes an RPC call. Rails has shipped its default frontend without a bundler since Rails 7 in 2021, so the approach has production miles behind it.</p>
         </div>
         <div class="grid gap-6 grid-cols-1 md:grid-cols-2 max-w-5xl mx-auto">
           <div class="flex flex-col min-w-0">

--- a/website/app/what-is-webjs/page.ts
+++ b/website/app/what-is-webjs/page.ts
@@ -178,7 +178,7 @@ const PROSE = 'text-fg-muted text-base leading-[1.7] m-0';
 // "and what does it actually give me", in concrete nouns rather than adjectives.
 const CAPABILITIES = [
   {
-    title: 'AI-first, in the file conventions',
+    title: 'AI-first, readable end to end',
     body: 'Predictable file conventions and an explicit .server.ts boundary decide the shape of an app, so an agent edits one route without reading the whole app, and Build me an app is the whole prompt. Every app ships an AGENTS.md contract that Claude Code, Cursor, Copilot, Gemini, and opencode read from one source, and the framework itself is plain JavaScript with JSDoc in node_modules rather than a compiled bundle.',
   },
   {

--- a/website/app/what-is-webjs/page.ts
+++ b/website/app/what-is-webjs/page.ts
@@ -178,7 +178,7 @@ const PROSE = 'text-fg-muted text-base leading-[1.7] m-0';
 // "and what does it actually give me", in concrete nouns rather than adjectives.
 const CAPABILITIES = [
   {
-    title: 'AI-first, readable end to end',
+    title: 'AI-first, in the file conventions',
     body: 'Predictable file conventions and an explicit .server.ts boundary decide the shape of an app, so an agent edits one route without reading the whole app, and Build me an app is the whole prompt. Every app ships an AGENTS.md contract that Claude Code, Cursor, Copilot, Gemini, and opencode read from one source, and the framework itself is plain JavaScript with JSDoc in node_modules rather than a compiled bundle.',
   },
   {
@@ -245,11 +245,11 @@ export default function WhatIsWebJs() {
         </p>
         <p class="text-base leading-[1.7] text-fg-muted max-w-[56ch] mx-auto mb-8 text-pretty">
           Nothing is hidden from your agent. The framework ships in node_modules as plain
-          JavaScript it can read end to end, and your app code is served to the browser
-          exactly as written. Any model
-          reasons about the whole stack and debugs it, with no training data required and no
-          single blessed model, on the web components and standard HTML every model already
-          knows.
+          JavaScript, so an agent opens the router or the renderer it is calling instead of
+          recalling an API from training data, and your app code is served to the browser
+          exactly as written. Any model debugs the running app against the real source, with
+          no single blessed model, on the web components and standard HTML every model
+          already knows.
         </p>
         <div class="flex gap-3 justify-center flex-wrap mb-8">
           <a class=${BTN_PRIMARY} href=${DOCS_START_PATH}>

--- a/website/app/why-webjs/page.ts
+++ b/website/app/why-webjs/page.ts
@@ -116,10 +116,10 @@ export default function Why() {
       <p class="text-lede leading-[1.6] text-fg-muted max-w-[56ch] mx-auto mb-8 text-pretty">
         WebJs is a full-stack JavaScript framework with no build step, so
         nothing is hidden from your agent. The framework ships in node_modules as
-        plain JavaScript it can read end to end, and your app code is served to
-        the browser exactly as written. Any model reasons about the whole stack
-        and debugs it, with no training data required and no single blessed
-        model, on the web components and standard HTML every model already knows.
+        plain JavaScript, so an agent opens the file it is calling instead of
+        recalling an API from training data, and your app code is served to the
+        browser exactly as written. Any model debugs the running app against the
+        real source, on the web components and standard HTML it already knows.
       </p>
       <div class="flex gap-3 justify-center flex-wrap mb-8">
         <a class=${BTN_PRIMARY} href=${DOCS_START_PATH}>
@@ -140,7 +140,8 @@ export default function Why() {
           <p class="text-fg-muted text-base leading-[1.6] m-0">
             No build step means two things, and both help your agent. The
             framework itself sits in node_modules as plain JavaScript with JSDoc,
-            so an agent reads it end to end and fits it into context. And your own
+            so an agent opens the file it needs at the version you installed,
+            rather than recalling an API from training data. And your own
             app code is served to the browser exactly as written, so the agent
             debugs the running app against the real source, never a bundled or
             minified artifact.

--- a/website/app/why-webjs/page.ts
+++ b/website/app/why-webjs/page.ts
@@ -64,7 +64,7 @@ const REASONS = [
   },
   {
     title: 'No training data required',
-    body: 'An agent does not need to have seen WebJs before. It fits the framework source into its context window, learns the real API from the code, and starts producing correct output. New model, same result, because the source is the documentation.',
+    body: 'An agent does not need to have seen WebJs before. It opens the file it is calling in node_modules, learns the real API from the code, and starts producing correct output. New model, same result, because the source is the documentation.',
   },
   {
     title: 'Standard HTML and JavaScript',


### PR DESCRIPTION
Two problems, both in text nobody re-reads.

## The title named neither keyword

```
WebJs - The Web Framework for AI Agents
```

No "web components." No "build step." The phrase the whole site is built around matched nothing in the strongest on-page signal there is, and it is what renders as the SERP headline.

```
WebJs: Full-stack web components framework, no build step
```

57 characters, inside the truncation limit, brand first.

**The H1 deliberately stays the positioning claim** ("Conventions your agent follows. Architecture you still own."). It is a minor ranking signal, it is the only line that differentiates us from any other framework in the category, and the definition sentence sits in bold directly beneath it either way.

## The description was false

> Lean enough for AI agents to read end to end.

`packages/core/src` alone is 23,465 lines; core plus server is 50,511. Nothing reads it end to end and none of it "fits in context." That sentence outlived the "Light enough for AI" section it was written for, because a section gets reviewed and metadata does not, and it was live in every search result.

It is also 155 characters now against 256, so a third of the old one was never rendered.

## The same claim had spread

All rewritten to the version that holds, which is about **location** rather than volume: the source sits in `node_modules` at the installed version, so an agent opens the file it is calling instead of recalling an API from training data.

| where | what it said |
|---|---|
| `/what-is-webjs` | the shared "nothing is hidden" paragraph, plus a capability titled *"AI-first, readable end to end"* whose own body says an agent edits one route **without** reading the whole app |
| `/why-webjs` | the hero, and "an agent reads it end to end and fits it into context" |
| `README.md` | the same shared paragraph |
| `llms.txt` | "designed to be read end to end by AI coding agents … its own readable source is the context a model needs", which is the file AI crawlers actually read |

**Left alone:** "trace a bug end to end without leaving the repo" and "Type safety, end to end" on `/why-webjs`. Those are the other sense of the phrase, following a path through the stack, and both are true.

## Verification

`npm run typecheck` clean, `webjs check` clean, 471/471 server, browser suite green. Booted the site and confirmed the rendered `<title>`, the `<meta name="description">`, and zero occurrences of the old claim across `/`, `/what-is-webjs`, `/why-webjs`, and `/llms.txt`.
