### PR TITLE
fix(website): drop the eyebrow label on blog, compare and changelog

### DIFF
--- a/website/app/blog/page.ts
+++ b/website/app/blog/page.ts
@@ -20,7 +20,7 @@ export default async function Blog() {
   const posts = await listPosts();
   return html`
     <main id="main" tabindex="-1" class="${READING} py-12 focus:outline-none">
-      ${pageHeader('Notes from building webjs', 'Posts on the design decisions, the trade-offs, the things that did not work, and what the framework looks like in production.', 'Blog')}
+      ${pageHeader('Notes from building webjs', 'Posts on the design decisions, the trade-offs, the things that did not work, and what the framework looks like in production.')}
 
       ${posts.length === 0
         ? html`<p class="text-fg-subtle italic">No posts yet.</p>`

--- a/website/app/changelog/page.ts
+++ b/website/app/changelog/page.ts
@@ -21,7 +21,6 @@ export default async function Changelog() {
   return html`
     <main id="main" tabindex="-1" class="max-w-210 mx-auto px-6 py-12 focus:outline-none">
       <header class="mb-10">
-        <p class="font-mono text-xs uppercase tracking-widest text-accent font-semibold mb-2">Changelog</p>
         <h1 class="font-serif text-hub leading-[1.05] tracking-tight text-fg mb-3">What shipped</h1>
         <p class="text-fg-muted text-sm leading-relaxed max-w-2xl">
           Per-package, per-version release notes for <code class="font-mono text-sm bg-fg/8 px-1 py-0.5 rounded">@webjsdev/core</code>,

--- a/website/app/compare/page.ts
+++ b/website/app/compare/page.ts
@@ -21,7 +21,7 @@ export default async function Compare() {
   const comparisons = await listComparisons();
   return html`
     <main id="main" tabindex="-1" class="${READING} py-12 focus:outline-none">
-      ${pageHeader('How WebJs compares', 'Honest head-to-head write-ups: where WebJs agrees with each framework, where it genuinely differs, and who should pick which. No trashing the alternative, and each one says where the other tool is the better call.', 'Compare')}
+      ${pageHeader('How WebJs compares', 'Honest head-to-head write-ups: where WebJs agrees with each framework, where it genuinely differs, and who should pick which. No trashing the alternative, and each one says where the other tool is the better call.')}
 
       ${comparisons.length === 0
         ? html`<p class="text-fg-subtle italic">No comparisons yet.</p>`


### PR DESCRIPTION
Removes the small uppercase headings BLOG, COMPARE and CHANGELOG above the page titles on /blog, /compare and /changelog. Each restated the nav item the reader just clicked.