### PR TITLE
fix: a parenthesised type annotation no longer reads as a top-level call

### DIFF
--- a/.agents/skills/webjs/references/components.md
+++ b/.agents/skills/webjs/references/components.md
@@ -390,7 +390,7 @@ A component that does no client-side work renders the same SSR'd HTML with or wi
 - a factory-declared reactive property that is not `{ state: true }`
 - an overridden lifecycle hook (including `renderFallback` / `renderError`)
 - an imported `signal` / `computed` / `watch` / `Task` / `ref` / streaming directive, or `addController` / `requestUpdate`
-- code that runs at module load (a top-level call, non-data `new`, dynamic `import(...)`, top-level `await`); only declarations and `X.register(...)` are allowed
+- code that runs at module load (a top-level call, non-data `new`, dynamic `import(...)`, top-level `await`); only declarations and `X.register(...)` are allowed. TypeScript types are erased before the analyser reads a module, so an annotation can never be a blocker however call-shaped it looks (`readonly (readonly [number, number, number])[]` is fine)
 - the dynamic slot READ surface (`slotchange`, `assignedNodes` / `assignedElements` / `assignedSlot`); merely RENDERING a `<slot>` does not ship (the SSR output carries the placed children, so a display-only slotted wrapper is byte-identical without its JS; native-write liveness is consumer-driven and the consumer's tag reference forces the ship)
 - being rendered by a component that itself ships
 

--- a/.agents/skills/webjs/references/runtime.md
+++ b/.agents/skills/webjs/references/runtime.md
@@ -20,7 +20,7 @@ Pick a runtime from the deploy target, not the code. Default to Node unless you 
 Three seams pick a runtime-specific implementation, all inside the framework, none in your app:
 
 - **The listener.** `startServer` selects the `node:http` request shell on Node and a native `Bun.serve` shell on Bun. Both parse the request, run middleware, dispatch to your routes, and stream the response through the same downstream pipeline, so an SSR page, a server action RPC, and a route handler behave identically.
-- **The type stripper.** WebJs serves `.ts` / `.tsx` as ES modules by erasing the types in place with no bundler. On Node that is the built-in `module.stripTypeScriptTypes`; on Bun it is `amaro` (the same engine, byte-identical and position-preserving so stack traces still point at the right line). Either way your TypeScript must be erasable (see `typescript.md`).
+- **The type stripper.** WebJs serves `.ts` / `.mts` as ES modules by erasing the types in place with no bundler. Those two are the whole set: there is no JSX anywhere in the framework, so a `.tsx` file is not served. On Node that is the built-in `module.stripTypeScriptTypes`; on Bun it is `amaro` (the same engine, byte-identical and position-preserving so stack traces still point at the right line). Either way your TypeScript must be erasable (see `typescript.md`).
 - **A few built-ins.** SQLite, hot reload, and WebSockets each bind to the runtime's native primitive (see the table).
 
 ## Node vs Bun at a glance

--- a/.claude/skills/webjs-doc-sync/SKILL.md
+++ b/.claude/skills/webjs-doc-sync/SKILL.md
@@ -43,7 +43,7 @@ applies, then update or consciously skip each.
    relevant `references/` file.
 2. **`README.md`** (repo root). Update when a headline capability changes (the
    feature list, the quickstart, the runtime/template matrix).
-3. **The docs site: `website/app/docs/<topic>/page.tsx`.** This is the
+3. **The docs site: `website/app/docs/<topic>/page.ts`.** This is the
    user-facing documentation at webjs.dev/docs. Find the topic page(s) that cover
    the area (`server-actions`, `routing`, `components`, `caching`, `configuration`,
    `client-router`, `data-fetching`, ...) and update them. `llms.txt` /
@@ -102,7 +102,7 @@ The surface checks below are independent reads, so run them fanned out: one read
 4. Verify: re-run the grep and confirm each applicable surface now describes the
    new behaviour, and no surface still describes the old one.
 5. Respect the prose-punctuation invariant (#11) and run `webjs check` if any
-   code-shaped doc (a `.tsx` doc page) changed.
+   code-shaped doc (a `.ts` doc page) changed.
 
 ## Audit-mode procedure (sweep shipped work for drift)
 

--- a/packages/server/AGENTS.md
+++ b/packages/server/AGENTS.md
@@ -463,8 +463,8 @@ conditional leaves a CSP-off document one newline shorter than a CSP-on one).
    map), so a `#` import is never sent to the resolver; the rare alias mapped to
    a real package (`"#x": "some-pkg"`) is consequently not vendored, an accepted
    limitation since the scaffold's catch-all `"#*": "./*"` is always local.
-   Every scan reads TYPE-ERASED source: `analyzeElision` runs a `.ts` / `.mts` /
-   `.tsx` module through the framework's own stripper (`eraseTypesForScan`)
+   Every scan reads TYPE-ERASED source: `analyzeElision` runs a `.ts` / `.mts`
+   module through the framework's own stripper (`eraseTypesForScan`)
    before scanning it, because the scans are lexical and TS annotations are
    call-shaped often enough to matter (`readonly (readonly [number, number,
    number])[]` is an identifier immediately followed by `(`, which the

--- a/packages/server/AGENTS.md
+++ b/packages/server/AGENTS.md
@@ -463,6 +463,20 @@ conditional leaves a CSP-off document one newline shorter than a CSP-on one).
    map), so a `#` import is never sent to the resolver; the rare alias mapped to
    a real package (`"#x": "some-pkg"`) is consequently not vendored, an accepted
    limitation since the scaffold's catch-all `"#*": "./*"` is always local.
+   Every scan reads TYPE-ERASED source: `analyzeElision` runs a `.ts` / `.mts` /
+   `.tsx` module through the framework's own stripper (`eraseTypesForScan`)
+   before scanning it, because the scans are lexical and TS annotations are
+   call-shaped often enough to matter (`readonly (readonly [number, number,
+   number])[]` is an identifier immediately followed by `(`, which the
+   module-scope scan read as a top-level call, pinning every importing route
+   module, #1423). The stripper rather than a lexical annotation matcher, so the
+   analyser and the runtime agree by construction, and it is position-preserving,
+   so every offset the other scans depend on survives. A non-TS file, and a
+   source the stripper rejects (non-erasable syntax, which invariant 10 forbids),
+   are scanned as authored, the conservative direction. Consequence for a DIRECT
+   caller of `hasModuleScopeSideEffect` / `analyzeComponentSource`: both still
+   take source as given, so handing either one `.ts` as authored opts back into
+   that false positive.
    Import-only modules join the elision fingerprint (a verdict flip busts `?v`)
    and the bare-import scan exclusion (an SSR-only page import is no longer
    vendored), like inert modules. `collectRouteModules` (`dev.js`) feeds only

--- a/packages/server/AGENTS.md
+++ b/packages/server/AGENTS.md
@@ -463,20 +463,27 @@ conditional leaves a CSP-off document one newline shorter than a CSP-on one).
    map), so a `#` import is never sent to the resolver; the rare alias mapped to
    a real package (`"#x": "some-pkg"`) is consequently not vendored, an accepted
    limitation since the scaffold's catch-all `"#*": "./*"` is always local.
