### PR TITLE
docs: scope the imperative optimistic() example signal per instance

### DIFF
--- a/.agents/skills/webjs/references/optimistic-ui.md
+++ b/.agents/skills/webjs/references/optimistic-ui.md
@@ -130,18 +130,30 @@ The component reads that seeded prop as its `optimistic()` `source`, so `source:
 For a boolean toggle where the value itself is the mutation (like, follow, pin), `optimistic(signal, value, action)` is a thin wrapper over the signal primitive.
 
 ```ts
-import { signal, optimistic } from '@webjsdev/core';
+import { WebComponent, prop, signal, optimistic, html } from '@webjsdev/core';
 import { likePost } from '#modules/posts/actions/like-post.server.ts';
 
-const liked = signal(false);
-// in an @click handler:
-const result = await optimistic(liked, true, () => likePost(postId));
-// `liked` flips to true instantly. If likePost THROWS or returns
-// { success: false }, `liked` rolls back to its prior value: the throw
-// re-throws, and the { success: false } result is returned so you can
-// read its error / fieldErrors. On success the optimistic value stays;
-// reconcile to the authoritative value from `result` if you need it.
+class LikeButton extends WebComponent({ postId: prop(String) }) {
+  // INSTANCE scope: one signal per element. A module-scope `signal()` is SHARED
+  // across every instance (invariant 5), so a feed of these would all flip
+  // together on one click. Scope per-item state to the instance.
+  private liked = signal(false);
+
+  private async toggle() {
+    const next = !this.liked.get();
+    // Returns the action's ActionResult, so a { success: false } is readable
+    // by the caller. The rollback has already happened by then.
+    return optimistic(this.liked, next, () => likePost(this.postId));
+  }
+
+  render() {
+    return html`<button @click=${() => this.toggle()}>${this.liked.get() ? 'Liked' : 'Like'}</button>`;
+  }
+}
+LikeButton.register('like-button');
 ```
+
+Reserve MODULE scope for state that genuinely is app-wide (a theme, a cart count, a sidebar-open flag), which is the case invariant 5's "module-scope signals share state across components" exists to serve. Per-item state goes on the instance, as above. `liked` is a plain instance field, not a reactive property declared in the factory, so the class-field ban does not reach it and `reactive-props-no-class-field` does not flag it. `gallery/modules/optimistic-ui/components/like-button.ts` is the same shape in shipped code.
 
 It rolls back on a thrown error OR an `ActionResult` `{ success: false }` envelope, and never on success. It is client-only (it mutates a signal), so a component importing it is never elided as a display-only component.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -491,13 +491,27 @@ TodoList.register('todo-list');
 For boolean toggles where the value itself is the mutation:
 
 ```ts
-import { signal, optimistic } from '@webjsdev/core';
+import { WebComponent, prop, signal, optimistic, html } from '@webjsdev/core';
 import { likePost } from '#actions/like-post.server.ts';
 
