### PR TITLE
docs: index the skill and gallery by intent, not feature name

### DIFF
--- a/.agents/skills/webjs/SKILL.md
+++ b/.agents/skills/webjs/SKILL.md
@@ -33,9 +33,44 @@ WebJs is an AI-first, web-components-first framework with **no build step**: sou
 - Answering "how should this be structured in WebJs?"
 - Finding the right export, reference doc, or default pattern for a task
 
+## Reach For The Right Primitive
+
+Scan this BEFORE deciding how to build something, while the shape of the code is still open. WebJs ships a primitive for most of the jobs below, and the failure to avoid is not picking the wrong one, it is not knowing one exists and hand-rolling the React-shaped version instead. That version compiles, passes `webjs check`, and ships, so nothing catches it. The "reflex to resist" column is what the hand-rolled version usually looks like.
+
+Rows point rather than explain. The reference is the authority on the rule, and it is the durable half: the demo lives in the scaffold gallery, which an app deletes with `npm run gallery:clear` once it has outgrown it.
+
+| I need to... | Reach for | Reflex to resist | Reference | Demo |
+| --- | --- | --- | --- | --- |
+| add a URL, static or with a dynamic segment | a file at `app/<path>/page.ts`, `[id]` for a param | registering the route in a table or config | `references/routing-and-pages.md` | `app/features/routing` |
+| abandon a render because something is missing or not allowed | throw `notFound()` / `forbidden()` / `unauthorized()` | returning an error object and branching in the template | `references/routing-and-pages.md` | `app/features/boundaries` |
+| set a page's title, description, or social preview | `export const metadata` or `generateMetadata()` | writing `<head>` tags in the page | `references/routing-and-pages.md` | `app/features/metadata` |
+| make part of the page respond to a click or hold state | a `WebComponent` custom element | expecting the page's own markup to hydrate | `references/components.md` | `app/features/components` |
+| render a keyed list, or swap one node when state changes | `repeat()` / `watch()` from `/directives` | re-rendering the component or diffing by hand | `references/components.md` | `app/features/directives` |
+| get server data into a component's first paint | `async render()` awaiting an action | fetching in `connectedCallback`, which SSR never calls | `references/components.md` | `app/features/async-render` |
+| call server code from the browser | import the `'use server'` function and call it | hand-writing `fetch()` against an endpoint | `references/data-and-actions.md` | `app/features/server-actions` |
+| expose JSON to a caller outside the app | `route.ts` with named `GET` / `POST` exports | a server action, which is the in-app path | `references/routing-and-pages.md` | `app/features/route-handler` |
+| write data from a form, JS off included | `<form action=${importedAction}>` | an `@submit` handler calling `fetch()` | `references/data-and-actions.md` | `app/features/forms` |
+| make a mutation feel instant | `optimistic()` | a manual try-catch that restores a cached copy | `references/optimistic-ui.md` | `app/features/optimistic-ui` |
+| navigate without a full page reload | nothing, the router is already on | importing or configuring a router | `references/client-router-and-streaming.md` | `app/features/client-router` |
+| cross-fade a navigation instead of snapping | the `view-transition` meta, via page metadata | animating the swap yourself | `references/client-router-and-streaming.md` | `app/features/view-transitions` |
+| show tokens or progress as the server produces them | an action returning an async generator | polling, or a socket for a one-shot answer | `references/client-router-and-streaming.md` | `app/features/streaming` |
+| change ONE element after a write | `<webjs-stream>` | redrawing the whole list around it | `references/client-router-and-streaming.md` | `app/features/stream` |
+| paint the page before a slow region is ready | `<webjs-suspense>` with a fallback | blocking the whole page on the slow await | `references/client-router-and-streaming.md` | `app/features/suspense` |
+| refresh one region on its own, with no navigation | `<webjs-frame>` | a stateful component that fetches and re-renders | `references/client-router-and-streaming.md` | `app/features/frames` |
+| hold a live two-way connection | a `WS()` route export plus `connectWS()` | polling on an interval | `references/client-router-and-streaming.md` | `app/features/websockets` |
+| push one event to every open tab | `broadcast()` | every client polling for changes | `references/client-router-and-streaming.md` | `app/features/broadcast` |
+| add login and a signed-in-only route | `createAuth` plus a redirect in the page | rolling password hashing and session cookies | `references/auth-and-sessions.md` | `app/features/auth` |
+| remember something per visitor across requests | `getSession()` on a signed cookie | a module-level map keyed by user | `references/auth-and-sessions.md` | `app/features/sessions` |
+| stop re-rendering a page identical for everyone | `export const revalidate` | caching by hand in a module variable | `references/built-ins.md` | `app/features/caching` |
+| read config or a secret at runtime | `process.env` server-side, `WEBJS_PUBLIC_` for the browser | importing a config module into a component | `references/built-ins.md` | `app/features/env` |
+| stop one caller hammering an endpoint | the `rateLimit()` middleware | counting requests inside the handler | `references/built-ins.md` | `app/features/rate-limit` |
+| accept an upload and serve it back | `FileStore` plus a streaming route | buffering the file in memory or writing to `public/` | `references/built-ins.md` | `app/features/file-storage` |
+| keep the app usable offline | the opt-in service worker | caching responses in `localStorage` | `references/service-worker.md` | `app/features/service-worker` |
+| see these composed in one real feature | the todo example app | stitching the single-feature demos together | `references/optimistic-ui.md` | `app/examples/todo` |
+
 ## Load Only The References You Need
 