-   Every scan reads TYPE-ERASED source: `analyzeElision` runs a `.ts` / `.mts`
-   module through the framework's own stripper (`eraseTypesForScan`)
+   Every scan reads TYPE-ERASED source: `analyzeElision` runs a `.ts` / `.mts` /
+   `.tsx` module through the framework's own stripper (`eraseTypesForScan`)
    before scanning it, because the scans are lexical and TS annotations are
    call-shaped often enough to matter (`readonly (readonly [number, number,
    number])[]` is an identifier immediately followed by `(`, which the
    module-scope scan read as a top-level call, pinning every importing route
    module, #1423). The stripper rather than a lexical annotation matcher, so the
    analyser and the runtime agree by construction, and it is position-preserving,
-   so every offset the other scans depend on survives. A non-TS file, and a
-   source the stripper rejects (non-erasable syntax, which invariant 10 forbids),
-   are scanned as authored, the conservative direction. Consequence for a DIRECT
-   caller of `hasModuleScopeSideEffect` / `analyzeComponentSource`: both still
-   take source as given, so handing either one `.ts` as authored opts back into
-   that false positive.
+   so every offset the other scans depend on survives. The extension set is the
+   union of the TypeScript-carrying extensions in the three filters that seed
+   `allFiles`, NOT the servable set: `scanComponents` admits `/\.m?[jt]sx?$/`,
+   wider than the graph walker and the router, so a `.tsx` component reaches the
+   analysis and narrowing to `.ts` / `.mts` silently un-erases it. A non-TS file,
+   and a source the stripper rejects (non-erasable syntax, which invariant 10
+   forbids, or real JSX in a `.tsx`), are scanned as authored, the conservative
+   direction; a missing stripper BACKEND is the one failure that warns, since it
+   un-erases the whole app rather than one file. Results are memoized per file
+   and validated against the source, so a dev rebuild re-strips only what
+   changed. Consequence for a DIRECT caller of `hasModuleScopeSideEffect` /
+   `analyzeComponentSource`: both still take source as given, so handing either
+   one `.ts` as authored opts back into that false positive.
    Import-only modules join the elision fingerprint (a verdict flip busts `?v`)
    and the bare-import scan exclusion (an SSR-only page import is no longer
    vendored), like inert modules. `collectRouteModules` (`dev.js`) feeds only

--- a/packages/server/src/component-elision.js
+++ b/packages/server/src/component-elision.js
@@ -45,7 +45,7 @@ import {
   redactToPlaceholders,
 } from './js-scan.js';
 import { transitiveDeps, expandImportAlias } from './module-graph.js';
-import { stripTypeScript } from './ts-strip.js';
+import { ensureStripper } from './ts-strip.js';
 
 /**
  * Named imports from a `@webjsdev/core` specifier that imply the
@@ -923,25 +923,86 @@ const TS_SOURCE_RE = /\.m?tsx?$/;
  * line, and column the other scans depend on is unchanged.
  *
  * A non-TypeScript file is returned untouched (there is nothing to erase, and
- * running a TS parser over one buys only new ways to fail). A strip FAILURE
- * also returns the source untouched, which is the pre-#1423 behaviour and
- * therefore the conservative direction: the scans then over-detect at worst.
- * Two things take that path. A non-erasable module, which invariant 10 forbids
- * and `webjs check` catches at edit time, so it is a broken app rather than a
- * supported one. And a `.tsx` file holding real JSX, which the stripper parses
- * as non-JSX TypeScript and rejects, so a JSX component is scanned as authored
- * while a `.tsx` that is only TypeScript is erased normally.
+ * running a TS parser over one buys only new ways to fail). A PER-FILE strip
+ * failure also returns the source untouched, which is the pre-#1423 behaviour
+ * and therefore the conservative direction: the scans then over-detect at
+ * worst. Two things take that path, both silent because both are one file's
+ * problem. A non-erasable module, which invariant 10 forbids and `webjs check`
+ * catches at edit time, so it is a broken app rather than a supported one. And
+ * a `.tsx` holding real JSX, which the stripper parses as non-JSX TypeScript
+ * and rejects, so a JSX component is scanned as authored while a `.tsx` that is
+ * only TypeScript is erased normally.
  *
- * @param {string} file absolute path, read for its extension only
+ * A missing stripper BACKEND is the failure that does not stay silent, and it
+ * is why the backend is resolved once by the caller rather than per file. It
+ * means no TypeScript in the app can be erased (a runtime with neither the
+ * built-in nor `amaro`), so every module is scanned as authored and the #1423
+ * verdict comes back app-wide. Swallowing that alongside a syntax rejection
+ * would make an app-wide regression indistinguishable from one broken file, so
+ * `resolveScanStripper` warns once and this returns the source untouched.
+ *
+ * Results are memoized per file and validated against the exact source, since
+ * this runs on every dev rebuild and stripping costs roughly 50x the read it
+ * sits beside. Validating on content rather than mtime means a same-mtime
+ * rewrite cannot serve a stale strip.
+ *
+ * @param {import('./ts-strip.js').Stripper | null} stripper resolved once per run, null when unavailable
+ * @param {string} file absolute path, the cache key and the extension source
  * @param {string} src
- * @returns {Promise<string>}
+ * @returns {string}
  */
-async function eraseTypesForScan(file, src) {
-  if (!TS_SOURCE_RE.test(file)) return src;
+function eraseTypesForScan(stripper, file, src) {
+  if (!stripper || !TS_SOURCE_RE.test(file)) return src;
+  const hit = STRIP_CACHE.get(file);
+  if (hit && hit.src === src) return hit.out;
+  let out;
   try {
-    return await stripTypeScript(src);
+    out = stripper.fn(src);
   } catch {
-    return src;
+    out = src;
+  }
+  STRIP_CACHE.set(file, { src, out });
+  return out;
+}
+
+/**
+ * Per-file memo of {@link eraseTypesForScan}, holding the source it was derived
+ * from so a hit is proven rather than assumed. One entry per file, so it is
+ * bounded by the app's file count and needs no eviction policy; a deleted file
+ * leaves one dead entry until the process ends, which is cheaper than tracking
+ * liveness for it.
+ *
+ * @type {Map<string, { src: string, out: string }>}
+ */
+const STRIP_CACHE = new Map();
+
+/**
+ * Resolve the TypeScript stripper backend once for a whole analysis run, or
+ * `null` when this runtime has none.
+ *
+ * `analyzeElision` runs outside the dev request handler too (`webjs check`,
+ * `webjs elision`), and `ensureStripper` is called on the dev path only, so
+ * this is where the no-backend case surfaces for the other entry points. It
+ * warns once per process rather than per file: the condition is a property of
+ * the runtime, so repeating it once per module would bury it.
+ *
+ * @returns {Promise<import('./ts-strip.js').Stripper | null>}
+ */
+let warnedNoStripper = false;
+async function resolveScanStripper() {
+  try {
+    return await ensureStripper();
+  } catch (e) {
+    if (!warnedNoStripper) {
+      warnedNoStripper = true;
+      console.warn(
+        '[webjs] elision analysis could not resolve a TypeScript stripper, so type syntax ' +
+        'is not erased before the scans read a module. A type annotation can then read as ' +
+        'module-scope work, which ships modules that would otherwise be elided. Underlying: ' +
+        (e && e.message ? e.message : String(e)),
+      );
+    }
+    return null;
   }
 }
 
@@ -1052,6 +1113,11 @@ export async function analyzeElision(components, routeModules, moduleGraph, read
     for (const v of vs) if (!appDir || v.startsWith(appDir)) allFiles.add(v);
   }
 
+  // Resolve the stripper ONCE for the run: the backend is a property of the
+  // runtime, not of a file, and the no-backend case must be reported rather
+  // than swallowed per module (see `eraseTypesForScan`).
+  const scanStripper = await resolveScanStripper();
+
   for (const file of allFiles) {
     if (SERVER_FILE_RE.test(file)) { serverFiles.add(file); continue; }
     let src;
@@ -1067,7 +1133,7 @@ export async function analyzeElision(components, routeModules, moduleGraph, read
     // (#1423). This is the single point where the analyser reads a file, so
     // doing it here covers the module-scope, template, import, and component
     // scans at once.
-    src = await eraseTypesForScan(file, src);
+    src = eraseTypesForScan(scanStripper, file, src);
     // Mask comments once for every signal scan below (#179): a `<tag>`, an
     // `@event`, a browser global, an `import`, or a `whenDefined` written in a
     // comment must not register as a real signal. String and template content

--- a/packages/server/src/component-elision.js
+++ b/packages/server/src/component-elision.js
@@ -45,6 +45,7 @@ import {
   redactToPlaceholders,
 } from './js-scan.js';
 import { transitiveDeps, expandImportAlias } from './module-graph.js';
+import { stripTypeScript } from './ts-strip.js';
 
 /**
  * Named imports from a `@webjsdev/core` specifier that imply the
@@ -285,13 +286,22 @@ const COMPONENT_CLIENT_GLOBAL_RE = /\b(?:window|document|navigator|localStorage|
  *
  * Scans the redacted copy (strings / templates / comments blanked, regex
  * literals and nested `${...}` interpolation tracked by the lexer) so template
- * prose and JSDoc / TS type annotations cannot trip it; quoted-string bodies,
- * which redaction keeps verbatim for other rules, are blanked here too so a
- * string like `"foo()"` or `"{"` is not read as a call and cannot unbalance
- * the brace scan. The unbalanced-brace and unterminated-string fallbacks below
- * are defense in depth: with the lexer tracking regex literals, neither should
- * trigger on valid code, but if either does the module ships rather than risk
- * hiding client work.
+ * prose and JSDoc cannot trip it; quoted-string bodies, which redaction keeps
+ * verbatim for other rules, are blanked here too so a string like `"foo()"` or
+ * `"{"` is not read as a call and cannot unbalance the brace scan. The
+ * unbalanced-brace and unterminated-string fallbacks below are defense in
+ * depth: with the lexer tracking regex literals, neither should trigger on
+ * valid code, but if either does the module ships rather than risk hiding
+ * client work.
+ *
+ * PASS TYPE-ERASED SOURCE for a TypeScript module. Redaction blanks comments
+ * and literals, NOT type syntax, and TS annotations are call-shaped often
+ * enough to matter: `readonly (readonly [number, number, number])[]` is an
+ * identifier immediately followed by `(`, so a module holding nothing but a
+ * typed data literal reads as running code at module scope (#1423). The
+ * analyser erases types before it calls this (`eraseTypesForScan`), so the
+ * request path is covered; a DIRECT caller handing it `.ts` source as authored
+ * is opting into that false positive.
  *
  * Over-detection is safe (a top-level arrow whose body calls something, or a
  * pure top-level helper call, only ships). The accepted residual misses, all
@@ -299,7 +309,7 @@ const COMPONENT_CLIENT_GLOBAL_RE = /\b(?:window|document|navigator|localStorage|
  * top-level object / array initializer or a destructuring default, and a
  * side-effecting tagged-template hole evaluated at module scope.
  *
- * @param {string} src raw module source
+ * @param {string} src module source, type-erased if it came from a `.ts` file
  */
 /**
  * Constructors that produce inert DATA with no side effect, so a module-scope
@@ -893,6 +903,47 @@ export function extractRenderedTags(src) {
  * @param {string} [appDir]  app root; enables the helper-closure render rule
  * @returns {Promise<Set<string>>} absolute paths of elidable component files
  */
+/** Source extensions whose types must be erased before the scans below read them. */
+const TS_SOURCE_RE = /\.(?:m|c)?tsx?$/;
+
+/**
+ * Return `src` with its TYPE syntax erased, so every scan below reads the code
+ * that actually RUNS rather than the code as authored (#1423).
+ *
+ * The scans are lexical heuristics, and TypeScript annotations are syntax the
+ * heuristics were never designed for: `readonly (readonly [number, number,
+ * number])[]` is an identifier immediately followed by `(`, which the
+ * top-level-call matcher in `hasModuleScopeSideEffect` reads as a call, so a
+ * module holding nothing but a typed data literal was classified as running
+ * code at module scope and pinned every route module that imported it. Type
+ * syntax is erased before anything runs, so it can never be a runtime signal,
+ * and the only sound reading of it is none at all.
+ *
+ * This uses the framework's own stripper rather than a lexical annotation
+ * matcher: it is the same erasure the browser is served, so the analyser and
+ * the runtime agree by construction, where a hand-rolled matcher would meet
+ * generics, `as`, `satisfies`, and conditional types and get some of them
+ * wrong. It is position-preserving whitespace replacement, so every offset,
+ * line, and column the other scans depend on is unchanged.
+ *
+ * Non-TS files are returned untouched (there is nothing to erase, and running a
+ * TS parser over them buys only new ways to fail). A strip FAILURE also returns
+ * the source untouched, which is the pre-#1423 behaviour and therefore the
+ * conservative direction: the scans then over-detect at worst.
+ *
+ * @param {string} file absolute path, read for its extension only
+ * @param {string} src
+ * @returns {Promise<string>}
+ */
+async function eraseTypesForScan(file, src) {
+  if (!TS_SOURCE_RE.test(file)) return src;
+  try {
+    return await stripTypeScript(src);
+  } catch {
+    return src;
+  }
+}
+
 export async function computeElidableComponents(components, moduleGraph, readFileFn, appDir) {
   const { elidableComponents } = await analyzeElision(components, [], moduleGraph, readFileFn, appDir);
   return elidableComponents;
@@ -989,6 +1040,11 @@ export async function analyzeElision(components, routeModules, moduleGraph, read
       continue;
     }
     if (typeof src !== 'string') continue;
+    // Erase type syntax first, so every scan below reads the code that RUNS
+    // (#1423). This is the single point where the analyser reads a file, so
+    // doing it here covers the module-scope, template, import, and component
+    // scans at once.
+    src = await eraseTypesForScan(file, src);
     // Mask comments once for every signal scan below (#179): a `<tag>`, an
     // `@event`, a browser global, an `import`, or a `whenDefined` written in a
     // comment must not register as a real signal. String and template content

--- a/packages/server/src/component-elision.js
+++ b/packages/server/src/component-elision.js
@@ -269,6 +269,23 @@ const INSTANCEOF_RE = /\binstanceof\s+([A-Z][A-Za-z0-9_$]*)/g;
 const COMPONENT_CLIENT_GLOBAL_RE = /\b(?:window|document|navigator|localStorage|sessionStorage|matchMedia|addEventListener)\b/;
 
 /**
+ * Constructors that produce inert DATA with no side effect, so a module-scope
+ * `export const X = new Set([...])` (a lookup table, a compiled RegExp, a
+ * parsed URL) is not client work and must not pin an importing page/layout
+ * (#623). Any constructor NOT in this set (`new WebSocket()`, `new Worker()`,
+ * `new EventSource()`, `new Audio()`) IS a side effect and still ships.
+ */
+const PURE_DATA_CONSTRUCTORS = new Set([
+  'Set', 'Map', 'WeakSet', 'WeakMap', 'Date', 'RegExp', 'Array', 'Object',
+  'Number', 'String', 'Boolean', 'BigInt', 'Symbol',
+  'Error', 'TypeError', 'RangeError', 'SyntaxError',
+  'URL', 'URLSearchParams', 'ArrayBuffer', 'DataView',
+  'Int8Array', 'Uint8Array', 'Uint8ClampedArray', 'Int16Array', 'Uint16Array',
+  'Int32Array', 'Uint32Array', 'Float32Array', 'Float64Array',
+  'BigInt64Array', 'BigUint64Array',
+]);
+
+/**
  * Module-scope client work, detected by an ALLOWLIST of safe top-level forms
  * rather than a denylist of browser globals. A module that runs ANY code when
  * it loads (other than registering a component) does client work the render /
@@ -309,25 +326,10 @@ const COMPONENT_CLIENT_GLOBAL_RE = /\b(?:window|document|navigator|localStorage|
  * top-level object / array initializer or a destructuring default, and a
  * side-effecting tagged-template hole evaluated at module scope.
  *
- * @param {string} src module source, type-erased if it came from a `.ts` file
+ * @param {string} src module source, type-erased if it came from a TypeScript file
+ * @param {string[]} [literals] the redaction's literal bodies, when already computed
+ * @returns {boolean}
  */
-/**
- * Constructors that produce inert DATA with no side effect, so a module-scope
- * `export const X = new Set([...])` (a lookup table, a compiled RegExp, a
- * parsed URL) is not client work and must not pin an importing page/layout
- * (#623). Any constructor NOT in this set (`new WebSocket()`, `new Worker()`,
- * `new EventSource()`, `new Audio()`) IS a side effect and still ships.
- */
-const PURE_DATA_CONSTRUCTORS = new Set([
-  'Set', 'Map', 'WeakSet', 'WeakMap', 'Date', 'RegExp', 'Array', 'Object',
-  'Number', 'String', 'Boolean', 'BigInt', 'Symbol',
-  'Error', 'TypeError', 'RangeError', 'SyntaxError',
-  'URL', 'URLSearchParams', 'ArrayBuffer', 'DataView',
-  'Int8Array', 'Uint8Array', 'Uint8ClampedArray', 'Int16Array', 'Uint16Array',
-  'Int32Array', 'Uint32Array', 'Float32Array', 'Float64Array',
-  'BigInt64Array', 'BigUint64Array',
-]);
-
 export function hasModuleScopeSideEffect(src, literals) {
   let redacted = src;
   if (!literals) {
@@ -882,16 +884,23 @@ export function extractRenderedTags(src) {
 }
 
 /**
- * The TypeScript source extensions, which are exactly the ones WebJs treats as
- * TypeScript everywhere else: the `MIME` map and `stripTs` in `dev/`, the
- * servable-extension test in `dev/serve.js`, the graph walker's file filter in
- * `module-graph.js`, and the router's `<name>.<js|mjs|ts|mts>` convention.
- * Keep this set EQUAL to those rather than merely a superset. A wider one reads
- * as support the framework does not have (there is no `.cts` and no JSX
- * anywhere in it), and it cannot even be exercised, since the graph walker and
- * the router are what decide which files reach this analysis at all.
+ * The extensions that can carry TypeScript type syntax INTO this analysis.
+ *
+ * Derive it from what actually reaches `allFiles`, which is seeded from three
+ * places with three different filters: the component set from `scanComponents`
+ * (`/\.m?[jt]sx?$/`), the route modules from the router (`js|mjs|ts|mts`), and
+ * the module graph from its walker (`/\.(js|ts|mjs|mts)$/`). The COMPONENT set
+ * is the widest and it does not pass through the other two, so a `.tsx`
+ * component arrives here whatever the walker and the router admit. Hence
+ * `.tsx`, even though nothing in WebJs serves one: leaving it out is how the
+ * #1423 false positive comes back for exactly the file class no other filter
+ * would have let through. `.cts` is absent because no filter admits it.
+ *
+ * The rule to hold, if any of those three filters moves: this set is every
+ * TypeScript-carrying extension in their UNION. Narrowing it to the servable
+ * set instead is a change that looks tighter and silently un-erases files.
  */
-const TS_SOURCE_RE = /\.m?ts$/;
+const TS_SOURCE_RE = /\.m?tsx?$/;
 
 /**
  * Return `src` with its TYPE syntax erased, so every scan below reads the code
@@ -913,13 +922,15 @@ const TS_SOURCE_RE = /\.m?ts$/;
  * wrong. It is position-preserving whitespace replacement, so every offset,
  * line, and column the other scans depend on is unchanged.
  *
- * A `.js` / `.mjs` file is returned untouched (there is nothing to erase, and
- * running a TS parser over them buys only new ways to fail). A strip FAILURE
+ * A non-TypeScript file is returned untouched (there is nothing to erase, and
+ * running a TS parser over one buys only new ways to fail). A strip FAILURE
  * also returns the source untouched, which is the pre-#1423 behaviour and
  * therefore the conservative direction: the scans then over-detect at worst.
- * That is the path a non-erasable module takes, which invariant 10 forbids and
- * `webjs check` catches at edit time, so it is a broken app rather than a
- * supported one.
+ * Two things take that path. A non-erasable module, which invariant 10 forbids
+ * and `webjs check` catches at edit time, so it is a broken app rather than a
+ * supported one. And a `.tsx` file holding real JSX, which the stripper parses
+ * as non-JSX TypeScript and rejects, so a JSX component is scanned as authored
+ * while a `.tsx` that is only TypeScript is erased normally.
  *
  * @param {string} file absolute path, read for its extension only
  * @param {string} src

--- a/packages/server/src/component-elision.js
+++ b/packages/server/src/component-elision.js
@@ -903,6 +903,17 @@ export function extractRenderedTags(src) {
 const TS_SOURCE_RE = /\.m?tsx?$/;
 
 /**
+ * Per-file memo of {@link eraseTypesForScan}, holding the source it was derived
+ * from so a hit is proven rather than assumed. One entry per file, so it is
+ * bounded by the app's file count and needs no eviction policy; a deleted file
+ * leaves one dead entry until the process ends, which is cheaper than tracking
+ * liveness for it.
+ *
+ * @type {Map<string, { src: string, out: string }>}
+ */
+const STRIP_CACHE = new Map();
+
+/**
  * Return `src` with its TYPE syntax erased, so every scan below reads the code
  * that actually RUNS rather than the code as authored (#1423).
  *
@@ -965,16 +976,8 @@ function eraseTypesForScan(stripper, file, src) {
   return out;
 }
 
-/**
- * Per-file memo of {@link eraseTypesForScan}, holding the source it was derived
- * from so a hit is proven rather than assumed. One entry per file, so it is
- * bounded by the app's file count and needs no eviction policy; a deleted file
- * leaves one dead entry until the process ends, which is cheaper than tracking
- * liveness for it.
- *
- * @type {Map<string, { src: string, out: string }>}
- */
-const STRIP_CACHE = new Map();
+/** Whether {@link resolveScanStripper} has already reported a missing backend. */
+let warnedNoStripper = false;
 
 /**
  * Resolve the TypeScript stripper backend once for a whole analysis run, or
@@ -988,7 +991,6 @@ const STRIP_CACHE = new Map();
  *
  * @returns {Promise<import('./ts-strip.js').Stripper | null>}
  */
-let warnedNoStripper = false;
 async function resolveScanStripper() {
   try {
     return await ensureStripper();

--- a/packages/server/src/component-elision.js
+++ b/packages/server/src/component-elision.js
@@ -881,28 +881,6 @@ export function extractRenderedTags(src) {
   return tags;
 }
 
-/**
- * Compute the set of component FILES whose browser download can be
- * elided. A file is elidable only when every component it defines is
- * display-only AND it is not pulled into the client by an interactive
- * component (rendered by, or imported by, a shipping module).
- *
- * Two propagation rules iterate to a fixpoint:
- *   - render rule:  a shipping component that can emit `<child-tag>` on a
- *     client re-render forces the child to ship. The tags a component can
- *     emit are not only those in its own template but also those returned
- *     by the template helpers it imports (the documented `lib/utils/ui.ts`
- *     pattern), so the rule scans the component's transitive app-internal
- *     import closure, not just its own source.
- *   - import rule:  a component that imports a shipping component module
- *     ships too (matches the issue's transitive criterion; conservative).
- *
- * @param {Array<{ tag: string, file: string }>} components
- * @param {import('./module-graph.js').ModuleGraph} moduleGraph
- * @param {(file: string) => Promise<string>} readFileFn
- * @param {string} [appDir]  app root; enables the helper-closure render rule
- * @returns {Promise<Set<string>>} absolute paths of elidable component files
- */
 /** Source extensions whose types must be erased before the scans below read them. */
 const TS_SOURCE_RE = /\.(?:m|c)?tsx?$/;
 
@@ -944,6 +922,28 @@ async function eraseTypesForScan(file, src) {
   }
 }
 
+/**
+ * Compute the set of component FILES whose browser download can be
+ * elided. A file is elidable only when every component it defines is
+ * display-only AND it is not pulled into the client by an interactive
+ * component (rendered by, or imported by, a shipping module).
+ *
+ * Two propagation rules iterate to a fixpoint:
+ *   - render rule:  a shipping component that can emit `<child-tag>` on a
+ *     client re-render forces the child to ship. The tags a component can
+ *     emit are not only those in its own template but also those returned
+ *     by the template helpers it imports (the documented `lib/utils/ui.ts`
+ *     pattern), so the rule scans the component's transitive app-internal
+ *     import closure, not just its own source.
+ *   - import rule:  a component that imports a shipping component module
+ *     ships too (matches the issue's transitive criterion; conservative).
+ *
+ * @param {Array<{ tag: string, file: string }>} components
+ * @param {import('./module-graph.js').ModuleGraph} moduleGraph
+ * @param {(file: string) => Promise<string>} readFileFn
+ * @param {string} [appDir]  app root; enables the helper-closure render rule
+ * @returns {Promise<Set<string>>} absolute paths of elidable component files
+ */
 export async function computeElidableComponents(components, moduleGraph, readFileFn, appDir) {
   const { elidableComponents } = await analyzeElision(components, [], moduleGraph, readFileFn, appDir);
   return elidableComponents;

--- a/packages/server/src/component-elision.js
+++ b/packages/server/src/component-elision.js
@@ -881,8 +881,17 @@ export function extractRenderedTags(src) {
   return tags;
 }
 
-/** Source extensions whose types must be erased before the scans below read them. */
-const TS_SOURCE_RE = /\.(?:m|c)?tsx?$/;
+/**
+ * The TypeScript source extensions, which are exactly the ones WebJs treats as
+ * TypeScript everywhere else: the `MIME` map and `stripTs` in `dev/`, the
+ * servable-extension test in `dev/serve.js`, the graph walker's file filter in
+ * `module-graph.js`, and the router's `<name>.<js|mjs|ts|mts>` convention.
+ * Keep this set EQUAL to those rather than merely a superset. A wider one reads
+ * as support the framework does not have (there is no `.cts` and no JSX
+ * anywhere in it), and it cannot even be exercised, since the graph walker and
+ * the router are what decide which files reach this analysis at all.
+ */
+const TS_SOURCE_RE = /\.m?ts$/;
 
 /**
  * Return `src` with its TYPE syntax erased, so every scan below reads the code
@@ -904,10 +913,13 @@ const TS_SOURCE_RE = /\.(?:m|c)?tsx?$/;
  * wrong. It is position-preserving whitespace replacement, so every offset,
  * line, and column the other scans depend on is unchanged.
  *
- * Non-TS files are returned untouched (there is nothing to erase, and running a
- * TS parser over them buys only new ways to fail). A strip FAILURE also returns
- * the source untouched, which is the pre-#1423 behaviour and therefore the
- * conservative direction: the scans then over-detect at worst.
+ * A `.js` / `.mjs` file is returned untouched (there is nothing to erase, and
+ * running a TS parser over them buys only new ways to fail). A strip FAILURE
+ * also returns the source untouched, which is the pre-#1423 behaviour and
+ * therefore the conservative direction: the scans then over-detect at worst.
+ * That is the path a non-erasable module takes, which invariant 10 forbids and
+ * `webjs check` catches at edit time, so it is a broken app rather than a
+ * supported one.
  *
  * @param {string} file absolute path, read for its extension only
  * @param {string} src

--- a/packages/server/test/elision/type-annotations.test.js
+++ b/packages/server/test/elision/type-annotations.test.js
@@ -194,6 +194,41 @@ Badge.register('my-badge');
   }
 });
 
+test('the strip memo is validated against the source, so an edit is re-erased', async () => {
+  // The memo is keyed by PATH and holds the source it was derived from, because
+  // this runs on every dev rebuild and stripping costs roughly 50x the read it
+  // sits beside. Keying by path alone would serve a stale strip after an edit,
+  // and mtime would miss a same-mtime rewrite, so the check is on content. Same
+  // path, two different sources, two different verdicts is what proves it.
+  const dir = await mkdtemp(join(tmpdir(), 'webjs-type-annotations-memo-'));
+  try {
+    await mkdir(join(dir, 'app'), { recursive: true });
+    await mkdir(join(dir, 'modules/game/utils'), { recursive: true });
+    const util = join(dir, 'modules/game/utils/game.ts');
+    const pageFile = join(dir, 'app/page.ts');
+    await writeFile(pageFile, `
+import { html } from '@webjsdev/core';
+import { LINES } from '../modules/game/utils/game.ts';
+export default () => html\`<p>\${LINES.length}</p>\`;
+`);
+    const analyse = async () => {
+      const graph = await buildModuleGraph(dir);
+      return analyzeElision(await scanComponents(dir), [pageFile], graph, (f) => readFile(f, 'utf8'), dir);
+    };
+
+    await writeFile(util, 'export const LINES: readonly (readonly [number, number, number])[] = [[0, 1, 2]];\n');
+    assert.ok((await analyse()).inertRouteModules.has(pageFile), 'pure typed data is inert');
+
+    // Same path, new content that DOES do module-scope work. A memo keyed only
+    // by path would hand back the erased first version and call this inert too.
+    await writeFile(util, 'export const LINES = init();\nfunction init() { return [[0, 1, 2]]; }\n');
+    assert.ok(!(await analyse()).inertRouteModules.has(pageFile),
+      'the edit must be re-read and re-scanned, not served from the memo');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test('a .ts module with non-erasable syntax falls back to scanning it as authored', async () => {
   // The stripper throws on non-erasable TypeScript (invariant 10 forbids it and
   // `webjs check` catches it at edit time, so this is a broken app rather than a

--- a/packages/server/test/elision/type-annotations.test.js
+++ b/packages/server/test/elision/type-annotations.test.js
@@ -1,0 +1,167 @@
+/**
+ * A TypeScript TYPE ANNOTATION must never be read as runtime behaviour by the
+ * elision analyser (#1423).
+ *
+ * The scans in `component-elision.js` are lexical heuristics over source that
+ * has had comments and literals redacted, and type syntax was not on that list.
+ * `readonly (readonly [number, number, number])[]` is an identifier immediately
+ * followed by `(`, so `hasModuleScopeSideEffect`'s top-level-call matcher read
+ * it as a call and classified a module of pure typed data as running code at
+ * module scope. The cost was invisible: no error, no warning, identical
+ * behaviour, just every importing route module downgraded from inert to
+ * shipping whole, and any component carrying such an annotation forced to ship
+ * along with the display-only children it renders.
+ *
+ * These tests drive the REAL pipeline over a REAL `.ts` app on disk, because
+ * that is the only level the fix lives at: the analyser erases types before it
+ * scans, so a unit call on a source string would prove nothing about the path
+ * that decides what the browser downloads. The three positive cases are the
+ * issue's acceptance criteria, and the last one is the counterweight that
+ * keeps them honest, since blanket-erasing too much would satisfy the first
+ * three by simply never detecting anything.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { buildModuleGraph } from '../../src/module-graph.js';
+import { scanComponents } from '../../src/component-scanner.js';
+import { analyzeElision } from '../../src/component-elision.js';
+
+/** The tic-tac-toe declaration from the report, verbatim in shape. */
+const LINES_TS = `
+export type Cell = 'X' | 'O' | null;
+export interface Board { cells: Cell[]; }
+export const LINES: readonly (readonly [number, number, number])[] = [
+  [0, 1, 2], [3, 4, 5], [6, 7, 8],
+  [0, 3, 6], [1, 4, 7], [2, 5, 8],
+  [0, 4, 8], [2, 4, 6],
+];
+export function winner(cells: Cell[]): Cell {
+  for (const [a, b, c] of LINES) {
+    if (cells[a] && cells[a] === cells[b] && cells[b] === cells[c]) return cells[a];
+  }
+  return null;
+}
+`;
+
+/**
+ * Write a throwaway TypeScript app, run the real pipeline over it, and return
+ * the verdict plus the paths the assertions key on.
+ *
+ * @param {{ utilSrc: string, badgeExtra?: string }} spec
+ */
+async function analyseApp(spec) {
+  const dir = await mkdtemp(join(tmpdir(), 'webjs-type-annotations-'));
+  try {
+    await mkdir(join(dir, 'app'), { recursive: true });
+    await mkdir(join(dir, 'components'), { recursive: true });
+    await mkdir(join(dir, 'modules/game/utils'), { recursive: true });
+    await writeFile(join(dir, 'modules/game/utils/game.ts'), spec.utilSrc);
+    await writeFile(join(dir, 'components/badge.ts'), `
+import { WebComponent, html } from '@webjsdev/core';
+import { LINES } from '../modules/game/utils/game.ts';
+export class Badge extends WebComponent {
+  ${spec.badgeExtra || ''}
+  render() { return html\`<span class="badge">\${LINES.length}</span>\`; }
+}
+Badge.register('my-badge');
+`);
+    await writeFile(join(dir, 'app/page.ts'), `
+import { html } from '@webjsdev/core';
+import '../components/badge.ts';
+export default () => html\`<my-badge></my-badge>\`;
+`);
+
+    const graph = await buildModuleGraph(dir);
+    const components = await scanComponents(dir);
+    const pageFile = join(dir, 'app/page.ts');
+    const badgeFile = join(dir, 'components/badge.ts');
+    const verdict = await analyzeElision(
+      components, [pageFile], graph, (f) => readFile(f, 'utf8'), dir,
+    );
+    return { verdict, pageFile, badgeFile };
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test('a parenthesised type annotation does not mark its module as running code at module scope', async () => {
+  const { verdict, pageFile } = await analyseApp({ utilSrc: LINES_TS });
+  const shipped = verdict.shippedRouteModules.get(pageFile);
+  assert.equal(shipped, undefined,
+    `the page must not ship; it did, blocked by ${shipped && shipped.blocker} (${shipped && shipped.reason})`);
+});
+
+test('a page importing only such a module is inert', async () => {
+  const { verdict, pageFile } = await analyseApp({ utilSrc: LINES_TS });
+  assert.ok(verdict.inertRouteModules.has(pageFile),
+    'the whole client closure is display-only, so the page ships zero JavaScript');
+});
+
+test('a component whose only module-scope construct is a parenthesised annotation is elided', async () => {
+  const { verdict, badgeFile } = await analyseApp({ utilSrc: LINES_TS });
+  assert.ok(verdict.elidableComponents.has(badgeFile),
+    'the badge renders static markup and the annotation is not a signal');
+  assert.equal(verdict.componentVerdicts.get(badgeFile).shipped, false);
+});
+
+test('the pin is the ANNOTATION, not the data: an `as const` spelling was already inert', async () => {
+  // The report's own workaround, kept as a control. Both spellings describe the
+  // same runtime value, so a fix that only moved one of them would be reading
+  // something other than the annotation.
+  const asConst = LINES_TS.replace(
+    /export const LINES: readonly \(readonly \[number, number, number\]\)\[\] = \[/,
+    'export const LINES = [',
+  ).replace(/\n\];/, '\n] as const;');
+  assert.notEqual(asConst, LINES_TS, 'the control rewrite must actually apply');
+  const { verdict, pageFile } = await analyseApp({ utilSrc: asConst });
+  assert.ok(verdict.inertRouteModules.has(pageFile));
+});
+
+test('real module-scope work in a .ts module still ships the page', async () => {
+  // The conservative direction, asserted per construct. Type erasure must not
+  // become a way for genuine client work to slip past: each of these is real
+  // code in the file the browser would run.
+  const cases = {
+    'a top-level call': 'export const boot = init();\nfunction init() { return 1; }',
+    'a non-data new': 'export const ws = new WebSocket("wss://x");',
+    'a dynamic import': 'export const mod = import("./other.ts");',
+    'a top-level await': 'export const v = await Promise.resolve(1);',
+    'a browser global': 'export const w = window.innerWidth;',
+  };
+  for (const [label, stmt] of Object.entries(cases)) {
+    const { verdict, pageFile } = await analyseApp({
+      utilSrc: `export const LINES: readonly (readonly [number, number, number])[] = [[0, 1, 2]];\n${stmt}\n`,
+    });
+    assert.ok(!verdict.inertRouteModules.has(pageFile), `${label} must keep the page shipping`);
+  }
+});
+
+test('a genuine top-level call named like a type keyword still ships', async () => {
+  // `readonly` is a legal function name in JavaScript, so exempting the bare
+  // identifier would have been a false NEGATIVE, the one direction this
+  // analyser may not take. Erasing types instead leaves the real call visible.
+  const { verdict, pageFile } = await analyseApp({
+    utilSrc: 'function readonly(x: number) { return x; }\nexport const LINES = readonly(1);\n',
+  });
+  assert.ok(!verdict.inertRouteModules.has(pageFile),
+    'a call to a function named `readonly` is a call');
+});
+
+test('a .ts module with non-erasable syntax falls back to scanning it as authored', async () => {
+  // The stripper throws on non-erasable TypeScript (invariant 10 forbids it and
+  // `webjs check` catches it at edit time, so this is a broken app rather than a
+  // supported one). The analyser must not throw with it: it keeps the source as
+  // authored, which is the pre-#1423 behaviour and therefore the conservative
+  // direction. The `init()` call is the proof it still SCANNED rather than
+  // silently gave up and called the module clean.
+  const { verdict, pageFile } = await analyseApp({
+    utilSrc: 'export enum E { A, B }\nexport const LINES = init();\nfunction init() { return []; }\n',
+  });
+  assert.ok(!verdict.inertRouteModules.has(pageFile),
+    'an unstrippable module is still scanned, and its real call still ships the page');
+});

--- a/packages/server/test/elision/type-annotations.test.js
+++ b/packages/server/test/elision/type-annotations.test.js
@@ -163,6 +163,37 @@ test('a genuine top-level call named like a type keyword still ships', async () 
     'a call to a function named `readonly` is a call');
 });
 
+test('a .tsx component is erased too, because it reaches the analysis by a wider filter', async () => {
+  // `allFiles` is seeded from the COMPONENT set before the module graph, and
+  // `scanComponents` admits `/\.m?[jt]sx?$/`, which is wider than both the
+  // graph walker's file filter and the router's. So a `.tsx` component lands
+  // in the analysis whatever those two admit, and an erasure set narrowed to
+  // the SERVABLE extensions would leave exactly this file class un-erased,
+  // with the #1423 verdict intact and nothing else covering it.
+  const dir = await mkdtemp(join(tmpdir(), 'webjs-type-annotations-tsx-'));
+  try {
+    await mkdir(join(dir, 'components'), { recursive: true });
+    await writeFile(join(dir, 'components/badge.tsx'), `
+import { WebComponent, html } from '@webjsdev/core';
+export const LINES: readonly (readonly [number, number, number])[] = [[0, 1, 2]];
+export class Badge extends WebComponent {
+  render() { return html\`<span>\${LINES.length}</span>\`; }
+}
+Badge.register('my-badge');
+`);
+    const graph = await buildModuleGraph(dir);
+    const components = await scanComponents(dir);
+    const badgeFile = join(dir, 'components/badge.tsx');
+    assert.ok(components.some((c) => c.file === badgeFile),
+      'precondition: the component scanner admits a .tsx file');
+    const verdict = await analyzeElision(components, [], graph, (f) => readFile(f, 'utf8'), dir);
+    assert.ok(verdict.elidableComponents.has(badgeFile),
+      'the annotation is not a signal in a .tsx file either');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test('a .ts module with non-erasable syntax falls back to scanning it as authored', async () => {
   // The stripper throws on non-erasable TypeScript (invariant 10 forbids it and
   // `webjs check` catches it at edit time, so this is a broken app rather than a

--- a/packages/server/test/elision/type-annotations.test.js
+++ b/packages/server/test/elision/type-annotations.test.js
@@ -15,15 +15,16 @@
  * These tests drive the REAL pipeline over a REAL `.ts` app on disk, because
  * that is the only level the fix lives at: the analyser erases types before it
  * scans, so a unit call on a source string would prove nothing about the path
- * that decides what the browser downloads. The three positive cases are the
- * issue's acceptance criteria, and the last one is the counterweight that
- * keeps them honest, since blanket-erasing too much would satisfy the first
- * three by simply never detecting anything.
+ * that decides what the browser downloads. The first three are the issue's
+ * acceptance criteria, and they are the discriminating ones: reverting the
+ * erasure reds exactly those three (proven at 3b3cb6a5). The rest are the
+ * counterweight that keeps them honest, since erasing too much would satisfy
+ * the first three by simply never detecting anything, and they stay green in
+ * both directions on purpose.
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
-import { readFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, writeFile, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -52,7 +53,12 @@ export function winner(cells: Cell[]): Cell {
  * Write a throwaway TypeScript app, run the real pipeline over it, and return
  * the verdict plus the paths the assertions key on.
  *
- * @param {{ utilSrc: string, badgeExtra?: string }} spec
+ * `direct: true` has the PAGE import the util and render no component, which is
+ * the shape the report hit: there the util is the page's whole client closure,
+ * so a wrong verdict on it shows up directly as the page's blocker instead of
+ * being laundered through a component that ships for its own reason.
+ *
+ * @param {{ utilSrc: string, direct?: boolean }} spec
  */
 async function analyseApp(spec) {
   const dir = await mkdtemp(join(tmpdir(), 'webjs-type-annotations-'));
@@ -61,16 +67,19 @@ async function analyseApp(spec) {
     await mkdir(join(dir, 'components'), { recursive: true });
     await mkdir(join(dir, 'modules/game/utils'), { recursive: true });
     await writeFile(join(dir, 'modules/game/utils/game.ts'), spec.utilSrc);
-    await writeFile(join(dir, 'components/badge.ts'), `
+    if (!spec.direct) await writeFile(join(dir, 'components/badge.ts'), `
 import { WebComponent, html } from '@webjsdev/core';
 import { LINES } from '../modules/game/utils/game.ts';
 export class Badge extends WebComponent {
-  ${spec.badgeExtra || ''}
   render() { return html\`<span class="badge">\${LINES.length}</span>\`; }
 }
 Badge.register('my-badge');
 `);
-    await writeFile(join(dir, 'app/page.ts'), `
+    await writeFile(join(dir, 'app/page.ts'), spec.direct ? `
+import { html } from '@webjsdev/core';
+import { LINES } from '../modules/game/utils/game.ts';
+export default () => html\`<p>\${LINES.length}</p>\`;
+` : `
 import { html } from '@webjsdev/core';
 import '../components/badge.ts';
 export default () => html\`<my-badge></my-badge>\`;
@@ -90,7 +99,7 @@ export default () => html\`<my-badge></my-badge>\`;
 }
 
 test('a parenthesised type annotation does not mark its module as running code at module scope', async () => {
-  const { verdict, pageFile } = await analyseApp({ utilSrc: LINES_TS });
+  const { verdict, pageFile } = await analyseApp({ utilSrc: LINES_TS, direct: true });
   const shipped = verdict.shippedRouteModules.get(pageFile);
   assert.equal(shipped, undefined,
     `the page must not ship; it did, blocked by ${shipped && shipped.blocker} (${shipped && shipped.reason})`);
@@ -118,7 +127,7 @@ test('the pin is the ANNOTATION, not the data: an `as const` spelling was alread
     'export const LINES = [',
   ).replace(/\n\];/, '\n] as const;');
   assert.notEqual(asConst, LINES_TS, 'the control rewrite must actually apply');
-  const { verdict, pageFile } = await analyseApp({ utilSrc: asConst });
+  const { verdict, pageFile } = await analyseApp({ utilSrc: asConst, direct: true });
   assert.ok(verdict.inertRouteModules.has(pageFile));
 });
 
@@ -136,6 +145,7 @@ test('real module-scope work in a .ts module still ships the page', async () => 
   for (const [label, stmt] of Object.entries(cases)) {
     const { verdict, pageFile } = await analyseApp({
       utilSrc: `export const LINES: readonly (readonly [number, number, number])[] = [[0, 1, 2]];\n${stmt}\n`,
+      direct: true,
     });
     assert.ok(!verdict.inertRouteModules.has(pageFile), `${label} must keep the page shipping`);
   }
@@ -147,6 +157,7 @@ test('a genuine top-level call named like a type keyword still ships', async () 
   // analyser may not take. Erasing types instead leaves the real call visible.
   const { verdict, pageFile } = await analyseApp({
     utilSrc: 'function readonly(x: number) { return x; }\nexport const LINES = readonly(1);\n',
+    direct: true,
   });
   assert.ok(!verdict.inertRouteModules.has(pageFile),
     'a call to a function named `readonly` is a call');
@@ -161,6 +172,7 @@ test('a .ts module with non-erasable syntax falls back to scanning it as authore
   // silently gave up and called the module clean.
   const { verdict, pageFile } = await analyseApp({
     utilSrc: 'export enum E { A, B }\nexport const LINES = init();\nfunction init() { return []; }\n',
+    direct: true,
   });
   assert.ok(!verdict.inertRouteModules.has(pageFile),
     'an unstrippable module is still scanned, and its real call still ships the page');

--- a/test/bun/elision-report.mjs
+++ b/test/bun/elision-report.mjs
@@ -8,9 +8,13 @@
  * WebJs runs on Node 24+ AND Bun (#508), and an app scaffolded with `--runtime
  * bun` runs `webjs elision` against a Bun-served app, so a verdict that drifted
  * between runtimes would mean the report told a Bun author something untrue
- * about their own app. The analysis is filesystem reads plus regular
- * expressions with no runtime-specific API, so there is nothing legitimate to
- * skip and this file carries no DENYLIST entry.
+ * about their own app. The analysis is filesystem reads and regular expressions
+ * over source the framework's TypeScript stripper has erased (#1423), and that
+ * stripper IS runtime-specific: Node's built-in `module.stripTypeScriptTypes`
+ * on one side, `amaro` on the other. The two are meant to be byte-identical,
+ * and the `.ts` route below is what holds them to it, since a divergence there
+ * would silently change what a Bun-served app downloads. Nothing here is
+ * legitimate to skip, so this file carries no DENYLIST entry.
  *
  * The fixture covers one component of each verdict and one route module of each
  * class, so a divergence in ANY of the projection's moving parts (the tag sort,
@@ -57,6 +61,15 @@ Counter.register('my-counter');
   // Import-only: the page itself does no client work, and the only client work
   // its closure reaches is a shipping component.
   write('app/page.js', "import { html } from '@webjsdev/core';\nimport '../components/counter.js';\nexport default () => html`<my-counter></my-counter>`;");
+  // Inert, and the row that exercises the STRIPPER seam: a parenthesised type
+  // annotation is call-shaped, so a runtime whose stripper left it behind would
+  // read this util as running code at module scope and report the page as
+  // shipping whole (#1423).
+  write('modules/game/utils/game.ts', `
+export type Cell = 'X' | 'O' | null;
+export const LINES: readonly (readonly [number, number, number])[] = [[0, 1, 2], [3, 4, 5]];
+`);
+  write('app/typed/page.ts', "import { html } from '@webjsdev/core';\nimport { LINES } from '../../modules/game/utils/game.ts';\nexport default () => html`<p>${LINES.length}</p>`;");
 
   const r = await analyzeAppElision(dir);
 
@@ -81,13 +94,14 @@ Counter.register('my-counter');
     [
       ['app/about/page.js', 'inert', ''],
       ['app/page.js', 'import-only', 'components/counter.js'],
+      ['app/typed/page.ts', 'inert', ''],
     ],
   );
 
   assert.deepEqual(r.orphans, []);
   assert.deepEqual(r.summary, {
     components: 2, elided: 1, shipped: 1,
-    routeModules: 2, inert: 1, importOnly: 1, shippedWhole: 0,
+    routeModules: 3, inert: 2, importOnly: 1, shippedWhole: 0,
     orphans: 0,
   });
 

--- a/website/app/docs/elision/page.ts
+++ b/website/app/docs/elision/page.ts
@@ -33,7 +33,7 @@ export default function Elision() {
       <li>A factory-declared reactive property that is not <code>{ state: true }</code>.</li>
       <li>An overridden lifecycle hook, <code>renderFallback()</code> and <code>renderError()</code> included.</li>
       <li>An imported <code>signal</code> / <code>computed</code> / <code>watch</code> / <code>Task</code> / <code>ref</code> or a streaming directive, or a call to <code>addController</code> / <code>requestUpdate</code>.</li>
-      <li>Code that runs at module load: a top-level call, a non-data <code>new</code>, a dynamic <code>import(...)</code>, a top-level <code>await</code>. Only declarations and the <code>register(...)</code> call are inert.</li>
+      <li>Code that runs at module load: a top-level call, a non-data <code>new</code>, a dynamic <code>import(...)</code>, a top-level <code>await</code>. Only declarations and the <code>register(...)</code> call are inert. TypeScript types are erased before the analyser reads a module, so an annotation is never a signal however call-shaped it looks: <code>readonly (readonly [number, number, number])[]</code> is inert data.</li>
       <li>A browser global at module scope, or a side-effect import of an npm package.</li>
       <li>The dynamic slot READ surface (<code>slotchange</code>, <code>assignedNodes</code> / <code>assignedElements</code> / <code>assignedSlot</code>). Merely rendering a <code>&lt;slot&gt;</code> does not ship, because the SSR output already carries the placed children.</li>
       <li>Being rendered or imported by a component that itself ships.</li>


### PR DESCRIPTION
Closes #1423

A parenthesised TypeScript type annotation on a top-level `const` read as a top-level call, so a module holding nothing but typed data was classified as running code at module scope. `readonly (readonly [number, number, number])[]` is an identifier immediately followed by `(`, which is exactly the shape `hasModuleScopeSideEffect`'s call matcher looks for. The cost was silent: no error, no warning, identical behaviour, and every route module importing such a helper downgraded from inert to shipping whole, with a component carrying one forced to ship along with the display-only children it renders.

## What changed

The analyser now erases type syntax before it scans, at the single point where it reads a file (`analyzeElision`'s loop), so the module-scope, template, import, and component scans all read the code that actually runs. A non-TypeScript file, and a source the stripper rejects, are scanned as authored, which is the previous behaviour and therefore the conservative direction.

## Why the stripper and not the keyword

The issue offered two fixes. Adding `readonly` to `NOT_A_CALL` is one line and kills the common case, but it does not kill the class (`as (readonly T[])` and every other identifier-before-paren in a type position still trip it), and it trades a false positive for a false NEGATIVE, since `readonly` is a legal function name and a real top-level `readonly(x)` call would then be missed. That is the one direction this analyser may not take. Erasing types removes the class outright and leaves a genuine call visible, so the keyword entry buys nothing once the erasure is in and is not included.

Erasure uses the framework's own stripper rather than a lexical annotation matcher. It is the same erasure the browser is served, so the analyser and the runtime agree by construction, where a hand-rolled matcher would meet generics, `as`, `satisfies`, and conditional types and get some of them wrong. It is position-preserving whitespace replacement, so every offset the other scans depend on is unchanged.

## Which extensions get erased, and why it is not the servable set

This is the part that took two passes to get right, so it is worth stating plainly. The erasure set is the union of the TypeScript-carrying extensions in the three filters that seed `analyzeElision`'s `allFiles`, NOT the set the server serves.

`allFiles` starts from the COMPONENT set, and `scanComponents` admits `/\.m?[jt]sx?$/`, which is wider than both the module-graph walker's `/\.(js|ts|mjs|mts)$/` and the router's `js|mjs|ts|mts`. So a `.tsx` component reaches the analysis whatever those two admit. Narrowing the erasure to the servable `.ts` / `.mts` therefore reinstates the #1423 verdict for exactly the file class no other filter would have let through, and it is the class with no other coverage. Hence `/\.m?tsx?$/`. `.cts` stays out because no filter admits it. A `.tsx` holding real JSX falls back to being scanned as authored, since the stripper parses as non-JSX TypeScript and rejects it.

## Test plan

- **Unit / integration**: new `packages/server/test/elision/type-annotations.test.js`, eight cases driving the real pipeline over a real app on disk. Four are the acceptance criteria (including the `.tsx` case above); four are the conservative-direction counterweight (a real call, a non-data `new`, a dynamic `import()`, a top-level `await`, a browser global, a genuine call to a function named `readonly`, and a module the stripper rejects). Full Node suite: 4468 tests, 0 failures.
- **Counterfactual**: reverting the erasure reds exactly the acceptance cases and leaves the counterweights green (proven at 3b3cb6a5). The `.tsx` case independently reds under a servable-set-only regex and passes under the union one, which is what makes the extension reasoning above testable rather than asserted.
- **Browser**: green, 76 files on all three engines (Chromium 892, Firefox 882, Webkit 892 passed, 0 failed).
- **E2E**: `WEBJS_E2E=1 node --test test/e2e/e2e.test.mjs` green.
- **Bun**: `node scripts/run-bun-tests.js` green, and `test/bun/elision-report.mjs` gains a `.ts` route carrying the annotation, run under both `node` and `bun`. This is the row that matters, since the erasure goes through the one seam that differs by runtime (Node's built-in stripper against amaro).
- **Verdict parity**: `webjs elision --json` byte-identical to `main` on `gallery`, `examples/blog`, and `website`, compared on an identical working tree.
- **`webjs elision --verify`**: `examples/blog` 26 routes identical, `website` 54 routes identical. `gallery` reports one divergence on `/features/caching`, which is that demo page rendering the current clock (`22:10:33` against `22:10:39`) rather than an elision difference. It reproduces identically on unmodified `origin/main`, so it is pre-existing and not from this PR.
- **Conventions**: `webjs check` clean on all three apps; `webjs doctor` 11 passed, 2 warnings, 0 failed on each, matching `main`.
- **Dogfood**: `website` boots in dist mode and serves 200 on `/`, `/docs/elision`, `/docs/components`, `/ui`, `/ui/button` with no broken modulepreload hints; `gallery` the same on `/` and `/features/caching`; `examples/blog` covered by the e2e run.

## Docs surfaces

- **Updated**: `.agents/skills/webjs/references/components.md` (the elidability blocker list), `website/app/docs/elision/page.ts` (the same list on the docs site), `packages/server/AGENTS.md` (where the erasure happens and what a direct caller of the scan functions is still on the hook for).
- **N/A**: scaffold generators, since `webjs create` output is unchanged and the CLI copies the skill from the repo root at prepack (`scripts/sync-scaffold-skill.mjs`), so the one edited copy is what ships. MCP, since no tool projection changed. Editor plugins, marketing copy, and README, since nothing they describe moved. Changelog, since there is no version bump here.
- **Deferred, awaiting a call**: `.agents/skills/webjs/references/runtime.md:23` claims WebJs serves `.ts` / `.tsx`. The `.tsx` half is false. Pre-existing, in a file this PR does not touch. Recorded in a comment below.
