### PR TITLE
fix: list Bluesky above X in the website footer

### DIFF
--- a/website/lib/ui/site-footer.ts
+++ b/website/lib/ui/site-footer.ts
@@ -54,8 +54,8 @@ export function siteFooter() {
             <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href=${GH_URL} target="_blank" rel="noopener noreferrer">GitHub${NEW_TAB}</a>
             <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href=${GH_URL + '/discussions'} target="_blank" rel="noopener noreferrer">Discussions${NEW_TAB}</a>
             <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href=${DISCORD_URL} target="_blank" rel="noopener noreferrer">Discord${NEW_TAB}</a>
-            <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href=${X_URL} target="_blank" rel="noopener noreferrer">X${NEW_TAB}</a>
             <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href=${BLUESKY_URL} target="_blank" rel="noopener noreferrer">Bluesky${NEW_TAB}</a>
+            <a class="text-fg-muted hover:text-accent no-underline text-sm transition-colors" href=${X_URL} target="_blank" rel="noopener noreferrer">X${NEW_TAB}</a>
           </div>
           <div class="flex flex-col gap-3">
             <a href="/" aria-label="WebJs home" class="no-underline text-fg inline-flex w-fit transition-opacity duration-150 hover:opacity-80">${brandLockup('ftr', { height: 26 })}</a>

--- a/website/test/ssr/nav-and-routes.test.ts
+++ b/website/test/ssr/nav-and-routes.test.ts
@@ -58,6 +58,8 @@ test('the footer Community column carries the social profiles', async () => {
   }
   assert.ok(out.includes('>X<'), 'the X link is labelled');
   assert.ok(out.includes('>Bluesky<'), 'the Bluesky link is labelled');
+  // Bluesky sits above X, so the column ends on the account we promote least.
+  assert.ok(out.indexOf('>Bluesky<') < out.indexOf('>X<'), 'Bluesky is listed before X');
 });
 
 test('the header still carries the rest of the nav', async () => {


### PR DESCRIPTION
The footer Community column listed X above Bluesky. Swaps the two so X comes last.

The footer test previously asserted only that both links render, so the order was unpinned; it now asserts Bluesky precedes X.

Verified: `node --test website/test/ssr/nav-and-routes.test.ts` (9/9 pass).