### PR TITLE
docs(website): update the footer, a card title, and the demo caption

### DIFF
--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -600,7 +600,7 @@ export default function LandingPage() {
               <pre class="col-start-1 row-start-1 min-w-0 invisible group-has-[:checked]/stage:visible m-0 p-5 overflow-x-auto font-mono text-xs leading-[1.72] text-left" role="region" tabindex="0" aria-label="like-button usage"><code>${highlight(USAGE_SAMPLE)}</code></pre>
             </div>
             <div class="px-4 py-3 border-t border-border text-center font-mono text-xs leading-[1.5] text-fg-subtle">
-              Server-rendered first, then upgraded. Click it.
+              Server-rendered, then upgraded. Click it.
             </div>
           </div>
         </div>

--- a/website/app/what-is-webjs/page.ts
+++ b/website/app/what-is-webjs/page.ts
@@ -178,7 +178,7 @@ const PROSE = 'text-fg-muted text-base leading-[1.7] m-0';
 // "and what does it actually give me", in concrete nouns rather than adjectives.
 const CAPABILITIES = [
   {
-    title: 'AI-first, readable end to end',
+    title: 'AI-first, one route at a time',
     body: 'Predictable file conventions and an explicit .server.ts boundary decide the shape of an app, so an agent edits one route without reading the whole app, and Build me an app is the whole prompt. Every app ships an AGENTS.md contract that Claude Code, Cursor, Copilot, Gemini, and opencode read from one source, and the framework itself is plain JavaScript with JSDoc in node_modules rather than a compiled bundle.',
   },
   {

--- a/website/lib/ui/site-footer.ts
+++ b/website/lib/ui/site-footer.ts
@@ -59,7 +59,7 @@ export function siteFooter() {
           </div>
           <div class="flex flex-col gap-3">
             <a href="/" aria-label="WebJs home" class="no-underline text-fg inline-flex w-fit transition-opacity duration-150 hover:opacity-80">${brandLockup('ftr', { height: 26 })}</a>
-            <p class="m-0 text-xs text-fg-muted leading-relaxed">The web framework for AI agents. Full-stack web components, SSR, zero build step.</p>
+            <p class="m-0 text-xs text-fg-muted leading-relaxed">A full-stack web components framework with no build step. Server-rendered, with its own source in your node_modules.</p>
           </div>
         </nav>
         <div class="pt-8 border-t border-border flex flex-col md:flex-row justify-between items-center gap-4 text-fg-subtle text-xs">


### PR DESCRIPTION
Three small copy fixes, all found by reading the site against the positioning that landed in #1402 and #1403.

## The footer was carrying the retired title

```
The web framework for AI agents. Full-stack web components, SSR, zero build step.
```

That is the line the `<title>` dropped in #1403, and "zero build step" is the one place on the site that does not say "no build step".

```
A full-stack web components framework with no build step.
Server-rendered, with its own source in your node_modules.
```

Naming `node_modules` is the point. "Readable by the agent that wrote it" was the first draft, and it states a property without saying where the source is, which is the entire claim.

## A card title that disclaimed itself

`/what-is-webjs` led with **"AI-first, readable end to end"** while its own body says an agent "edits one route **without** reading the whole app". Now **"AI-first, one route at a time"**, which is what the paragraph beneath it actually argues.

## The hero demo caption wrapped on a phone

"Server-rendered **first**, then upgraded. Click it." is 338px of 12px mono in a 313px box on a 393px phone, so it took two lines. Dropping "first", which "then" already implies, brings it to 295px and one line.

Below about 380px it still wraps. Nothing with a call to action fits a 320px box there, so that is left alone.

## Verification

`npm run typecheck` clean, `webjs check` clean, 471/471. Every width above was measured in a browser at 320 / 375 / 393, not estimated.