-Classify the task first, then load the smallest useful reference set. Each reference starts with a "What This Covers" section; read that to confirm relevance before reading the rest. Loading more than two or three at once usually means the task is not narrowed yet.
+The table above routes by the job; this one routes by the topic, for when you already know which surface you are working on. Classify the task first, then load the smallest useful reference set. Each reference starts with a "What This Covers" section; read that to confirm relevance before reading the rest. Loading more than two or three at once usually means the task is not narrowed yet.
 
 | Task involves...                                                            | Start with                                    |
 | --------------------------------------------------------------------------- | --------------------------------------------- |

--- a/.agents/skills/webjs/SKILL.md
+++ b/.agents/skills/webjs/SKILL.md
@@ -35,7 +35,7 @@ WebJs is an AI-first, web-components-first framework with **no build step**: sou
 
 ## Reach For The Right Primitive
 
-Scan this BEFORE deciding how to build something, while the shape of the code is still open. WebJs ships a primitive for most of the jobs below, and the failure to avoid is not picking the wrong one, it is not knowing one exists and hand-rolling the React-shaped version instead. That version compiles, passes `webjs check`, and ships, so nothing catches it. The "reflex to resist" column is what the hand-rolled version usually looks like.
+Scan this BEFORE deciding how to build something, while the shape of the code is still open. WebJs ships a primitive for most of the jobs below, and the mistake to guard against is rarely choosing badly between them. It is that the primitive never comes to mind at all, so the React-shaped version gets hand-rolled in its place. That version compiles, passes `webjs check`, and ships, so nothing catches it. The "reflex to resist" column is what the hand-rolled version usually looks like.
 
 Rows point rather than explain. The reference is the authority on the rule, and it is the durable half: the demo lives in the scaffold gallery, which an app deletes with `npm run gallery:clear` once it has outgrown it.
 

--- a/.agents/skills/webjs/SKILL.md
+++ b/.agents/skills/webjs/SKILL.md
@@ -58,7 +58,7 @@ Rows point rather than explain. The reference is the authority on the rule, and 
 | paint the page before a slow region is ready | `<webjs-suspense>` with a fallback | blocking the whole page on the slow await | `references/client-router-and-streaming.md` | `app/features/suspense` |
 | refresh one region on its own, with no navigation | `<webjs-frame>` | a stateful component that fetches and re-renders | `references/client-router-and-streaming.md` | `app/features/frames` |
 | hold a live two-way connection | a `WS()` route export plus `connectWS()` | polling on an interval | `references/client-router-and-streaming.md` | `app/features/websockets` |
-| push one event to every open tab | `broadcast()` | every client polling for changes | `references/client-router-and-streaming.md` | `app/features/broadcast` |
+| push one update to every client on a socket path | `broadcast()` | every client polling for changes | `references/client-router-and-streaming.md` | `app/features/broadcast` |
 | add login and a signed-in-only route | `createAuth` plus a redirect in the page | rolling password hashing and session cookies | `references/auth-and-sessions.md` | `app/features/auth` |
 | remember something per visitor across requests | `getSession()` on a signed cookie | a module-level map keyed by user | `references/auth-and-sessions.md` | `app/features/sessions` |
 | stop re-rendering a page identical for everyone | `export const revalidate` | caching by hand in a module variable | `references/built-ins.md` | `app/features/caching` |

