### PR TITLE
chore: release cli 0.10.56

### DIFF
--- a/changelog/cli/0.10.56.md
+++ b/changelog/cli/0.10.56.md
@@ -1,0 +1,20 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.56
+date: 2026-08-15T08:05:00.000Z
+commit_count: 1
+---
+## Fixes
+
+- **a fresh scaffold no longer reports 5 high-severity npm audit advisories** ([#1419](https://github.com/webjsdev/webjs/pull/1419)) [`818c27b2`](https://github.com/webjsdev/webjs/commit/818c27b2)
+  A newly created app reported 5 high-severity advisories the moment `webjs create`
+  finished installing, which is the first thing anyone saw after scaffolding. All 5
+  were one advisory, GHSA-jmr9-qjv8-65gv in `extract-zip`, reached only through
+  `@web/test-runner`'s unconditional dependency on `@web/test-runner-chrome` and its
+  `puppeteer-core@24` chain. Nothing in a generated app ever ran that code, since the
+  emitted `web-test-runner.config.js` launches browsers through Playwright.
+  `extract-zip` has no patched version, so the floor sits one level up at
+  `puppeteer-core`, whose 25 line moved to `@puppeteer/browsers@3` and dropped
+  `extract-zip` entirely. The generated `package.json` now carries that override, and
+  a fresh scaffold audits clean with `extract-zip` absent from the tree rather than
+  merely tolerated.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6979,7 +6979,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.55",
+      "version": "0.10.56",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.55",
+  "version": "0.10.56",
   "type": "module",
   "description": "The CLI for WebJs, a full-stack JavaScript framework built on web components with server-side rendering and no build step. Runs the dev and production servers, scaffolds apps, validates conventions, and drives the database. Node 24+ or Bun.",
   "bin": {


### PR DESCRIPTION
Releases `@webjsdev/cli` 0.10.56, carrying the scaffold audit fix from #1419.

## Why this needs a release at all

The fix is in `lib/create.js`, which ships inside the published `@webjsdev/cli` tarball, and `create-webjs` depends on `@webjsdev/cli: ^0.10.0` resolved from the registry. npm currently serves 0.10.55, the version without the override, so until this publishes, `npm create webjs@latest` keeps emitting apps that report 5 high-severity advisories on their first install. Merging #1419 changed nothing for anyone outside this repo.

## Scope

`@webjsdev/cli` only. `core`, `server`, and `ui` released in #1415 and carry no unreleased qualifying commits, and `mcp` and `intellisense` are current. A patch bump keeps `cli` inside the `^0.10.0` range that `examples/blog`, `website`, `gallery`, `create-webjs`, and `webjsdev` all pin, so no dependent range moves. The two lockstep wrappers are deliberately left alone; the release workflow owns their versions.

## The changelog is hand-written on purpose

`scripts/backfill-changelog.js` matches `^(feat|fix|breaking|perf)` subjects in the package's tree. The unreleased log for `@webjsdev/cli` holds two matching commits, not one:

- `818c27b2` fix(cli): the audit fix, which belongs in this release
- `09f81345` feat: make the UI kit and AI design guidance first class (#1414)

The second was fully reverted by `948d8555` (#1417), but that revert landed with a `revert:` prefix the generator does not match, so nothing cancels the original. An auto-generated changelog would therefore have advertised a feature that is not in the code. `changelog/cli/0.10.56.md` is written by hand to carry the fix alone, and the pre-commit hook skips generation when the file already exists.

Worth noting separately, since it outlives this PR: any future release of a package whose tree holds a reverted `feat:` will hit the same gap. The generator has no revert awareness at all.

## Test plan

- [x] The lockfile diff is exactly the one version line, confirmed with `git diff package-lock.json`
- [x] Every dependent pins `^0.10.0`, which 0.10.56 satisfies, so no range edits are needed
- [x] `@webjsdev/intellisense` is not part of this bump, so the webjs.nvim vendor re-sync that a manifest change would require does not apply
- [ ] CI, which was not waited on before opening this at the author's request

## On merge

Adding `changelog/cli/0.10.56.md` to `main` triggers `release.yml` to `npm publish` and cut the GitHub Release. That step is idempotent.