-const liked = signal(false);
-// in an @click handler:
-const result = await optimistic(liked, true, () => likePost(postId));
+class LikeButton extends WebComponent({ postId: prop(String) }) {
+  // INSTANCE scope, one signal per element. A module-scope `signal()` is SHARED
+  // by every instance (invariant 5), so a list of these would all flip together.
+  private liked = signal(false);
+
+  private async toggle() {
+    const next = !this.liked.get();
+    return optimistic(this.liked, next, () => likePost(this.postId));
+  }
+
+  render() {
+    return html`<button @click=${() => this.toggle()}>${this.liked.get() ? 'Liked' : 'Like'}</button>`;
+  }
+}
+LikeButton.register('like-button');
 ```
+
+The call RETURNS the action's `ActionResult`, so a `{ success: false }` both rolls back the signal and comes back to you for its `error` / `fieldErrors`. Module scope is the right choice when the state genuinely IS app-wide (a theme, a cart count, a sidebar-open flag). Per-item state belongs on the instance. `liked` is a plain instance field rather than a reactive property, so the class-field ban does not apply to it.
 
 ### When to skip optimistic UI
 

--- a/website/app/docs/optimistic-ui/page.ts
+++ b/website/app/docs/optimistic-ui/page.ts
@@ -161,13 +161,31 @@ export default async function NotesPage() {
       For a boolean flip where the value itself is the mutation (like, follow, pin), the imperative form is a thin wrapper over the signal primitive. It sets the signal, awaits the action, and restores the previous value on failure.
     </p>
 
-    <code-block>import { signal, optimistic } from '@webjsdev/core';
+    <code-block>import { WebComponent, prop, signal, optimistic, html } from '@webjsdev/core';
 import { likePost } from '#modules/posts/actions/like-post.server.ts';
 
-const liked = signal(false);
-// in an @click handler:
-const result = await optimistic(liked, true, () =&gt; likePost(postId));
-// liked flips to true instantly, and stays on success.</code-block>
+class LikeButton extends WebComponent({ postId: prop(String) }) {
+  // INSTANCE scope: one signal per element. A module-scope signal() is SHARED
+  // across every instance, so a feed of these would all flip on one click.
+  private liked = signal(false);
+
+  private async toggle() {
+    const next = !this.liked.get();
+    // Returns the action's ActionResult; the rollback already happened by then.
+    return optimistic(this.liked, next, () =&gt; likePost(this.postId));
+  }
+
+  render() {
+    return html\`&lt;button @click=\${() =&gt; this.toggle()}&gt;
+      \${this.liked.get() ? 'Liked' : 'Like'}
+    &lt;/button&gt;\`;
+  }
+}
+LikeButton.register('like-button');</code-block>
+
+    <p>
+      Note the scope. A module-scope <code>signal()</code> is shared by every component instance, which is exactly right for state that genuinely is app-wide (a theme, a cart count, a sidebar-open flag) and exactly wrong for a per-item flip, where a list of buttons would all light up on one click. Per-item state goes on the instance, as above. <code>liked</code> is a plain instance field rather than a reactive property declared in the factory, so the class-field rule that protects reactive props does not apply to it.
+    </p>
 
     <p>
       Two failure modes restore the previous value. A <strong>throw</strong> from the action rolls back and then re-throws, so a caller that wants to react still has to catch it. A returned <code>{ success: false }</code> envelope rolls back and is <em>returned</em> rather than thrown, so you read its <code>error</code> or <code>fieldErrors</code> off the result.


### PR DESCRIPTION
Closes #1438

The imperative `optimistic(signal, value, action)` example declared its signal at module scope while calling `likePost(postId)`. It claimed per-item state and implemented app-global state, so a feed of like buttons built from it flips every heart on one click.

## Verified, not reasoned

Three `<like-button>` elements against the real `packages/core/dist/webjs-core-browser.js`, clicking only the middle one:

| example shape | before | after clicking only p2 |
|---|---|---|
| module scope (what shipped) | `Like Like Like` | `Liked Liked Liked` |
| instance scope (this PR) | `Like Like Like` | `Like Liked Like` |

The corrected snippet was extracted VERBATIM from the edited docs page, run through the framework's own TypeScript stripper, and driven in Chromium. It also toggles back off correctly, and the page logs no errors.

## Not a framework bug

The runtime does exactly what invariant 5 specifies, and `gallery/modules/optimistic-ui/components/like-button.ts` already carried the right shape in shipped code. The docs were the outlier. In `AGENTS.md` the bad example sat thirty lines above the invariant it contradicted.

No `webjs check` rule comes out of this. A module-scope signal is legitimately what an app wants for shared state, which puts it on the conventions side of the check's dividing line.

## What changed

All three surfaces now match the gallery's shape (`private liked = signal(false)` plus `optimistic(this.liked, next, ...)`):

- `AGENTS.md` (kept lean)
- `.agents/skills/webjs/references/optimistic-ui.md`
- `website/app/docs/optimistic-ui/page.ts`

The scaffold copies the repo-root skill at prepack, so no fourth copy exists.

Each keeps a line naming the legitimate module-scope case (a theme, a cart count, a sidebar-open flag), so the fix reads as a distinction rather than a ban, and each notes that `liked` is a plain instance field rather than a reactive property, so the class-field rule protecting reactive props does not reach it.

## Checks

`webjs check` clean in website and gallery, `tsc --noEmit` clean, website suite 474 node plus 88 browser green, and `packages/mcp/test/mcp-docs.test.mjs` green since it reads the docs corpus that includes `AGENTS.md`.