--- a/gallery/modules/gallery/nav.ts
+++ b/gallery/modules/gallery/nav.ts
@@ -29,7 +29,7 @@ export const FEATURE_GROUPS: NavGroup[] = [
     items: [
       { href: '/features/components', title: 'Components', blurb: 'Make one part of the page respond to a click or hold state. A page never hydrates, so interactivity lives in a component.' },
       { href: '/features/directives', title: 'Directives', blurb: 'Render a keyed list, or swap a single node when state changes, without re-rendering the component around it.' },
-      { href: '/features/async-render', title: 'Async render', blurb: 'Get server data into a component first paint. Await it in async render() rather than fetching after mount, which SSR never runs.' },
+      { href: '/features/async-render', title: 'Async render', blurb: 'Get server data into the first paint. Await it in async render() rather than fetching after mount, which SSR never runs.' },
     ],
   },
   {

--- a/gallery/modules/gallery/nav.ts
+++ b/gallery/modules/gallery/nav.ts
@@ -57,7 +57,7 @@ export const FEATURE_GROUPS: NavGroup[] = [
     label: 'Real-time',
     items: [
       { href: '/features/websockets', title: 'WebSockets', blurb: 'Hold a live two-way connection instead of polling. A WS(ws, req) route export on the server, connectWS() on the client.' },
-      { href: '/features/broadcast', title: 'Broadcast', blurb: 'Push one event to every open tab at once, so a change made in one client shows up in the others.' },
+      { href: '/features/broadcast', title: 'Broadcast', blurb: 'Push one update to every client connected on a WebSocket path, so a change made in one of them shows up in the rest. Optionally excluding the sender.' },
     ],
   },
   {

--- a/gallery/modules/gallery/nav.ts
+++ b/gallery/modules/gallery/nav.ts
@@ -3,6 +3,14 @@
  * left sidebar (so they can never drift). A browser-safe data module (no server
  * imports, no client globals): the home flattens the groups into its card grid,
  * and <gallery-nav> renders them grouped. gallery:clear removes this module.
+ *
+ * Blurbs are INTENT-shaped, not noun-shaped: each one opens on the job you would
+ * be doing when you want this demo, because the index is the first thing an
+ * agent reads and a card that only names the feature cannot be found by someone
+ * who does not know the feature exists. The skill's cheat sheet
+ * (.agents/skills/webjs/SKILL.md, "Reach For The Right Primitive") carries the
+ * same set keyed the same way, and test/repo-health/skill-gallery-intent-parity
+ * fails if the two fall out of step.
  */
 export interface NavItem { href: string; title: string; blurb: string; }
 export interface NavGroup { label: string; items: NavItem[]; }
@@ -11,68 +19,68 @@ export const FEATURE_GROUPS: NavGroup[] = [
   {
     label: 'Routing',
     items: [
-      { href: '/features/routing', title: 'Routing', blurb: 'A static route plus a dynamic [id] segment that reads params. The file-based router in miniature.' },
-      { href: '/features/boundaries', title: 'Boundaries', blurb: 'The control-flow throws (forbidden / unauthorized / notFound) and the nearest boundary file that catches each.' },
-      { href: '/features/metadata', title: 'Metadata', blurb: 'Static metadata plus generateMetadata(ctx), which reads the request to compute the title and Open Graph tags.' },
+      { href: '/features/routing', title: 'Routing', blurb: 'Add a URL to the app, static or with a dynamic [id] segment. The file is the route, so there is no table to register it in.' },
+      { href: '/features/boundaries', title: 'Boundaries', blurb: 'Abandon a render because something is missing or not allowed. Throw notFound / forbidden / unauthorized and the nearest boundary file catches it.' },
+      { href: '/features/metadata', title: 'Metadata', blurb: 'Give a page its own title, description, and social preview without writing head markup yourself.' },
     ],
   },
   {
     label: 'Components',
     items: [
-      { href: '/features/components', title: 'Components', blurb: 'The WebComponent factory, reactive props, instance signals, and slot projection in light DOM.' },
-      { href: '/features/directives', title: 'Directives', blurb: 'The lit-html directive set: repeat for keyed lists, watch(signal) for a fine-grained node swap.' },
-      { href: '/features/async-render', title: 'Async render', blurb: 'A component that awaits server data in async render(), so the resolved value is in the first paint.' },
+      { href: '/features/components', title: 'Components', blurb: 'Make one part of the page respond to a click or hold state. A page never hydrates, so interactivity lives in a component.' },
+      { href: '/features/directives', title: 'Directives', blurb: 'Render a keyed list, or swap a single node when state changes, without re-rendering the component around it.' },
+      { href: '/features/async-render', title: 'Async render', blurb: 'Get server data into a component first paint. Await it in async render() rather than fetching after mount, which SSR never runs.' },
     ],
   },
   {
     label: 'Data & actions',
     items: [
-      { href: '/features/server-actions', title: 'Server actions', blurb: 'A use-server RPC action next to a server-only .server.ts utility, plus the HTTP-verb config exports that make a read a cached GET.' },
-      { href: '/features/route-handler', title: 'Route handlers', blurb: 'A server-only route.ts HTTP endpoint returning JSON, the WebJs equivalent of a Next route handler.' },
-      { href: '/features/forms', title: 'Forms', blurb: 'A no-JS progressive-enhancement form bound to a server action, with server-side validation errors.' },
-      { href: '/features/optimistic-ui', title: 'Optimistic UI', blurb: 'The imperative optimistic(signal, value, action) flip: instant update, automatic rollback on failure.' },
+      { href: '/features/server-actions', title: 'Server actions', blurb: 'Call server code from the browser by importing the function. No fetch, no endpoint to name, and the types survive the trip.' },
+      { href: '/features/route-handler', title: 'Route handlers', blurb: 'Expose JSON to a caller outside the app. A server-only route.ts, the WebJs equivalent of a Next route handler.' },
+      { href: '/features/forms', title: 'Forms', blurb: 'Write data from a form that still works with JS off. Binding the action to the form is the whole wiring.' },
+      { href: '/features/optimistic-ui', title: 'Optimistic UI', blurb: 'Make a mutation feel instant. optimistic() applies the change immediately and rolls it back if the server refuses.' },
     ],
   },
   {
     label: 'Client & streaming',
     items: [
-      { href: '/features/client-router', title: 'Client router', blurb: 'Automatic soft navigation: fragment-only fetches, hover prefetch, scroll restore, and graceful no-JS fallback.' },
-      { href: '/features/view-transitions', title: 'View transitions', blurb: 'The opt-in view-transition meta cross-fades a soft navigation, with a data-webjs-permanent element persisted across the swap.' },
-      { href: '/features/streaming', title: 'Streaming actions', blurb: 'A use-server action that returns an async generator, streamed to the call site token by token with for await.' },
-      { href: '/features/stream', title: 'Stream updates', blurb: 'The <webjs-stream> element: renderStream() applies surgical append / replace / remove DOM updates by target id, no region redraw.' },
-      { href: '/features/suspense', title: 'Suspense boundary', blurb: 'The <webjs-suspense> element: a first-paint fallback for a SLOW component, with the resolved content streamed in.' },
-      { href: '/features/frames', title: 'Frames', blurb: 'A webjs-frame region that swaps a filtered sub-list in place from a link, shipping zero component JS, with a no-JS full-nav fallback.' },
+      { href: '/features/client-router', title: 'Client router', blurb: 'Navigate without a full page reload. Automatic the moment a page ships a component, with nothing to import or configure.' },
+      { href: '/features/view-transitions', title: 'View transitions', blurb: 'Cross-fade a navigation instead of snapping. One opt-in meta, plus a marker for elements that must survive the swap.' },
+      { href: '/features/streaming', title: 'Streaming actions', blurb: 'Show tokens or progress as the server produces them. An action returning an async generator, consumed with for await.' },
+      { href: '/features/stream', title: 'Stream updates', blurb: 'Change one element after a write, like appending a row or bumping a count, without redrawing the region around it.' },
+      { href: '/features/suspense', title: 'Suspense boundary', blurb: 'Paint the page before a slow region is ready. The fallback flushes on the first byte and the content streams in behind it.' },
+      { href: '/features/frames', title: 'Frames', blurb: 'Refresh one region on its own with no navigation, like a filtered list or a tab panel. Zero component JS, full-nav fallback with JS off.' },
     ],
   },
   {
     label: 'Real-time',
     items: [
-      { href: '/features/websockets', title: 'WebSockets', blurb: 'A WS(ws, req) route endpoint plus the connectWS() client, echoing messages over a live socket.' },
-      { href: '/features/broadcast', title: 'Broadcast', blurb: 'Fan a message out to every connected client on a WebSocket path, so all open tabs stay in sync.' },
+      { href: '/features/websockets', title: 'WebSockets', blurb: 'Hold a live two-way connection instead of polling. A WS(ws, req) route export on the server, connectWS() on the client.' },
+      { href: '/features/broadcast', title: 'Broadcast', blurb: 'Push one event to every open tab at once, so a change made in one client shows up in the others.' },
     ],
   },
   {
     label: 'Auth & sessions',
     items: [
-      { href: '/features/auth', title: 'Auth', blurb: 'Password login on createAuth, a signed session cookie, and a real protected route that redirects anonymous visitors to login.' },
-      { href: '/features/sessions', title: 'Sessions', blurb: 'A signed-cookie session applied by a segment middleware, read and written per visitor with getSession() in a route.' },
+      { href: '/features/auth', title: 'Auth', blurb: 'Add login and a route only signed-in visitors can open, without rolling password hashing and session cookies yourself.' },
+      { href: '/features/sessions', title: 'Sessions', blurb: 'Remember something per visitor across requests. A signed cookie applied by middleware, read and written with getSession().' },
     ],
   },
   {
     label: 'Built-ins',
     items: [
-      { href: '/features/caching', title: 'Caching', blurb: 'export const revalidate caches the page HTML per URL, with the safety rule for when a shared cache is allowed.' },
-      { href: '/features/env', title: 'Env vars', blurb: 'The server-only vs WEBJS_PUBLIC_ boundary, read during SSR so secrets never reach the browser.' },
-      { href: '/features/rate-limit', title: 'Rate limiting', blurb: 'The rateLimit() middleware scoped to one endpoint, returning a 429 with Retry-After once the interval resets.' },
-      { href: '/features/file-storage', title: 'File storage', blurb: 'A no-JS multipart upload streamed into the FileStore, then served back through a streaming route.' },
-      { href: '/features/service-worker', title: 'Service worker', blurb: 'The opt-in offline enhancement, registered from a browser-only lifecycle hook (never a page or layout).' },
+      { href: '/features/caching', title: 'Caching', blurb: 'Stop re-rendering a page that is identical for every visitor. export const revalidate, with the rule for when that is safe.' },
+      { href: '/features/env', title: 'Env vars', blurb: 'Read config and secrets at runtime while keeping the secrets server-side. WEBJS_PUBLIC_ is the only prefix the browser sees.' },
+      { href: '/features/rate-limit', title: 'Rate limiting', blurb: 'Stop one caller hammering an endpoint. The rateLimit() middleware returns a 429 with Retry-After until the interval resets.' },
+      { href: '/features/file-storage', title: 'File storage', blurb: 'Accept an upload and serve it back, streamed both ways, with nothing buffered in memory and nothing written into public/.' },
+      { href: '/features/service-worker', title: 'Service worker', blurb: 'Keep the app usable offline. The opt-in service worker, registered from a browser-only lifecycle hook (never a page or layout).' },
     ],
   },
 ];
 
 /** The whole example apps (composed features), shown after the single-feature demos. */
 export const EXAMPLES: NavItem[] = [
-  { href: '/examples/todo', title: 'Optimistic todo', blurb: 'A whole app composing several features: the declarative optimistic() list API, progressive-enhancement forms, accessible labels, the modules split, and SQLite.' },
+  { href: '/examples/todo', title: 'Optimistic todo', blurb: 'See the pieces composed in one real feature: the declarative optimistic() list API, progressive-enhancement forms, accessible labels, the modules split, and SQLite.' },
 ];
 
 /**

--- a/gallery/modules/gallery/nav.ts
+++ b/gallery/modules/gallery/nav.ts
@@ -9,8 +9,9 @@
  * agent reads and a card that only names the feature cannot be found by someone
  * who does not know the feature exists. The skill's cheat sheet
  * (.agents/skills/webjs/SKILL.md, "Reach For The Right Primitive") carries the
- * same set keyed the same way, and test/repo-health/skill-gallery-intent-parity
- * fails if the two fall out of step.
+ * same set keyed the same way, and the repo's
+ * test/repo-health/skill-gallery-intent-parity.test.mjs fails if the two fall
+ * out of step.
  */
 export interface NavItem { href: string; title: string; blurb: string; }
 export interface NavGroup { label: string; items: NavItem[]; }

--- a/test/repo-health/skill-gallery-intent-parity.test.mjs
+++ b/test/repo-health/skill-gallery-intent-parity.test.mjs
@@ -43,6 +43,11 @@ function cheatSheetRows() {
   const end = rest.indexOf('\n## ');
   const section = end === -1 ? rest : rest.slice(0, end);
 
+  // Cells are split on a bare `|`, so no cell may CONTAIN one, escaped as `\|`
+  // or otherwise. That is a real constraint on the table rather than a parser
+  // shortcut, and the 5-cell assertion below is what enforces it: a row with a
+  // pipe in a cell fails loudly here instead of being silently mis-parsed into
+  // the wrong columns. If a row ever needs a literal pipe, phrase around it.
   return section
     .split('\n')
     .filter((l) => l.startsWith('|') && !/^\|[\s|:-]*\|$/.test(l))
@@ -88,7 +93,13 @@ test('every gallery demo has exactly one cheat-sheet row', () => {
   const rows = cheatSheetRows();
   const demos = navDemoPaths();
   const onDisk = diskDemoPaths();
-  assert.ok(demos.length >= 20, `expected the gallery index to list its demos, found ${demos.length}`);
+  // Non-vacuity is asserted on the DISK set, not on a hand-written floor over
+  // the parsed ones. The disk set is the anchor, so it is the only one that
+  // cannot go quietly empty (a missing directory throws in readdirSync rather
+  // than returning nothing), and once it is known non-empty the three-way
+  // equality below carries every other case. A `demos.length >= N` floor would
+  // just be a second number to remember to raise.
+  assert.ok(onDisk.length > 0, 'found no demo directories under gallery/app');
 
   const rowDemos = rows.map((r) => r.demo);
   assert.deepEqual(

--- a/test/repo-health/skill-gallery-intent-parity.test.mjs
+++ b/test/repo-health/skill-gallery-intent-parity.test.mjs
@@ -1,0 +1,114 @@
+/**
+ * The skill's intent cheat sheet and the gallery's demo index must describe the
+ * same set of features.
+ *
+ * An agent building a WebJs app meets the gallery index first and the skill
+ * second, so both have to answer "I need to do X, does WebJs have something for
+ * that?". `SKILL.md`'s "Reach For The Right Primitive" table and
+ * `gallery/modules/gallery/nav.ts` each carry one entry per demo, keyed the same
+ * way. Nothing kept them in step, and a feature landing in one surface but not
+ * the other is invisible until an agent hand-rolls a primitive that already
+ * exists (#1408).
+ *
+ * Prose parity is deliberately NOT asserted: a card blurb is a sentence and a
+ * cheat-sheet row is a clause, so forcing the strings to match would make one of
+ * them bad. What is asserted is the correspondence between the SETS, plus that
+ * every path a row points at actually resolves. The reference is the load-bearing
+ * pointer, because `gallery:clear` deletes the demos once an app outgrows them.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const SKILL_DIR = join(repoRoot, '.agents/skills/webjs');
+const SKILL = join(SKILL_DIR, 'SKILL.md');
+const NAV = join(repoRoot, 'gallery/modules/gallery/nav.ts');
+const HEADING = '## Reach For The Right Primitive';
+
+/**
+ * The cheat-sheet rows, one per demo.
+ *
+ * Sliced to the section rather than scanned over the whole file, so the topic
+ * routing table further down (which has its own pipe rows and no demo paths)
+ * cannot be mistaken for a cheat-sheet row.
+ */
+function cheatSheetRows() {
+  const md = readFileSync(SKILL, 'utf8');
+  const start = md.indexOf(HEADING);
+  assert.notEqual(start, -1, `${HEADING} is missing from SKILL.md`);
+  const rest = md.slice(start + HEADING.length);
+  const end = rest.indexOf('\n## ');
+  const section = end === -1 ? rest : rest.slice(0, end);
+
+  return section
+    .split('\n')
+    .filter((l) => l.startsWith('|') && !/^\|[\s|:-]*\|$/.test(l))
+    .map((l) => l.split('|').slice(1, -1).map((c) => c.trim()))
+    .filter((cells) => cells[0] !== 'I need to...')
+    .map((cells, i) => {
+      assert.equal(cells.length, 5, `cheat-sheet row ${i + 1} has ${cells.length} cells, want 5`);
+      const [intent, primitive, reflex, reference, demo] = cells;
+      return {
+        intent,
+        primitive,
+        reflex,
+        reference: reference.replaceAll('`', ''),
+        demo: demo.replaceAll('`', ''),
+      };
+    });
+}
+
+/** Every demo href the gallery index lists, as the `app/...` path a row names. */
+function navDemoPaths() {
+  const src = readFileSync(NAV, 'utf8');
+  return [...src.matchAll(/href: '\/((?:features|examples)\/[a-z0-9-]+)'/g)].map((m) => `app/${m[1]}`);
+}
+
+test('every gallery demo has exactly one cheat-sheet row', () => {
+  const rows = cheatSheetRows();
+  const demos = navDemoPaths();
+  assert.ok(demos.length >= 20, `expected the gallery index to list its demos, found ${demos.length}`);
+
+  const rowDemos = rows.map((r) => r.demo);
+  assert.deepEqual(
+    [...new Set(rowDemos)].sort(),
+    rowDemos.slice().sort(),
+    'a demo is named by more than one cheat-sheet row',
+  );
+  assert.deepEqual(
+    rowDemos.slice().sort(),
+    demos.slice().sort(),
+    'the cheat sheet and the gallery index list different demos',
+  );
+});
+
+test('every cheat-sheet row points at paths that exist', () => {
+  for (const row of cheatSheetRows()) {
+    // The reference is the half that survives `gallery:clear`, so a row without
+    // a resolvable one is a row that goes dead the moment an app prunes the
+    // gallery.
+    assert.match(row.reference, /^references\/[a-z-]+\.md$/, `row "${row.intent}" names no reference file`);
+    assert.ok(
+      existsSync(join(SKILL_DIR, row.reference)),
+      `row "${row.intent}" points at ${row.reference}, which does not exist`,
+    );
+    assert.ok(
+      existsSync(join(repoRoot, 'gallery', row.demo)),
+      `row "${row.intent}" points at ${row.demo}, which does not exist in the gallery`,
+    );
+  }
+});
+
+test('every cheat-sheet row names a primitive and the reflex it replaces', () => {
+  // The reflex column is what makes a row fire for an agent that is already
+  // reaching for the React-shaped version. A row missing it is a row that only
+  // helps someone who was looking for the feature by name.
+  for (const row of cheatSheetRows()) {
+    assert.ok(row.intent.length > 0, 'a cheat-sheet row has an empty intent');
+    assert.ok(row.primitive.length > 0, `row "${row.intent}" names no primitive`);
+    assert.ok(row.reflex.length > 0, `row "${row.intent}" names no reflex to resist`);
+  }
+});

--- a/test/repo-health/skill-gallery-intent-parity.test.mjs
+++ b/test/repo-health/skill-gallery-intent-parity.test.mjs
@@ -18,7 +18,7 @@
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -67,9 +67,27 @@ function navDemoPaths() {
   return [...src.matchAll(/href: '\/((?:features|examples)\/[a-z0-9-]+)'/g)].map((m) => `app/${m[1]}`);
 }
 
+/**
+ * Every demo that EXISTS on disk, read from the filesystem rather than from
+ * either index.
+ *
+ * Comparing the cheat sheet against `nav.ts` alone would compare two hand-kept
+ * lists with no anchor: a demo directory added to neither leaves both sets equal
+ * and the parity assertion green, which is exactly the drift this test exists to
+ * catch. The directories are the ground truth, so they are the third set.
+ */
+function diskDemoPaths() {
+  return ['features', 'examples'].flatMap((kind) =>
+    readdirSync(join(repoRoot, 'gallery/app', kind), { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => `app/${kind}/${e.name}`),
+  );
+}
+
 test('every gallery demo has exactly one cheat-sheet row', () => {
   const rows = cheatSheetRows();
   const demos = navDemoPaths();
+  const onDisk = diskDemoPaths();
   assert.ok(demos.length >= 20, `expected the gallery index to list its demos, found ${demos.length}`);
 
   const rowDemos = rows.map((r) => r.demo);
@@ -82,6 +100,11 @@ test('every gallery demo has exactly one cheat-sheet row', () => {
     rowDemos.slice().sort(),
     demos.slice().sort(),
     'the cheat sheet and the gallery index list different demos',
+  );
+  assert.deepEqual(
+    onDisk.slice().sort(),
+    demos.slice().sort(),
+    'the gallery has demo directories that neither index lists (or lists one that is gone)',
   );
 });
 


### PR DESCRIPTION
Closes #1408

## Summary

An agent building a WebJs app rarely picks the wrong primitive. It forgets the primitive exists and hand-rolls the React-shaped version instead, which compiles, passes `webjs check`, and ships, so nothing catches it. This adds an intent-keyed index to the two layers an agent reads first, so the question "does WebJs already have something for this?" gets answered before the shape of the code is decided.

Both layers were organised so they could not fire in time. The skill routed by TOPIC, with a left column naming the features themselves, so an agent that did not already know `<webjs-frame>` existed had no path into the file that would tell it. The gallery cards described what each demo IS rather than when you would want it, which left the real selection guidance buried in the demo header comments one file deeper than the index that is supposed to sell it.

## What changed

- **`.agents/skills/webjs/SKILL.md`**: a new `## Reach For The Right Primitive` table ahead of the topic routing table. One row per gallery demo, each naming the job, the primitive, **the reflex it replaces**, its `references/` file, and its demo path. The reflex column is what makes a row fire for an agent already reaching for the React-shaped version.
- **`gallery/modules/gallery/nav.ts`**: blurbs rewritten from noun-shaped to intent-shaped, opening on the job rather than the feature. Rewritten in place rather than adding a second field, since two prose fields on one card doubles the copy and gives drift somewhere to hide. This one module already drives both the home card grid and the sidebar.
- **`test/repo-health/skill-gallery-intent-parity.test.mjs`**: asserts the two surfaces list the same demos, that every row resolves to a real reference file and a real demo directory, and that no row is missing its primitive or its reflex.

## Decisions

**Rows point, they do not restate.** The decision rules already live in the references (`components.md` L318 on async render vs `Task` vs `<webjs-suspense>`, `optimistic-ui.md` on when to skip it, `data-and-actions.md` on verb choice). A row carrying its own copy becomes a second source that drifts, which this repo has been bitten by before.

**Coverage is complete, not curated.** Every demo gets a row, including the ones nobody picks by accident. A curated high-value subset needs a hand-maintained exclusion list, and the exclusion list is exactly the thing that rots. Completeness is also what makes the table work as a recall aid.

**Prose parity is not asserted.** A card blurb is a sentence and a cheat-sheet row is a clause. Forcing the strings to match would make one of them bad, so the test asserts the SETS correspond and leaves the wording to review.

**Every row names its reference, not just its demo.** `npm run gallery:clear` deletes `app/features/**` once an app outgrows the gallery, so a row pointing only at a demo goes dead exactly when the app gets serious. The test enforces the reference half.

## Test plan

- [ ] `node --test test/repo-health/skill-gallery-intent-parity.test.mjs`
- [ ] Counterfactual: a demo added without a row goes red, and a row added without a demo goes red
- [ ] `test/scaffolds/scaffold-gallery.test.js` and `test/repo-health/agent-skill-parity.test.mjs` still pass
- [ ] A freshly generated app carries both edits, and `webjs check` passes in the gallery

## Doc surfaces

This IS the doc surface. No `packages/*/src` change, so the Bun parity gate and the dogfood boot check are N/A. The skill and the gallery both reach a scaffolded app by copy from the repo-root canonical (`packages/cli/lib/create.js`), so there is no second copy to update by hand.
