### PR TITLE
chore: make the maintainer the only approval that satisfies the review gate

### DIFF
--- a/.claude/skills/webjs-start-work/SKILL.md
+++ b/.claude/skills/webjs-start-work/SKILL.md
@@ -298,7 +298,7 @@ Beyond review findings, proactively record the *reasoning* behind a PR as commen
 
 ### Merge is gated on green CI, enforced at the branch level, not by trust
 
-A PR must not merge until all CI checks pass. `main` branch protection requires the five `ci.yml` checks (Conventions, Unit+integration, Browser, E2E, Build) before any merge. If `gh api repos/webjsdev/webjs/branches/main/protection` shows `required_status_checks: null`, run `bash scripts/protect-main.sh` once (needs repo admin) to restore it. Do not work around a red or pending check. Wait for green, and fix whatever is red before merging.
+A PR must not merge until all CI checks pass. `main` branch protection requires the six `ci.yml` checks (Conventions, Unit+integration, Browser, E2E, Build, In-repo app tests) before any merge, plus one approving review from a CODEOWNER (`.github/CODEOWNERS` names @vivek7405 for every path, so that means the maintainer). If `gh api repos/webjsdev/webjs/branches/main/protection` shows `required_status_checks: null`, run `bash scripts/protect-main.sh` once (needs repo admin) to restore it. Do not work around a red or pending check. Wait for green, and fix whatever is red before merging.
 
 CI is read ONCE, at merge, never in a mid-work sleep loop. Read `gh pr checks` in full rather than trusting the merge button to have judged for you, because `ci.yml` defines roughly twice as many jobs as `main` requires, so the non-required ones are held by this instruction rather than by anything that can refuse a merge.
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Every path in this repo is owned by the maintainer.
+#
+# This exists to give branch protection something to key on. `main` requires
+# one approving review, and with `require_code_owner_reviews` turned on in
+# scripts/protect-main.sh, only an approval from an owner listed here counts
+# toward it. Without this file that setting matches nothing and the gate is a
+# no-op, so the two are a pair: neither works alone.
+#
+# A drive-by contributor approving another contributor's PR therefore does not
+# unblock a merge. Their review is still welcome and still visible, it just is
+# not the one the gate is waiting for.
+
+*       @vivek7405

--- a/scripts/protect-main.sh
+++ b/scripts/protect-main.sh
@@ -13,6 +13,12 @@
 # locking solo PRs. Flip enforce_admins to true only once a second reviewer
 # (a human or a bot account) exists to provide the non-author approval.
 #
+# NOTE on require_code_owner_reviews: it is paired with .github/CODEOWNERS,
+# which names @vivek7405 for every path. Without that file the setting matches
+# nothing and silently does nothing, so the two ship together. With both in
+# place, the one required approval must come from the maintainer, which is
+# what stops two drive-by contributors from approving each other onto main.
+#
 #   bash scripts/protect-main.sh
 #
 # The contexts below must match the `name:` of each job in ci.yml exactly,
@@ -40,10 +46,10 @@ gh api -X PUT "repos/${REPO}/branches/main/protection" \
   "required_pull_request_reviews": {
     "required_approving_review_count": 1,
     "dismiss_stale_reviews": false,
-    "require_code_owner_reviews": false
+    "require_code_owner_reviews": true
   },
   "restrictions": null
 }
 JSON
 
-echo "main is now protected: 1 approving review + all CI checks required before merge."
+echo "main is now protected: 1 approving CODEOWNER review + all CI checks required before merge."


### PR DESCRIPTION
Closes #1463

## Summary

`main` already required one approving review, but nothing said whose. Now that
the repo takes outside contributions, two drive-by contributors can approve each
other's PRs, and with CI green that is enough to merge. This makes the maintainer
the only approval that satisfies the gate.

Two halves, and they only work as a pair:

- `.github/CODEOWNERS` names `@vivek7405` for every path.
- `scripts/protect-main.sh` flips `require_code_owner_reviews` to `true`.

`require_code_owner_reviews` with no CODEOWNERS file matches nothing and is a
silent no-op, which is why both land in one commit. `enforce_admins` stays
`false`, unchanged: GitHub will not let me approve my own PR, so without the
admin bypass every solo PR would be unmergeable.

Re-running the script also repairs a drift I noticed while reading the live rule.
Protection enforces five required contexts, but `ci.yml` has six jobs and the
script has listed all six for a while, so `In-repo app tests (website + blog)`
was never actually required. Applying the script fixes that as a side effect.

## Applying it

The script is the source of truth but nothing runs it automatically, so the rule
does not change until someone with repo admin runs it:

```sh
bash scripts/protect-main.sh
```

I will run it after this merges, and confirm with
`gh api repos/webjsdev/webjs/branches/main/protection`.

## Definition of done

- **Tests.** N/A because nothing here is framework code. The change is a GitHub
  config file plus the shell script that pushes branch protection through the
  API; there is no unit, browser, e2e, smoke, or Bun surface to assert against.
  It is verified by reading back the live protection object after the script
  runs, which is in the Applying it section above.
- **Markdown.** Updated `.claude/skills/webjs-start-work/SKILL.md`, whose merge
  section described the gate as five contexts and did not mention who the
  approval has to come from. Both corrected. No other markdown describes branch
  protection (checked with a repo-wide grep for `protect-main`, `branch
  protection`, `approving review`, `CODEOWNERS`).
- **Docs site.** N/A because the review gate is repo governance, not a webjs API
  a user reads about.
- **Scaffold, MCP, editor plugins, marketing copy.** N/A because none of them
  project repo governance.
- **Dogfood boot check.** N/A because no framework code, dist output, importmap,
  or served wire changed. Nothing the blog or website serves is affected.
- **Version bumps.** N/A because no published package changed.

https://claude.ai/code/session_01MYGjB4NnsBZaDktR2E4y2Q
