### PR TITLE
chore: release core 0.7.52

### DIFF
--- a/changelog/core/0.7.52.md
+++ b/changelog/core/0.7.52.md
@@ -1,0 +1,24 @@
+---
+package: "@webjsdev/core"
+version: 0.7.52
+date: 2026-08-20T20:58:47.906Z
+commit_count: 3
+---
+## Fixes
+
+- **a <webjs-frame> swap no longer scrolls the page to top** ([#1429](https://github.com/webjsdev/webjs/pull/1429)) [`13bd030c`](https://github.com/webjsdev/webjs/commit/13bd030c)
+  * fix: a <webjs-frame> swap no longer scrolls the page to top
+  
+  The router's scroll block was gated on `recordHistory` alone, which means
+  "a foreground navigation the reader initiated". A click on a frame-driving
+- **leave scroll restoration to the browser so iOS previews the back-swipe** ([#1430](https://github.com/webjsdev/webjs/pull/1430)) [`ad81d4b3`](https://github.com/webjsdev/webjs/commit/ad81d4b3)
+  * The router set `history.scrollRestoration = 'manual'`, which suppresses the
+  per-entry scroll recording WebKit composes the iOS back-swipe preview from, so
+  the preview rendered blank. Scroll restoration now stays with the browser (the
+  single-writer model Next and Remix use), with the router reserving the
+  snapshot's height so the recorded offset is reachable across the swap.
+- **resolve live() in an attribute hole so a falsy ?bool omits it** ([#1444](https://github.com/webjsdev/webjs/pull/1444)) [`e0abcf96`](https://github.com/webjsdev/webjs/commit/e0abcf96)
+  * fix: resolve live() in an attribute hole so a falsy ?bool omits it
+  
+  The SSR renderer resolved live() only in a child hole, so the directive's
+  wrapper object reached the attribute emit sites raw. Each kind failed its

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.51",
+  "version": "0.7.52",
   "type": "module",
   "description": "The runtime for WebJs, a full-stack JavaScript framework built on web components with server-side rendering and no build step. Ships the html and css template tags, the WebComponent base class, signals, directives, and the isomorphic renderers.",
   "types": "./index.d.ts",


### PR DESCRIPTION
Releases `@webjsdev/core` 0.7.51 to 0.7.52.

## What ships

Three user-facing fixes, all client-router or renderer:

- **#1429** a `<webjs-frame>` swap no longer scrolls the page to top
- **#1430** scroll restoration is left to the browser, so iOS previews the back-swipe
- **#1444** `live()` resolves in an attribute hole, so a falsy `?bool` omits it

## Packages NOT bumped, and why

- **server 0.8.65, cli 0.10.56, ui 0.3.14, intellisense 0.5.5**: zero commits touching their paths since each one's last release commit.
- **mcp 0.1.14**: one commit since its last release (#1376), a `refactor:` with no user-facing change. `backfill-changelog.js` correctly emits nothing for it, and the pre-commit hook fails a bump with an empty changelog by design, so there is nothing to release. Reported rather than force-bumped with `--no-verify`.

No dependency-range bump is needed: `packages/server/package.json` declares `"@webjsdev/core": "^0.7.51"`, which `0.7.52` satisfies. This release also introduces no new core export, so the core-publishes-first ordering constraint does not apply and core is the only file in the batch regardless.

## Changelog note

The generated entry for #1430 quoted that PR's first commit (`chore: add guarded on-device levers...`), which describes intermediate scaffolding rather than the shipped change. Rewritten by hand to state the actual fix, per the documented "review and edit the generated file before pushing" step.
