### PR TITLE
feat(website): embed intro video below the hero install command

### DIFF
--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -470,6 +470,22 @@ export default function LandingPage() {
       </div>
     </section>
 
+    <section class="pb-16">
+      <div class="max-w-3xl mx-auto px-6">
+        <div class="aspect-video rounded-2xl overflow-hidden border border-border-strong shadow-[var(--shadow)]">
+          <iframe
+            class="w-full h-full"
+            src="https://www.youtube-nocookie.com/embed/iz23lVMvlVY"
+            title="WebJs introduction video"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            referrerpolicy="strict-origin-when-cross-origin"
+            allowfullscreen
+          ></iframe>
+        </div>
+      </div>
+    </section>
+
     <section class="py-16">
       <div class="max-w-6xl mx-auto px-6">
         <div class="max-w-3xl mx-auto mb-12 text-center">

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -475,7 +475,7 @@ export default function LandingPage() {
         <div class="aspect-video overflow-hidden border border-border-strong shadow-[var(--shadow)]">
           <iframe
             class="w-full h-full"
-            src="https://www.youtube-nocookie.com/embed/iz23lVMvlVY"
+            src="https://www.youtube-nocookie.com/embed/iz23lVMvlVY?rel=0"
             title="WebJs introduction video"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -472,7 +472,7 @@ export default function LandingPage() {
 
     <section class="pb-16">
       <div class="max-w-3xl mx-auto px-6">
-        <div class="aspect-video rounded-2xl overflow-hidden border border-border-strong shadow-[var(--shadow)]">
+        <div class="aspect-video overflow-hidden border border-border-strong shadow-[var(--shadow)]">
           <iframe
             class="w-full h-full"
             src="https://www.youtube-nocookie.com/embed/iz23lVMvlVY"


### PR DESCRIPTION
## Summary
- Adds a responsive YouTube embed (https://youtu.be/iz23lVMvlVY) to the home page, placed directly below the hero's `npm create webjs@latest my-app` install command / below the hero section.
- Uses `youtube-nocookie.com` for the embed, `loading="lazy"`, and an `aspect-video` container so it never causes layout shift.

## Test plan
- [x] `npx webjs check` passes in `website/`
- [x] `npm run typecheck` passes in `website/`
- [x] Verified via `npm run dev` that the iframe renders in the SSR output right below the install command