### PR TITLE
chore: release core 0.7.53, server 0.8.66 and cli 0.10.57

### DIFF
--- a/changelog/cli/0.10.57.md
+++ b/changelog/cli/0.10.57.md
@@ -1,0 +1,20 @@
+---
+package: "@webjsdev/cli"
+version: 0.10.57
+date: 2026-08-21T15:41:57.474Z
+commit_count: 2
+---
+## Fixes
+
+- **npm install in a linked worktree corrupts the shared node_modules** ([#1447](https://github.com/webjsdev/webjs/pull/1447)) [`da63edad`](https://github.com/webjsdev/webjs/commit/da63edad)
+  * fix: block a package-manager install inside a linked worktree
+  
+  `npm run worktree:link` symlinks a worktree's node_modules at the primary
+  checkout's, so an install run in the worktree acts on the primary. Measured
+- **scaffolded apps get real core types and a usable typescript range** ([#1452](https://github.com/webjsdev/webjs/pull/1452)) [`b8e8bd3e`](https://github.com/webjsdev/webjs/commit/b8e8bd3e)
+  * fix: stop the scaffold declaring a typescript it cannot use
+  
+  The generated package.json declared `"typescript": "^5.6.0"` while the
+  tsconfig.json the same generator writes sets `erasableSyntaxOnly`, which
+  landed in 5.8. Every version in the lower half of that range refuses the
+  config outright with `TS5023: Unknown compiler option`.

--- a/changelog/core/0.7.53.md
+++ b/changelog/core/0.7.53.md
@@ -1,0 +1,26 @@
+---
+package: "@webjsdev/core"
+version: 0.7.53
+date: 2026-08-21T15:41:57.351Z
+commit_count: 3
+---
+## Features
+
+- **add data-preserve-scroll to opt out of the forward-nav scroll** ([#1446](https://github.com/webjsdev/webjs/pull/1446)) [`761fad3e`](https://github.com/webjsdev/webjs/commit/761fad3e)
+  * feat: add data-preserve-scroll to opt out of the forward-nav scroll
+  
+  A forward navigation always scrolls to the top and an author had no way to
+  say otherwise. That default is right and matches Next and Remix 3, but there
+
+## Fixes
+
+- **leave a same-document fragment jump to the browser** ([#1448](https://github.com/webjsdev/webjs/pull/1448)) [`7749d29a`](https://github.com/webjsdev/webjs/commit/7749d29a)
+  * fix: leave a same-document fragment jump to the browser
+  
+  Clicking an in-page fragment link re-fetched the current URL and re-swapped
+  the page, so live DOM identity and hydrated component state outside the
+- **scaffolded apps get real core types and a usable typescript range** ([#1452](https://github.com/webjsdev/webjs/pull/1452)) [`b8e8bd3e`](https://github.com/webjsdev/webjs/commit/b8e8bd3e)
+  * fix: type the core exports an app resolves as any
+  
+  `@webjsdev/core`'s overlay re-exported seven modules from their JSDoc `.js`
+  with no `.d.ts` sibling. An app has `allowJs` off, so `html`, `css`,

--- a/changelog/server/0.8.66.md
+++ b/changelog/server/0.8.66.md
@@ -1,0 +1,21 @@
+---
+package: "@webjsdev/server"
+version: 0.8.66
+date: 2026-08-21T15:41:57.407Z
+commit_count: 2
+---
+## Fixes
+
+- **make @webjsdev/core a peer dependency of @webjsdev/server** ([#1450](https://github.com/webjsdev/webjs/pull/1450)) [`ac89745c`](https://github.com/webjsdev/webjs/commit/ac89745c)
+  Three of core's server-facing features are provider seams held in module
+  scope: asset(), cspNonce(), and the bound-form identity resolver. The server
+  installs each at boot by importing core and calling a setter, which only
+  reaches the app when both sides load the SAME module instance. Two copies of
+- **scaffolded apps get real core types and a usable typescript range** ([#1452](https://github.com/webjsdev/webjs/pull/1452)) [`b8e8bd3e`](https://github.com/webjsdev/webjs/commit/b8e8bd3e)
+  * fix: repair the three consumers the Handle fix exposed
+  
+  `RequestHandler` referenced `Handle` on the strength of an `export *`, which
+  re-exports a name without binding it locally, so `handle` was an error type.
+  Typing it for real broke every place that had restated the signature as
+  `(req: Request) => Promise<Response>`, which only passed while the error type
+  absorbed the mismatch.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6979,7 +6979,7 @@
     },
     "packages/cli": {
       "name": "@webjsdev/cli",
-      "version": "0.10.56",
+      "version": "0.10.57",
       "license": "MIT",
       "dependencies": {
         "@webjsdev/mcp": "^0.1.0",
@@ -6995,7 +6995,7 @@
     },
     "packages/core": {
       "name": "@webjsdev/core",
-      "version": "0.7.52",
+      "version": "0.7.53",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.25.0"
@@ -7044,7 +7044,7 @@
     },
     "packages/server": {
       "name": "@webjsdev/server",
-      "version": "0.8.65",
+      "version": "0.8.66",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.20.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/cli",
-  "version": "0.10.56",
+  "version": "0.10.57",
   "type": "module",
   "description": "The CLI for WebJs, a full-stack JavaScript framework built on web components with server-side rendering and no build step. Runs the dev and production servers, scaffolds apps, validates conventions, and drives the database. Node 24+ or Bun.",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/core",
-  "version": "0.7.52",
+  "version": "0.7.53",
   "type": "module",
   "description": "The runtime for WebJs, a full-stack JavaScript framework built on web components with server-side rendering and no build step. Ships the html and css template tags, the WebComponent base class, signals, directives, and the isomorphic renderers.",
   "types": "./index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webjsdev/server",
-  "version": "0.8.65",
+  "version": "0.8.66",
   "type": "module",
   "description": "The server for WebJs, a full-stack JavaScript framework built on web components with server-side rendering and no build step. Provides the file-based router, SSR, server actions, route handlers, middleware, and live reload on Node 24+ or Bun.",
   "main": "index.js",


### PR DESCRIPTION
Releases the three packages carrying unreleased user-facing commits. `mcp`, `ui` and `intellisense` have none since their last bump, so they stay put.

| Package | From | To | Commits |
|---|---|---|---|
| `@webjsdev/core` | 0.7.52 | 0.7.53 | #1446, #1448, #1452 |
| `@webjsdev/server` | 0.8.65 | 0.8.66 | #1450, #1452 |
| `@webjsdev/cli` | 0.10.56 | 0.10.57 | #1447, #1452 |

## Publish order

`changelog/core/0.7.53.md` carries the earliest `date:` of the batch, so the `set -e` publish loop ships core first and no core/server skew can reach the registry. `packages/server/package.json` declares `@webjsdev/core` as a peer at `^0.7.51`, which 0.7.53 satisfies; no new core export is consumed in this batch, so the range is unchanged.

## Changelog hand-edits

#1452 is a squashed multi-package commit, so the generator opened all three entries on its first sub-commit, which is core-specific. The `server` and `cli` excerpts were retargeted to the sub-commit that describes what each package actually shipped (the `Handle` typing repair, and the scaffold's typescript range). Core's generated excerpt was already correct.
