### PR TITLE
chore: release core 0.7.51, server 0.8.64 and ui 0.3.14

### DIFF
--- a/changelog/core/0.7.51.md
+++ b/changelog/core/0.7.51.md
@@ -1,0 +1,26 @@
+---
+package: "@webjsdev/core"
+version: 0.7.51
+date: 2026-08-15T05:45:41.183Z
+commit_count: 3
+---
+## Features
+
+- **refresh page and layout edits in place in dev** ([#1405](https://github.com/webjsdev/webjs/pull/1405)) [`b8f46ac1`](https://github.com/webjsdev/webjs/commit/b8f46ac1)
+  * feat: refresh page and layout edits in place in dev
+  
+  Every dev edit produced a full page reload: the page blinked, hydrated
+  component state reset, scroll position was lost. Most dev edits do not
+- **prefetch frame links in their own frame dimension** ([#1411](https://github.com/webjsdev/webjs/pull/1411)) [`a3eff3a2`](https://github.com/webjsdev/webjs/commit/a3eff3a2)
+  * feat: prefetch frame links in their own frame dimension
+  
+  A link inside a `<webjs-frame>` was prefetched like any other link, and the
+  click could not use it: the consume guard refused any prefetch whenever a
+
+## Fixes
+
+- **record the history entry before the swap, not after** ([#1410](https://github.com/webjsdev/webjs/pull/1410)) [`8b90f95b`](https://github.com/webjsdev/webjs/commit/8b90f95b)
+  * fix: record the history entry before the swap, not after
+  
+  WebKit binds a same-document pushState entry's back-forward gesture
+  snapshot to the page state at the moment the entry is recorded. The

--- a/changelog/server/0.8.64.md
+++ b/changelog/server/0.8.64.md
@@ -1,0 +1,36 @@
+---
+package: "@webjsdev/server"
+version: 0.8.64
+date: 2026-08-15T05:45:41.243Z
+commit_count: 5
+---
+## Features
+
+- **refresh page and layout edits in place in dev** ([#1405](https://github.com/webjsdev/webjs/pull/1405)) [`b8f46ac1`](https://github.com/webjsdev/webjs/commit/b8f46ac1)
+  * feat: refresh page and layout edits in place in dev
+  
+  Every dev edit produced a full page reload: the page blinked, hydrated
+  component state reset, scroll position was lost. Most dev edits do not
+- **prefetch frame links in their own frame dimension** ([#1411](https://github.com/webjsdev/webjs/pull/1411)) [`a3eff3a2`](https://github.com/webjsdev/webjs/commit/a3eff3a2)
+  * feat: prefetch frame links in their own frame dimension
+  
+  A link inside a `<webjs-frame>` was prefetched like any other link, and the
+  click could not use it: the consume guard refused any prefetch whenever a
+
+## Fixes
+
+- **root the vendor specifier scan in the module graph** ([#1401](https://github.com/webjsdev/webjs/pull/1401)) [`16b60af8`](https://github.com/webjsdev/webjs/commit/16b60af8)
+  * fix: root the vendor specifier scan in the module graph
+  
+  The scan behind the vendor importmap walked the whole app directory and
+  regex-scanned every file that survived a hardcoded list of name
+- **stop rapid dev edits leaving the page unstyled** ([#1400](https://github.com/webjsdev/webjs/pull/1400)) [`43464d87`](https://github.com/webjsdev/webjs/commit/43464d87)
+  * fix: stop rapid dev edits leaving the page unstyled
+  
+  Editing several files a few seconds apart in dev left the browser showing
+  unstyled HTML until a manual refresh. Two independent causes, both fixed
+- **render error boundaries inside their layout chain** ([#1413](https://github.com/webjsdev/webjs/pull/1413)) [`daf17f7f`](https://github.com/webjsdev/webjs/commit/daf17f7f)
+  * fix: render error boundaries inside their layout chain
+  
+  A boundary render was handed straight to wrapInDocument with no layouts, so
+  the response carried none of the keyed wj:children comments the layout

--- a/changelog/ui/0.3.14.md
+++ b/changelog/ui/0.3.14.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/ui"
+version: 0.3.14
+date: 2026-08-15T05:45:41.419Z
+commit_count: 1
+---
+## Fixes
+
+- **expose one dialog role and one live root per toast in ui** ([#1412](https://github.com/webjsdev/webjs/pull/1412)) [`9b0af339`](https://github.com/webjsdev/webjs/commit/9b0af339)
+  * fix: expose one dialog role and one live root per toast in ui
+  
+  Both findings the #1080 audit marked needs-runtime-check are real, measured
+  against Chrome's computed accessibility tree rather than guessed at.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6995,7 +6995,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.50",
+      "version": "0.7.51",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.25.0"
@@ -7044,10 +7044,10 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.63",
+      "version": "0.8.64",
       "license": "MIT",
       "dependencies": {
-        "@webjsdev/core": "^0.7.50",
+        "@webjsdev/core": "^0.7.51",
         "ws": "^8.20.0"
       },
       "engines": {
@@ -7080,7 +7080,7 @@
     },
     "packages/ui": {
       "name": "@webjsdev/ui",
-      "version": "0.3.13",
+      "version": "0.3.14",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.50",
+  "version": "0.7.51",
   "type": "module",
   "description": "The runtime for WebJs, a full-stack JavaScript framework built on web components with server-side rendering and no build step. Ships the html and css template tags, the WebComponent base class, signals, directives, and the isomorphic renderers.",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.63",
+  "version": "0.8.64",
   "type": "module",
   "description": "The server for WebJs, a full-stack JavaScript framework built on web components with server-side rendering and no build step. Provides the file-based router, SSR, server actions, route handlers, middleware, and live reload on Node 24+ or Bun.",
   "main": "index.js",
@@ -28,7 +28,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@webjsdev/core": "^0.7.50",
+    "@webjsdev/core": "^0.7.51",
     "ws": "^8.20.0"
   },
   "publishConfig": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/ui",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "type": "module",
   "description": "The AI-first component library for WebJs, a full-stack JavaScript framework built on web components with server-side rendering and no build step. Class-helper functions for visuals, custom elements only where state matters, source-copied into your repo so you own it.",
   "bin": {


### PR DESCRIPTION
Clears every package carrying unreleased user-facing work since 0.7.50.

core adds refreshPage, which re-renders the current url on the server and
applies it in place with no reload, no history entry and no scroll, and
prefetches a link that drives a frame in that frame's own dimension so the
click costs no round trip. The fix records a same-document history entry
before the swap rather than after, which is what made an iOS swipe-back
preview the page the user was already on.

server stops a dev edit to a page or layout reloading the browser, so hydrated
state and scroll survive a save, and marks a sliced frame response so the
client can tell a real subtree from a whole document. The fixes render an
error boundary inside its own layout chain, coalesce a burst of dev reload
signals so rapid edits stop leaving the page unstyled, and root the vendor
specifier scan in the module graph.

ui takes the a11y fix alone.

Three packages are deliberately absent. cli, mcp and intellisense carry no
user-facing change in the range. cli's only such commit was #1414, which #1417
reverted in full, so what remains is the doctor barrel split, an internal move
with an unchanged export surface. mcp picked up three doc-string edits from
the same refactor, naming the new sibling-directory paths its `source` tool can
read, and the paths it already documents still resolve because they are
barrels. intellisense picked up nothing at all.

Raises packages/server's declared @webjsdev/core range from ^0.7.50 to
^0.7.51. The dev refresh reads refreshPage through a runtime feature check
rather than a static import, so nothing breaks without it, but the release PR
is the only place that bump is legal and core carries the earliest date in the
batch so it publishes first.

core and server carry the generated notes verbatim. ui is edited twice, both
because the generator reads conventional-commit prefixes and cannot see
anything else. It wrote #1414 into the entry for work #1417 has since reverted,
which is removed along with the Features section it emptied; and its excerpt is
the first lines of a squashed message, which for #1412 opened on the CDP
measurement instrument rather than on the fix, so the fix sub-commit takes its
place.