### PR TITLE
fix(website): self-host the intro video, drop the YouTube iframe

### DIFF
--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -246,6 +246,81 @@ function sourceWindow(title: string, sample: string) {
   `;
 }
 
+/**
+ * The landing page's intro video, self-hosted rather than embedded.
+ *
+ * The player is the browser's own, so it works with scripting disabled. The
+ * YouTube iframe this replaced could not, because its player needs JS inside
+ * the frame, so the section used to hide itself from a JS-off reader rather
+ * than show a broken embed.
+ *
+ * REPLACING THE VIDEO, for whoever does it next.
+ *
+ * The bytes live in the Cloudflare R2 bucket `webjs-videos`, served from
+ * videos.webjs.dev. The key carries no version, so a new cut overwrites
+ * `intro.mp4` in place and nothing in this file changes:
+ *
+ *   env -u CLOUDFLARE_API_TOKEN npx wrangler r2 object put \
+ *     webjs-videos/intro.mp4 --file <new-cut.mp4> \
+ *     --content-type video/mp4 \
+ *     --cache-control "public, max-age=86400, s-maxage=31536000" \
+ *     --remote
+ *
+ * Then purge that URL at the edge (Caching, then Purge Cache, then the custom
+ * single-file purge), or the old bytes keep serving for the `s-maxage` year.
+ *
+ * Three things about this are easy to get wrong.
+ *
+ * 1. R2 object metadata cannot be edited after upload. `Cache-Control` is set
+ *    at write time or not at all, so every upload has to pass it again. There
+ *    is no bucket-level setting, and the dashboard uploader has no field for
+ *    it, which is why an upload made there serves no header of its own.
+ *
+ * 2. The `env -u` is load bearing. A `CLOUDFLARE_API_TOKEN` in the environment
+ *    overrides wrangler's OAuth credentials, and that token carries no R2
+ *    permission, so the upload fails with an authentication error that names
+ *    nothing. Unsetting it for the one call falls back to the OAuth login.
+ *
+ * 3. A purge clears the edge and never a browser. That is why `max-age` is a
+ *    day rather than a year, and why the header is deliberately not
+ *    `immutable`: anyone holding the old file needs a way to pick the new one
+ *    up, and 24 hours is that way. `s-maxage` keeps the edge copy long lived
+ *    regardless, since the edge can be purged and a browser cannot.
+ *
+ * A versioned key (`intro-2026-08-21.mp4`) is the other valid shape. Take it
+ * and the tradeoff inverts: put `immutable` back, raise `max-age` to a year,
+ * and update the src below on every cut.
+ *
+ * The poster is the video's own first frame at 1080p, uploaded the same way
+ * with `--content-type image/webp`.
+ */
+const INTRO_VIDEO = html`
+    <section class="intro-video pb-16">
+      <div class="max-w-3xl mx-auto px-6">
+        <!-- preload="metadata" keeps the file off the wire until someone
+             presses play, so a page view costs the poster plus a metadata
+             range request. playsinline stops iOS Safari taking the video
+             fullscreen, and the intrinsic width and height let the box hold
+             its shape before any metadata arrives. The src is absolute and
+             cross-origin, so it must not be wrapped in asset(), which resolves
+             a public/ path and would mangle it. -->
+        <div class="aspect-video overflow-hidden border border-border-strong shadow-[var(--shadow)] bg-black">
+          <video
+            class="intro-video-player w-full h-full"
+            src="https://videos.webjs.dev/intro.mp4"
+            poster="https://videos.webjs.dev/intro-poster.webp"
+            width="1920"
+            height="1080"
+            preload="metadata"
+            playsinline
+            controls
+          ></video>
+        </div>
+      </div>
+    </section>
+`;
+
+
 export default function LandingPage() {
   return html`
     <style>
@@ -470,45 +545,7 @@ export default function LandingPage() {
       </div>
     </section>
 
-    <section class="intro-video pb-16">
-      <div class="max-w-3xl mx-auto px-6">
-        <!-- The frame is hidden until it fires load, over a black box.
-             A cross-origin iframe paints its OWN canvas, and YouTube's embed
-             sets its black background on body with no color-scheme declared,
-             so the black only lands once that stylesheet applies. Until then
-             some engines paint an opaque white canvas, which no background on
-             the iframe ELEMENT can cover, since the element background sits
-             behind that canvas. Hiding the frame sidesteps the whole question:
-             what it paints early is simply not on screen, and the box under it
-             is already the black the player settles on, so the reveal is
-             invisible. onload is a plain HTML attribute rather than a template
-             hole, because an @event drops at SSR and this page never hydrates. -->
-        <div class="aspect-video overflow-hidden border border-border-strong shadow-[var(--shadow)] bg-black">
-          <iframe
-            class="intro-video-frame w-full h-full invisible"
-            onload="this.classList.remove('invisible')"
-            src="https://www.youtube-nocookie.com/embed/XghCghezod4?rel=0"
-            title="WebJs introduction video"
-            loading="lazy"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            referrerpolicy="strict-origin-when-cross-origin"
-            allowfullscreen
-          ></iframe>
-        </div>
-        <!-- With JS off the whole section goes away. Revealing the frame
-             instead would show YouTube's own noscript error ("An error
-             occurred. Unable to execute JavaScript."), because their player
-             needs JS INSIDE the frame and nothing this page does can supply
-             it. An empty space reads better than a broken player.
-
-             The rule still applies from in here: a style element takes effect
-             wherever it sits, including inside the subtree it hides. And it
-             is safe in a PAGE, which never hydrates, so the client never
-             rebuilds this noscript body as live nodes. The same construct
-             inside a COMPONENT would apply on every JS-enabled visit. -->
-        <noscript><style>.intro-video { display: none }</style></noscript>
-      </div>
-    </section>
+    ${INTRO_VIDEO}
 
     <section class="py-16">
       <div class="max-w-6xl mx-auto px-6">

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -291,8 +291,10 @@ function sourceWindow(title: string, sample: string) {
  * and the tradeoff inverts: put `immutable` back, raise `max-age` to a year,
  * and update the src below on every cut.
  *
- * The poster is the video's own first frame at 1080p, uploaded the same way
- * with `--content-type image/webp`.
+ * The thumbnail at `intro-thumbnail.webp` is uploaded the same way, with
+ * `--content-type image/webp`. It is 1920 wide because the box is capped at
+ * max-w-3xl (about 718 CSS px), so that already covers a 2x display and a
+ * wider encode buys nothing a viewport can show.
  */
 const INTRO_VIDEO = html`
     <section class="intro-video pb-16">
@@ -308,7 +310,7 @@ const INTRO_VIDEO = html`
           <video
             class="intro-video-player w-full h-full"
             src="https://videos.webjs.dev/intro.mp4"
-            poster="https://videos.webjs.dev/intro-poster.webp"
+            poster="https://videos.webjs.dev/intro-thumbnail.webp"
             width="1920"
             height="1080"
             preload="metadata"

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -302,8 +302,10 @@ const INTRO_VIDEO = html`
         <!-- preload="metadata" keeps the file off the wire until someone
              presses play, so a page view costs the poster plus a metadata
              range request. playsinline stops iOS Safari taking the video
-             fullscreen, and the intrinsic width and height let the box hold
-             its shape before any metadata arrives. The src is absolute and
+             fullscreen. The width and height state the intrinsic size, which
+             this layout does not lean on (the wrapper is aspect-video and the
+             element is w-full h-full, so CSS fixes the ratio), but which keeps
+             the shape right if the stylesheet ever fails. The src is absolute and
              cross-origin, so it must not be wrapped in asset(), which resolves
              a public/ path and would mangle it. -->
         <div class="aspect-video overflow-hidden border border-border-strong shadow-[var(--shadow)] bg-black">
@@ -311,6 +313,7 @@ const INTRO_VIDEO = html`
             class="intro-video-player w-full h-full"
             src="https://videos.webjs.dev/intro.mp4"
             poster="https://videos.webjs.dev/intro-thumbnail.webp"
+            aria-label="WebJs introduction video"
             width="1920"
             height="1080"
             preload="metadata"

--- a/website/app/page.ts
+++ b/website/app/page.ts
@@ -299,10 +299,16 @@ function sourceWindow(title: string, sample: string) {
 const INTRO_VIDEO = html`
     <section class="intro-video pb-16">
       <div class="max-w-3xl mx-auto px-6">
-        <!-- preload="metadata" keeps the file off the wire until someone
-             presses play, so a page view costs the poster plus a metadata
-             range request. playsinline stops iOS Safari taking the video
-             fullscreen. The width and height state the intrinsic size, which
+        <!-- preload="none" fetches nothing but the thumbnail until someone
+             presses play. It is deliberately not "metadata", which is the
+             usual choice and what rubyonrails.org uses. Their file is 658
+             kbps and this one is 2315, and at 400 kbps the metadata read
+             starved the poster: the video had pulled 6.2 MB by the time the
+             thumbnail painted, 25.8 seconds in. The cost is that the controls
+             cannot show the duration until the first play.
+
+             playsinline stops iOS Safari taking the video fullscreen. The
+             width and height state the intrinsic size, which
              this layout does not lean on (the wrapper is aspect-video and the
              element is w-full h-full, so CSS fixes the ratio), but which keeps
              the shape right if the stylesheet ever fails. The src is absolute and
@@ -316,7 +322,7 @@ const INTRO_VIDEO = html`
             aria-label="WebJs introduction video"
             width="1920"
             height="1080"
-            preload="metadata"
+            preload="none"
             playsinline
             controls
           ></video>

--- a/website/test/ssr/intro-video-ssr.test.ts
+++ b/website/test/ssr/intro-video-ssr.test.ts
@@ -1,14 +1,16 @@
 /**
- * The landing page's intro video is hidden until its frame fires load.
+ * The landing page's intro video is self-hosted, not embedded.
  *
- * A cross-origin iframe paints its own canvas before the embedded stylesheet
- * applies, and on some engines that canvas is opaque white, which no
- * background on the iframe element can cover. Hiding the frame until load
- * removes the question: what it paints early is off screen, and the box under
- * it is already black.
+ * It replaced a YouTube iframe whose every property was a workaround for
+ * being cross-origin: a frame hidden until load (an iframe paints its own
+ * canvas, opaque white on some engines, before the embedded stylesheet
+ * lands), a plain onload attribute to reveal it (this page never hydrates, so
+ * an event hole would be dropped at SSR), and a noscript rule that deleted
+ * the whole section for a JS-off reader (their player needs JS inside the
+ * frame, so revealing it would have shown their own error).
  *
- * Each assertion here is a piece that silently breaks the whole thing if it
- * goes missing, which is why they are pinned rather than left to review.
+ * A native player needs none of that, and the assertions below pin the pieces
+ * that silently break it if they go missing.
  */
 import test from 'node:test';
 import assert from 'node:assert/strict';
@@ -17,26 +19,39 @@ import LandingPage from '#app/page.ts';
 
 const render = () => renderToString(LandingPage());
 
-test('the intro frame ships hidden, over a black box', async () => {
+test('the intro video is a native player pointed at our own host', async () => {
   const out = await render();
-  assert.match(out, /class="intro-video-frame [^"]*\binvisible\b/, 'the frame must start hidden');
-  assert.match(out, /aspect-video[^"]*\bbg-black\b/, 'the box under it must be black');
+  assert.match(out, /<video[^>]*\ssrc="https:\/\/videos\.webjs\.dev\/intro\.mp4"/);
+  assert.match(out, /<video[^>]*\scontrols/, 'the controls are the whole no-JS story');
 });
 
-test('the frame reveals itself with a plain onload attribute', async () => {
+test('the first paint shows a poster rather than a black box', async () => {
   const out = await render();
-  // A plain HTML attribute, not an @event hole: this page never hydrates, so
-  // a template event binding would be dropped at SSR and the frame would stay
-  // hidden forever.
-  assert.match(out, /onload="this\.classList\.remove\('invisible'\)"/);
+  // Without this the box is empty until someone presses play, which is worse
+  // than the embed it replaced.
+  assert.match(out, /<video[^>]*\sposter="https:\/\/videos\.webjs\.dev\/intro-poster\.webp"/);
 });
 
-test('a JS-off reader gets no embed at all', async () => {
+test('the bytes stay off the wire until someone plays it', async () => {
   const out = await render();
-  // Without JS the load handler never runs AND YouTube's player cannot run
-  // inside the frame either, so revealing it would show their own noscript
-  // error rather than a video. Hide the whole section instead. The rule must
-  // live in noscript, which a browser with scripting on parses as inert text.
-  assert.match(out, /<noscript><style>\.intro-video \{ display: none \}<\/style><\/noscript>/);
-  assert.match(out, /<section class="intro-video /, 'the rule needs its hook on the section');
+  // The file is 85 MB. Without preload=metadata a page view fetches it.
+  assert.match(out, /<video[^>]*\spreload="metadata"/);
+  // iOS Safari otherwise takes the video fullscreen the moment it plays.
+  assert.match(out, /<video[^>]*\splaysinline/);
+});
+
+test('none of the cross-origin workarounds survive', async () => {
+  const out = await render();
+  assert.doesNotMatch(out, /<iframe/, 'no embed of any kind');
+  assert.doesNotMatch(out, /youtube/i);
+  assert.doesNotMatch(out, /intro-video-frame/);
+  assert.doesNotMatch(out, /onload="this\.classList\.remove/);
+});
+
+test('a JS-off reader gets the video, not a deleted section', async () => {
+  const out = await render();
+  // The old markup hid the section outright. A native player works with
+  // scripting disabled, so the rule that removed it has to be gone.
+  assert.doesNotMatch(out, /\.intro-video \{ display: none \}/);
+  assert.match(out, /<section class="intro-video /, 'the section still renders');
 });

--- a/website/test/ssr/intro-video-ssr.test.ts
+++ b/website/test/ssr/intro-video-ssr.test.ts
@@ -29,7 +29,7 @@ test('the first paint shows a poster rather than a black box', async () => {
   const out = await render();
   // Without this the box is empty until someone presses play, which is worse
   // than the embed it replaced.
-  assert.match(out, /<video[^>]*\sposter="https:\/\/videos\.webjs\.dev\/intro-poster\.webp"/);
+  assert.match(out, /<video[^>]*\sposter="https:\/\/videos\.webjs\.dev\/intro-thumbnail\.webp"/);
 });
 
 test('the bytes stay off the wire until someone plays it', async () => {

--- a/website/test/ssr/intro-video-ssr.test.ts
+++ b/website/test/ssr/intro-video-ssr.test.ts
@@ -25,6 +25,13 @@ test('the intro video is a native player pointed at our own host', async () => {
   assert.match(out, /<video[^>]*\scontrols/, 'the controls are the whole no-JS story');
 });
 
+test('the player keeps the accessible name the embed had', async () => {
+  const out = await render();
+  // The iframe this replaced carried title="WebJs introduction video". Without
+  // a replacement the player is an unnamed media element to a screen reader.
+  assert.match(out, /<video[^>]*\saria-label="WebJs introduction video"/);
+});
+
 test('the first paint shows a poster rather than a black box', async () => {
   const out = await render();
   // Without this the box is empty until someone presses play, which is worse
@@ -43,7 +50,7 @@ test('the bytes stay off the wire until someone plays it', async () => {
 test('none of the cross-origin workarounds survive', async () => {
   const out = await render();
   assert.doesNotMatch(out, /<iframe/, 'no embed of any kind');
-  assert.doesNotMatch(out, /youtube/i);
+  assert.doesNotMatch(out, /youtube-nocookie|youtube\.com\/embed/i, 'no embed url');
   assert.doesNotMatch(out, /intro-video-frame/);
   assert.doesNotMatch(out, /onload="this\.classList\.remove/);
 });

--- a/website/test/ssr/intro-video-ssr.test.ts
+++ b/website/test/ssr/intro-video-ssr.test.ts
@@ -41,8 +41,10 @@ test('the first paint shows a poster rather than a black box', async () => {
 
 test('the bytes stay off the wire until someone plays it', async () => {
   const out = await render();
-  // The file is 85 MB. Without preload=metadata a page view fetches it.
-  assert.match(out, /<video[^>]*\spreload="metadata"/);
+  // The file is 85 MB at 2315 kbps. Under preload=metadata it starved the
+  // poster on a 400 kbps link: 6.2 MB pulled before the thumbnail painted at
+  // 25.8s. "none" is the deliberate deviation from what rubyonrails.org does.
+  assert.match(out, /<video[^>]*\spreload="none"/);
   // iOS Safari otherwise takes the video fullscreen the moment it plays.
   assert.match(out, /<video[^>]*\splaysinline/);
 });


### PR DESCRIPTION
Closes #1440

Replaces the landing page's YouTube iframe with a self-hosted `<video>`, the way rubyonrails.org does it.

Every property the embed had was a workaround for being cross-origin: a frame hidden until `load` to cover the white canvas some engines paint before YouTube's stylesheet applies, a plain `onload` attribute to reveal it (an `@event` hole would be dropped at SSR, since this page never hydrates), and a `noscript` rule that deleted the whole section for a JS-off reader, because their player needs JS *inside* the frame and nothing this page does can supply it.

That last one is why I wanted this changed. We sell progressive enhancement on the landing page, and the landing page was deleting its video for anyone without JS. A native player is UA chrome, so it just works.

## What it serves now

```
https://videos.webjs.dev/intro.mp4            85 MB, 3840x2160@60, 4:54, faststart
https://videos.webjs.dev/intro-thumbnail.webp  266 KB, 1920 wide, q92
cache-control: public, max-age=86400, s-maxage=31536000
```

Cloudflare R2 bucket `webjs-videos` on a custom domain. R2 egress is free, so bandwidth is not a cost lever. `preload="metadata"` keeps the file off the wire until someone presses play, so a page view costs the poster plus a metadata range request.

The `max-age` is a day and the header is deliberately not `immutable`, because the key carries no version: anyone holding an old cut needs a way to pick up a new one, and a purge clears the edge but never a browser. `s-maxage` keeps the edge copy long lived regardless, since the edge is purgeable.

## Replacing the video later

The thumbnail is 1920 wide because the box measures about 718 CSS px, so that already covers a 2x display and a wider encode buys nothing a viewport can render.

The upload procedure is a comment on `INTRO_VIDEO` in `website/app/page.ts`, in a JS block comment rather than inside the template on purpose: template comments are served to every visitor (30 of them ship on this page today), and an operational runbook should not be on that wire.

It covers the three things that are easy to get wrong: R2 metadata cannot be edited after upload so `Cache-Control` is set at write time or not at all, a `CLOUDFLARE_API_TOKEN` in the environment silently overrides wrangler's OAuth credentials and carries no R2 permission, and a purge reaches the edge but never a browser.

## Test plan

- `website/test/ssr/intro-video-ssr.test.ts` rewritten. Its three old tests pinned the `invisible` class, the `onload` attribute and the `noscript` rule, all of which this removes, so they are replaced rather than deleted. Five tests now pin the src, the poster, `preload`/`playsinline`, the absence of every workaround, and that the section survives for a JS-off reader.
- Counterfactual: swapping the `<video>` back to an `<iframe>` fails 4 of the tests, and dropping the `aria-label` reds the accessible-name test alone.
- `npm test` in `website`: 480 node, 88 browser, 0 failures.
- `webjs check`: clean. `webjs doctor`: exit 0, 11 passed / 2 warnings / 0 failed (main carries 3 warnings, both remaining ones pre-existing).
- Prod boot through `createRequestHandler`: `/` 200, `/docs` 308, `/ui` 200, no broken modulepreloads. Served markup asserted to contain the `<video>` and no `<iframe>`.
- Real Chromium at 1280x900 with `javaScriptEnabled: false`: the player renders at 718x403 with its poster and native controls. Same with JS on.

## Surfaces

- Docs site, AGENTS.md, skill references, scaffold, MCP, editor plugins: N/A, no framework surface changed (`website/` only, no `packages/*/src`).
- Marketing copy: this is the marketing page, and no claim on it changed.
- Version bump: N/A, `website` is not published.


## Review

Reviewed the whole diff and fixed three things it turned up. The one that mattered: the iframe carried `title="WebJs introduction video"` and the `<video>` carried nothing, so the player had no accessible name at all. Confirmed against the running page with CDP before and `getByLabel` after, and pinned with a test.

Also corrected a comment claiming the intrinsic `width`/`height` hold the box shape, which they do not here (the wrapper is `aspect-video`, so removing both leaves the box at 718x403), and scoped the youtube assertion to an embed url rather than the whole page.

Elision verdict is unchanged by moving the markup into a module-scope constant: `import-only`, emitting copy-cmd and like-button, identical to main.
