### PR TITLE
chore: release server 0.8.65

### DIFF
--- a/changelog/server/0.8.65.md
+++ b/changelog/server/0.8.65.md
@@ -1,0 +1,13 @@
+---
+package: "@webjsdev/server"
+version: 0.8.65
+date: 2026-08-16T19:43:12.799Z
+commit_count: 1
+---
+## Fixes
+
+- **a parenthesised type annotation no longer reads as a top-level call** ([#1424](https://github.com/webjsdev/webjs/pull/1424)) [`720cadc8`](https://github.com/webjsdev/webjs/commit/720cadc8)
+  * fix: erase TypeScript types before the elision scans read a module
+  
+  A parenthesised type annotation on a top-level const read as a top-level
+  call, so a module holding nothing but typed data was classified as running

--- a/package-lock.json
+++ b/package-lock.json
@@ -7044,7 +7044,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.64",
+      "version": "0.8.65",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/core": "^0.7.51",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.64",
+  "version": "0.8.65",
   "type": "module",
   "description": "The server for WebJs, a full-stack JavaScript framework built on web components with server-side rendering and no build step. Provides the file-based router, SSR, server actions, route handlers, middleware, and live reload on Node 24+ or Bun.",
   "main": "index.js",


### PR DESCRIPTION
Releases `@webjsdev/server` 0.8.65, carrying the #1423 elision fix.

## What is in it

One user-facing change since 0.8.64, which is what `commit_count: 1` in the changelog reflects:

- **fix: a parenthesised type annotation no longer reads as a top-level call** (#1424). A TypeScript type annotation like `readonly (readonly [number, number, number])[]` read as a top-level call to the elision analyser, so a module of pure typed data was classified as running code at module scope. Every route module importing such a helper was downgraded from inert to shipping whole, and a component carrying one was forced to ship along with the display-only children it renders. Silent: no error, no warning, identical behaviour, only bytes.

## Why server only

`ui` is NOT due, and I want to record why, because my first pass said otherwise. I counted unreleased commits with `git log --grep="chore: release <pkg>"` to find each package's last release, which matched an OLD single-package release subject (`chore: release ui 0.3.9, mcp 0.1.10, cli 0.10.43`) rather than the current combined form (`chore: release core 0.7.51, server 0.8.64 and ui 0.3.14`). The range therefore started too far back and swept in already-released work. Reading the changelog files instead, which is what `scripts/backfill-changelog.js` does, `ui` has zero qualifying commits since 0.3.14 and `core`, `cli`, `mcp`, and `intellisense` are clean too.

## Bump level and ranges

Patch, matching how this package is kept in a single minor line. Every in-repo dependent pins `^0.8.0` (`packages/cli`, `packages/mcp`, `examples/blog`, `website`, `gallery`), so a patch stays inside every caret and no dependent range needed editing. `package-lock.json` regenerated with `npm install --package-lock-only`.

`@webjsdev/intellisense` is not bumped, so the webjs.nvim vendored copy needs no re-vendor.

## Changelog

`changelog/server/0.8.65.md` generated by the pre-commit hook, not hand-written. Merging this adds it to `main`, which triggers `release.yml` to `npm publish` and cut the GitHub Release (idempotent).
